### PR TITLE
Start using doc-gen4 for API-level documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: Build
+
+on:
+  pull_request:
+
+jobs:
+  get-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get branch name
+        shell: bash
+        # The workflow is triggered by pull_request so we use `GITHUB_BASE_REF`
+        run: echo "branch_name=${GITHUB_BASE_REF}" >> $GITHUB_OUTPUT
+        id: get_branch_name
+    outputs:
+      branch_name: ${{ steps.get_branch_name.outputs.branch_name }}
+
+  build_and_test_lean:
+    name: Build and test Lean
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Lean
+        shell: bash
+        run: |
+              wget https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh
+              bash elan-init.sh -y
+      - name: Install cvc5
+        shell: bash
+        run: |
+              ARCH=$(uname -m)
+              if [ "$ARCH" = "x86_64" ]; then
+                ARCH_NAME="x86_64"
+              elif [ "$ARCH" = "aarch64" ] || [ "$ARCH" = "arm64" ]; then
+                ARCH_NAME="arm64"
+              else
+                echo "Unsupported architecture: $ARCH"
+                exit 1
+              fi
+              wget https://github.com/cvc5/cvc5/releases/download/cvc5-1.2.1/cvc5-Linux-${ARCH_NAME}-static.zip
+              unzip cvc5-Linux-${ARCH_NAME}-static.zip
+              chmod +x cvc5-Linux-${ARCH_NAME}-static/bin/cvc5
+              echo "$GITHUB_WORKSPACE/cvc5-Linux-${ARCH_NAME}-static/bin/" >> $GITHUB_PATH
+      - name: Download dependencies
+        shell: bash
+        run: source ~/.profile && lake -R -Kenv=dev update
+      - name: Build
+        shell: bash
+        run: source ~/.profile && lake build
+      - name: Test
+        shell: bash
+        run: source ~/.profile && lake test

--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -237,7 +237,8 @@ partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (ot
   let xt := .forAll [] (.ftvar xt')
   let S ← match oty with
   | .some ty =>
-    (Constraints.unify [(.ftvar xt', ty)] T.state.subst)
+    let (optTyy, T) := (ty.aliasInst T)
+    (Constraints.unify [(.ftvar xt', optTyy.getD ty)] T.state.subst)
   | .none =>
     .ok T.state.subst
 
@@ -250,9 +251,10 @@ partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (ot
   let mty := LMonoTy.subst T.state.subst (.ftvar xt')
   match oty with
   | .some ty =>
-    if ty == mty
+    let (optTyy, _) := (ty.aliasInst T)
+    if optTyy.getD ty == mty
     then .ok ()
-    else .error "Type annotation on LTerm.quant doesn't match inferred argument type"
+    else .error f!"Type annotation on LTerm.quant {ty} (alias for {optTyy.getD ty}) doesn't match inferred argument type"
   | _ => .ok ()
   if ety = LMonoTy.bool then do
     let etclosed := .varClose 0 xv et

--- a/Strata/Languages/Boogie/Examples/QuantifiersWithTypeAliases.lean
+++ b/Strata/Languages/Boogie/Examples/QuantifiersWithTypeAliases.lean
@@ -1,0 +1,74 @@
+import Strata.Languages.Boogie.Verifier
+
+---------------------------------------------------------------------
+namespace Strata
+
+def QuantTypeAliases : Environment :=
+#strata
+open Boogie;
+
+type Ref;
+type Field;
+
+type Struct := Map Field int;
+type Heap := Map Ref Struct;
+
+axiom forall m: Struct, okk: Field, kk: Field, vv: int :: okk != kk ==> m[okk] == m[kk := vv][okk];
+axiom forall m: Struct, kk: Field, vv: int :: m[kk := vv][kk] == vv;
+
+axiom forall m: Heap, okk: Ref, kk: Ref, vv: Struct :: okk != kk ==> m[okk] == m[kk := vv][okk];
+axiom forall m: Heap, kk: Ref, vv: Struct :: m[kk := vv][kk] == vv;
+
+procedure test(h: Heap, ref: Ref, field: Field) returns ()
+{
+  var newH: Heap := h[ref := h[ref][field := h[ref][field] + 1]];
+  assert newH[ref][field] == h[ref][field] + 1;
+};
+
+#end
+
+#eval TransM.run (translateProgram (QuantTypeAliases.commands)) |>.snd |>.isEmpty
+
+/--
+info: type Boogie.Boundedness.Infinite Ref []
+type Boogie.Boundedness.Infinite Field []
+type Struct := (Map Field int)
+type Heap := (Map Ref Struct)
+axiom TODO: (∀ (∀ (∀ (∀ ((~Bool.Implies (~Bool.Not (%2 == %1))) (((~select %3) %2) == ((~select (((~update %3) %1) %0)) %2)))))));
+axiom TODO: (∀ (∀ (∀ (((~select (((~update %2) %1) %0)) %1) == %0))));
+axiom TODO: (∀ (∀ (∀ (∀ ((~Bool.Implies (~Bool.Not (%2 == %1))) (((~select %3) %2) == ((~select (((~update %3) %1) %0)) %2)))))));
+axiom TODO: (∀ (∀ (∀ (((~select (((~update %2) %1) %0)) %1) == %0))));
+(procedure test :  ((h : Heap) (ref : Ref) (field : Field)) → ())
+modifies: []
+preconditions: ⏎
+postconditions: ⏎
+body: init (newH : Heap) := (((~update h) ref) (((~update ((~select h) ref)) field) ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int))))
+assert [assert: (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int)))] (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int)))
+
+Errors: #[]
+-/
+#guard_msgs in
+#eval TransM.run (translateProgram (QuantTypeAliases.commands))
+
+/--
+info: [Strata.Boogie] Type checking succeeded.
+
+
+VCs:
+Label: assert: (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int)))
+Assumptions:
+(TODO, (∀ (∀ (∀ (((~select (((~update %2) %1) %0)) %1) == %0)))))
+(TODO, (∀ (∀ (∀ (∀ ((~Bool.Implies (~Bool.Not (%2 == %1))) (((~select %3) %2) == ((~select (((~update %3) %1) %0)) %2))))))))
+(TODO, (∀ (∀ (∀ (((~select (((~update %2) %1) %0)) %1) == %0)))))
+(TODO, (∀ (∀ (∀ (∀ ((~Bool.Implies (~Bool.Not (%2 == %1))) (((~select %3) %2) == ((~select (((~update %3) %1) %0)) %2))))))))
+Proof Obligation:
+(((~select ((~select (((~update $__h0) $__ref1) (((~update ((~select $__h0) $__ref1)) $__field2) ((~Int.Add ((~select ((~select $__h0) $__ref1)) $__field2)) #1)))) $__ref1)) $__field2) == ((~Int.Add ((~select ((~select $__h0) $__ref1)) $__field2)) #1))
+
+Wrote problem to vcs/assert: (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int))).smt2.
+---
+info:
+Obligation: assert: (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int)))
+Result: verified
+-/
+#guard_msgs in
+#eval verify "cvc5" QuantTypeAliases

--- a/Strata/Languages/Boogie/Verifier.lean
+++ b/Strata/Languages/Boogie/Verifier.lean
@@ -123,7 +123,7 @@ def runSolver (solver : String) (args : Array String) : IO String := do
 def solverResult (vars : List (IdentT BoogieIdent)) (ans : String) (ctx : SMT.Context) (E : EncoderState) :
   Except Format Result := do
   let pos := (ans.find (fun c => c == '\n')).byteIdx
-  let verdict := ans.take pos
+  let verdict := (ans.take pos).trim
   let rest := ans.drop pos
   match verdict with
   | "sat"     =>

--- a/Strata/SMT/Solver.lean
+++ b/Strata/SMT/Solver.lean
@@ -142,13 +142,18 @@ private def readlnD (dflt : String) : SolverM String := do
 
 def checkSat (vars : List String) : SolverM Decision := do
   emitln "(check-sat)"
-  if !vars.isEmpty then
-    getValue vars
-  match (← readlnD "unknown\n") with
-  | "sat\n"     => return Decision.sat
-  | "unsat\n"   => return Decision.unsat
-  | "unknown\n" => return Decision.unknown
-  | other       => throw (IO.userError s!"Unrecognized solver output: {other}")
+  let result := (← readlnD "unknown").trim
+  match result with
+  | "sat"     =>
+    if !vars.isEmpty then
+      getValue vars
+    return Decision.sat
+  | "unsat"   => return Decision.unsat
+  | "unknown" =>
+    if !vars.isEmpty then
+      getValue vars
+    return Decision.unknown
+  | other     => throw (IO.userError s!"Unrecognized solver output: {other}")
 
 def reset : SolverM Unit :=
   emitln "(reset)"


### PR DESCRIPTION
*Description of changes:*

Doc-gen4 is now used to generate API-level documentation in `docs/api` to encourage the addition and formatting of documentation strings in Strata source code. 

NOTE: Docs. are not generated as a part of the CI yet.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
