### PR TITLE
Add one LICENSE file that refers to the other two

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,0 @@
-The contents of this repository are licensed under the terms of either
-the Apache-2.0 or MIT license, at your choice. See LICENSE-APACHE and
-LICENSE-MIT for details of the two licenses.

--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ internal format of the dialects used to implement the language under
 analysis). These VCs are then encoded into SMT, and counterexamples,
 if any, report models for the variables present in the problem.
 
+## License
+
+The contents of this repository are licensed under the terms of either
+the Apache-2.0 or MIT license, at your choice. See
+[LICENSE-APACHE](LICENSE-APACHE) and [LICENSE-MIT](LICENSE-MIT) for
+details of the two licenses.


### PR DESCRIPTION
This just makes it extra clear that we intend that anyone can choose between Apache-2.0 and MIT.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
