### PR TITLE
wip: simplify Arith example by directly using strata_gen outputs

### DIFF
--- a/StrataTest/DL/Imperative/DDMDefinition.lean
+++ b/StrataTest/DL/Imperative/DDMDefinition.lean
@@ -11,6 +11,9 @@ type num;
 // Literals
 fn numLit (n : Num) : num => n;
 
+// Type annotation
+fn ty_expr (tp : Type, e : tp) : tp => "(" e ":" tp ")";
+
 // Expressions
 fn add_expr (a : num, b : num) : num => @[prec(25), leftassoc] a "+" b;
 fn mul_expr (a : num, b : num) : num => @[prec(27), leftassoc] a "*" b;
@@ -44,8 +47,11 @@ namespace ArithPrograms
 -- set_option trace.Strata.generator true
 -- set_option trace.Strata.DDM.syntax true
 #strata_gen ArithPrograms
--- #print Command.toAst
--- #print Command.ofAst
+#print ArithProgramsType
+#print Command
+#print Expr
+#print Command.toAst
+#print Command.ofAst
 
 end ArithPrograms
 


### PR DESCRIPTION
In the Arith example (StrataTest/DL/Imperative/...), Arith.Ty and Arith.Expr are inductive data structures that are being used to be a parameter of the Imperative dialect. These are lowered from the data structures automatically generated by `strata_gen`. The lowering is done at `DDMTranslate.lean`.

I think this example can be simplified further, by replacing `Arith.Ty` and `Arith.Expr` simply with the output of `strata_gen` and directly using it. Since `Arith.Ty` and `Arith.Expr` has been defined manually, but `strata_gen` is fully automatic, we can show that our existing automation can be used to reduce such manual effort.

This patch is under construction, but already shows that `ArithEval.lean`/`ArithExpr.lean`/`ArithType.lean` can be successfully updated & pass proof check.
Eventually, `DDMTranslate.lean` (which was a translator from strata_gen) will be eliminated.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
