### PR TITLE
Fix loop elimination transformation with false guard

### DIFF
--- a/Strata/Languages/C_Simp/Examples/Coprime.lean
+++ b/Strata/Languages/C_Simp/Examples/Coprime.lean
@@ -81,7 +81,7 @@ postconditions: (post, #true)
 body: init (i : int) := a
 if ((~Int.Lt b) a) then {i := b}
 else{}
-transformed loop block : {first_iter_asserts : {assert [entry_invariant] #true
+if ((~Int.Gt i) #1) then {first_iter_asserts : {assert [entry_invariant] #true
   assert [assert measure_pos] ((~Int.Ge i) #0)}
  arbitrary iter facts : {loop havoc : {havoc return
    havoc i}
@@ -99,6 +99,7 @@ transformed loop block : {first_iter_asserts : {assert [entry_invariant] #true
   havoc i}
  assume [not_guard] (~Bool.Not ((~Int.Gt i) #1))
  assume [invariant] #true}
+else{}
 return := #true
 -/
 #guard_msgs in

--- a/Strata/Languages/C_Simp/Examples/LinearSearch.lean
+++ b/Strata/Languages/C_Simp/Examples/LinearSearch.lean
@@ -76,7 +76,7 @@ preconditions: (pre, #true)
 postconditions: (post, #true)
 body: init (idx : int) := init_idx
 idx := #0
-transformed loop block : {first_iter_asserts : {assert [entry_invariant] #true
+if ((~Int.Lt idx) (~Array.Len arr)) then {first_iter_asserts : {assert [entry_invariant] #true
   assert [assert measure_pos] ((~Int.Ge ((~Int.Sub (~Array.Len arr)) idx)) #0)}
  arbitrary iter facts : {loop havoc : {havoc return
    havoc idx}
@@ -94,6 +94,7 @@ transformed loop block : {first_iter_asserts : {assert [entry_invariant] #true
   havoc idx}
  assume [not_guard] (~Bool.Not ((~Int.Lt idx) (~Array.Len arr)))
  assume [invariant] #true}
+else{}
 return := #false
 -/
 #guard_msgs in

--- a/Strata/Languages/C_Simp/Examples/LoopSimple.lean
+++ b/Strata/Languages/C_Simp/Examples/LoopSimple.lean
@@ -78,7 +78,7 @@ body: init (sum : int) := init_sum
 init (i : int) := init_i
 sum := #0
 i := #0
-transformed loop block : {first_iter_asserts : {assert [entry_invariant] ((~Bool.And ((~Int.Le i) n)) (((~Int.Div ((~Int.Mul i) ((~Int.Sub i) #1))) #2) == sum))
+if ((~Int.Lt i) n) then {first_iter_asserts : {assert [entry_invariant] ((~Bool.And ((~Int.Le i) n)) (((~Int.Div ((~Int.Mul i) ((~Int.Sub i) #1))) #2) == sum))
   assert [assert measure_pos] ((~Int.Ge ((~Int.Sub n) i)) #0)}
  arbitrary iter facts : {loop havoc : {havoc sum
    havoc i}
@@ -95,6 +95,7 @@ transformed loop block : {first_iter_asserts : {assert [entry_invariant] ((~Bool
   havoc i}
  assume [not_guard] (~Bool.Not ((~Int.Lt i) n))
  assume [invariant] ((~Bool.And ((~Int.Le i) n)) (((~Int.Div ((~Int.Mul i) ((~Int.Sub i) #1))) #2) == sum))}
+else{}
 assert [sum_assert] (((~Int.Div ((~Int.Mul n) ((~Int.Sub n) #1))) #2) == sum)
 return := sum
 -/
@@ -105,49 +106,58 @@ return := sum
 info: [Strata.Boogie] Type checking succeeded.
 
 
-Obligation post proved via evaluation!
-
-
 VCs:
 Label: entry_invariant
 Assumptions:
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Bool.And ((~Int.Le #0) $__n0)) #true)
 
 Label: assert measure_pos
 Assumptions:
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Int.Ge ((~Int.Sub $__n0) #0)) #0)
 
 Label: measure_decreases
 Assumptions:
-(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (assume_guard, ((~Int.Lt $__i3) $__n0)) (assume_invariant, ((~Bool.And ((~Int.Le $__i3) $__n0)) (((~Int.Div ((~Int.Mul $__i3) ((~Int.Sub $__i3) #1))) #2) == $__sum2))) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i3)) #0))
+(pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Int.Lt ((~Int.Sub $__n0) ((~Int.Add $__i3) #1))) ((~Int.Sub $__n0) $__i3))
 
 Label: measure_imp_not_guard
 Assumptions:
-(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (assume_guard, ((~Int.Lt $__i3) $__n0)) (assume_invariant, ((~Bool.And ((~Int.Le $__i3) $__n0)) (((~Int.Div ((~Int.Mul $__i3) ((~Int.Sub $__i3) #1))) #2) == $__sum2))) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i3)) #0))
+(pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 (if ((~Int.Le ((~Int.Sub $__n0) ((~Int.Add $__i3) #1))) #0) then (~Bool.Not ((~Int.Lt ((~Int.Add $__i3) #1)) $__n0)) else #true)
 
 Label: arbitrary_iter_maintain_invariant
 Assumptions:
-(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (assume_guard, ((~Int.Lt $__i3) $__n0)) (assume_invariant, ((~Bool.And ((~Int.Le $__i3) $__n0)) (((~Int.Div ((~Int.Mul $__i3) ((~Int.Sub $__i3) #1))) #2) == $__sum2))) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i3)) #0))
+(pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Bool.And ((~Int.Le ((~Int.Add $__i3) #1)) $__n0)) (((~Int.Div ((~Int.Mul ((~Int.Add $__i3) #1)) ((~Int.Sub ((~Int.Add $__i3) #1)) #1))) #2) == ((~Int.Add $__sum2) $__i3)))
 
 Label: sum_assert
 Assumptions:
 (pre, ((~Int.Ge $__n0) #0))
-(assume_guard, ((~Int.Lt $__i3) $__n0)) (assume_invariant, ((~Bool.And ((~Int.Le $__i3) $__n0)) (((~Int.Div ((~Int.Mul $__i3) ((~Int.Sub $__i3) #1))) #2) == $__sum2))) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i3)) #0)) (not_guard, (~Bool.Not ((~Int.Lt $__i5) $__n0))) (invariant, ((~Bool.And ((~Int.Le $__i5) $__n0)) (((~Int.Div ((~Int.Mul $__i5) ((~Int.Sub $__i5) #1))) #2) == $__sum4)))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt #0) $__n0) else #true)) (assume_guard, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt $__i3) $__n0) else #true)) (assume_invariant, (if ((~Int.Lt #0) $__n0) then ((~Bool.And ((~Int.Le $__i3) $__n0)) (((~Int.Div ((~Int.Mul $__i3) ((~Int.Sub $__i3) #1))) #2) == $__sum2)) else #true)) (assume_measure_pos, (if ((~Int.Lt #0) $__n0) then ((~Int.Ge ((~Int.Sub $__n0) $__i3)) #0) else #true)) (not_guard, (if ((~Int.Lt #0) $__n0) then (~Bool.Not ((~Int.Lt $__i5) $__n0)) else #true)) (invariant, (if ((~Int.Lt #0) $__n0) then ((~Bool.And ((~Int.Le $__i5) $__n0)) (((~Int.Div ((~Int.Mul $__i5) ((~Int.Sub $__i5) #1))) #2) == $__sum4)) else #true)) (<label_ite_cond_false: !((~Int.Lt i) n)>, (if (if ((~Int.Lt #0) $__n0) then #false else #true) then (if ((~Int.Lt #0) $__n0) then #false else #true) else #true))
 Proof Obligation:
-(((~Int.Div ((~Int.Mul $__n0) ((~Int.Sub $__n0) #1))) #2) == $__sum4)
+(((~Int.Div ((~Int.Mul $__n0) ((~Int.Sub $__n0) #1))) #2) == (if ((~Int.Lt #0) $__n0) then $__sum4 else #0))
+
+Label: post
+Assumptions:
+(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt #0) $__n0) else #true)) (assume_guard, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt $__i3) $__n0) else #true)) (assume_invariant, (if ((~Int.Lt #0) $__n0) then ((~Bool.And ((~Int.Le $__i3) $__n0)) (((~Int.Div ((~Int.Mul $__i3) ((~Int.Sub $__i3) #1))) #2) == $__sum2)) else #true)) (assume_measure_pos, (if ((~Int.Lt #0) $__n0) then ((~Int.Ge ((~Int.Sub $__n0) $__i3)) #0) else #true)) (not_guard, (if ((~Int.Lt #0) $__n0) then (~Bool.Not ((~Int.Lt $__i5) $__n0)) else #true)) (invariant, (if ((~Int.Lt #0) $__n0) then ((~Bool.And ((~Int.Le $__i5) $__n0)) (((~Int.Div ((~Int.Mul $__i5) ((~Int.Sub $__i5) #1))) #2) == $__sum4)) else #true)) (<label_ite_cond_false: !((~Int.Lt i) n)>, (if (if ((~Int.Lt #0) $__n0) then #false else #true) then (if ((~Int.Lt #0) $__n0) then #false else #true) else #true))
+Proof Obligation:
+#true
 
 Wrote problem to vcs/entry_invariant.smt2.
 Wrote problem to vcs/assert_measure_pos.smt2.
@@ -155,6 +165,7 @@ Wrote problem to vcs/measure_decreases.smt2.
 Wrote problem to vcs/measure_imp_not_guard.smt2.
 Wrote problem to vcs/arbitrary_iter_maintain_invariant.smt2.
 Wrote problem to vcs/sum_assert.smt2.
+Wrote problem to vcs/post.smt2.
 ---
 info:
 Obligation: entry_invariant
@@ -173,6 +184,9 @@ Obligation: arbitrary_iter_maintain_invariant
 Result: verified
 
 Obligation: sum_assert
+Result: verified
+
+Obligation: post
 Result: verified
 -/
 #guard_msgs in

--- a/Strata/Languages/C_Simp/Examples/LoopTrivial.lean
+++ b/Strata/Languages/C_Simp/Examples/LoopTrivial.lean
@@ -71,7 +71,7 @@ preconditions: (pre, ((~Int.Ge n) #0))
 postconditions: (post, #true)
 body: init (i : int) := init_i
 i := #0
-transformed loop block : {first_iter_asserts : {assert [entry_invariant] ((~Int.Le i) n)
+if ((~Int.Lt i) n) then {first_iter_asserts : {assert [entry_invariant] ((~Int.Le i) n)
   assert [assert measure_pos] ((~Int.Ge ((~Int.Sub n) i)) #0)}
  arbitrary iter facts : {loop havoc : {havoc i}
   arbitrary_iter_assumes : {assume [assume_guard] ((~Int.Lt i) n)
@@ -85,6 +85,7 @@ transformed loop block : {first_iter_asserts : {assert [entry_invariant] ((~Int.
  loop havoc : {havoc i}
  assume [not_guard] (~Bool.Not ((~Int.Lt i) n))
  assume [invariant] ((~Int.Le i) n)}
+else{}
 assert [i_eq_n] (i == n)
 return := i
 -/
@@ -98,48 +99,53 @@ info: [Strata.Boogie] Type checking succeeded.
 VCs:
 Label: entry_invariant
 Assumptions:
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Int.Le #0) $__n0)
 
 Label: assert measure_pos
 Assumptions:
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Int.Ge ((~Int.Sub $__n0) #0)) #0)
 
 Label: measure_decreases
 Assumptions:
-(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (assume_guard, ((~Int.Lt $__i2) $__n0)) (assume_invariant, ((~Int.Le $__i2) $__n0)) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0))
+(pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Int.Lt ((~Int.Sub $__n0) ((~Int.Add $__i2) #1))) ((~Int.Sub $__n0) $__i2))
 
 Label: measure_imp_not_guard
 Assumptions:
-(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (assume_guard, ((~Int.Lt $__i2) $__n0)) (assume_invariant, ((~Int.Le $__i2) $__n0)) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0))
+(pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 (if ((~Int.Le ((~Int.Sub $__n0) ((~Int.Add $__i2) #1))) #0) then (~Bool.Not ((~Int.Lt ((~Int.Add $__i2) #1)) $__n0)) else #true)
 
 Label: arbitrary_iter_maintain_invariant
 Assumptions:
-(pre, ((~Int.Ge $__n0) #0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, ((~Int.Lt #0) $__n0))
 (assume_guard, ((~Int.Lt $__i2) $__n0)) (assume_invariant, ((~Int.Le $__i2) $__n0)) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0))
+(pre, ((~Int.Ge $__n0) #0))
 Proof Obligation:
 ((~Int.Le ((~Int.Add $__i2) #1)) $__n0)
 
 Label: i_eq_n
 Assumptions:
 (pre, ((~Int.Ge $__n0) #0))
-(assume_guard, ((~Int.Lt $__i2) $__n0)) (assume_invariant, ((~Int.Le $__i2) $__n0)) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0)) (not_guard, (~Bool.Not ((~Int.Lt $__i3) $__n0))) (invariant, ((~Int.Le $__i3) $__n0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt #0) $__n0) else #true)) (assume_guard, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt $__i2) $__n0) else #true)) (assume_invariant, (if ((~Int.Lt #0) $__n0) then ((~Int.Le $__i2) $__n0) else #true)) (assume_measure_pos, (if ((~Int.Lt #0) $__n0) then ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0) else #true)) (not_guard, (if ((~Int.Lt #0) $__n0) then (~Bool.Not ((~Int.Lt $__i3) $__n0)) else #true)) (invariant, (if ((~Int.Lt #0) $__n0) then ((~Int.Le $__i3) $__n0) else #true)) (<label_ite_cond_false: !((~Int.Lt i) n)>, (if (if ((~Int.Lt #0) $__n0) then #false else #true) then (if ((~Int.Lt #0) $__n0) then #false else #true) else #true))
 Proof Obligation:
-($__i3 == $__n0)
+((if ((~Int.Lt #0) $__n0) then $__i3 else #0) == $__n0)
 
 Label: post
 Assumptions:
 (pre, ((~Int.Ge $__n0) #0))
-(assume_guard, ((~Int.Lt $__i2) $__n0)) (assume_invariant, ((~Int.Le $__i2) $__n0)) (assume_measure_pos, ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0)) (not_guard, (~Bool.Not ((~Int.Lt $__i3) $__n0))) (invariant, ((~Int.Le $__i3) $__n0))
+(<label_ite_cond_true: ((~Int.Lt i) n)>, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt #0) $__n0) else #true)) (assume_guard, (if ((~Int.Lt #0) $__n0) then ((~Int.Lt $__i2) $__n0) else #true)) (assume_invariant, (if ((~Int.Lt #0) $__n0) then ((~Int.Le $__i2) $__n0) else #true)) (assume_measure_pos, (if ((~Int.Lt #0) $__n0) then ((~Int.Ge ((~Int.Sub $__n0) $__i2)) #0) else #true)) (not_guard, (if ((~Int.Lt #0) $__n0) then (~Bool.Not ((~Int.Lt $__i3) $__n0)) else #true)) (invariant, (if ((~Int.Lt #0) $__n0) then ((~Int.Le $__i3) $__n0) else #true)) (<label_ite_cond_false: !((~Int.Lt i) n)>, (if (if ((~Int.Lt #0) $__n0) then #false else #true) then (if ((~Int.Lt #0) $__n0) then #false else #true) else #true))
 Proof Obligation:
 #true
 

--- a/Strata/Languages/C_Simp/Verify.lean
+++ b/Strata/Languages/C_Simp/Verify.lean
@@ -96,7 +96,7 @@ def loop_elimination_statement(s : C_Simp.Statement) : Boogie.Statement :=
       let not_guard : Boogie.Statement := .assume "not_guard" (.app (.op "Bool.Not" none) (translate_expr guard)) {}
       let invariant : Boogie.Statement := .assume "invariant" (translate_expr invariant) {}
 
-      .block "transformed loop block" {ss := [first_iter_facts, arbitrary_iter_facts, havocd, not_guard, invariant]} {}
+      .ite (translate_expr guard) {ss := [first_iter_facts, arbitrary_iter_facts, havocd, not_guard, invariant]} {ss := []} {}
     | _, _ => panic! "Loop elimination require measure and invariant"
   | _ => translate_stmt s
 


### PR DESCRIPTION
Fix loop elimination transformation for case where guard may be false on entry.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
