### PR TITLE
Fix grammatical errors in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ changes!**
 
    You can install Lean4 by following the instructions [here](https://lean-lang.org/).
 
-2. **SMT Solver**: Analyses tools in Strata use SMT solvers for program
+2. **SMT Solver**: Analysis tools in Strata use SMT solvers for program
    verification.
    - Install an SMT solver. You can use any solver you want, but the unit
      tests assume `cvc5` is on your `PATH` [cvc5](https://cvc5.github.io/).
@@ -39,7 +39,7 @@ Unit tests are run with `#guard_msgs` commands. No output means the tests passed
 
 ## Running Analyses on Existing Strata Programs
 
-Strata programs use the `.st` file extension, preceded the dialect name,
+Strata programs use the `.st` file extension, preceded by the dialect name,
 preceded by a second `.` e.g., `SimpleProc.boogie.st` or
 `LoopSimple.csimp.st`. Note the current `StrataVerify` executable
 relies on this file extension convention to know what dialect it's


### PR DESCRIPTION
Fix two grammatical errors in the documentation:

1. "Analyses tools" → "Analysis tools"
   - "Analysis" functions as an attributive noun modifying "tools"
   - Attributive nouns in English remain singular (e.g., "computer systems"  not "computers systems")
   - The plural "Analyses" would only be correct as a standalone noun, not  as a modifier

2. "preceded the dialect name" → "preceded by the dialect name"
   - The verb "precede" requires the preposition "by" in passive voice
   - Active: "X precedes Y" → Passive: "Y is preceded by X"
   - The missing "by" creates an ungrammatical construction

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
