### PR TITLE
Support for type alias in LExprT (temporary fix, if needed)

### DIFF
--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -409,8 +409,6 @@ partial def fromLExprAux.app (T : (TEnv Identifier)) (e1 e2 : (LExpr Identifier)
   let (optTyy2, T) := (ty2.aliasInst T)
   let (fresh_name2, T) := TEnv.genTyVar T
   let freshty2: LMonoTy := (.ftvar fresh_name2)
-  dbg_trace f!"optTyy1.getD ty1 ({optTyy1.getD ty1})"
-  dbg_trace f!"optTyy2.getD ty2 ({optTyy2.getD ty2})"
   let S ← Constraints.unify [(freshty1, optTyy1.getD ty1 )] T.state.subst
   let T := TEnv.updateSubst T S
   let S ← Constraints.unify [(freshty2, optTyy2.getD ty1 )] T.state.subst

--- a/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
+++ b/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
@@ -14,16 +14,26 @@ def mapEnv : Environment :=
 #strata
 program Boogie;
 
-var a : Map int int;
+type MapII := Map int int;
+type MapIMapII := Map int MapII;
+
+var a : MapII;
 var b : Map bool int;
+var c : Map int MapII;
 
 procedure P() returns ()
 spec {
   modifies a;
   modifies b;
+  modifies c;
   requires a[0] == 0;
+  requires c[0] == a;
 }
 {
+  assert [asdf]: c[0] == a;
+  c := c[1 := a];
+  assert [asdf2]: c[1] == a;
+
   assert [a0eq0]: a[0] == 0;
   a := a[1 := 1];
   assert [a1eq1]: a[1] == 1;
@@ -37,90 +47,90 @@ spec {
 #end
 
 
-/-- info: true -/
-#guard_msgs in
+-- /-- info: true -/
+-- #guard_msgs in
 -- No errors in translation.
 #eval TransM.run (translateProgram (mapEnv.commands)) |>.snd |>.isEmpty
 
-/--
-info: var (a : (Map int int)) := init_a_0
-var (b : (Map bool int)) := init_b_1
-(procedure P :  () → ())
-modifies: [a, b]
-preconditions: (P_requires_2, ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int)))
-postconditions: ⏎
-body: assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))
-a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#1 : int)) (#1 : int))
-assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (#1 : int))
-a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#0 : int)) (#1 : int))
-assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
-b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) b) (#true : bool)) (~Int.Neg (#1 : int)))
-assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool)) == (~Int.Neg (#1 : int)))
-assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (~Int.Neg (((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool))))
+-- /--
+-- info: var (a : (Map int int)) := init_a_0
+-- var (b : (Map bool int)) := init_b_1
+-- (procedure P :  () → ())
+-- modifies: [a, b]
+-- preconditions: (P_requires_2, ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int)))
+-- postconditions: ⏎
+-- body: assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))
+-- a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#1 : int)) (#1 : int))
+-- assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (#1 : int))
+-- a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#0 : int)) (#1 : int))
+-- assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
+-- b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) b) (#true : bool)) (~Int.Neg (#1 : int)))
+-- assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool)) == (~Int.Neg (#1 : int)))
+-- assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (~Int.Neg (((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool))))
 
-Errors: #[]
--/
-#guard_msgs in
+-- Errors: #[]
+-- -/
+-- #guard_msgs in
 #eval TransM.run (translateProgram (mapEnv.commands))
 
-/--
-info: [Strata.Boogie] Type checking succeeded.
+-- /--
+-- info: [Strata.Boogie] Type checking succeeded.
 
 
-VCs:
-Label: a0eq0
-Assumptions:
-(P_requires_2, (((~select $__a0) #0) == #0))
-Proof Obligation:
-(((~select $__a0) #0) == #0)
+-- VCs:
+-- Label: a0eq0
+-- Assumptions:
+-- (P_requires_2, (((~select $__a0) #0) == #0))
+-- Proof Obligation:
+-- (((~select $__a0) #0) == #0)
 
-Label: a1eq1
-Assumptions:
-(P_requires_2, (((~select $__a0) #0) == #0))
-Proof Obligation:
-(((~select (((~update $__a0) #1) #1)) #1) == #1)
+-- Label: a1eq1
+-- Assumptions:
+-- (P_requires_2, (((~select $__a0) #0) == #0))
+-- Proof Obligation:
+-- (((~select (((~update $__a0) #1) #1)) #1) == #1)
 
-Label: a0eq1
-Assumptions:
-(P_requires_2, (((~select $__a0) #0) == #0))
-Proof Obligation:
-(((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #0) == #1)
+-- Label: a0eq1
+-- Assumptions:
+-- (P_requires_2, (((~select $__a0) #0) == #0))
+-- Proof Obligation:
+-- (((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #0) == #1)
 
-Label: bTrueEqTrue
-Assumptions:
-(P_requires_2, (((~select $__a0) #0) == #0))
-Proof Obligation:
-(((~select (((~update $__b1) #true) #-1)) #true) == #-1)
+-- Label: bTrueEqTrue
+-- Assumptions:
+-- (P_requires_2, (((~select $__a0) #0) == #0))
+-- Proof Obligation:
+-- (((~select (((~update $__b1) #true) #-1)) #true) == #-1)
 
-Label: mix
-Assumptions:
-(P_requires_2, (((~select $__a0) #0) == #0))
-Proof Obligation:
-(((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #1) == (~Int.Neg ((~select (((~update $__b1) #true) #-1)) #true)))
+-- Label: mix
+-- Assumptions:
+-- (P_requires_2, (((~select $__a0) #0) == #0))
+-- Proof Obligation:
+-- (((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #1) == (~Int.Neg ((~select (((~update $__b1) #true) #-1)) #true)))
 
-Wrote problem to vcs/a0eq0.smt2.
-Wrote problem to vcs/a1eq1.smt2.
-Wrote problem to vcs/a0eq1.smt2.
-Wrote problem to vcs/bTrueEqTrue.smt2.
-Wrote problem to vcs/mix.smt2.
----
-info:
-Obligation: a0eq0
-Result: verified
+-- Wrote problem to vcs/a0eq0.smt2.
+-- Wrote problem to vcs/a1eq1.smt2.
+-- Wrote problem to vcs/a0eq1.smt2.
+-- Wrote problem to vcs/bTrueEqTrue.smt2.
+-- Wrote problem to vcs/mix.smt2.
+-- ---
+-- info:
+-- Obligation: a0eq0
+-- Result: verified
 
-Obligation: a1eq1
-Result: verified
+-- Obligation: a1eq1
+-- Result: verified
 
-Obligation: a0eq1
-Result: verified
+-- Obligation: a0eq1
+-- Result: verified
 
-Obligation: bTrueEqTrue
-Result: verified
+-- Obligation: bTrueEqTrue
+-- Result: verified
 
-Obligation: mix
-Result: verified
--/
-#guard_msgs in
+-- Obligation: mix
+-- Result: verified
+-- -/
+-- #guard_msgs in
 #eval verify "cvc5" mapEnv
 
 ---------------------------------------------------------------------

--- a/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
+++ b/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
@@ -30,9 +30,9 @@ spec {
   requires c[0] == a;
 }
 {
-  assert [asdf]: c[0] == a;
+  assert [c_0_eq_a]: c[0] == a;
   c := c[1 := a];
-  assert [asdf2]: c[1] == a;
+  assert [c_1_eq_a]: c[1] == a;
 
   assert [a0eq0]: a[0] == 0;
   a := a[1 := 1];
@@ -47,90 +47,123 @@ spec {
 #end
 
 
--- /-- info: true -/
--- #guard_msgs in
+/-- info: true -/
+#guard_msgs in
 -- No errors in translation.
 #eval TransM.run (translateProgram (mapEnv.commands)) |>.snd |>.isEmpty
 
--- /--
--- info: var (a : (Map int int)) := init_a_0
--- var (b : (Map bool int)) := init_b_1
--- (procedure P :  () → ())
--- modifies: [a, b]
--- preconditions: (P_requires_2, ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int)))
--- postconditions: ⏎
--- body: assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))
--- a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#1 : int)) (#1 : int))
--- assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (#1 : int))
--- a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#0 : int)) (#1 : int))
--- assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
--- b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) b) (#true : bool)) (~Int.Neg (#1 : int)))
--- assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool)) == (~Int.Neg (#1 : int)))
--- assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (~Int.Neg (((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool))))
+/--
+type MapII := (Map int int)
+type MapIMapII := (Map int MapII)
+var (a : MapII) := init_a_0
+var (b : (Map bool int)) := init_b_1
+var (c : (Map int MapII)) := init_c_2
+(procedure P :  () → ())
+modifies: [a, b, c]
+preconditions: (P_requires_3, ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))) (P_requires_4, ((((~select : (arrow (Map int MapII) (arrow int MapII))) c) (#0 : int)) == a))
+postconditions:
+body: assert [c_0_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) c) (#0 : int)) == a)
+c := ((((~update : (arrow (Map int MapII) (arrow int (arrow MapII (Map int MapII))))) c) (#1 : int)) a)
+assert [c_1_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) c) (#1 : int)) == a)
+assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))
+a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#1 : int)) (#1 : int))
+assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (#1 : int))
+a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#0 : int)) (#1 : int))
+assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
+b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) b) (#true : bool)) (~Int.Neg (#1 : int)))
+assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool)) == (~Int.Neg (#1 : int)))
+assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (~Int.Neg (((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool))))
 
--- Errors: #[]
--- -/
--- #guard_msgs in
+Errors: #[]
+-/
+#guard_msgs in
 #eval TransM.run (translateProgram (mapEnv.commands))
 
--- /--
--- info: [Strata.Boogie] Type checking succeeded.
+/--
+info: [Strata.Boogie] Type checking succeeded.
 
 
--- VCs:
--- Label: a0eq0
--- Assumptions:
--- (P_requires_2, (((~select $__a0) #0) == #0))
--- Proof Obligation:
--- (((~select $__a0) #0) == #0)
+VCs:
+Label: c_0_eq_a
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select $__c2) #0) == $__a0)
 
--- Label: a1eq1
--- Assumptions:
--- (P_requires_2, (((~select $__a0) #0) == #0))
--- Proof Obligation:
--- (((~select (((~update $__a0) #1) #1)) #1) == #1)
+Label: c_1_eq_a
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select (((~update $__c2) #1) $__a0)) #1) == $__a0)
 
--- Label: a0eq1
--- Assumptions:
--- (P_requires_2, (((~select $__a0) #0) == #0))
--- Proof Obligation:
--- (((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #0) == #1)
+Label: a0eq0
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select $__a0) #0) == #0)
 
--- Label: bTrueEqTrue
--- Assumptions:
--- (P_requires_2, (((~select $__a0) #0) == #0))
--- Proof Obligation:
--- (((~select (((~update $__b1) #true) #-1)) #true) == #-1)
+Label: a1eq1
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select (((~update $__a0) #1) #1)) #1) == #1)
 
--- Label: mix
--- Assumptions:
--- (P_requires_2, (((~select $__a0) #0) == #0))
--- Proof Obligation:
--- (((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #1) == (~Int.Neg ((~select (((~update $__b1) #true) #-1)) #true)))
+Label: a0eq1
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #0) == #1)
 
--- Wrote problem to vcs/a0eq0.smt2.
--- Wrote problem to vcs/a1eq1.smt2.
--- Wrote problem to vcs/a0eq1.smt2.
--- Wrote problem to vcs/bTrueEqTrue.smt2.
--- Wrote problem to vcs/mix.smt2.
--- ---
--- info:
--- Obligation: a0eq0
--- Result: verified
+Label: bTrueEqTrue
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select (((~update $__b1) #true) #-1)) #true) == #-1)
 
--- Obligation: a1eq1
--- Result: verified
+Label: mix
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #1) == (~Int.Neg ((~select (((~update $__b1) #true) #-1)) #true)))
 
--- Obligation: a0eq1
--- Result: verified
+Wrote problem to vcs/c_0_eq_a.smt2.
+Wrote problem to vcs/c_1_eq_a.smt2.
+Wrote problem to vcs/a0eq0.smt2.
+Wrote problem to vcs/a1eq1.smt2.
+Wrote problem to vcs/a0eq1.smt2.
+Wrote problem to vcs/bTrueEqTrue.smt2.
+Wrote problem to vcs/mix.smt2.
+---
+info:
+Obligation: c_0_eq_a
+Result: verified
 
--- Obligation: bTrueEqTrue
--- Result: verified
+Obligation: c_1_eq_a
+Result: verified
 
--- Obligation: mix
--- Result: verified
--- -/
--- #guard_msgs in
+Obligation: a0eq0
+Result: verified
+
+Obligation: a1eq1
+Result: verified
+
+Obligation: a0eq1
+Result: verified
+
+Obligation: bTrueEqTrue
+Result: verified
+
+Obligation: mix
+Result: verified
+-/
+#guard_msgs in
 #eval verify "cvc5" mapEnv
 
 ---------------------------------------------------------------------

--- a/Strata/Languages/Boogie/Factory.lean
+++ b/Strata/Languages/Boogie/Factory.lean
@@ -33,15 +33,15 @@ def KnownTypes : List LTy :=
 open LExpr.Syntax LTy.Syntax
 
 /--
-  Convert an LExpr String to an LExpr BoogieIdent, by considering all identifier as global, which is valid for axioms
+  Convert an LExpr String to an LExpr BoogieIdent
   TODO: Remove when Lambda elaborator offers parametric identifier type
 -/
 def ToBoogieIdent (ine: LExpr String): (LExpr BoogieIdent) :=
 match ine with
     | .const c ty => .const c ty
-    | .op o oty => .op (BoogieIdent.glob o) oty
+    | .op o oty => .op (BoogieIdent.unres o) oty
     | .bvar deBruijnIndex => .bvar deBruijnIndex
-    | .fvar name oty => .fvar (BoogieIdent.glob name) oty
+    | .fvar name oty => .fvar (BoogieIdent.unres name) oty
     | .mdata info e => .mdata info (ToBoogieIdent e)
     | .abs oty e => .abs oty (ToBoogieIdent e)
     | .quant k oty e => .quant k oty (ToBoogieIdent e)


### PR DESCRIPTION
*Description of changes:*

This adds supports for Type aliases in type annotations on LExpr. Ideally, we'd like to parametrized LExpr on the type of type annotations, to let users write LExpr with LTy, and have LExpr with only LMonoTy later in the type analysis and partial evaluation.
This PR fixes the bug in case we need a temporary fix.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
