### PR TITLE
Add another code owner in most places

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 
 /Strata/Languages/C_Simp/ @andrewmwells-amazon @shigoel
 
-/Strata/Transform/ @atomb
+/Strata/Transform/ @atomb @andrewmwells-amazon 
 
 # Documentation
 /docs/ddm/ @joehendrix

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 
 /Strata/DL/SMT/ @andrewmwells-amazon @atomb
 
-/Strata/DL/Utils/ @shigoel
+/Strata/DL/Utils/ @shigoel @atomb
 
 # Languages
 /Strata/Languages/Boogie/ @atomb @shigoel

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,26 +3,26 @@
 *       @strata-org/reviewers
 
 # CSimp dialect files
-*.csimp.st    @andrewmwells-amazon
+*.csimp.st    @andrewmwells-amazon @atomb
 
 # Boogie dialect files
-*.boogie.st    @atomb
+*.boogie.st    @atomb @MikaelMayer
 
 # Tools
-/Tools/BoogieToStrata/ @atomb
+/Tools/BoogieToStrata/ @atomb @MikaelMayer
 
 # DDM
 /Strata/DDM/ @joehendrix
 /StrataTest/DDM/ @joehendrix
 
 # Dialects
-/Strata/DL/Lambda/ @shigoel
-/StrataTest/DL/Lambda/ @shigoel
+/Strata/DL/Lambda/ @shigoel @atomb
+/StrataTest/DL/Lambda/ @shigoel @atomb
 
 /Strata/DL/Imperative/ @atomb @shigoel
 /StrataTest/DL/Imperative/ @atomb @shigoel
 
-/Strata/DL/SMT/ @andrewmwells-amazon
+/Strata/DL/SMT/ @andrewmwells-amazon @atomb
 
 /Strata/DL/Utils/ @shigoel
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,4 +35,4 @@
 /Strata/Transform/ @atomb @andrewmwells-amazon 
 
 # Documentation
-/docs/ddm/ @joehendrix
+/docs/ddm/ @joehendrix @shigoel 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 /Tools/BoogieToStrata/ @atomb @MikaelMayer
 
 # DDM
-/Strata/DDM/ @joehendrix
-/StrataTest/DDM/ @joehendrix
+/Strata/DDM/ @joehendrix @shigoel
+/StrataTest/DDM/ @joehendrix @shigoel 
 
 # Dialects
 /Strata/DL/Lambda/ @shigoel @atomb

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 *       @strata-org/reviewers
 
 # CSimp dialect files
-*.csimp.st    @andrewmwells-amazon @atomb
+*.csimp.st    @andrewmwells-amazon @shigoel
 
 # Boogie dialect files
 *.boogie.st    @atomb @MikaelMayer
@@ -30,7 +30,7 @@
 /Strata/Languages/Boogie/ @atomb @shigoel
 /StrataTest/Languages/Boogie/ @atomb @shigoel
 
-/Strata/Languages/C_Simp/ @andrewmwells-amazon
+/Strata/Languages/C_Simp/ @andrewmwells-amazon @shigoel
 
 /Strata/Transform/ @atomb
 


### PR DESCRIPTION
This makes sure every entry in `CODEOWNERS` has two owners, to avoid bottlenecks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
