### PR TITLE
Avoid calls of `SubstWF` during execution

### DIFF
--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -174,7 +174,7 @@ def inferFVar (T : (TEnv Identifier)) (x : Identifier) (fty : Option LMonoTy) :
     | some fty =>
       -- We do not support expressions to be annotated with type synonyms yet.
       -- As such, if `fty` is a synonym, then the following may raise an error.
-      let S ← Constraints.unify [(fty, ty)] T.state.subst
+      let S ← Constraints.unify [(fty, ty)] T.state.substInfo
       .ok (ty, TEnv.updateSubst T S)
 
 /--
@@ -308,7 +308,7 @@ partial def inferOp (T : (TEnv Identifier)) (o : Identifier) (oty : Option LMono
             let (body_typed, T) ← fromLExprAux T body
             let bodyty := body_typed.toLMonoTy
             let (retty, T) ← func.outputPolyType.instantiateWithCheck T
-            let S ← Constraints.unify [(retty, bodyty)] T.state.subst
+            let S ← Constraints.unify [(retty, bodyty)] T.state.substInfo
             let T := T.updateSubst S
             let T := T.popContext
             .ok T
@@ -318,7 +318,7 @@ partial def inferOp (T : (TEnv Identifier)) (o : Identifier) (oty : Option LMono
       match oty with
       | none => .ok (ty, T)
       | some cty =>
-        let S ← Constraints.unify [(cty, ty)] T.state.subst
+        let S ← Constraints.unify [(cty, ty)] T.state.substInfo
         .ok (ty, TEnv.updateSubst T S)
 
 partial def fromLExprAux.ite (T : (TEnv Identifier)) (c th el : (LExpr Identifier)) := do
@@ -328,7 +328,7 @@ partial def fromLExprAux.ite (T : (TEnv Identifier)) (c th el : (LExpr Identifie
   let cty := ct.toLMonoTy
   let tty := tt.toLMonoTy
   let ety := et.toLMonoTy
-  let S ← Constraints.unify [(cty, LMonoTy.bool), (tty, ety)] T.state.subst
+  let S ← Constraints.unify [(cty, LMonoTy.bool), (tty, ety)] T.state.substInfo
   .ok (.ite ct tt et tty, TEnv.updateSubst T S)
 
 partial def fromLExprAux.eq (T : (TEnv Identifier)) (e1 e2 : (LExpr Identifier)) := do
@@ -338,7 +338,7 @@ partial def fromLExprAux.eq (T : (TEnv Identifier)) (e1 e2 : (LExpr Identifier))
   let (e2t, T) ← fromLExprAux T e2
   let ty1 := e1t.toLMonoTy
   let ty2 := e2t.toLMonoTy
-  let S ← Constraints.unify [(ty1, ty2)] T.state.subst
+  let S ← Constraints.unify [(ty1, ty2)] T.state.substInfo
   .ok (.eq e1t e2t LMonoTy.bool, TEnv.updateSubst T S)
 
 partial def fromLExprAux.abs (T : (TEnv Identifier)) (oty : Option LMonoTy) (e : (LExpr Identifier)) := do
@@ -352,7 +352,7 @@ partial def fromLExprAux.abs (T : (TEnv Identifier)) (oty : Option LMonoTy) (e :
   let etclosed := .varClose 0 xv et
   let T := T.eraseFromContext xv
   let ty := (.tcons "arrow" [(.ftvar xt'), ety])
-  let mty := LMonoTy.subst T.state.subst ty
+  let mty := LMonoTy.subst T.state.substInfo.subst ty
   match mty, oty with
   | .arrow aty _, .some ty =>
     if aty == ty
@@ -368,9 +368,9 @@ partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (ot
   let S ← match oty with
   | .some ty =>
     let (optTyy, T) := (ty.aliasInst T)
-    (Constraints.unify [(.ftvar xt', optTyy.getD ty)] T.state.subst)
+    (Constraints.unify [(.ftvar xt', optTyy.getD ty)] T.state.substInfo)
   | .none =>
-    .ok T.state.subst
+    .ok T.state.substInfo
 
   let T := TEnv.updateSubst T S
 
@@ -378,7 +378,7 @@ partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (ot
   let e' := LExpr.varOpen 0 (xv, some (.ftvar xt')) e
   let (et, T) ← fromLExprAux T e'
   let ety := et.toLMonoTy
-  let mty := LMonoTy.subst T.state.subst (.ftvar xt')
+  let mty := LMonoTy.subst T.state.substInfo.subst (.ftvar xt')
   match oty with
   | .some ty =>
     let (optTyy, _) := (ty.aliasInst T)
@@ -400,8 +400,8 @@ partial def fromLExprAux.app (T : (TEnv Identifier)) (e1 e2 : (LExpr Identifier)
   let ty2 := e2t.toLMonoTy
   let (fresh_name, T) := TEnv.genTyVar T
   let freshty := (.ftvar fresh_name)
-  let S ← Constraints.unify [(ty1, (.tcons "arrow" [ty2, freshty]))] T.state.subst
-  let mty := LMonoTy.subst S freshty
+  let S ← Constraints.unify [(ty1, (.tcons "arrow" [ty2, freshty]))] T.state.substInfo
+  let mty := LMonoTy.subst S.subst freshty
   .ok (.app e1t e2t mty, TEnv.updateSubst T S)
 
 end
@@ -409,7 +409,7 @@ end
 protected def fromLExpr (T : (TEnv Identifier)) (e : (LExpr Identifier)) :
     Except Format ((LExprT Identifier) × (TEnv Identifier)) := do
   let (et, T) ← fromLExprAux T e
-  .ok (LExprT.applySubst et T.state.subst, T)
+  .ok (LExprT.applySubst et T.state.substInfo.subst, T)
 
 protected def fromLExprs (T : (TEnv Identifier)) (es : List (LExpr Identifier)) :
     Except Format (List (LExprT Identifier) × (TEnv Identifier)) := do

--- a/Strata/Languages/Boogie/CmdType.lean
+++ b/Strata/Languages/Boogie/CmdType.lean
@@ -42,7 +42,7 @@ def preprocess (T : TEnv BoogieIdent) (ty : LTy) : Except Format (LTy × TEnv Bo
 
 def postprocess (T : TEnv BoogieIdent) (ty : LTy) : Except Format (LTy × TEnv BoogieIdent) := do
   if h: ty.isMonoType then
-    let ty := LMonoTy.subst T.state.subst (ty.toMonoType h)
+    let ty := LMonoTy.subst T.state.substInfo.subst (ty.toMonoType h)
     .ok (.forAll [] ty, T)
   else
     .error f!"[postprocess] Expected mono-type; instead got {ty}"
@@ -88,7 +88,7 @@ def canonicalizeConstraints (constraints : List (LTy × LTy)) : Except Format Co
 
 def unifyTypes (T : TEnv BoogieIdent) (constraints : List (LTy × LTy)) : Except Format (TEnv BoogieIdent) := do
   let constraints ← canonicalizeConstraints constraints
-  let S ← Constraints.unify constraints T.state.subst
+  let S ← Constraints.unify constraints T.state.substInfo
   let T := T.updateSubst S
   return T
 

--- a/Strata/Languages/Boogie/FunctionType.lean
+++ b/Strata/Languages/Boogie/FunctionType.lean
@@ -38,7 +38,7 @@ def typeCheck (T : Boogie.Expression.TyEnv) (func : Function) :
     let (bodya, T) ← LExprT.fromLExpr T body
     let bodyty := bodya.toLMonoTy
     let (retty, T) ← func.outputPolyType.instantiateWithCheck T
-    let S ← Constraints.unify [(retty, bodyty)] T.state.subst
+    let S ← Constraints.unify [(retty, bodyty)] T.state.substInfo
     let T := T.updateSubst S
     let T := T.popContext
     let new_func := { func with body := bodya.toLExpr }

--- a/Strata/Languages/Boogie/ProgramWF.lean
+++ b/Strata/Languages/Boogie/ProgramWF.lean
@@ -109,7 +109,7 @@ theorem Program.typeCheck.goWF' : Program.typeCheck.go p T (d :: ds) = .ok (ds',
     | error _ => simp_all
     | ok res =>
       simp_all
-      cases Heq2: Statement.Statement.subst.go res.snd.state.subst res.fst with
+      cases Heq2: Statement.Statement.subst.go res.snd.state.substInfo.subst res.fst with
       | nil => simp_all
       | cons h t =>
         simp_all
@@ -134,7 +134,7 @@ theorem Program.typeCheck.goWF' : Program.typeCheck.go p T (d :: ds) = .ok (ds',
                   -- 2. All declared global variables are `BoogieIdent.glob`.
                   sorry
                 . exists v.1, {
-                  context := res.snd.context.subst res.snd.state.subst,
+                  context := res.snd.context.subst res.snd.state.substInfo.subst,
                   state := res.snd.state, functions := res.snd.functions,
                   knownTypes := res.snd.knownTypes }, v.2
             | _ => simp_all

--- a/Strata/Languages/Boogie/StatementType.lean
+++ b/Strata/Languages/Boogie/StatementType.lean
@@ -53,9 +53,9 @@ def typeCheckCmd (T : (TEnv BoogieIdent)) (P : Program) (c : Command) :
          | some (lhs_tys, T) =>
            let _ ← T.freeVarChecks args
            let (ret_sig, T) ← LMonoTySignature.instantiate T proc.header.typeArgs proc.header.outputs
-           let ret_mtys := LMonoTys.subst T.state.subst ret_sig.values
+           let ret_mtys := LMonoTys.subst T.state.substInfo.subst ret_sig.values
            let constraints := lhs_tys.zip ret_mtys
-           let S ← Constraints.unify constraints T.state.subst
+           let S ← Constraints.unify constraints T.state.substInfo
            let T := T.updateSubst S
            -- Infer the types of the actuals and unify with the types of the
            -- procedure's formals.
@@ -63,9 +63,9 @@ def typeCheckCmd (T : (TEnv BoogieIdent)) (P : Program) (c : Command) :
            let args_tys := argsa.map LExprT.toLMonoTy
            let args' := argsa.map $ LExprT.toLExpr
            let (inp_sig, T) ← LMonoTySignature.instantiate T proc.header.typeArgs proc.header.inputs
-           let inp_mtys := LMonoTys.subst T.state.subst inp_sig.values
+           let inp_mtys := LMonoTys.subst T.state.substInfo.subst inp_sig.values
            let constraints := args_tys.zip inp_mtys
-           let S ← Constraints.unify constraints T.state.subst
+           let S ← Constraints.unify constraints T.state.substInfo
            let T := T.updateSubst S
            let s' := .call lhs pname args' md
            .ok (s', T)
@@ -209,9 +209,9 @@ inside a procedure).
 def typeCheck (T : Expression.TyEnv) (P : Program) (op : Option Procedure) (ss : List Statement) :
   Except Format (List Statement × Expression.TyEnv) := do
   let (ss', T) ← typeCheckAux T P op ss
-  let context := TContext.subst T.context T.state.subst
+  let context := TContext.subst T.context T.state.substInfo.subst
   let T := { T with context := context }
-  let ss' := Statement.subst.go T.state.subst ss'
+  let ss' := Statement.subst.go T.state.substInfo.subst ss'
   .ok (ss', T)
 
 ---------------------------------------------------------------------


### PR DESCRIPTION
*Description of changes:*

Change `Constraints.unify` to take `SubstInfo` instead of `Subst` in an effort to avoid expensive calls of `SubstWF` during runtime.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
