### PR TITLE
Fix: Generated file names acceptable on Windows file systems.

### DIFF
--- a/Strata/DL/Imperative/SMTUtils.lean
+++ b/Strata/DL/Imperative/SMTUtils.lean
@@ -144,7 +144,13 @@ def solverResult {P : PureExpr} [ToFormat P.Ident]
 def VC_folder_name: String := "vcs"
 
 def smt2_filename (name: String): String :=
-  ((name.replace "==" "eq").replace "=" "-").replace " " "_" ++ ".smt2"
+  (name
+  |>.replace "==" "eq"
+  |>.replace "=" "-"
+  |>.replace " " "_"
+  |>.replace "<" "("
+  |>.replace ":" "-"
+  |>.replace ">" ")") ++ ".smt2"
 
 def dischargeObligation {P : PureExpr} [ToFormat P.Ident]
   (encodeTerms : List Strata.SMT.Term → Strata.SMT.SolverM (List String × Strata.SMT.EncoderState))

--- a/Strata/Languages/Boogie/Examples/AssertionDefaultNames.lean
+++ b/Strata/Languages/Boogie/Examples/AssertionDefaultNames.lean
@@ -51,7 +51,7 @@ Assumptions:
 Proof Obligation:
 ($__x0 == #1)
 
-Wrote problem to vcs/assert:_(x_eq_(#1_:_int)).smt2.
+Wrote problem to vcs/assert-_(x_eq_(#1_-_int)).smt2.
 ---
 info:
 Obligation: assert: (x == (#1 : int))

--- a/Strata/Languages/Boogie/Examples/ProcedureCall.lean
+++ b/Strata/Languages/Boogie/Examples/ProcedureCall.lean
@@ -91,10 +91,10 @@ Proof Obligation:
 
 Wrote problem to vcs/new_g_value.smt2.
 Wrote problem to vcs/old_g_property.smt2.
-Wrote problem to vcs/<Origin:Inc_Requires>a_positive.smt2.
-Wrote problem to vcs/<Origin:Inc_Requires>a_positive.smt2.
+Wrote problem to vcs/(Origin-Inc_Requires)a_positive.smt2.
+Wrote problem to vcs/(Origin-Inc_Requires)a_positive.smt2.
 Wrote problem to vcs/return_value_lemma.smt2.
-Wrote problem to vcs/assert:_(#true_:_bool).smt2.
+Wrote problem to vcs/assert-_(#true_-_bool).smt2.
 ---
 info:
 Obligation: new_g_value


### PR DESCRIPTION
Previously, SMT filename generation was emitting characters incompatible with Windows file systems.
This PR fixes it so that the build now passes on Windows


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
