### PR TITLE
Translate polymorphic maps to uninterpreted heaps

### DIFF
--- a/Strata/Languages/Boogie/Examples/QuantifiersWithTypeAliases.lean
+++ b/Strata/Languages/Boogie/Examples/QuantifiersWithTypeAliases.lean
@@ -74,7 +74,7 @@ Assumptions:
 Proof Obligation:
 (((~select ((~select (((~update $__h0) $__ref1) (((~update ((~select $__h0) $__ref1)) $__field2) ((~Int.Add ((~select ((~select $__h0) $__ref1)) $__field2)) #1)))) $__ref1)) $__field2) == ((~Int.Add ((~select ((~select $__h0) $__ref1)) $__field2)) #1))
 
-Wrote problem to vcs/assert: (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int))).smt2.
+Wrote problem to vcs/assert:_(((~select_((~select_newH)_ref))_field)_eq_((~Int.Add_((~select_((~select_h)_ref))_field))_(#1_:_int))).smt2.
 ---
 info:
 Obligation: assert: (((~select ((~select newH) ref)) field) == ((~Int.Add ((~select ((~select h) ref)) field)) (#1 : int)))


### PR DESCRIPTION
Detect types that match the structure of references, fields, and heaps, and translate these into one monomorphic instance for each field type that occurs in the program.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
