### PR TITLE
Fix extremely inefficient hash function leading to exponential SMT Encoding

### DIFF
--- a/Strata/DL/SMT/Op.lean
+++ b/Strata/DL/SMT/Op.lean
@@ -104,7 +104,7 @@ inductive Op : Type where
   | str_concat
   ---------- Core ADT operators with a trusted mapping to SMT ----------
   | option.get
-deriving Repr, DecidableEq, Inhabited
+deriving Repr, DecidableEq, Inhabited, Hashable
 
 
 def Op.mkName : Op → String

--- a/Strata/DL/SMT/Term.lean
+++ b/Strata/DL/SMT/Term.lean
@@ -62,7 +62,7 @@ instance TermPrim.decLt (x y : TermPrim) : Decidable (x < y) :=
 inductive QuantifierKind
   | all
   | exist
-deriving Repr, DecidableEq
+deriving Repr, DecidableEq, Hashable
 
 inductive Term : Type where
   | prim    : TermPrim → Term
@@ -121,8 +121,17 @@ end
 
 instance : DecidableEq Term := Term.hasDecEq
 
+def hashTerm (t: Term): UInt64 :=
+  match t with
+    | .prim _ => 1
+    | .var _ => 3
+    | .none _ => 5
+    | .some _ => 7
+    | .app op _ retTy => 11 * (hash op) * (hash retTy)
+    | .quant qk args _ _ => 13 * (hash qk) * (hash args)
+
 instance : Hashable Term where
-  hash := λ a => hash s!"{repr a}"
+  hash := hashTerm
 
 def Term.mkName : Term → String
   | .prim _     => "prim"

--- a/Strata/DL/SMT/Term.lean
+++ b/Strata/DL/SMT/Term.lean
@@ -123,7 +123,7 @@ instance : DecidableEq Term := Term.hasDecEq
 
 def hashTerm (t: Term): UInt64 :=
   match t with
-    | .prim _ => 1
+    | .prim _ => 2
     | .var _ => 3
     | .none _ => 5
     | .some _ => 7


### PR DESCRIPTION
*Description of changes:*

@MikaelMayer and I found the source of the slowness of the SMT Encoding:

The previous hash function on `Term` was computing the string representation of the term before hashing it. As this is done for all terms in `encodeTerm` to check there presence in the environment hash tables, this introduced an exponential complexity for the SMT Encoder.

With this new hash function which is extremely efficient, the time to verify one of my benchmark goes down from 38sec to 1.2sec.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
