### PR TITLE
Fix unsound axioms for maps

### DIFF
--- a/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
+++ b/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
@@ -39,6 +39,7 @@ spec {
   assert [a1eq1]: a[1] == 1;
   a := a[0 := 1];
   assert [a0eq1]: a[0] == 1;
+  assert [a0neq2]: a[0] != 2;
 
   b := b[true := -1];
   assert [bTrueEqTrue]: b[true] == -1;
@@ -70,6 +71,7 @@ a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) 
 assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (#1 : int))
 a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#0 : int)) (#1 : int))
 assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
+assert [a0neq2] (~Bool.Not ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#2 : int)))
 b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) b) (#true : bool)) (~Int.Neg (#1 : int)))
 assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool)) == (~Int.Neg (#1 : int)))
 assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (~Int.Neg (((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool))))
@@ -119,6 +121,13 @@ Assumptions:
 Proof Obligation:
 (((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #0) == #1)
 
+Label: a0neq2
+Assumptions:
+(P_requires_3, (((~select $__a0) #0) == #0))
+(P_requires_4, (((~select $__c2) #0) == $__a0))
+Proof Obligation:
+(~Bool.Not (((~select (((~update (((~update $__a0) #1) #1)) #0) #1)) #0) == #2))
+
 Label: bTrueEqTrue
 Assumptions:
 (P_requires_3, (((~select $__a0) #0) == #0))
@@ -138,6 +147,7 @@ Wrote problem to vcs/c_1_eq_a.smt2.
 Wrote problem to vcs/a0eq0.smt2.
 Wrote problem to vcs/a1eq1.smt2.
 Wrote problem to vcs/a0eq1.smt2.
+Wrote problem to vcs/a0neq2.smt2.
 Wrote problem to vcs/bTrueEqTrue.smt2.
 Wrote problem to vcs/mix.smt2.
 ---
@@ -155,6 +165,9 @@ Obligation: a1eq1
 Result: verified
 
 Obligation: a0eq1
+Result: verified
+
+Obligation: a0neq2
 Result: verified
 
 Obligation: bTrueEqTrue

--- a/Strata/Languages/Boogie/Factory.lean
+++ b/Strata/Languages/Boogie/Factory.lean
@@ -161,21 +161,29 @@ def mapUpdateFunc : LFunc BoogieIdent :=
      output := mapTy mty[%k] mty[%v],
      axioms :=
      [
-      -- updateSelect
+      -- updateSelect: forall m: Map k v, kk: k, vv: v :: m[kk := vv][kk] == vv
       ToBoogieIdent esM[∀(Map %k %v):
           (∀ (%k):
             (∀ (%v):
               (((~select : (Map %k %v) → %k → %v)
                 ((((~update : (Map %k %v) → %k → %v → (Map %k %v)) %2) %1) %0)) %1) == %0))],
-      -- update preserves
-      ToBoogieIdent esM[∀ (Map %k %v):
-          (∀ (%k):
-            (∀ (%k):
-              (∀ (%v):
-                  (((~select : (Map %k %v) → %k → %v)
-                    ((((~update : (Map %k %v) → %k → %v → (Map %k %v)) %3) %1) %0)) %2)
-                  ==
-                  ((((~select : (Map %k %v) → %k → %v) %3) %2)))))]
+      -- updatePreserve: forall m: Map k v, okk: k, kk: k, vv: v :: okk != kk ==> m[kk := vv][okk] == m[okk]
+      ToBoogieIdent esM[∀ (Map %k %v): -- %3 m
+          (∀ (%k): -- %2 okk
+            (∀ (%k): -- %1 kk
+              (∀ (%v): -- %0 vv
+                  -- okk != kk ==> ...
+                  (if (%2 == %1) then
+                      #true
+                  else
+                    -- if keys are different, the value of the other key one remains unchanged
+                    -- (select (update m kk vv) okk) ==  (select m okk)
+                    ((((~select : (Map %k %v) → %k → %v)
+                        ((((~update : (Map %k %v) → %k → %v → (Map %k %v)) %3) %1) %0)
+                      ) %2)
+                    ==
+                    ((((~select : (Map %k %v) → %k → %v) %3) %2)))
+                    ))))]
      ]
    }
 


### PR DESCRIPTION
*Description of changes:*

The map axioms were unsound. Indeed, the second axiom was:
`forall m: Map k v, okk: k, kk: k, vv: v :: m[kk := vv][okk] == m[okk]`

but should have been:

`forall m: Map k v, okk: k, kk: k, vv: v :: okk != kk ==> m[kk := vv][okk] == m[okk]`

This is indeed true only when the keys are different.

This PR fixes the axiom, adding some comments for readability, as well as an assertion in the `AdvancedMap.lean` example proving a negative equality on a modified key, to ensure consistensy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
