### PR TITLE
Rename `denote` to `concreteEval` in the Lambda factory

### DIFF
--- a/Strata/DL/Lambda/Factory.lean
+++ b/Strata/DL/Lambda/Factory.lean
@@ -53,11 +53,12 @@ A Lambda factory function, where the body can be optional. Universally
 quantified type identifiers, if any, appear before this signature and can
 quantify over the type identifiers in it.
 
-A optional denotation function can be provided in the `denote` field for each
-factory function. Such a function should take two inputs: a function call
-expression and also -- somewhat redundantly, but perhaps more conveniently --
-the list of arguments in this expression.  Here's an example of a `denote`
-function for `Int.Add`:
+A optional evaluation function can be provided in the `concreteEval` field for
+each factory function to allow the partial evaluator to do constant propagation
+when all the arguments of a function are concrete. Such a function should take
+two inputs: a function call expression and also -- somewhat redundantly, but
+perhaps more conveniently -- the list of arguments in this expression.  Here's
+an example of a `concreteEval` function for `Int.Add`:
 
 ```
 (fun e args => match args with
@@ -71,7 +72,7 @@ function for `Int.Add`:
 ```
 
 Note that if there is an arity mismatch or if the arguments are not
-concrete/constants and `denoteInt` fails, we return the original term `e`.
+concrete/constants, this fails and we return the original term `e`.
 
 (TODO) Can we enforce well-formedness of the denotation function? E.g., that it
 has the right number and type of arguments, etc.?
@@ -87,7 +88,7 @@ structure LFunc (Identifier : Type) where
   -- (TODO): Add support for a fixed set of attributes (e.g., whether to inline
   -- a function, etc.).
   attr     : Array String := #[]
-  denote   : Option ((LExpr LMonoTy Identifier) → List (LExpr LMonoTy Identifier) → (LExpr LMonoTy Identifier)) := .none
+  concreteEval : Option ((LExpr LMonoTy Identifier) → List (LExpr LMonoTy Identifier) → (LExpr LMonoTy Identifier)) := .none
   axioms   : List (LExpr LMonoTy Identifier) := []  -- For axiomatic definitions
 
 instance : Inhabited (LFunc Identifier) where

--- a/Strata/DL/Lambda/IntBoolFactory.lean
+++ b/Strata/DL/Lambda/IntBoolFactory.lean
@@ -22,50 +22,50 @@ section IntBoolFactory
 def unaryOp [Coe String Ident]
             (n : Ident)
             (ty : LMonoTy)
-            (denote : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
+            (ceval : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
   { name := n,
     inputs := [("x", ty)],
     output := ty,
-    denote := denote }
+    concreteEval := ceval }
 
 def binaryOp [Coe String Ident]
              (n : Ident)
              (ty : LMonoTy)
-             (denote : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
+             (ceval : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
   { name := n,
     inputs := [("x", ty), ("y", ty)],
     output := ty,
-    denote := denote }
+    concreteEval := ceval }
 
 def binaryPredicate [Coe String Ident]
                     (n : Ident)
                     (ty : LMonoTy)
-                    (denote : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
+                    (ceval : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
   { name := n,
     inputs := [("x", ty), ("y", ty)],
     output := .bool,
-    denote := denote }
+    concreteEval := ceval }
 
-def unOpDenote  {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
-                (denoteInTy : (LExpr LMonoTy Identifier) → Option InTy) (op : InTy → OutTy)
+def unOpCeval  {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
+                (cevalInTy : (LExpr LMonoTy Identifier) → Option InTy) (op : InTy → OutTy)
                 (ty : LMonoTy) :
                 (LExpr LMonoTy Identifier) → List (LExpr LMonoTy Identifier) → (LExpr LMonoTy Identifier) :=
   (fun e args => match args with
    | [e1] =>
-     let e1i := denoteInTy e1
+     let e1i := cevalInTy e1
      match e1i with
      | some x => (LExpr.const (toString (op x)) ty)
      | _ => e
    | _ => e)
 
-def binOpDenote {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
-                (denoteInTy : (LExpr LMonoTy Identifier) → Option InTy) (op : InTy → InTy → OutTy)
+def binOpCeval {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
+                (cevalInTy : (LExpr LMonoTy Identifier) → Option InTy) (op : InTy → InTy → OutTy)
                 (ty : LMonoTy) :
                 (LExpr LMonoTy Identifier) → List (LExpr LMonoTy Identifier) → (LExpr LMonoTy Identifier) :=
   (fun e args => match args with
    | [e1, e2] =>
-     let e1i := denoteInTy e1
-     let e2i := denoteInTy e2
+     let e1i := cevalInTy e1
+     let e2i := cevalInTy e2
      match e1i, e2i with
      | some x, some y => (LExpr.const (toString (op x y)) ty)
      | _, _ => e
@@ -73,7 +73,7 @@ def binOpDenote {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
 
 -- We hand-code a denotation for `Int.Div` to leave the expression
 -- unchanged if we have `0` for the denominator.
-def denoteIntDiv (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : LExpr LMonoTy Ident :=
+def cevalIntDiv (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : LExpr LMonoTy Ident :=
   match args with
   | [e1, e2] =>
     let e1i := LExpr.denoteInt e1
@@ -86,7 +86,7 @@ def denoteIntDiv (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) :
 
 -- We hand-code a denotation for `Int.Mod` to leave the expression
 -- unchanged if we have `0` for the denominator.
-def denoteIntMod (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : LExpr LMonoTy Ident :=
+def cevalIntMod (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : LExpr LMonoTy Ident :=
   match args with
   | [e1, e2] =>
     let e1i := LExpr.denoteInt e1
@@ -101,64 +101,64 @@ def denoteIntMod (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) :
 
 def intAddFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Int.Add" .int
-  (some (binOpDenote Int Int LExpr.denoteInt Int.add .int))
+  (some (binOpCeval Int Int LExpr.denoteInt Int.add .int))
 
 def intSubFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Int.Sub" .int
-  (some (binOpDenote Int Int LExpr.denoteInt Int.sub .int))
+  (some (binOpCeval Int Int LExpr.denoteInt Int.sub .int))
 
 def intMulFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Int.Mul" .int
-  (some (binOpDenote Int Int LExpr.denoteInt Int.mul .int))
+  (some (binOpCeval Int Int LExpr.denoteInt Int.mul .int))
 
 def intDivFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Int.Div" .int
-  (some denoteIntDiv)
+  (some cevalIntDiv)
 
 def intModFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Int.Mod" .int
-  (some denoteIntMod)
+  (some cevalIntMod)
 
 def intNegFunc [Coe String Ident] : LFunc Ident :=
   unaryOp "Int.Neg" .int
-  (some (unOpDenote Int Int LExpr.denoteInt Int.neg .int))
+  (some (unOpCeval Int Int LExpr.denoteInt Int.neg .int))
 
 def intLtFunc [Coe String Ident] : LFunc Ident :=
   binaryPredicate "Int.Lt" .int
-  (some (binOpDenote Int Bool LExpr.denoteInt (fun x y => x < y) .bool))
+  (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x < y) .bool))
 
 def intLeFunc [Coe String Ident] : LFunc Ident :=
   binaryPredicate "Int.Le" .int
-  (some (binOpDenote Int Bool LExpr.denoteInt (fun x y => x <= y) .bool))
+  (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x <= y) .bool))
 
 def intGtFunc [Coe String Ident] : LFunc Ident :=
   binaryPredicate "Int.Gt" .int
-  (some (binOpDenote Int Bool LExpr.denoteInt (fun x y => x > y) .bool))
+  (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x > y) .bool))
 
 def intGeFunc [Coe String Ident] : LFunc Ident :=
   binaryPredicate "Int.Ge" .int
-  (some (binOpDenote Int Bool LExpr.denoteInt (fun x y => x >= y) .bool))
+  (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x >= y) .bool))
 
 /- Boolean Operations -/
 def boolAndFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Bool.And" .bool
-  (some (binOpDenote Bool Bool LExpr.denoteBool Bool.and .bool))
+  (some (binOpCeval Bool Bool LExpr.denoteBool Bool.and .bool))
 
 def boolOrFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Bool.Or" .bool
-  (some (binOpDenote Bool Bool LExpr.denoteBool Bool.or .bool))
+  (some (binOpCeval Bool Bool LExpr.denoteBool Bool.or .bool))
 
 def boolImpliesFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Bool.Implies" .bool
-  (some (binOpDenote Bool Bool LExpr.denoteBool (fun x y => ((not x) || y)) .bool))
+  (some (binOpCeval Bool Bool LExpr.denoteBool (fun x y => ((not x) || y)) .bool))
 
 def boolEquivFunc [Coe String Ident] : LFunc Ident :=
   binaryOp "Bool.Equiv" .bool
-  (some (binOpDenote Bool Bool LExpr.denoteBool (fun x y => (x == y)) .bool))
+  (some (binOpCeval Bool Bool LExpr.denoteBool (fun x y => (x == y)) .bool))
 
 def boolNotFunc [Coe String Ident] : LFunc Ident :=
   unaryOp "Bool.Not" .bool
-  (some (unOpDenote Bool Bool LExpr.denoteBool Bool.not .bool))
+  (some (unOpCeval Bool Bool LExpr.denoteBool Bool.not .bool))
 
 def IntBoolFactory : @Factory String :=
   open LTy.Syntax in #[

--- a/Strata/DL/Lambda/LExpr.lean
+++ b/Strata/DL/Lambda/LExpr.lean
@@ -37,11 +37,11 @@ We leave placeholders for type annotations only for constants
 variables (`.fvar`).
 
 LExpr is parameterized by `TypeType`, which represents
-user-allowed type annotations (which are allowed to be missing),
-and `Identifier` for allowed identifiers. For a fully annotated AST,
-see `LExprT` that is created after the type inference transform.
+user-allowed type annotations (optional), and `Identifier` for allowed
+identifiers. For a fully annotated AST, see `LExprT` that is created after the
+type inference transform.
 -/
-inductive LExpr (TypeType: Type) (Identifier : Type) : Type where
+inductive LExpr (TypeType : Type) (Identifier : Type) : Type where
   /-- `.const c ty`: constants (in the sense of literals). -/
   | const   (c : String) (ty : Option TypeType)
   /-- `.op c ty`: operation names. -/
@@ -249,9 +249,11 @@ def eraseTypes (e : (LExpr TypeType Identifier)) : (LExpr TypeType Identifier) :
 
 /- Formatting and Parsing of Lambda Expressions -/
 
-instance (Identifier : Type) [Repr Identifier] [Repr TypeType] : ToString (LExpr TypeType Identifier) where toString a := toString (repr a)
+instance (Identifier : Type) [Repr Identifier] [Repr TypeType] : ToString (LExpr TypeType Identifier) where
+   toString a := toString (repr a)
 
-private def formatLExpr [ToFormat Identifier] [ToFormat TypeType] (e : (LExpr TypeType Identifier)) : Format :=
+private def formatLExpr [ToFormat Identifier] [ToFormat TypeType] (e : (LExpr TypeType Identifier)) :
+    Format :=
   match e with
   | .const c ty =>
     match ty with

--- a/Strata/DL/Lambda/LExprEval.lean
+++ b/Strata/DL/Lambda/LExprEval.lean
@@ -114,8 +114,8 @@ def eval (n : Nat) (σ : (LState Identifier)) (e : (LExpr LMonoTy Identifier)) :
             -- All arguments in the function call are concrete.
             -- We can, provided a denotation function, evaluate this function
             -- call.
-            match lfunc.denote with
-            | none => new_e | some denote => denote new_e args
+            match lfunc.concreteEval with
+            | none => new_e | some ceval => ceval new_e args
           else
             -- At least one argument in the function call is symbolic.
             new_e

--- a/Strata/Languages/Boogie/Factory.lean
+++ b/Strata/Languages/Boogie/Factory.lean
@@ -127,17 +127,17 @@ def strLengthFunc : LFunc BoogieIdent :=
       typeArgs := [],
       inputs := [("x", mty[string])]
       output := mty[int],
-      denote := some (unOpDenote String Int LExpr.denoteString
-                        (fun s => (Int.ofNat (String.length s)))
-                        mty[int])}
+      concreteEval := some (unOpCeval String Int LExpr.denoteString
+                            (fun s => (Int.ofNat (String.length s)))
+                            mty[int])}
 
 def strConcatFunc : LFunc BoogieIdent :=
     { name := "Str.Concat",
       typeArgs := [],
       inputs := [("x", mty[string]), ("y", mty[string])]
       output := mty[string],
-      denote := some (binOpDenote String String LExpr.denoteString
-                       String.append mty[string])}
+      concreteEval := some (binOpCeval String String LExpr.denoteString
+                            String.append mty[string])}
 
 /- A polymorphic `old` function with type `∀a. a → a`. -/
 def polyOldFunc : LFunc BoogieIdent :=

--- a/StrataTest/DL/Lambda/LExprEvalTests.lean
+++ b/StrataTest/DL/Lambda/LExprEvalTests.lean
@@ -71,7 +71,7 @@ private def testBuiltIn : @Factory String :=
   #[{ name := "Int.Add",
       inputs := [("x", mty[int]), ("y", mty[int])],
       output := mty[int],
-      denote := some (fun e args => match args with
+      concreteEval := some (fun e args => match args with
                         | [e1, e2] =>
                           let e1i := LExpr.denoteInt e1
                           let e2i := LExpr.denoteInt e2
@@ -82,7 +82,7 @@ private def testBuiltIn : @Factory String :=
     { name := "Int.Div",
       inputs := [("x", mty[int]), ("y", mty[int])],
       output := mty[int],
-      denote :=  some (fun e args => match args with
+      concreteEval :=  some (fun e args => match args with
                           | [e1, e2] =>
                             let e1i := LExpr.denoteInt e1
                             let e2i := LExpr.denoteInt e2
@@ -94,7 +94,7 @@ private def testBuiltIn : @Factory String :=
     { name := "Int.Neg",
       inputs := [("x", mty[int])],
       output := mty[int],
-      denote :=  some (fun e args => match args with
+      concreteEval :=  some (fun e args => match args with
                               | [e1] =>
                                 let e1i := LExpr.denoteInt e1
                                 match e1i with


### PR DESCRIPTION
*Description of changes:*

This is to clarify that the provided function will aid in constant propagation, not denotation into Lean.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
