### PR TITLE
Fix CI failure due to broken example

### DIFF
--- a/Examples/LoopSimple.boogie.st
+++ b/Examples/LoopSimple.boogie.st
@@ -10,7 +10,6 @@ spec {
   sum := 0;
   i := 0;
   while(i < n)
-    decreases (n-i);
     invariant (i <= n && ((i * (i-1)) div 2 == sum));
   {
     sum := sum + i;


### PR DESCRIPTION
The file `Examples/LoopSimple.boogie.st` included a `decreases` clause, which existed in the first version of the Boogie dialect but was then removed. However, CI wasn't checking examples until #34. Once #34 was merged, checking of that example started failing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
