### PR TITLE
Put Dyn dialect in namespace

### DIFF
--- a/Strata/Languages/Dyn/DDMTransform/Parse.lean
+++ b/Strata/Languages/Dyn/DDMTransform/Parse.lean
@@ -7,6 +7,8 @@
 import Strata.DDM.Integration.Lean
 import Strata.DDM.Util.Format
 
+namespace Strata
+
 #dialect
 dialect Dyn;
 
@@ -146,4 +148,6 @@ op function_def (ret_type : Type,
 #end
 
 -- Generate AST
+namespace Dyn
 #strata_gen Dyn
+end Dyn


### PR DESCRIPTION
The Dyn module currently adds declarations to the root namespace.  This puts the dialects inside Strata and Strata.Dyn.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
