### PR TITLE
Bypass the cache in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
           dotnet-version: '8.0.x'
       - name: Build and test Strata
         uses: leanprover/lean-action@v1
+        with:
+          use-github-cache: false
       - name: Build and run StrataVerify
         run: lake exe StrataVerify Examples/SimpleProc.boogie.st
       - name: Build BoogieToStrata


### PR DESCRIPTION
*Description of changes:*

CI runs for https://github.com/strata-org/Strata/pull/94 are showing a bogus failure; the thesis is that perhaps a corrupted cache is causing that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
