### PR TITLE
Allow multiple failures in one program

### DIFF
--- a/Strata/Languages/Boogie/Examples/FailingAssertion.lean
+++ b/Strata/Languages/Boogie/Examples/FailingAssertion.lean
@@ -85,3 +85,54 @@ Result: err Cannot find model for id: t0
 #eval verify "cvc5" failing
 
 ---------------------------------------------------------------------
+
+private def failingThrice :=
+#strata
+program Boogie;
+
+procedure P(x : int) returns ()
+spec {
+  requires x != 0;
+}
+{
+  assert x == 1;
+  assert x == 2;
+  assert x != 7;
+};
+#end
+
+/--
+info:
+
+Obligation assert_0: could not be proved!
+
+Result: failed
+CEx: ($__x0, (- 1))
+
+
+Obligation assert_1: could not be proved!
+
+Result: failed
+CEx: ($__x0, (- 1))
+
+
+Obligation assert_2: could not be proved!
+
+Result: failed
+CEx: ($__x0, 7)
+---
+info:
+Obligation: assert_0
+Result: failed
+CEx: ($__x0, (- 1))
+
+Obligation: assert_1
+Result: failed
+CEx: ($__x0, (- 1))
+
+Obligation: assert_2
+Result: failed
+CEx: ($__x0, 7)
+-/
+#guard_msgs in
+#eval verify "cvc5" failingThrice Options.quiet

--- a/Strata/Languages/Boogie/Options.lean
+++ b/Strata/Languages/Boogie/Options.lean
@@ -8,6 +8,7 @@ structure Options where
   verbose : Bool
   parseOnly : Bool
   checkOnly : Bool
+  stopOnFirstError : Bool
   /-- Solver time limit in seconds -/
   solverTimeout : Nat
 
@@ -15,6 +16,7 @@ def Options.default : Options := {
   verbose := true,
   parseOnly := false,
   checkOnly := false,
+  stopOnFirstError := false,
   solverTimeout := 10
 }
 

--- a/Strata/Languages/Boogie/Verifier.lean
+++ b/Strata/Languages/Boogie/Verifier.lean
@@ -203,7 +203,6 @@ def verifySingleEnv (smtsolver : String) (pE : Program × Env) (options : Option
                      Evaluated program: {p}\n\n"
         let _ ← dbg_trace msg
         results := results.push { obligation, result := .err msg }
-        break
       | .ok (terms, ctx) =>
         -- let ufids := (ctx.ufs.map (fun f => f.id))
         -- let ufs := f!"Uninterpreted Functions:{Format.line}\
@@ -230,14 +229,12 @@ def verifySingleEnv (smtsolver : String) (pE : Program × Env) (options : Option
             dbg_trace f!"\n\nObligation {obligation.label}: could not be proved!\
                          \n\nResult: {result}\
                          {if options.verbose then prog else ""}"
-            break
         | .error e =>
            results := results.push { obligation, result := .err (toString e) }
            let prog := f!"\n\nEvaluated program:\n{p}"
            dbg_trace f!"\n\nObligation {obligation.label}: solver error!\
                         \n\nError: {e}\
                         {if options.verbose then prog else ""}"
-           break
     return results
 
 def verify (smtsolver : String) (program : Program) (options : Options := Options.default) : EIO Format VCResults := do

--- a/Strata/Languages/Boogie/Verifier.lean
+++ b/Strata/Languages/Boogie/Verifier.lean
@@ -203,6 +203,7 @@ def verifySingleEnv (smtsolver : String) (pE : Program × Env) (options : Option
                      Evaluated program: {p}\n\n"
         let _ ← dbg_trace msg
         results := results.push { obligation, result := .err msg }
+        if options.stopOnFirstError then break
       | .ok (terms, ctx) =>
         -- let ufids := (ctx.ufs.map (fun f => f.id))
         -- let ufs := f!"Uninterpreted Functions:{Format.line}\
@@ -229,12 +230,14 @@ def verifySingleEnv (smtsolver : String) (pE : Program × Env) (options : Option
             dbg_trace f!"\n\nObligation {obligation.label}: could not be proved!\
                          \n\nResult: {result}\
                          {if options.verbose then prog else ""}"
+           if options.stopOnFirstError then break
         | .error e =>
            results := results.push { obligation, result := .err (toString e) }
            let prog := f!"\n\nEvaluated program:\n{p}"
            dbg_trace f!"\n\nObligation {obligation.label}: solver error!\
                         \n\nError: {e}\
                         {if options.verbose then prog else ""}"
+           if options.stopOnFirstError then break
     return results
 
 def verify (smtsolver : String) (program : Program) (options : Options := Options.default) : EIO Format VCResults := do

--- a/StrataVerify.lean
+++ b/StrataVerify.lean
@@ -28,6 +28,7 @@ def parseOptions (args : List String) : Except Std.Format (Options × String) :=
       | opts, "--verbose" :: rest => go {opts with verbose := true} rest
       | opts, "--check" :: rest => go {opts with checkOnly := true} rest
       | opts, "--parse-only" :: rest => go {opts with parseOnly := true} rest
+      | opts, "--stop-on-first-error" :: rest => go {opts with stopOnFirstError := true} rest
       | opts, "--solver-timeout" :: secondsStr :: rest =>
          let n? := String.toNat? secondsStr
          match n? with
@@ -37,8 +38,16 @@ def parseOptions (args : List String) : Except Std.Format (Options × String) :=
       | _, [] => .error "StrataVerify requires a file as input"
       | _, args => .error f!"Unknown options: {args}"
 
-def usageMessage : String :=
-  "Usage: StrataVerify [--verbose] [--parse-only] [--check] [--solver-timeout <seconds>] <file.{boogie, csimp}.st>"
+def usageMessage : Std.Format :=
+  f!"Usage: StrataVerify [OPTIONS] <file.\{boogie, csimp}.st>{Std.Format.line}\
+  {Std.Format.line}\
+  Options:{Std.Format.line}\
+  {Std.Format.line}  \
+  --verbose                   Print extra information during analysis.{Std.Format.line}  \
+  --check                     Exit after Lambda type checking.{Std.Format.line}  \
+  --parse-only                Exit after DDM parsing and type checking.{Std.Format.line}  \
+  --stop-on-first-error       Exit after the first verification error.{Std.Format.line}  \
+  --solver-timeout <seconds>  Set the solver time limit per proof goal."
 
 def main (args : List String) : IO UInt32 := do
   let parseResult := parseOptions args


### PR DESCRIPTION
This changes only how errors are reported, so it doesn't increase the computational cost of verification.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
