### PR TITLE
More explict types in Boogie dialect translation

### DIFF
--- a/Strata/DL/Lambda/Factory.lean
+++ b/Strata/DL/Lambda/Factory.lean
@@ -139,6 +139,12 @@ def LFunc.inputPolyTypes (f : (LFunc Identifier)) : @LTySignature Identifier :=
 def LFunc.outputPolyType (f : (LFunc Identifier)) : LTy :=
   .forAll f.typeArgs f.output
 
+def LFunc.eraseTypes (f : LFunc Identifier) : LFunc Identifier :=
+  { f with
+    body := f.body.map LExpr.eraseTypes,
+    axioms := f.axioms.map LExpr.eraseTypes
+  }
+
 /--
 The type checker and partial evaluator for Lambda is parameterizable by
 a user-provided `Factory`.

--- a/Strata/Languages/Boogie/Axiom.lean
+++ b/Strata/Languages/Boogie/Axiom.lean
@@ -28,3 +28,6 @@ structure Axiom where
 
 instance : ToFormat Axiom where
   format a := f!"axiom {a.name}: {a.e};"
+
+def Axiom.eraseTypes (a : Axiom) : Axiom :=
+  { a with e := a.e.eraseTypes }

--- a/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
+++ b/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
@@ -61,20 +61,20 @@ var (b : (Map bool int)) := init_b_1
 var (c : (Map int MapII)) := init_c_2
 (procedure P :  () → ())
 modifies: [a, b, c]
-preconditions: (P_requires_3, ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))) (P_requires_4, ((((~select : (arrow (Map int MapII) (arrow int MapII))) c) (#0 : int)) == a))
+preconditions: (P_requires_3, ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#0 : int)) == (#0 : int))) (P_requires_4, ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) (#0 : int)) == (a : MapII)))
 postconditions: ⏎
-body: assert [c_0_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) c) (#0 : int)) == a)
-c := ((((~update : (arrow (Map int MapII) (arrow int (arrow MapII (Map int MapII))))) c) (#1 : int)) a)
-assert [c_1_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) c) (#1 : int)) == a)
-assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int))
-a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#1 : int)) (#1 : int))
-assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (#1 : int))
-a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) a) (#0 : int)) (#1 : int))
-assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
-assert [a0neq2] (~Bool.Not ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#2 : int)))
-b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) b) (#true : bool)) (~Int.Neg (#1 : int)))
-assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool)) == (~Int.Neg (#1 : int)))
-assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) a) (#1 : int)) == (~Int.Neg (((~select : (arrow (Map bool int) (arrow bool int))) b) (#true : bool))))
+body: assert [c_0_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) (#0 : int)) == (a : MapII))
+c := ((((~update : (arrow (Map int MapII) (arrow int (arrow MapII (Map int MapII))))) (c : (Map int MapII))) (#1 : int)) (a : MapII))
+assert [c_1_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) (#1 : int)) == (a : MapII))
+assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#0 : int)) == (#0 : int))
+a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) (a : MapII)) (#1 : int)) (#1 : int))
+assert [a1eq1] ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#1 : int)) == (#1 : int))
+a := ((((~update : (arrow (Map int int) (arrow int (arrow int (Map int int))))) (a : MapII)) (#0 : int)) (#1 : int))
+assert [a0eq1] ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#0 : int)) == (#1 : int))
+assert [a0neq2] ((~Bool.Not : (arrow bool bool)) ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#0 : int)) == (#2 : int)))
+b := ((((~update : (arrow (Map bool int) (arrow bool (arrow int (Map bool int))))) (b : (Map bool int))) (#true : bool)) ((~Int.Neg : (arrow int int)) (#1 : int)))
+assert [bTrueEqTrue] ((((~select : (arrow (Map bool int) (arrow bool int))) (b : (Map bool int))) (#true : bool)) == ((~Int.Neg : (arrow int int)) (#1 : int)))
+assert [mix] ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#1 : int)) == ((~Int.Neg : (arrow int int)) (((~select : (arrow (Map bool int) (arrow bool int))) (b : (Map bool int))) (#true : bool))))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/AssertionDefaultNames.lean
+++ b/Strata/Languages/Boogie/Examples/AssertionDefaultNames.lean
@@ -31,9 +31,9 @@ spec {
 /--
 info: (procedure Test :  ((x : int)) → ())
 modifies: []
-preconditions: (Test_requires_0, (x == (#1 : int)))
+preconditions: (Test_requires_0, ((x : int) == (#1 : int)))
 postconditions: ⏎
-body: assert [assert_0] (x == (#1 : int))
+body: assert [assert_0] ((x : int) == (#1 : int))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/FailingAssertion.lean
+++ b/Strata/Languages/Boogie/Examples/FailingAssertion.lean
@@ -39,9 +39,9 @@ info: type MapII := (Map int int)
 var (a : MapII) := init_a_0
 (procedure P :  () → ())
 modifies: [a]
-preconditions: (P_requires_1, ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#0 : int)))
+preconditions: (P_requires_1, ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#0 : int)) == (#0 : int)))
 postconditions: ⏎
-body: assert [assert_0] ((((~select : (arrow (Map int int) (arrow int int))) a) (#0 : int)) == (#1 : int))
+body: assert [assert_0] ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) (#0 : int)) == (#1 : int))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/GeneratedLabels.lean
+++ b/Strata/Languages/Boogie/Examples/GeneratedLabels.lean
@@ -38,16 +38,16 @@ info: type Boogie.Boundedness.Infinite Ref []
 type Boogie.Boundedness.Infinite Field []
 type Struct := (Map Field int)
 type Heap := (Map Ref Struct)
-axiom axiom_0: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) (~Bool.Not (%2 == %1))) ((((~select : (arrow (Map Field int) (arrow Field int))) %3) %2) == (((~select : (arrow (Map Field int) (arrow Field int))) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) %3) %1) %0)) %2)))))));
+axiom axiom_0: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) ((~Bool.Not : (arrow bool bool)) (%2 == %1))) ((((~select : (arrow (Map Field int) (arrow Field int))) %3) %2) == (((~select : (arrow (Map Field int) (arrow Field int))) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) %3) %1) %0)) %2)))))));
 axiom axiom_1: (∀ (∀ (∀ ((((~select : (arrow (Map Field int) (arrow Field int))) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) %2) %1) %0)) %1) == %0))));
-axiom axiom_2: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) (~Bool.Not (%2 == %1))) ((((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) %3) %2) == (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) %3) %1) %0)) %2)))))));
+axiom axiom_2: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) ((~Bool.Not : (arrow bool bool)) (%2 == %1))) ((((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) %3) %2) == (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) %3) %1) %0)) %2)))))));
 axiom axiom_3: (∀ (∀ (∀ ((((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) %2) %1) %0)) %1) == %0))));
 (procedure test :  ((h : Heap) (ref : Ref) (field : Field)) → ())
 modifies: []
 preconditions: ⏎
 postconditions: ⏎
-body: init (newH : Heap) := ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) h) ref) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) h) ref)) field) (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) h) ref)) field)) (#1 : int))))
-assert [assert_0] ((((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) newH) ref)) field) == (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) h) ref)) field)) (#1 : int)))
+body: init (newH : Heap) := ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) (h : Heap)) (ref : Ref)) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (h : Heap)) (ref : Ref))) (field : Field)) (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (h : Heap)) (ref : Ref))) (field : Field))) (#1 : int))))
+assert [assert_0] ((((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (newH : Heap)) (ref : Ref))) (field : Field)) == (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (h : Heap)) (ref : Ref))) (field : Field))) (#1 : int)))
 -/
 #guard_msgs in
 #eval (TransM.run (translateProgram genLabelsPgm) |>.fst)

--- a/Strata/Languages/Boogie/Examples/Havoc.lean
+++ b/Strata/Languages/Boogie/Examples/Havoc.lean
@@ -34,7 +34,7 @@ postconditions: ⏎
 body: init (x : int) := init_x_0
 x := (#1 : int)
 havoc x
-assert [x_eq_1] (x == (#1 : int))
+assert [x_eq_1] ((x : int) == (#1 : int))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/Map.lean
+++ b/Strata/Languages/Boogie/Examples/Map.lean
@@ -34,9 +34,9 @@ info: func a :  () → (Map int bool);
 modifies: []
 preconditions: ⏎
 postconditions: ⏎
-body: assume [a_zero_true_assumption] ((((~select : (arrow (Map int bool) (arrow int bool))) ~a) (#0 : int)) == (#true : bool))
-assert [a_zero_true] (((~select : (arrow (Map int bool) (arrow int bool))) ~a) (#0 : int))
-assert [a_one_true] (((~select : (arrow (Map int bool) (arrow int bool))) ~a) (#1 : int))
+body: assume [a_zero_true_assumption] ((((~select : (arrow (Map int bool) (arrow int bool))) (~a : (Map int bool))) (#0 : int)) == (#true : bool))
+assert [a_zero_true] (((~select : (arrow (Map int bool) (arrow int bool))) (~a : (Map int bool))) (#0 : int))
+assert [a_one_true] (((~select : (arrow (Map int bool) (arrow int bool))) (~a : (Map int bool))) (#1 : int))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/QuantifiersWithTypeAliases.lean
+++ b/Strata/Languages/Boogie/Examples/QuantifiersWithTypeAliases.lean
@@ -40,16 +40,16 @@ info: type Boogie.Boundedness.Infinite Ref []
 type Boogie.Boundedness.Infinite Field []
 type Struct := (Map Field int)
 type Heap := (Map Ref Struct)
-axiom axiom_0: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) (~Bool.Not (%2 == %1))) ((((~select : (arrow (Map Field int) (arrow Field int))) %3) %2) == (((~select : (arrow (Map Field int) (arrow Field int))) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) %3) %1) %0)) %2)))))));
+axiom axiom_0: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) ((~Bool.Not : (arrow bool bool)) (%2 == %1))) ((((~select : (arrow (Map Field int) (arrow Field int))) %3) %2) == (((~select : (arrow (Map Field int) (arrow Field int))) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) %3) %1) %0)) %2)))))));
 axiom axiom_1: (∀ (∀ (∀ ((((~select : (arrow (Map Field int) (arrow Field int))) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) %2) %1) %0)) %1) == %0))));
-axiom axiom_2: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) (~Bool.Not (%2 == %1))) ((((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) %3) %2) == (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) %3) %1) %0)) %2)))))));
+axiom axiom_2: (∀ (∀ (∀ (∀ (((~Bool.Implies : (arrow bool (arrow bool bool))) ((~Bool.Not : (arrow bool bool)) (%2 == %1))) ((((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) %3) %2) == (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) %3) %1) %0)) %2)))))));
 axiom axiom_3: (∀ (∀ (∀ ((((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) %2) %1) %0)) %1) == %0))));
 (procedure test :  ((h : Heap) (ref : Ref) (field : Field)) → ())
 modifies: []
 preconditions: ⏎
 postconditions: ⏎
-body: init (newH : Heap) := ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) h) ref) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) h) ref)) field) (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) h) ref)) field)) (#1 : int))))
-assert [assert0] ((((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) newH) ref)) field) == (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) h) ref)) field)) (#1 : int)))
+body: init (newH : Heap) := ((((~update : (arrow (Map Ref Struct) (arrow Ref (arrow Struct (Map Ref Struct))))) (h : Heap)) (ref : Ref)) ((((~update : (arrow (Map Field int) (arrow Field (arrow int (Map Field int))))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (h : Heap)) (ref : Ref))) (field : Field)) (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (h : Heap)) (ref : Ref))) (field : Field))) (#1 : int))))
+assert [assert0] ((((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (newH : Heap)) (ref : Ref))) (field : Field)) == (((~Int.Add : (arrow int (arrow int int))) (((~select : (arrow (Map Field int) (arrow Field int))) (((~select : (arrow (Map Ref Struct) (arrow Ref Struct))) (h : Heap)) (ref : Ref))) (field : Field))) (#1 : int)))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/RealBitVector.lean
+++ b/Strata/Languages/Boogie/Examples/RealBitVector.lean
@@ -34,14 +34,14 @@ procedure P() returns ()
 /--
 info: func x :  () → real;
 func y :  () → real;
-axiom real_x_ge_1: (((~Real.Ge : (arrow real (arrow real bool))) ~x) (#1.0 : real));
-axiom real_y_ge_2: (((~Real.Ge : (arrow real (arrow real bool))) ~y) (#2.0 : real));
+axiom real_x_ge_1: (((~Real.Ge : (arrow real (arrow real bool))) (~x : real)) (#1.0 : real));
+axiom real_y_ge_2: (((~Real.Ge : (arrow real (arrow real bool))) (~y : real)) (#2.0 : real));
 (procedure P :  () → ())
 modifies: []
 preconditions: ⏎
 postconditions: ⏎
-body: assert [real_add_ge_good] (((~Real.Ge : (arrow real (arrow real bool))) (((~Real.Add : (arrow real (arrow real real))) ~x) ~y)) (#3.0 : real))
-assert [real_add_ge_bad] (((~Real.Ge : (arrow real (arrow real bool))) (((~Real.Add : (arrow real (arrow real real))) ~x) ~y)) (#4.0 : real))
+body: assert [real_add_ge_good] (((~Real.Ge : (arrow real (arrow real bool))) (((~Real.Add : (arrow real (arrow real real))) (~x : real)) (~y : real))) (#3.0 : real))
+assert [real_add_ge_bad] (((~Real.Ge : (arrow real (arrow real bool))) (((~Real.Add : (arrow real (arrow real real))) (~x : real)) (~y : real))) (#4.0 : real))
 
 Errors: #[]
 -/
@@ -133,19 +133,19 @@ spec {
 /--
 info: func x :  () → bv8;
 func y :  () → bv8;
-axiom bv_x_ge_1: (((~Bv8.Le : (arrow bv8 (arrow bv8 bool))) (#1 : bv8)) ~x);
-axiom bv_y_ge_2: (((~Bv8.Le : (arrow bv8 (arrow bv8 bool))) (#2 : bv8)) ~y);
+axiom bv_x_ge_1: (((~Bv8.Le : (arrow bv8 (arrow bv8 bool))) (#1 : bv8)) (~x : bv8));
+axiom bv_y_ge_2: (((~Bv8.Le : (arrow bv8 (arrow bv8 bool))) (#2 : bv8)) (~y : bv8));
 (procedure P :  () → ())
 modifies: []
 preconditions: ⏎
 postconditions: ⏎
-body: assert [bv_add_ge] ((((~Bv8.Add : (arrow bv8 (arrow bv8 bv8))) ~x) ~y) == (((~Bv8.Add : (arrow bv8 (arrow bv8 bv8))) ~y) ~x))
+body: assert [bv_add_ge] ((((~Bv8.Add : (arrow bv8 (arrow bv8 bv8))) (~x : bv8)) (~y : bv8)) == (((~Bv8.Add : (arrow bv8 (arrow bv8 bv8))) (~y : bv8)) (~x : bv8)))
 
 (procedure Q :  ((x : bv1)) → ((r : bv1)))
 modifies: []
 preconditions: ⏎
-postconditions: (Q_ensures_0, (r == (((~Bv1.Sub : (arrow bv1 (arrow bv1 bv1))) x) x)))
-body: r := (((~Bv1.Add : (arrow bv1 (arrow bv1 bv1))) x) x)
+postconditions: (Q_ensures_0, ((r : bv1) == (((~Bv1.Sub : (arrow bv1 (arrow bv1 bv1))) (x : bv1)) (x : bv1))))
+body: r := (((~Bv1.Add : (arrow bv1 (arrow bv1 bv1))) (x : bv1)) (x : bv1))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/SimpleProc.lean
+++ b/Strata/Languages/Boogie/Examples/SimpleProc.lean
@@ -36,8 +36,8 @@ info: var (g : bool) := init_g_0
 (procedure Test :  ((x : bool)) → ((y : bool)))
 modifies: []
 preconditions: ⏎
-postconditions: (Test_ensures_0, (y == x)) (Test_ensures_1, (x == y)) (Test_ensures_2, (g == (~old g)))
-body: y := (((~Bool.Or : (arrow bool (arrow bool bool))) x) x)
+postconditions: (Test_ensures_0, ((y : bool) == (x : bool))) (Test_ensures_1, ((x : bool) == (y : bool))) (Test_ensures_2, ((g : bool) == ((~old : (arrow a a)) (g : bool))))
+body: y := (((~Bool.Or : (arrow bool (arrow bool bool))) (x : bool)) (x : bool))
 
 Errors: #[]
 -/

--- a/Strata/Languages/Boogie/Examples/TypeAlias.lean
+++ b/Strata/Languages/Boogie/Examples/TypeAlias.lean
@@ -67,9 +67,9 @@ func fooConst2 :  () → (Foo int bool);
 modifies: []
 preconditions: ⏎
 postconditions: ⏎
-body: assume [fooConst1_value] (~fooConst1 == ~fooVal)
-assume [fooConst2_value] (~fooConst2 == ~fooVal)
-assert [fooAssertion] (~fooConst1 == ~fooConst2)
+body: assume [fooConst1_value] ((~fooConst1 : (Foo int bool)) == (~fooVal : (FooAlias2 (Foo int int))))
+assume [fooConst2_value] ((~fooConst2 : (Foo int bool)) == (~fooVal : (FooAlias2 (Foo int int))))
+assert [fooAssertion] ((~fooConst1 : (Foo int bool)) == (~fooConst2 : (Foo int bool)))
 -/
 #guard_msgs in
 #eval TransM.run (translateProgram goodTypeAlias) |>.fst

--- a/Strata/Languages/Boogie/Procedure.lean
+++ b/Strata/Languages/Boogie/Procedure.lean
@@ -56,6 +56,9 @@ structure Procedure.Check where
 instance : ToFormat Procedure.Check where
   format c := f!"{c.expr}{c.attr}"
 
+def Procedure.Check.eraseTypes (c : Procedure.Check) : Procedure.Check :=
+  { c with expr := c.expr.eraseTypes }
+
 structure Procedure.Spec where
   modifies       : List Expression.Ident
   preconditions  : ListMap BoogieLabel Procedure.Check
@@ -67,6 +70,12 @@ instance : ToFormat Procedure.Spec where
     f!"modifies: {format p.modifies}\n\
        preconditions: {format p.preconditions}\n\
        postconditions: {format p.postconditions}"
+
+def Procedure.Spec.eraseTypes (s : Procedure.Spec) : Procedure.Spec :=
+  { s with
+    preconditions := s.preconditions.map (fun (l, c) => (l, c.eraseTypes)),
+    postconditions := s.postconditions.map (fun (l, c) => (l, c.eraseTypes))
+  }
 
 def Procedure.Spec.getCheckExprs (conds : ListMap BoogieLabel Procedure.Check) :
   List Expression.Expr :=
@@ -115,6 +124,9 @@ instance : HasVarsPure Expression Procedure where
 instance : HasVarsImp Expression Procedure where
   definedVars := Procedure.definedVars
   modifiedVars := Procedure.modifiedVars
+
+def Procedure.eraseTypes (p : Procedure) : Procedure :=
+  { p with body := Statements.eraseTypes p.body, spec := p.spec }
 
 /-- Transitive variable lookup for procedures.
     This is a version that looks into the body,

--- a/Strata/Languages/Boogie/Program.lean
+++ b/Strata/Languages/Boogie/Program.lean
@@ -89,6 +89,13 @@ def Decl.getFunc? (d : Decl) : Option Function :=
 def Decl.getFunc (d : Decl) (H: d.kind = .func): Function :=
   let .func f _ := d; f
 
+def Decl.eraseTypes (d : Decl) : Decl :=
+  match d with
+  | .ax a md     => .ax a.eraseTypes md
+  | .proc p md   => .proc p.eraseTypes md
+  | .func f md   => .func f.eraseTypes md
+  | _ => d
+
 instance : ToFormat Decl where
   format d := match d with
     | .var name ty e md => f!"{md}var ({name} : {ty}) := {e}"
@@ -111,6 +118,9 @@ instance : ToFormat Program where
 
 instance : Inhabited Program where
   default := .init
+
+def Program.eraseTypes (p : Program) : Program :=
+  { p with decls := p.decls.map Decl.eraseTypes }
 
 ---------------------------------------------------------------------
 

--- a/Strata/Transform/Examples.lean
+++ b/Strata/Transform/Examples.lean
@@ -200,10 +200,10 @@ def callElim (p : Boogie.Program)
 info: true
 -/
 #guard_msgs in
-#eval tests.all (λ (test, ans) ↦ (toString (callElim test)) == (toString ans))
+#eval tests.all (λ (test, ans) ↦ (toString (callElim test).eraseTypes) == (toString ans.eraseTypes))
 
--- #eval callElim tests[1].fst
--- #eval tests[1].snd
+--#eval callElim tests[1].fst
+--#eval tests[1].snd
 
 end CallElimExamples
 


### PR DESCRIPTION
This brings us close to not needing Lambda's type inference for Boogie programs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
