### PR TITLE
Allow solver-specific SMT preludes

### DIFF
--- a/Strata/DL/SMT/Solver.lean
+++ b/Strata/DL/SMT/Solver.lean
@@ -93,6 +93,9 @@ private def emitln (str : String) : SolverM Unit := do
 def setLogic (logic : String) : SolverM Unit :=
   emitln s!"(set-logic {logic})"
 
+def setOption (name value : String) : SolverM Unit :=
+  emitln s!"(set-option :{name} {value})"
+
 def comment (comment : String) : SolverM Unit :=
   let inline := comment.replace "\n" " "
   emitln s!"; {inline}"


### PR DESCRIPTION
For the moment, this is used only for the Boogie dialect and only when using Z3. It sets two options that substantially speed up the `Lambda` and `Quantifiers` Boogie tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
