### PR TITLE
Correct assumptions when havocing multiple vars

### DIFF
--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -871,6 +871,12 @@ public class StrataGenerator : ReadOnlyVisitor {
     public override Cmd VisitHavocCmd(HavocCmd node) {
         foreach (var x in node.Vars) {
             IndentLine($"havoc {Name(x.Name)};");
+        }
+
+        // All assumptions come after all havocs! This allows where clauses
+        // to relate variables and then to havoc them in such a way as to
+        // preserve those relationships.
+        foreach (var x in node.Vars) {
             EmitWhereAssumption(x.Decl.TypedIdent);
         }
 

--- a/Tools/BoogieToStrata/Tests/Where.expect
+++ b/Tools/BoogieToStrata/Tests/Where.expect
@@ -1,0 +1,19 @@
+Successfully parsed.
+assert_0: verified
+assert_1: verified
+assert_2: failed
+CEx: (init_y_1, 5) (init_x_0, 0)
+assert_3: verified
+assert_4: verified
+assert_5: failed
+CEx: ($__x1, 6) ($__y0, 5) (init_x_2, 0) (init_y_3, 0)
+assert_6: failed
+CEx: ($__x3, 1) ($__y2, 0) (init_x_4, 0) (init_y_5, 0)
+assert_7: verified
+assert_8: failed
+CEx: ($__y5, 0) (init_x_6, 0) (init_y_7, 0) ($__x4, 0)
+assert_9: verified
+assert_10: verified
+assert_11: failed
+CEx: ($__x9, 0) (init_x_8, 0) (init_y_9, 0) ($__x6, 0) ($__y7, 0) ($__y8, 0)
+Finished with 7 goals proved, 5 failed.


### PR DESCRIPTION
Previously, if `var x : T where xe` and `var y : T where ye` were in scope, the statement `havoc x, y` would be translated into

    havoc x
    assume xe
    havoc y
    assume ye

But now it gets translated into

    havoc x
    havoc y
    assume xe
    assume ye

This allows `xe` and `ye` to relate the values of `x` and `y`, and allows `Tests/Havoc.bpl` to produce the correct verification output (which is now tested).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
