### PR TITLE
Truncate bitvecs appropriately in the DDM transform

### DIFF
--- a/Strata/Languages/Boogie/DDMTransform/Translate.lean
+++ b/Strata/Languages/Boogie/DDMTransform/Translate.lean
@@ -100,6 +100,11 @@ def translateNat (arg : Arg) : TransM Nat := do
     | TransM.error s!"translateNat expects num lit"
   return n
 
+def translateBitVec (width : Nat) (arg : Arg) : TransM Nat := do
+  let .num n := arg
+    | TransM.error s!"translateBitVec expects num lit"
+  return (n % (2 ^ width))
+
 def translateStr (arg : Arg) : TransM String := do
   let .strlit s := arg
     | TransM.error s!"translateStr expects string lit"
@@ -641,19 +646,19 @@ partial def translateExpr (p : Program) (bindings : TransBindings) (arg : Arg) :
     let n ← translateNat xa
     return .const (toString n) Lambda.LMonoTy.int
   | .fn q`Boogie.bv1Lit, [xa] =>
-    let n ← translateNat xa
+    let n ← translateBitVec 1 xa
     return .const (toString n) Lambda.LMonoTy.bv1
   | .fn q`Boogie.bv8Lit, [xa] =>
-    let n ← translateNat xa
+    let n ← translateBitVec 8 xa
     return .const (toString n) Lambda.LMonoTy.bv8
   | .fn q`Boogie.bv16Lit, [xa] =>
-    let n ← translateNat xa
+    let n ← translateBitVec 16 xa
     return .const (toString n) Lambda.LMonoTy.bv16
   | .fn q`Boogie.bv32Lit, [xa] =>
-    let n ← translateNat xa
+    let n ← translateBitVec 32 xa
     return .const (toString n) Lambda.LMonoTy.bv32
   | .fn q`Boogie.bv64Lit, [xa] =>
-    let n ← translateNat xa
+    let n ← translateBitVec 64 xa
     return .const (toString n) Lambda.LMonoTy.bv64
   | .fn q`Boogie.strLit, [xa] =>
     let x ← translateStr xa

--- a/Strata/Languages/Boogie/Examples/BitVecParse.lean
+++ b/Strata/Languages/Boogie/Examples/BitVecParse.lean
@@ -41,7 +41,6 @@ Assumptions:
 Proof Obligation:
 #false
 
-Wrote problem to vcs/bitvec32_test.smt2.
 Wrote problem to vcs/bitvec64_test.smt2.
 
 

--- a/Strata/Languages/Boogie/Examples/BitVecParse.lean
+++ b/Strata/Languages/Boogie/Examples/BitVecParse.lean
@@ -1,0 +1,73 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Boogie.Verifier
+
+---------------------------------------------------------------------
+namespace Strata
+
+private def pgm : Program :=
+#strata
+program Boogie;
+
+procedure bitVecParseTest() returns () {
+
+  assert [bitvec32_test]: (bv{32}(0xF_FFFF_ABCD) == bv{32}(0xFFFF_ABCD));
+  assert [bitvec64_test]: (bv{64}(0xF_FFFF_ABCD) == bv{64}(0xFFFF_ABCD));
+
+};
+
+#end
+
+/--
+info: [Strata.Boogie] Type checking succeeded.
+
+
+VCs:
+Label: bitvec32_test
+Assumptions:
+
+
+Proof Obligation:
+#true
+
+Label: bitvec64_test
+Assumptions:
+
+
+Proof Obligation:
+#false
+
+Wrote problem to vcs/bitvec32_test.smt2.
+Wrote problem to vcs/bitvec64_test.smt2.
+
+
+Obligation bitvec64_test: could not be proved!
+
+Result: failed
+CEx: ⏎
+
+Evaluated program:
+(procedure bitVecParseTest :  () → ())
+modifies: []
+preconditions: ⏎
+postconditions: ⏎
+body: assert [bitvec32_test] #true
+assert [bitvec64_test] #false
+
+---
+info:
+Obligation: bitvec32_test
+Result: verified
+
+Obligation: bitvec64_test
+Result: failed
+CEx:
+-/
+#guard_msgs in
+#eval verify "cvc5" pgm
+
+---------------------------------------------------------------------

--- a/Strata/Languages/Boogie/Examples/Examples.lean
+++ b/Strata/Languages/Boogie/Examples/Examples.lean
@@ -8,6 +8,7 @@ import Strata.Languages.Boogie.Examples.AdvancedMaps
 import Strata.Languages.Boogie.Examples.AdvancedQuantifiers
 import Strata.Languages.Boogie.Examples.AssertionDefaultNames
 import Strata.Languages.Boogie.Examples.Axioms
+import Strata.Languages.Boogie.Examples.BitVecParse
 import Strata.Languages.Boogie.Examples.DDMAxiomsExtraction
 import Strata.Languages.Boogie.Examples.DDMTransform
 import Strata.Languages.Boogie.Examples.FreeRequireEnsure


### PR DESCRIPTION
*Description of changes:*

This makes Boogie's DDM transform into Lambda/Imperative analogous to what Lean does when parsing bitvectors. E.g.,
`#eval (0xF_FFFF_ABCD : BitVec 32) == (0xFFFF_ABCD : BitVec 32)` is `true`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
