### PR TITLE
Speed up Lambda type inference and add a `--type-check` option to StrataVerify

### DIFF
--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -24,6 +24,37 @@ open LTy
 variable {Identifier : Type} [ToString Identifier] [DecidableEq Identifier] [ToFormat Identifier] [HasGen Identifier]
 
 /--
+Apply type substitution `S` to `LExpr e`.
+-/
+def LExpr.applySubst (e : (LExpr LMonoTy Identifier)) (S : Subst) : (LExpr LMonoTy Identifier) :=
+  match e with
+  | .const c ty =>
+    match ty with
+    | none => e
+    | some ty =>
+      let ty := LMonoTy.subst S ty
+      .const c ty
+  | .op o ty =>
+    match ty with
+    | none => e
+    | some ty =>
+      let ty := LMonoTy.subst S ty
+      .op o ty
+  | .fvar x ty =>
+      match ty with
+    | none => e
+    | some ty =>
+      let ty := LMonoTy.subst S ty
+      .fvar x ty
+  | .bvar _ => e
+  | .abs ty e => .abs ty (e.applySubst S)
+  | .quant qk ty tr e => .quant qk ty (tr.applySubst S) (e.applySubst S)
+  | .app e1 e2 => .app (e1.applySubst S) (e2.applySubst S)
+  | .ite c t f => .ite (c.applySubst S) (t.applySubst S) (f.applySubst S)
+  | .eq e1 e2 => .eq (e1.applySubst S) (e2.applySubst S)
+  | .mdata m e => .mdata m (e.applySubst S)
+
+/--
 Monotype-annotated Lambda expressions, obtained after a type inference transform
 from Lambda expressions `LExpr`.
 -/
@@ -343,73 +374,133 @@ partial def fromLExprAux.eq (T : (TEnv Identifier)) (e1 e2 : (LExpr LMonoTy Iden
   .ok (.eq e1t e2t LMonoTy.bool, TEnv.updateSubst T S)
 
 partial def fromLExprAux.abs (T : (TEnv Identifier)) (bty : Option LMonoTy) (e : (LExpr LMonoTy Identifier)) := do
-  -- Generate a fresh expression variable to stand in for the bound variable
+  -- Generate a fresh expression variable to stand in for the bound variable.
   let (xv, T) := HasGen.genVar T
-  -- Generate a fresh type variable to stand in for the type of the bound
-  -- variable.
-  let (xt', T) := TEnv.genTyVar T
-  let xmt := (.ftvar xt')
-  let xt := .forAll [] xmt
-  let T := T.insertInContext xv xt
+  -- For the bound variable, use type annotation if present. Otherwise,
+  -- generate a fresh type variable.
+  let (xty, T) ← match bty with
+    | some bty =>
+      let ans := LMonoTy.instantiateWithCheck bty T
+      match ans with
+      | .error e => .error e
+      | .ok (bty, T) => .ok (bty, T)
+    | none =>
+      let (xtyid, T) := TEnv.genTyVar T
+      -- dbg_trace f!"[fromLExprAux.abs]\n e: {e}\n xtyid: {xtyid}"
+      let xty := (LMonoTy.ftvar xtyid)
+      .ok (xty, T)
+  -- let (xtyid, T) := TEnv.genTyVar T
+  -- -- dbg_trace f!"[fromLExprAux.abs]\n e: {e}\n xtyid: {xtyid}"
+  -- let xty := (LMonoTy.ftvar xtyid)
+  -- let T ← match bty with
+  --   | none => .ok T
+  --   | some bty =>
+  --     let ans := LMonoTy.instantiateWithCheck bty T
+  --     match ans with
+  --     | .error e => .error e
+  --     | .ok (bty, T) =>
+  --         let constraints := [(xty, bty)]
+  --         let S ← Constraints.unify constraints T.state.substInfo
+  --         .ok (T.updateSubst S)
+  let T := T.insertInContext xv (.forAll [] xty)
   -- Construct `e'` from `e`, where the bound variable has been replaced by
   -- `xv`.
-  let e' := LExpr.varOpen 0 (xv, some xmt) e
+  let e' := LExpr.varOpen 0 (xv, some xty) e
   let (et, T) ← fromLExprAux T e'
-  let ety := et.toLMonoTy
   let etclosed := .varClose 0 xv et
+  -- let etclosed := LExprT.applySubst etclosed T.state.substInfo.subst
+  let ety := etclosed.toLMonoTy
+  -- dbg_trace f!"[fromLExprAux.abs]\n S: {T.state.substInfo.subst}"
+  -- dbg_trace f!"[fromLExprAux.abs]\n mty: {(LMonoTy.tcons "arrow" [xty, ety])}"
+  let mty := LMonoTy.subst T.state.substInfo.subst (.tcons "arrow" [xty, ety])
   -- Safe to erase fresh variable from context after closing the expressions.
   let T := T.eraseFromContext xv
-  let ty := (.tcons "arrow" [xmt, ety])
-  let mty := LMonoTy.subst T.state.substInfo.subst ty
-  match bty with
-  | none => .ok ((.abs etclosed mty), T)
-  | some bty =>
-    let (bty, T) ← LMonoTy.instantiateWithCheck bty T
-    let S ← Constraints.unify [(mty, bty)] T.state.substInfo
-    .ok (.abs etclosed mty, TEnv.updateSubst T S)
+  -- Also safe to erase fresh type variable, if one was needed.
+  -- let T := match fresh_name with
+  --   | none => T
+  --   | some fresh_name =>
+  --     have hWF : SubstWF (Map.remove T.state.substInfo.subst fresh_name) := by
+  --       apply @SubstWF_of_remove T.state.substInfo.subst fresh_name T.state.substInfo.isWF
+  --    { T with state.substInfo.subst := T.state.substInfo.subst.remove fresh_name,
+  --             state.substInfo.isWF := hWF }
+  .ok ((.abs etclosed mty), T)
 
 partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (bty : Option LMonoTy)
     (triggers : LExpr LMonoTy Identifier) (e : (LExpr LMonoTy Identifier)) := do
   -- Generate a fresh variable to stand in for the bound variable.
   let (xv, T) := HasGen.genVar T
-  -- Generate a fresh type variable to stand in for the type of the bound
-  -- variable.
-  let (xt', T) := TEnv.genTyVar T
-  let xmt := (.ftvar xt')
-  let xt := .forAll [] xmt
-  let T := T.insertInContext xv xt
+  -- For the bound variable, use type annotation if present. Otherwise,
+  -- generate a fresh type variable.
+  let (_fresh_name, xty, T) ← match bty with
+    | some bty =>
+      let ans := LMonoTy.instantiateWithCheck bty T
+      match ans with
+      | .error e => .error e
+      | .ok (bty, T) => .ok (none, bty, T)
+    | none =>
+      let (xtyid, T) := TEnv.genTyVar T
+      -- dbg_trace f!"[fromLExprAux.quant]\n e: {e}\n xt': {xtyid}"
+      let xty := (LMonoTy.ftvar xtyid)
+      .ok (some xtyid, xty, T)
+  -- let (xtyid, T) := TEnv.genTyVar T
+  -- dbg_trace f!"[fromLExprAux.quant]\n e: {e}\n xtyid: {xtyid}"
+  -- let xty := (LMonoTy.ftvar xtyid)
+  -- let T ← match bty with
+  --   | none => .ok T
+  --   | some bty =>
+  --     let ans := LMonoTy.instantiateWithCheck bty T
+  --     match ans with
+  --     | .error e => .error e
+  --     | .ok (bty, T) =>
+  --         let constraints := [(xty, bty)]
+  --         let S ← Constraints.unify constraints T.state.substInfo
+  --         .ok (T.updateSubst S)
+  let T := T.insertInContext xv (.forAll [] xty)
   -- Construct new expressions, where the bound variable has been replaced by
   -- `xv`.
-  let e' := LExpr.varOpen 0 (xv, some xmt) e
-  let triggers' := LExpr.varOpen 0 (xv, some xmt) triggers
+  let e' := LExpr.varOpen 0 (xv, some xty) e
+  let triggers' := LExpr.varOpen 0 (xv, some xty) triggers
   let (et, T) ← fromLExprAux T e'
   let (triggersT, T) ← fromLExprAux T triggers'
+  -- let et := LExprT.applySubst et T.state.substInfo.subst
+  -- let triggersT := LExprT.applySubst triggersT T.state.substInfo.subst
   let ety := et.toLMonoTy
-  let mty := LMonoTy.subst T.state.substInfo.subst xmt
+  let xty := LMonoTy.subst T.state.substInfo.subst xty
   let etclosed := LExprT.varClose 0 xv et
   let triggersClosed := LExprT.varClose 0 xv triggersT
   -- Safe to erase fresh variable from context after closing the expressions.
   let T := T.eraseFromContext xv
+  -- Also safe to erase fresh type variable, if one was needed.
+  -- let T :=
+  --     have hWF : SubstWF (Map.remove T.state.substInfo.subst xtyid) := by
+  --       apply @SubstWF_of_remove T.state.substInfo.subst xtyid T.state.substInfo.isWF
+  --    { T with state.substInfo.subst := T.state.substInfo.subst.remove xtyid,
+  --             state.substInfo.isWF := hWF }
   if ety != LMonoTy.bool then do
     .error f!"Quantifier body has non-Boolean type: {ety}"
   else
-    match bty with
-    | none => .ok (.quant qk mty triggersClosed etclosed, T)
-    | some bty =>
-      let (bty, T) ← LMonoTy.instantiateWithCheck bty T
-      let S ← Constraints.unify [(mty, bty)] T.state.substInfo
-      .ok (.quant qk mty triggersClosed etclosed, TEnv.updateSubst T S)
+    .ok (.quant qk xty triggersClosed etclosed, T)
 
 partial def fromLExprAux.app (T : (TEnv Identifier)) (e1 e2 : (LExpr LMonoTy Identifier)) := do
   let (e1t, T) ← fromLExprAux T e1
   let ty1 := e1t.toLMonoTy
   let (e2t, T) ← fromLExprAux T e2
   let ty2 := e2t.toLMonoTy
+  -- `freshty` is the type variable whose identifier is `fresh_name`. It denotes
+  -- the type of `(.app e1 e2)`.
   let (fresh_name, T) := TEnv.genTyVar T
+  -- dbg_trace f!"[fromLExprAux.app]\n e1: {e1}\n e2: {e2}\n fresh_name: {fresh_name}"
   let freshty := (.ftvar fresh_name)
+  -- `ty1` must be of the form `ty2 → freshty`.
   let constraints := [(ty1, (.tcons "arrow" [ty2, freshty]))]
   let S ← Constraints.unify constraints T.state.substInfo
+  -- The type of `(.app e1 e2)` is `freshty`, with appropriate substitutions
+  -- applied.
   let mty := LMonoTy.subst S.subst freshty
+  -- `freshty` can now be safely removed from the substitutions.
+  have hWF : SubstWF (Map.remove S.subst fresh_name) := by
+    apply @SubstWF_of_remove S.subst fresh_name S.isWF
+  let S := { S with subst := S.subst.remove fresh_name, isWF := hWF }
   .ok (.app e1t e2t mty, TEnv.updateSubst T S)
 
 end
@@ -442,37 +533,6 @@ def LExpr.annotate (T : (TEnv Identifier)) (e : (LExpr LMonoTy Identifier)) :
     Except Format ((LExpr LMonoTy Identifier) × (TEnv Identifier)) := do
   let (e_a, T) ← LExprT.fromLExpr T e
   return (LExprT.toLExpr e_a, T)
-
-/--
-Apply type substitution `S` to `LExpr e`.
--/
-def LExpr.applySubst (e : (LExpr LMonoTy Identifier)) (S : Subst) : (LExpr LMonoTy Identifier) :=
-  match e with
-  | .const c ty =>
-    match ty with
-    | none => e
-    | some ty =>
-      let ty := LMonoTy.subst S ty
-      .const c ty
-  | .op o ty =>
-    match ty with
-    | none => e
-    | some ty =>
-      let ty := LMonoTy.subst S ty
-      .op o ty
-  | .fvar x ty =>
-      match ty with
-    | none => e
-    | some ty =>
-      let ty := LMonoTy.subst S ty
-      .fvar x ty
-  | .bvar _ => e
-  | .abs ty e => .abs ty (e.applySubst S)
-  | .quant qk ty tr e => .quant qk ty (tr.applySubst S) (e.applySubst S)
-  | .app e1 e2 => .app (e1.applySubst S) (e2.applySubst S)
-  | .ite c t f => .ite (c.applySubst S) (t.applySubst S) (f.applySubst S)
-  | .eq e1 e2 => .eq (e1.applySubst S) (e2.applySubst S)
-  | .mdata m e => .mdata m (e.applySubst S)
 
 ---------------------------------------------------------------------
 

--- a/Strata/DL/Lambda/LTyUnify.lean
+++ b/Strata/DL/Lambda/LTyUnify.lean
@@ -100,6 +100,29 @@ theorem SubstWF.single_subst (id : TyIdentifier) (h : ¬id ∈ ty.freeVars) :
 theorem SubstWF_of_empty : SubstWF [] := by
   simp [SubstWF]
 
+
+theorem Subst.mem_freeVars_of_mem_freeVars_remove (s : Subst) (id : TyIdentifier)
+  (h : xty ∈ Subst.freeVars (Map.remove s id)) :
+  xty ∈ Subst.freeVars s := by
+  induction s
+  case nil => simp_all [Map.remove]
+  case cons head tail tail_ih =>
+    by_cases h_id_head : head.fst = id
+    case pos =>
+      simp_all [Map.remove]
+    case neg =>
+      simp_all [Map.remove]
+      cases h <;> try simp_all
+
+theorem SubstWF_of_remove (id : TyIdentifier) (h : SubstWF s) :
+  SubstWF (Map.remove s id) := by
+  simp_all [SubstWF]
+  intro xty h_xty_in_keys h_xty_in_fvs
+  have h_xty_in_s_keys := @Map.mem_keys_of_mem_keys_remove _ _ _ s id xty h_xty_in_keys
+  have h_xty_not_in_fvs := @h xty h_xty_in_s_keys
+  have := @Subst.mem_freeVars_of_mem_freeVars_remove xty s id h_xty_in_fvs
+  contradiction
+
 /--
 A type substitution, along with a proof that it is well-formed.
 -/

--- a/Strata/DL/Util/Map.lean
+++ b/Strata/DL/Util/Map.lean
@@ -154,4 +154,16 @@ theorem Map.keys.length :
   induction ls <;> simp [keys]
   case cons h t ih => assumption
 
+theorem Map.mem_keys_of_mem_keys_remove [DecidableEq α] (s : Map α β) (id xty : α)
+  (h : xty ∈ (Map.remove s id).keys) : xty ∈ s.keys := by
+  induction s
+  case nil => simp_all [Map.keys, Map.remove]
+  case cons head tail tail_ih =>
+    by_cases h_id_head : head.fst = id
+    case pos =>
+      simp_all [Map.remove, Map.keys]
+    case neg =>
+      simp_all [Map.remove, Map.keys]
+      cases h <;> try simp_all
+
 -------------------------------------------------------------------------------

--- a/Strata/Languages/Boogie/Boogie.lean
+++ b/Strata/Languages/Boogie/Boogie.lean
@@ -36,7 +36,7 @@ namespace Boogie
 
 def typeCheck (options : Options) (program : Program) : Except Std.Format Program := do
   let T := { Lambda.TEnv.default with functions := Boogie.Factory, knownTypes := Boogie.KnownTypes }
-  let (program, T) ← Program.typeCheck T program
+  let (program, _T) ← Program.typeCheck T program
   -- dbg_trace f!"[Strata.Boogie] Type variables:\n{T.state.substInfo.subst.length}"
   -- dbg_trace f!"[Strata.Boogie] Annotated program:\n{program}"
   if options.verbose then dbg_trace f!"[Strata.Boogie] Type checking succeeded.\n"

--- a/Strata/Languages/Boogie/Boogie.lean
+++ b/Strata/Languages/Boogie/Boogie.lean
@@ -34,7 +34,7 @@ namespace Boogie
    types.
 -/
 
-def typeCheck (options : Options) (program : Program) := do
+def typeCheck (options : Options) (program : Program) : Except Std.Format Program := do
   let T := { Lambda.TEnv.default with functions := Boogie.Factory, knownTypes := Boogie.KnownTypes }
   let (program, T) ← Program.typeCheck T program
   -- dbg_trace f!"[Strata.Boogie] Type variables:\n{T.state.substInfo.subst.length}"

--- a/Strata/Languages/Boogie/Boogie.lean
+++ b/Strata/Languages/Boogie/Boogie.lean
@@ -36,7 +36,8 @@ namespace Boogie
 
 def typeCheck (options : Options) (program : Program) := do
   let T := { Lambda.TEnv.default with functions := Boogie.Factory, knownTypes := Boogie.KnownTypes }
-  let (program, _T) ← Program.typeCheck T program
+  let (program, T) ← Program.typeCheck T program
+  -- dbg_trace f!"[Strata.Boogie] Type variables:\n{T.state.substInfo.subst.length}"
   -- dbg_trace f!"[Strata.Boogie] Annotated program:\n{program}"
   if options.verbose then dbg_trace f!"[Strata.Boogie] Type checking succeeded.\n"
   return program

--- a/Strata/Languages/Boogie/Examples/ProcedureCall.lean
+++ b/Strata/Languages/Boogie/Examples/ProcedureCall.lean
@@ -48,6 +48,23 @@ procedure Q2() returns () {
 };
 #end
 
+/-
+def p : Boogie.Program :=
+   TransM.run (translateProgram (globalCounterPgm)) |>.fst
+
+open Boogie in
+def Boogie.typeCheckDbg (options : Options) (program : Boogie.Program) := do
+  let T := { Lambda.TEnv.default with functions := Boogie.Factory, knownTypes := Boogie.KnownTypes }
+  let (program, T) ← Program.typeCheck T program
+  dbg_trace f!"T.subst:\n{T.state.substInfo.subst}"
+  dbg_trace f!"T.subst Length:\n{T.state.substInfo.subst.length}"
+  -- dbg_trace f!"[Strata.Boogie] Annotated program:\n{program}"
+  if options.verbose then dbg_trace f!"[Strata.Boogie] Type checking succeeded.\n"
+  return program
+
+#eval! Boogie.typeCheckDbg Options.default p
+-/
+
 /--
 info: [Strata.Boogie] Type checking succeeded.
 

--- a/Strata/Languages/Boogie/Examples/ProcedureCall.lean
+++ b/Strata/Languages/Boogie/Examples/ProcedureCall.lean
@@ -48,23 +48,6 @@ procedure Q2() returns () {
 };
 #end
 
-/-
-def p : Boogie.Program :=
-   TransM.run (translateProgram (globalCounterPgm)) |>.fst
-
-open Boogie in
-def Boogie.typeCheckDbg (options : Options) (program : Boogie.Program) := do
-  let T := { Lambda.TEnv.default with functions := Boogie.Factory, knownTypes := Boogie.KnownTypes }
-  let (program, T) ← Program.typeCheck T program
-  dbg_trace f!"T.subst:\n{T.state.substInfo.subst}"
-  dbg_trace f!"T.subst Length:\n{T.state.substInfo.subst.length}"
-  -- dbg_trace f!"[Strata.Boogie] Annotated program:\n{program}"
-  if options.verbose then dbg_trace f!"[Strata.Boogie] Type checking succeeded.\n"
-  return program
-
-#eval! Boogie.typeCheckDbg Options.default p
--/
-
 /--
 info: [Strata.Boogie] Type checking succeeded.
 

--- a/Strata/Languages/Boogie/Options.lean
+++ b/Strata/Languages/Boogie/Options.lean
@@ -7,6 +7,7 @@
 structure Options where
   verbose : Bool
   parseOnly : Bool
+  typeCheckOnly : Bool
   checkOnly : Bool
   stopOnFirstError : Bool
   /-- Solver time limit in seconds -/
@@ -15,6 +16,7 @@ structure Options where
 def Options.default : Options := {
   verbose := true,
   parseOnly := false,
+  typeCheckOnly := false,
   checkOnly := false,
   stopOnFirstError := false,
   solverTimeout := 10

--- a/Strata/Languages/Boogie/Verifier.lean
+++ b/Strata/Languages/Boogie/Verifier.lean
@@ -271,6 +271,15 @@ end Boogie
 
 namespace Strata
 
+def typeCheck (env : Program) (options : Options := Options.default) :
+  Except Std.Format Boogie.Program := do
+  let (program, errors) := TransM.run (translateProgram env)
+  if errors.isEmpty then
+    -- dbg_trace f!"AST: {program}"
+    Boogie.typeCheck options program
+  else
+    .error s!"DDM Transform Error: {repr errors}"
+
 def verify (smtsolver : String) (env : Program)
     (options : Options := Options.default) : IO Boogie.VCResults := do
   let (program, errors) := TransM.run (translateProgram env)

--- a/Strata/Languages/C_Simp/Verify.lean
+++ b/Strata/Languages/C_Simp/Verify.lean
@@ -123,6 +123,11 @@ def to_boogie(program : C_Simp.Program) : Boogie.Program :=
 def C_Simp.get_program (p : Strata.Program) : C_Simp.Program :=
   (Strata.C_Simp.TransM.run (Strata.C_Simp.translateProgram (p.commands))).fst
 
+def C_Simp.typeCheck (p : Strata.Program) (options : Options := Options.default):
+  Except Std.Format Boogie.Program := do
+  let program := C_Simp.get_program p
+  Boogie.typeCheck options (to_boogie program)
+
 def C_Simp.verify (smtsolver : String) (p : Strata.Program) (options : Options := Options.default):
   IO Boogie.VCResults := do
   let program := C_Simp.get_program p

--- a/StrataTest/Languages/Boogie/ProcedureTypeTests.lean
+++ b/StrataTest/Languages/Boogie/ProcedureTypeTests.lean
@@ -29,13 +29,9 @@ info: ok: ((procedure P :  ((x : int)) → ((y : int)))
  tyPrefix: $__ty
  exprGen: 0
  exprPrefix: $__var
- subst: ($__ty5, int)
- ($__ty4, (arrow int int))
- ($__ty3, bool)
- ($__ty2, (arrow int bool))
- ($__ty1, bool)
- ($__ty0, (arrow int bool))
-  known types: [∀[0, 1]. (arrow 0 1), bool, int, string])
+ subst: ⏎
+ known types:
+ [∀[0, 1]. (arrow 0 1), bool, int, string])
 -/
 #guard_msgs in
 #eval do let ans ← typeCheck { TEnv.default with functions := Boogie.Factory }

--- a/StrataTest/Languages/Boogie/StatementTypeTests.lean
+++ b/StrataTest/Languages/Boogie/StatementTypeTests.lean
@@ -159,7 +159,6 @@ exprPrefix: $__var
 subst: ($__ty9, int)
 ($__ty3, (arrow bool int))
 ($__ty5, (arrow bool int))
-($__ty8, bool)
 ($__ty7, bool)
 ($__ty6, (arrow bool int))
 ($__ty2, int)

--- a/StrataVerify.lean
+++ b/StrataVerify.lean
@@ -68,10 +68,10 @@ def main (args : List String) : IO UInt32 := do
           return 0
       else if opts.typeCheckOnly then
         let ans := if file.endsWith ".csimp.st" then
-                    C_Simp.typeCheck pgm opts
+                     C_Simp.typeCheck pgm opts
                    else
-                    -- Boogie.
-                    typeCheck pgm opts
+                     -- Boogie.
+                     typeCheck pgm opts
         match ans with
         | .error e =>
           println! f!"Type checking error: {e}"


### PR DESCRIPTION
*Description of changes:*

During type inference, we now prune the substitution list for `.app` by removing the fresh type variable (that stands in for the type of the `.app` expression) once it's safe to do so. This also includes a proof that the pruning doesn't violate the well-formedness criteria of the substitution list.

This step brings around 80% performance improvement vis-a-vis type inference on certain Boogie benchmarks.

Also, added an option `--type-check` to StrataVerify, which parses and checks the DDM program and then exits after invoking the semantic dialect's type check/inference. Contrast this with the pre-existing `--check` option which does all of the above plus PE and SMT generation (not SMT solving).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
