### PR TITLE
Remove SemanticEvalBool in SemanticProps.lean

### DIFF
--- a/Strata/DL/Imperative/SemanticsProps.lean
+++ b/Strata/DL/Imperative/SemanticsProps.lean
@@ -11,17 +11,17 @@ namespace Imperative
 
 theorem eval_assert_store_cst
   [HasFvar P] [HasBool P] [HasBoolNeg P]:
-  EvalCmd P δ δP σ₀ σ (.assert l e md) σ' → σ = σ' := by
+  EvalCmd P δ σ₀ σ (.assert l e md) σ' → σ = σ' := by
   intros Heval; cases Heval with | eval_assert _ => rfl
 
 theorem eval_stmt_assert_store_cst
   [HasVarsImp P (List (Stmt P (Cmd P)))] [HasVarsImp P (Cmd P)] [HasFvar P] [HasVal P] [HasBool P] [HasBoolNeg P] :
-  EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (Cmd.assert l e md)) σ' → σ = σ' := by
+  EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (Cmd.assert l e md)) σ' → σ = σ' := by
   intros Heval; cases Heval with | cmd_sem Hcmd => exact eval_assert_store_cst Hcmd
 
 theorem eval_stmts_assert_store_cst
   [HasVarsImp P (List (Stmt P (Cmd P)))] [HasVarsImp P (Cmd P)] [HasFvar P] [HasVal P] [HasBool P] [HasBoolNeg P] :
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ [(.cmd (Cmd.assert l e md))] σ' → σ = σ' := by
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ [(.cmd (Cmd.assert l e md))] σ' → σ = σ' := by
   intros Heval; cases Heval with
   | stmts_some_sem H1 H2 =>
     cases H1 with
@@ -31,9 +31,9 @@ theorem eval_stmts_assert_store_cst
 
 theorem eval_stmt_assert_eq_of_pure_expr_eq
   [HasVarsImp P (List (Stmt P (Cmd P)))] [HasFvar P] [HasVal P] [HasBool P] [HasBoolNeg P] :
-  WellFormedSemanticEvalBool δ δP →
-  (EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (Cmd.assert l1 e md1)) σ' ↔
-  EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (Cmd.assert l2 e md2)) σ') := by
+  WellFormedSemanticEvalBool δ →
+  (EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (Cmd.assert l1 e md1)) σ' ↔
+  EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (Cmd.assert l2 e md2)) σ') := by
   intro Hwf
   constructor <;>
   (
@@ -48,20 +48,20 @@ theorem eval_stmt_assert_eq_of_pure_expr_eq
 
 theorem eval_stmts_assert_elim
   [HasVarsImp P (List (Stmt P (Cmd P)))] [HasFvar P] [HasVal P] [HasBool P] [HasBoolNeg P] :
-  WellFormedSemanticEvalBool δ δP →
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (.assert l1 e md1) :: cmds) σ' →
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ cmds σ' := by
+  WellFormedSemanticEvalBool δ →
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (.assert l1 e md1) :: cmds) σ' →
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ cmds σ' := by
   intros Hwf Heval
   cases Heval with
-  | @stmts_some_sem _ _ _ _ _ σ1 _ _ Has1 Has2 =>
+  | @stmts_some_sem _ _ _ _ σ1 _ _ Has1 Has2 =>
     rw [← eval_stmt_assert_store_cst Has1] at Has2
     assumption
 
 theorem assert_elim
   [HasVarsImp P (List (Stmt P (Cmd P)))] [HasFvar P] [HasVal P] [HasBool P] [HasBoolNeg P] :
-  WellFormedSemanticEvalBool δ δP →
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (.assert l1 e md1) :: [.cmd (.assert l2 e md2)]) σ' →
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ [.cmd (.assert l3 e md3)] σ' := by
+  WellFormedSemanticEvalBool δ →
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (.assert l1 e md1) :: [.cmd (.assert l2 e md2)]) σ' →
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ [.cmd (.assert l3 e md3)] σ' := by
   intro Hwf Heval
   have Heval := eval_stmts_assert_elim Hwf Heval
   rw [eval_stmts_singleton] at *
@@ -124,7 +124,7 @@ theorem semantic_eval_eq_of_eval_cmd_set_unrelated_var
   [HasFvar P] [HasVal P] [HasBool P] [HasBoolNeg P]:
   WellFormedSemanticEvalExprCongr δ →
   ¬ v ∈ HasVarsPure.getVars e →
-  EvalCmd P δ δP σ₀ σ (Cmd.set v e') σ' →
+  EvalCmd P δ σ₀ σ (Cmd.set v e') σ' →
   δ σ₀ σ e = δ σ₀ σ' e := by
   intro Hwf Hnin Heval
   unfold WellFormedSemanticEvalExprCongr at Hwf
@@ -148,10 +148,10 @@ theorem eval_cmd_set_comm'
   ¬ x1 = x2 →
   δ σ₀ σ v1 = δ σ₀ σ2 v1 →
   δ σ₀ σ v2 = δ σ₀ σ1 v2 →
-  EvalCmd P δ δP σ₀ σ (Cmd.set x1 v1) σ1 →
-  EvalCmd P δ δP σ₀ σ1 (Cmd.set x2 v2) σ' →
-  EvalCmd P δ δP σ₀ σ (Cmd.set x2 v2) σ2 →
-  EvalCmd P δ δP σ₀ σ2 (Cmd.set x1 v1) σ'' →
+  EvalCmd P δ σ₀ σ (Cmd.set x1 v1) σ1 →
+  EvalCmd P δ σ₀ σ1 (Cmd.set x2 v2) σ' →
+  EvalCmd P δ σ₀ σ (Cmd.set x2 v2) σ2 →
+  EvalCmd P δ σ₀ σ2 (Cmd.set x1 v1) σ'' →
   σ' = σ'' := by
   intro Hneq Heq1 Heq2 Hs1 Hs2 Hs3 Hs4
   cases Hs1; cases Hs2; cases Hs3; cases Hs4
@@ -166,10 +166,10 @@ theorem eval_cmd_set_comm
   ¬ x1 = x2 →
   ¬ x1 ∈ HasVarsPure.getVars v2 →
   ¬ x2 ∈ HasVarsPure.getVars v1 →
-  EvalCmd P δ δP σ₀ σ (Cmd.set x1 v1) σ1 →
-  EvalCmd P δ δP σ₀ σ1 (Cmd.set x2 v2) σ' →
-  EvalCmd P δ δP σ₀ σ (Cmd.set x2 v2) σ2 →
-  EvalCmd P δ δP σ₀ σ2 (Cmd.set x1 v1) σ'' →
+  EvalCmd P δ σ₀ σ (Cmd.set x1 v1) σ1 →
+  EvalCmd P δ σ₀ σ1 (Cmd.set x2 v2) σ' →
+  EvalCmd P δ σ₀ σ (Cmd.set x2 v2) σ2 →
+  EvalCmd P δ σ₀ σ2 (Cmd.set x1 v1) σ'' →
   σ' = σ'' := by
   intro Hwf Hneq Hnin1 Hnin2 Hs1 Hs2 Hs3 Hs4
   have Heval2:= semantic_eval_eq_of_eval_cmd_set_unrelated_var Hwf Hnin1 Hs1
@@ -183,10 +183,10 @@ theorem eval_stmt_set_comm
   ¬ x1 = x2 →
   ¬ x1 ∈ HasVarsPure.getVars v2 →
   ¬ x2 ∈ HasVarsPure.getVars v1 →
-  EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (Cmd.set x1 v1)) σ1 →
-  EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ1 (.cmd (Cmd.set x2 v2)) σ' →
-  EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ (.cmd (Cmd.set x2 v2)) σ2 →
-  EvalStmt P (Cmd P) (EvalCmd P) δ δP σ₀ σ2 (.cmd (Cmd.set x1 v1)) σ'' →
+  EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (Cmd.set x1 v1)) σ1 →
+  EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ1 (.cmd (Cmd.set x2 v2)) σ' →
+  EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ (.cmd (Cmd.set x2 v2)) σ2 →
+  EvalStmt P (Cmd P) (EvalCmd P) δ σ₀ σ2 (.cmd (Cmd.set x1 v1)) σ'' →
   σ' = σ'' := by
   intro Hwf Hneq Hnin1 Hnin2 Hs1 Hs2 Hs3 Hs4
   cases Hs1; cases Hs2; cases Hs3; cases Hs4
@@ -200,8 +200,8 @@ theorem eval_stmts_set_comm
   ¬ x1 = x2 →
   ¬ x1 ∈ HasVarsPure.getVars v2 →
   ¬ x2 ∈ HasVarsPure.getVars v1 →
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ [(.cmd (Cmd.set x1 v1)), (.cmd (Cmd.set x2 v2))] σ' →
-  EvalStmts P (Cmd P) (EvalCmd P) δ δP σ₀ σ [(.cmd (Cmd.set x2 v2)), (.cmd (Cmd.set x1 v1))] σ'' →
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ [(.cmd (Cmd.set x1 v1)), (.cmd (Cmd.set x2 v2))] σ' →
+  EvalStmts P (Cmd P) (EvalCmd P) δ σ₀ σ [(.cmd (Cmd.set x2 v2)), (.cmd (Cmd.set x1 v1))] σ'' →
   σ' = σ'' := by
   intro Hwf Hneq Hnin1 Hnin2 Hss1 Hss2
   cases Hss1; cases Hss2


### PR DESCRIPTION
*Description of changes:* Remove SemanticEvalBool (δP) in SemanticProps.lean. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
