### PR TITLE
Add scopes to Lambda's substitution list

### DIFF
--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -450,10 +450,10 @@ partial def fromLExprAux.app (T : (TEnv Identifier)) (e1 e2 : (LExpr LMonoTy Ide
   -- applied.
   let mty := LMonoTy.subst S.subst freshty
   -- `freshty` can now be safely removed from the substitution list.
-  -- have hWF : SubstWF (Map.remove S.subst fresh_name) := by
-  --   apply @SubstWF_of_remove S.subst fresh_name S.isWF
-  -- let S := { S with subst := S.subst.remove fresh_name, isWF := hWF }
-  let S := { S with subst := S.subst.remove fresh_name, isWF := sorry }
+  have hWF : SubstWF (Maps.remove S.subst fresh_name) := by
+    -- apply @SubstWF_of_remove S.subst fresh_name S.isWF
+    sorry
+  let S := { S with subst := S.subst.remove fresh_name, isWF := hWF }
   .ok (.app e1t e2t mty, TEnv.updateSubst T S)
 
 end

--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -407,9 +407,9 @@ partial def fromLExprAux.abs (T : (TEnv Identifier)) (bty : Option LMonoTy) (e :
   let ety := etclosed.toLMonoTy
   let mty := LMonoTy.subst T.state.substInfo.subst (.tcons "arrow" [xty, ety])
   -- Safe to erase fresh variable from context after closing the expressions.
-  -- Note that we don't erase `xtyid` (if it was created) from the substitution
+  -- Note that we don't erase `xty` (if it was a fresh type variable) from the substitution
   -- list because it may occur in `etclosed`, which hasn't undergone a
-  -- substitution. We could, of course, substitute `xtyid` in `etclosed`, but
+  -- substitution. We could, of course, substitute `xty` in `etclosed`, but
   -- that'd require crawling over that expression, which could be expensive.
   let T := T.eraseFromContext xv
   .ok ((.abs etclosed mty), T)
@@ -418,8 +418,6 @@ partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (bt
     (triggers : LExpr LMonoTy Identifier) (e : (LExpr LMonoTy Identifier)) := do
   let (xv, xty, T) ← typeBoundVar T bty
   let e' := LExpr.varOpen 0 (xv, some xty) e
-  -- Construct `e'` from `e`, where the bound variable has been replaced by
-  -- `xv`.
   let triggers' := LExpr.varOpen 0 (xv, some xty) triggers
   let (et, T) ← fromLExprAux T e'
   let (triggersT, T) ← fromLExprAux T triggers'
@@ -428,7 +426,7 @@ partial def fromLExprAux.quant (T : (TEnv Identifier)) (qk : QuantifierKind) (bt
   let etclosed := LExprT.varClose 0 xv et
   let triggersClosed := LExprT.varClose 0 xv triggersT
   -- Safe to erase fresh variable from context after closing the expressions.
-  -- Again, as in `abs`, we do not erase `xtyid` (if it was created) from the
+  -- Again, as in `abs`, we do not erase `xty` (if it was a fresh variable) from the
   -- substitution list.
   let T := T.eraseFromContext xv
   if ety != LMonoTy.bool then do
@@ -452,9 +450,10 @@ partial def fromLExprAux.app (T : (TEnv Identifier)) (e1 e2 : (LExpr LMonoTy Ide
   -- applied.
   let mty := LMonoTy.subst S.subst freshty
   -- `freshty` can now be safely removed from the substitution list.
-  have hWF : SubstWF (Map.remove S.subst fresh_name) := by
-    apply @SubstWF_of_remove S.subst fresh_name S.isWF
-  let S := { S with subst := S.subst.remove fresh_name, isWF := hWF }
+  -- have hWF : SubstWF (Map.remove S.subst fresh_name) := by
+  --   apply @SubstWF_of_remove S.subst fresh_name S.isWF
+  -- let S := { S with subst := S.subst.remove fresh_name, isWF := hWF }
+  let S := { S with subst := S.subst.remove fresh_name, isWF := sorry }
   .ok (.app e1t e2t mty, TEnv.updateSubst T S)
 
 end

--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -451,8 +451,7 @@ partial def fromLExprAux.app (T : (TEnv Identifier)) (e1 e2 : (LExpr LMonoTy Ide
   let mty := LMonoTy.subst S.subst freshty
   -- `freshty` can now be safely removed from the substitution list.
   have hWF : SubstWF (Maps.remove S.subst fresh_name) := by
-    -- apply @SubstWF_of_remove S.subst fresh_name S.isWF
-    sorry
+    apply @SubstWF_of_remove S.subst fresh_name S.isWF
   let S := { S with subst := S.subst.remove fresh_name, isWF := hWF }
   .ok (.app e1t e2t mty, TEnv.updateSubst T S)
 

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -165,8 +165,7 @@ example : LExpr.HasType { types := [[("x", t[∀a. %a])]]} esM[x] t[int] := by
   simp +ground at h_tvar
   simp [h_tvar] at h_tinst
   simp +ground at h_tinst
-  simp [Maps.isEmpty, Bool.decEq] at h_tinst
-  assumption
+  exact h_tinst rfl
 
 example : LExpr.HasType { types := [[("m", t[∀a. %a → int])]]}
                         esM[(m #true)]
@@ -177,7 +176,7 @@ example : LExpr.HasType { types := [[("m", t[∀a. %a → int])]]}
   · apply LExpr.HasType.tvar
     simp +ground
   · simp +ground
-    simp [Maps.isEmpty, Bool.decEq]
+    exact rfl
   done
 
 example : LExpr.HasType {} esM[λ %0] t[∀a. %a → %a] := by

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -45,7 +45,7 @@ def LTy.open (x : TyIdentifier) (xty : LMonoTy) (ty : LTy) : LTy :=
   | .forAll vars lty =>
     if x ∈ vars then
       let S := [(x, xty)]
-      .forAll (vars.removeAll [x]) (LMonoTy.subst S lty)
+      .forAll (vars.removeAll [x]) (LMonoTy.subst [S] lty)
     else
       ty
 
@@ -165,7 +165,7 @@ example : LExpr.HasType { types := [[("x", t[∀a. %a])]]} esM[x] t[int] := by
   simp +ground at h_tvar
   simp [h_tvar] at h_tinst
   simp +ground at h_tinst
-  simp [Map.isEmpty, Bool.decEq] at h_tinst
+  simp [Maps.isEmpty, Bool.decEq] at h_tinst
   assumption
 
 example : LExpr.HasType { types := [[("m", t[∀a. %a → int])]]}
@@ -177,7 +177,7 @@ example : LExpr.HasType { types := [[("m", t[∀a. %a → int])]]}
   · apply LExpr.HasType.tvar
     simp +ground
   · simp +ground
-    simp [Map.isEmpty, Bool.decEq]
+    simp [Maps.isEmpty, Bool.decEq]
   done
 
 example : LExpr.HasType {} esM[λ %0] t[∀a. %a → %a] := by

--- a/Strata/DL/Lambda/LTyUnify.lean
+++ b/Strata/DL/Lambda/LTyUnify.lean
@@ -100,23 +100,15 @@ theorem SubstWF.single_subst (id : TyIdentifier) (h : ¬id ∈ ty.freeVars) :
   simp_all
   done
 
-/-
-theorem SubstWF_mk_cons
-    (h_s_not_in_S_values : s.fst ∉ S.freeVars)
-    (h_s_not_in_S_keys : S.keys.all (fun k => k ∉ s.snd.freeVars))
-    (h_s_WF : SubstWF [s])
-    (h_S_WF : SubstWF S) :
-    SubstWF (s :: S) := by
-  simp_all [SubstWF, Map.values, Map.keys, Subst.freeVars]
-  done
 
-
-theorem Subst.mem_freeVars_of_mem_freeVars_remove (s : Subst) (id : TyIdentifier)
-  (h : xty ∈ Subst.freeVars (Map.remove s id)) :
+theorem Subst.mem_freeVars_of_mem_freeVars_remove (S : Subst) (id : TyIdentifier)
+  (h : xty ∈ Subst.freeVars (Maps.remove S id)) :
   xty ∈ Subst.freeVars s := by
-  induction s
-  case nil => simp_all [Map.remove]
+  induction S
+  case nil => simp_all [Maps.remove]
   case cons head tail tail_ih =>
+    sorry
+    stop
     by_cases h_id_head : head.fst = id
     case pos =>
       simp_all [Map.remove]
@@ -124,15 +116,15 @@ theorem Subst.mem_freeVars_of_mem_freeVars_remove (s : Subst) (id : TyIdentifier
       simp_all [Map.remove]
       cases h <;> try simp_all
 
-theorem SubstWF_of_remove (id : TyIdentifier) (h : SubstWF s) :
-  SubstWF (Map.remove s id) := by
-  simp_all [SubstWF]
-  intro xty h_xty_in_keys h_xty_in_fvs
-  have h_xty_in_s_keys := @Map.mem_keys_of_mem_keys_remove _ _ _ s id xty h_xty_in_keys
-  have h_xty_not_in_fvs := @h xty h_xty_in_s_keys
-  have := @Subst.mem_freeVars_of_mem_freeVars_remove xty s id h_xty_in_fvs
-  contradiction
--/
+theorem SubstWF_of_remove (id : TyIdentifier) (h : SubstWF S) :
+  SubstWF (Maps.remove S id) := by
+  -- simp_all [SubstWF]
+  -- intro xty h_xty_in_keys h_xty_in_fvs
+  -- have h_xty_in_s_keys := @Map.mem_keys_of_mem_keys_remove _ _ _ s id xty h_xty_in_keys
+  -- have h_xty_not_in_fvs := @h xty h_xty_in_s_keys
+  -- have := @Subst.mem_freeVars_of_mem_freeVars_remove xty s id h_xty_in_fvs
+  -- contradiction
+  sorry
 
 /--
 A type substitution, along with a proof that it is well-formed.

--- a/Strata/DL/Lambda/LTyUnify.lean
+++ b/Strata/DL/Lambda/LTyUnify.lean
@@ -103,28 +103,20 @@ theorem SubstWF.single_subst (id : TyIdentifier) (h : ¬id ∈ ty.freeVars) :
 
 theorem Subst.mem_freeVars_of_mem_freeVars_remove (S : Subst) (id : TyIdentifier)
   (h : xty ∈ Subst.freeVars (Maps.remove S id)) :
-  xty ∈ Subst.freeVars s := by
-  induction S
-  case nil => simp_all [Maps.remove]
-  case cons head tail tail_ih =>
-    sorry
-    stop
-    by_cases h_id_head : head.fst = id
-    case pos =>
-      simp_all [Map.remove]
-    case neg =>
-      simp_all [Map.remove]
-      cases h <;> try simp_all
+  xty ∈ Subst.freeVars S := by
+  simp_all [Subst.freeVars]
+  obtain ⟨aty, h1, h2⟩ := h
+  apply Exists.intro aty; simp_all
+  simp [@Maps.mem_values_of_mem_keys_remove _ _ _ _ S id aty h1]
 
 theorem SubstWF_of_remove (id : TyIdentifier) (h : SubstWF S) :
   SubstWF (Maps.remove S id) := by
-  -- simp_all [SubstWF]
-  -- intro xty h_xty_in_keys h_xty_in_fvs
-  -- have h_xty_in_s_keys := @Map.mem_keys_of_mem_keys_remove _ _ _ s id xty h_xty_in_keys
-  -- have h_xty_not_in_fvs := @h xty h_xty_in_s_keys
-  -- have := @Subst.mem_freeVars_of_mem_freeVars_remove xty s id h_xty_in_fvs
-  -- contradiction
-  sorry
+  simp_all [SubstWF]
+  intro xty h_xty_in_keys h_xty_in_fvs
+  have h_xty_in_s_keys := @Maps.mem_keys_of_mem_keys_remove _ _ _ _ S id xty h_xty_in_keys
+  have h_xty_not_in_fvs := @h xty h_xty_in_s_keys
+  have := @Subst.mem_freeVars_of_mem_freeVars_remove xty S id h_xty_in_fvs
+  contradiction
 
 /--
 A type substitution, along with a proof that it is well-formed.
@@ -1112,7 +1104,7 @@ def Constraints.unify (constraints : Constraints) (S : SubstInfo) :
 /-- info: ok: [(a, int) (b, (arrow c d))] -/
 #guard_msgs in
 open LTy.Syntax in
-#eval!  do let S ← Constraints.unify [(mty[%a → %b], mty[int → (%c → %d)])] SubstInfo.empty
+#eval  do let S ← Constraints.unify [(mty[%a → %b], mty[int → (%c → %d)])] SubstInfo.empty
            return (format S.subst)
 
 ---------------------------------------------------------------------

--- a/Strata/DL/Util/Map.lean
+++ b/Strata/DL/Util/Map.lean
@@ -166,4 +166,28 @@ theorem Map.mem_keys_of_mem_keys_remove [DecidableEq α] (s : Map α β) (id xty
       simp_all [Map.remove, Map.keys]
       cases h <;> try simp_all
 
+theorem Map.insert_keys [DecidableEq α] (m : Map α β) :
+  (Map.insert m key val).keys ⊆ key :: Map.keys m := by
+  induction m
+  case nil => simp_all [Map.insert, Map.keys]
+  case cons hd tl ih =>
+    simp_all [Map.insert]
+    split
+    · simp_all [Map.keys]
+    · simp_all [Map.keys]
+      grind
+  done
+
+theorem Map.insert_values [DecidableEq α] (m : Map α β) :
+  (Map.insert m key val).values ⊆ val :: Map.values m := by
+  induction m
+  case nil => simp_all [Map.insert, Map.values]
+  case cons hd tl ih =>
+    simp_all [Map.insert]
+    split
+    · simp_all [Map.values]
+    · simp_all [Map.values]
+      grind
+  done
+
 -------------------------------------------------------------------------------

--- a/Strata/DL/Util/Map.lean
+++ b/Strata/DL/Util/Map.lean
@@ -154,16 +154,28 @@ theorem Map.keys.length :
   induction ls <;> simp [keys]
   case cons h t ih => assumption
 
-theorem Map.mem_keys_of_mem_keys_remove [DecidableEq α] (s : Map α β) (id xty : α)
-  (h : xty ∈ (Map.remove s id).keys) : xty ∈ s.keys := by
-  induction s
+theorem Map.mem_keys_of_mem_keys_remove [DecidableEq α] (m : Map α β) (k1 k2 : α)
+  (h : k2 ∈ (Map.remove m k1).keys) : k2 ∈ m.keys := by
+  induction m
   case nil => simp_all [Map.keys, Map.remove]
   case cons head tail tail_ih =>
-    by_cases h_id_head : head.fst = id
+    by_cases h_id_head : head.fst = k1
     case pos =>
       simp_all [Map.remove, Map.keys]
     case neg =>
       simp_all [Map.remove, Map.keys]
+      cases h <;> try simp_all
+
+theorem Map.mem_values_of_mem_keys_remove [DecidableEq α] (m : Map α β) (k : α) (v : β)
+  (h : v ∈ (Map.remove m k).values) : v ∈ m.values := by
+  induction m
+  case nil => simp_all [Map.values, Map.remove]
+  case cons head tail tail_ih =>
+    by_cases h_id_head : head.fst = k
+    case pos =>
+      simp_all [Map.remove, Map.values]
+    case neg =>
+      simp_all [Map.remove, Map.values]
       cases h <;> try simp_all
 
 theorem Map.insert_keys [DecidableEq α] (m : Map α β) :

--- a/Strata/DL/Util/Maps.lean
+++ b/Strata/DL/Util/Maps.lean
@@ -302,4 +302,40 @@ theorem Maps.insert_values_subset [DecidableEq α] (ms : Maps α β) :
   have h2 := @Maps.insert_key_update_subset_value _ _ key val _ ms
   grind
 
+@[simp]
+theorem Maps.keys_of_push_empty :
+  (Maps.push ms []).keys = ms.keys := by
+  simp_all [Maps.push, Maps.keys, Map.keys]
+
+@[simp]
+theorem Maps.values_of_push_empty :
+  (Maps.push ms []).values = ms.values := by
+  simp_all [Maps.push, Maps.values, Map.values]
+
+theorem Maps.mem_keys_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
+  (ms : Maps α β) (k1 k2 : α) (h : k2 ∈ (Maps.remove ms k1).keys) :
+  k2 ∈ ms.keys := by
+  induction ms
+  case nil => simp_all [Maps.keys, Maps.remove]
+  case cons m ms ih =>
+    simp_all [Maps.remove, Maps.keys]
+    split at h <;> simp_all [Maps.keys]
+    · grind
+    · cases h
+      · simp [@Map.mem_keys_of_mem_keys_remove _ _ _ m k1 k2 (by assumption)]
+      · simp_all
+
+theorem Maps.mem_values_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
+  (ms : Maps α β) (k : α) (v : β) (h : v ∈ (Maps.remove ms k).values) :
+  v ∈ ms.values := by
+  induction ms
+  case nil => simp_all [Maps.values, Maps.remove]
+  case cons m ms ih =>
+    simp_all [Maps.remove, Maps.values]
+    split at h <;> simp_all [Maps.values]
+    · grind
+    · cases h
+      · simp [@Map.mem_values_of_mem_keys_remove _ _ _ m k v (by assumption)]
+      · simp_all
+
 ---------------------------------------------------------------------

--- a/Strata/DL/Util/Maps.lean
+++ b/Strata/DL/Util/Maps.lean
@@ -232,4 +232,74 @@ theorem Maps.find?_of_not_mem_values [DecidableEq α] (S : Maps α β)
   exact Map.find?_of_not_mem_values head h
   done
 
+private theorem Maps.insert_fresh_key_subset [DecidableEq α] (ms : Maps α β)
+  (h : Maps.find? ms key = none) :
+  (Maps.insert ms key val).keys ⊆ key :: Maps.keys ms := by
+  simp_all [Maps.insert, Maps.pop, Maps.push, Maps.newest, Maps.keys]
+  split <;> simp_all [Map.insert, Maps.keys, Map.keys]
+  rename_i ms m ms_rest
+  have := @Map.insert_keys _ _ key val _ m
+  grind
+  done
+
+private theorem Maps.insert_fresh_key_subset_value [DecidableEq α] (ms : Maps α β)
+  (h : Maps.find? ms key = none) :
+  (Maps.insert ms key val).values ⊆ val :: Maps.values ms := by
+  simp_all [Maps.insert, Maps.pop, Maps.push, Maps.newest, Maps.values]
+  split <;> simp_all [Map.insert, Maps.values, Map.values]
+  rename_i ms m ms_rest
+  have := @Map.insert_values _ _ key val _ m
+  grind
+  done
+
+private theorem Maps.insert_key_update_subset [DecidableEq α] (ms : Maps α β)
+  (h : ¬ Maps.find? ms key = none) :
+  (Maps.insert ms key val).keys ⊆ Maps.keys ms := by
+  simp_all [Maps.insert, Maps.pop, Maps.push, Maps.newest]
+  split <;> simp_all
+  rename_i v heq
+  induction ms
+  case nil => simp_all [Maps.find?]
+  case cons hd tl ih =>
+    simp_all [Maps.update, Maps.find?]
+    split <;> simp_all [Maps.keys]
+    rename_i heq_hd_key
+    have := @Map.find?_mem_keys _ _ key v _ hd heq_hd_key
+    have := @Map.insert_keys _ _ key val _ hd
+    grind
+  done
+
+private theorem Maps.insert_key_update_subset_value [DecidableEq α] (ms : Maps α β)
+  (h : ¬ Maps.find? ms key = none) :
+  (Maps.insert ms key val).values ⊆ val :: Maps.values ms := by
+  simp_all [Maps.insert, Maps.pop, Maps.push, Maps.newest]
+  split <;> simp_all
+  rename_i v heq
+  induction ms
+  case nil => simp_all [Maps.find?]
+  case cons hd tl ih =>
+    simp_all [Maps.update, Maps.find?]
+    split <;> simp_all [Maps.values]
+    rename_i heq_hd_key
+    · have := @Map.find?_mem_values _ _ key val _ hd;
+      have := @Map.insert_values _ _ key val _ hd;
+      grind
+    · have := @Map.find?_mem_values _ _ key val _ hd
+      have := @Map.insert_values _ _ key val _ hd
+      grind
+  done
+
+theorem Maps.insert_keys_subset [DecidableEq α] (ms : Maps α β) :
+  (Maps.insert ms key val).keys ⊆ key :: Maps.keys ms := by
+  have h1 := @Maps.insert_fresh_key_subset _ _ key val _ ms
+  have h2 := @Maps.insert_key_update_subset _ _ key val _ ms
+  grind
+  done
+
+theorem Maps.insert_values_subset [DecidableEq α] (ms : Maps α β) :
+  (Maps.insert ms key val).values ⊆ val :: Maps.values ms := by
+  have h1 := @Maps.insert_fresh_key_subset_value _ _ key val _ ms
+  have h2 := @Maps.insert_key_update_subset_value _ _ key val _ ms
+  grind
+
 ---------------------------------------------------------------------

--- a/Strata/Languages/Boogie/ProgramWF.lean
+++ b/Strata/Languages/Boogie/ProgramWF.lean
@@ -252,11 +252,9 @@ theorem Program.typeCheckWF : Program.typeCheck T p = .ok (p', T') → WF.WFProg
         constructor <;> try assumption
         rw [if_pos pvar, if_pos pproc, if_pos pfunc] at tcok
         simp [bind, Except.bind] at tcok
-        cases Hgo : Program.typeCheck.go p T p.decls [] with
+        cases Hgo : Program.typeCheck.go p (TEnv.updateSubst T { subst := [[]], isWF := SubstWF_of_empty_empty }) p.decls [] with
         | error _ => simp_all
-        | ok res =>
-
-          exact typeCheck.goWF Hgo
+        | ok res => exact typeCheck.goWF Hgo
 
 end WF
 end Boogie

--- a/StrataTest/Languages/Boogie/ProcedureTypeTests.lean
+++ b/StrataTest/Languages/Boogie/ProcedureTypeTests.lean
@@ -29,7 +29,7 @@ info: ok: ((procedure P :  ((x : int)) → ((y : int)))
  tyPrefix: $__ty
  exprGen: 0
  exprPrefix: $__var
- subst: ⏎
+ subst: []
  known types:
  [∀[0, 1]. (arrow 0 1), bool, int, string])
 -/

--- a/StrataTest/Languages/Boogie/StatementTypeTests.lean
+++ b/StrataTest/Languages/Boogie/StatementTypeTests.lean
@@ -113,8 +113,7 @@ tyGen: 2
 tyPrefix: $__ty
 exprGen: 0
 exprPrefix: $__var
-subst: ($__ty0, int)
-
+subst: [($__ty0, int)]
 known types:
 [∀[0, 1]. (arrow 0 1), bool, int, string]
 -/
@@ -156,14 +155,7 @@ tyGen: 10
 tyPrefix: $__ty
 exprGen: 1
 exprPrefix: $__var
-subst: ($__ty9, int)
-($__ty3, (arrow bool int))
-($__ty5, (arrow bool int))
-($__ty7, bool)
-($__ty6, (arrow bool int))
-($__ty2, int)
-($__ty0, int)
-
+subst: [($__ty0, int) ($__ty2, int) ($__ty6, (arrow bool int)) ($__ty7, bool) ($__ty5, (arrow bool int)) ($__ty3, (arrow bool int)) ($__ty9, int)]
 known types:
 [∀[0, 1]. (arrow 0 1), bool, int, string]
 -/


### PR DESCRIPTION
*Description of changes:*

A `Subst` is now a stack of scopes, which allows us to throw away transient type variables when they go out of scope during Boogie program type inference.

As a result, Boogie type inference is ~34X faster on some benchmarks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
