### PR TITLE
Introduce source ranges and cleanup error handling.

### DIFF
--- a/Strata/DDM/AST.lean
+++ b/Strata/DDM/AST.lean
@@ -244,6 +244,30 @@ def asCommaSepList : Arg → Array Arg
 
 end Arg
 
+/--
+Source location information in the DDM is defined
+by a range of bytes in a UTF-8 string with the input
+Line/column information can be construced from a
+`Lean.FileMap`
+
+As an example, in the string `"123abc\ndef"`, the string
+`"abc"` has the position `{start := 3, stop := 6 }` while
+`"def"` has the position `{start := 7, stop := 10 }`.
+-/
+structure SourceRange where
+  /-- The starting offset of the source range. -/
+  start : String.Pos
+  /-- One past the end of the range. -/
+  stop : String.Pos
+deriving BEq, Inhabited, Repr
+
+namespace SourceRange
+
+def none : SourceRange := { start := 0, stop := 0 }
+
+def isNone (loc : SourceRange) : Bool := loc.start = 0 ∧ loc.stop = 0
+
+end SourceRange
 
 mutual
 /--

--- a/Strata/DDM/Elab/Core.lean
+++ b/Strata/DDM/Elab/Core.lean
@@ -69,7 +69,7 @@ structure ElabContext where
 
 structure ElabState where
   -- Errors found in elaboration.
-  errors : Array (Syntax × Message) := #[]
+  errors : Array Message := #[]
 
 @[reducible]
 def ElabM α := ReaderT ElabContext (StateM ElabState) α
@@ -80,8 +80,8 @@ instance : ElabClass ElabM where
   getOpenDialects := return (←read).openDialectSet
   getGlobalContext := return (←read).globalContext
   getErrorCount := return (←get).errors.size
-  logErrorMessage stx msg :=
-    modify fun s => { s with errors := s.errors.push (stx, msg) }
+  logErrorMessage msg :=
+    modify fun s => { s with errors := s.errors.push msg }
 
 section
 
@@ -92,23 +92,23 @@ inductive MaybeQualifiedIdent where
 | name : String → MaybeQualifiedIdent
 deriving Inhabited
 
-def resolveTypeBinding (tctx : TypingContext) (stx : Syntax) (name : String)
+def resolveTypeBinding (tctx : TypingContext) (loc : SourceRange) (name : String)
     (binding : TypingContext.VarBinding) (args : Array Tree) : ElabM Tree := do
   match binding with
   | .bvar idx k =>
     if let some a := args[0]? then
-      logErrorMF a.info.stx mf!"Unexpected arguments to {name}."
+      logErrorMF a.info.loc mf!"Unexpected arguments to {name}."
       return default
     if let .type [] _ := k then
-      let info : TypeInfo := { inputCtx := tctx, stx := stx, typeExpr := .bvar idx, isInferred := false }
+      let info : TypeInfo := { inputCtx := tctx, loc := loc, typeExpr := .bvar idx, isInferred := false }
       return .node (.ofTypeInfo info) #[]
     else
-      logErrorMF stx mf!"Expected a type instead of {k}"
+      logErrorMF loc mf!"Expected a type instead of {k}"
       return default
   | .fvar fidx k =>
     match k with
     | .expr tp =>
-      logErrorMF stx mf!"Expected a type instead of expression with type {tp}."
+      logErrorMF loc mf!"Expected a type instead of expression with type {tp}."
       return default
     | .type params _ =>
       let params := params.toArray
@@ -119,31 +119,31 @@ def resolveTypeBinding (tctx : TypingContext) (stx : Syntax) (name : String)
         for i in Fin.range args.size do
           let c := args[i]
           let .ofTypeInfo cinfo := c.info
-            | logErrorMF c.info.stx mf!"Expected type"
+            | logErrorMF c.info.loc mf!"Expected type"
           tpArgs := tpArgs.push cinfo.typeExpr
           children := children.push c
         let tp :=  .fvar fidx tpArgs
-        let info : TypeInfo := { inputCtx := tctx, stx := stx, typeExpr := tp, isInferred := false }
+        let info : TypeInfo := { inputCtx := tctx, loc := loc, typeExpr := tp, isInferred := false }
         return .node (.ofTypeInfo info) children
       else if let some a := args[params.size]? then
-        logErrorMF a.info.stx mf!"Unexpected argument to {name}."
+        logErrorMF a.info.loc mf!"Unexpected argument to {name}."
         return default
       else
-        logErrorMF stx mf!"{name} expects {params.size} arguments."
+        logErrorMF loc mf!"{name} expects {params.size} arguments."
         return default
 
 /--
 This translate a possibly qualified identifier into a declaration in an
 open dialect.
 -/
-def resolveTypeOrCat (stx : Syntax) (tpId : MaybeQualifiedIdent) : ElabM (Option (QualifiedIdent × TypeOrCatDecl)) :=
+def resolveTypeOrCat (loc : SourceRange) (tpId : MaybeQualifiedIdent) : ElabM (Option (QualifiedIdent × TypeOrCatDecl)) :=
   match tpId with
   | .qid qid => do
     let decls := (← read).typeOrCatDeclMap.get qid.name
     let decls := decls.filter fun (dialect, _) => dialect = qid.dialect
     match decls[0]? with
     | none => do
-      logErrorMF stx mf!"Undeclared type or category {qid}."
+      logErrorMF loc mf!"Undeclared type or category {qid}."
       return none
     | some (_, decl) =>
       assert! decls.size = 1
@@ -153,12 +153,12 @@ def resolveTypeOrCat (stx : Syntax) (tpId : MaybeQualifiedIdent) : ElabM (Option
     let decls:= m.get name
     match decls[0]? with
     | none => do
-      logErrorMF stx mf!"Undeclared type or category {name}."
+      logErrorMF loc mf!"Undeclared type or category {name}."
       return none
     | some (d, decl) =>
       if let some (candD, _) := decls[1]? then
         assert! d ≠ candD
-        logError stx s!"{name} is ambiguous: declared in {d} and {candD}."
+        logError loc s!"{name} is ambiguous: declared in {d} and {candD}."
         return none
       else
         return some ({ dialect := d, name }, decl.val)
@@ -180,40 +180,39 @@ def asTypeInfo (tree : Tree) : ElabM TypeInfo := do
   | .ofTypeInfo info =>
     return info
   | _ =>
-    logError tree.info.stx "Expected type."
+    logError tree.info.loc "Expected type."
     return default
 
-def checkArgSize {α} [ToStrataFormat α] (stx : Syntax) (name : α) (expected : Nat) (args : Array Tree) : ElabM Unit := do
+def checkArgSize {α} [ToStrataFormat α] (loc : SourceRange) (name : α) (expected : Nat) (args : Array Tree) : ElabM Unit := do
   if p : expected < args.size then
-    logErrorMF args[expected].info.stx mf!"Unexpected argument to {name}."
+    logErrorMF args[expected].info.loc mf!"Unexpected argument to {name}."
   else if expected > args.size then
-    logErrorMF stx mf!"{name} expects {expected} arguments."
+    logErrorMF loc mf!"{name} expects {expected} arguments."
 
 /--
 This resolves a type identifer using the name of the type (as `name`) and the
-arguments (as `args`) passed into it.
+arguments
 -/
 def translateTypeIdent (elabInfo : ElabInfo) (qualIdentInfo : Tree) (args : Array Tree) : ElabM Tree := do
-  let stx := qualIdentInfo.info.stx
+  let loc := qualIdentInfo.info.loc
   let tctx := qualIdentInfo.info.inputCtx
   let tpId := translateQualifiedIdent qualIdentInfo
 
   if let .name name := tpId then
     if let some binding := tctx.lookupVar name then
-      return ← resolveTypeBinding tctx stx name binding args
-
-  let some (ident, decl) ← resolveTypeOrCat stx tpId
+      return ← resolveTypeBinding tctx loc name binding args
+  let some (ident, decl) ← resolveTypeOrCat loc tpId
     | return default
 
   match decl with
   | .type decl =>
-    checkArgSize stx ident decl.argNames.size args
+    checkArgSize loc ident decl.argNames.size args
     let tpArgs ← args.mapM fun a => return (← asTypeInfo a).typeExpr
     let tp := .ident ident tpArgs
     let info : TypeInfo := { toElabInfo := elabInfo, typeExpr := tp, isInferred := false }
     return .node (.ofTypeInfo info) args
   | .syncat decl =>
-    let (_, success) ← runChecked <| checkArgSize stx ident decl.argNames.size args
+    let (_, success) ← runChecked <| checkArgSize loc ident decl.argNames.size args
     if !success then
       return default
     let mut sc : SyntaxCat := .atom ident
@@ -222,7 +221,7 @@ def translateTypeIdent (elabInfo : ElabInfo) (qualIdentInfo : Tree) (args : Arra
       | .ofCatInfo info =>
         sc := .app sc info.cat
       | _ =>
-        logError a.info.stx "Expected category."
+        logError a.info.loc "Expected category."
         return default
     let info : CatInfo := { toElabInfo := elabInfo, cat := sc }
     return .node (.ofCatInfo info) args
@@ -238,16 +237,16 @@ the root is in a normal for,.
 
 N.B. This expects that macros have already been expanded in e.
 -/
-partial def grnf (gctx : GlobalContext) (e : TypeExpr) : TypeExpr :=
+partial def headExpandTypeAlias (gctx : GlobalContext) (e : TypeExpr) : TypeExpr :=
   match e with
-  | .arrow _ _ | .ident _ _ | .bvar _ => e
+  | .arrow .. | .ident .. | .bvar .. => e
   | .fvar idx args =>
     match gctx.kindOf! idx with
     | .expr _ => panic! "Type free variable bound to expression."
     | .type params (some d) =>
       assert! params.length = args.size
       assert! !d.hasUnboundVar (bindingCount := args.size)
-      grnf gctx (d.instType args)
+      headExpandTypeAlias gctx (d.instType args)
     | .type _ none => e
 
 /--
@@ -352,35 +351,38 @@ partial def unifyTypes
     (exprSyntax : Syntax)
     (inferredType : TypeExpr)
     (args : Vector (Option Tree) b.size)
-    : ElabM (Vector (Option Tree) b.size) :=
+    : ElabM (Vector (Option Tree) b.size) := do
   let ⟨argLevel, argLevelP⟩ := argLevel0
   -- Expand defined free vars at root to get head norm form
-  let expectedType := grnf tctx.globalContext expectedType
+  let expectedType := headExpandTypeAlias tctx.globalContext expectedType
+  assert! exprSyntax.getKind != `null
+  let some exprLoc := mkSourceRange? exprSyntax
+    | panic! "unifyTypes missing source location"
   match expectedType with
-  | .ident eid ea => do
-    let ih := rnf tctx inferredType
-    match ih with
+  | .ident eid ea =>
+    let inferredHead := rnf tctx inferredType
+    match inferredHead with
     | .ident iid ia =>
       if eid != iid then
-        logErrorMF exprSyntax mf!"Encountered {ih} expression when {expectedType} expected."
+        logErrorMF exprLoc mf!"Encountered {inferredHead} expression when {expectedType} expected."
         return args
       assert! ea.size = ia.size
       unifyTypeVectors b argLevel0 ea tctx exprSyntax ia args
     | _ =>
-      logErrorMF exprSyntax mf!"Encountered {ih} expression when {expectedType} expected."
+      logErrorMF exprLoc mf!"Encountered {inferredHead} expression when {expectedType} expected."
       return args
   | .fvar eid ea =>
     match rnf tctx inferredType with
-    | .fvar iid ia => do
+    | .fvar iid ia =>
       if eid != iid then
-        logErrorMF exprSyntax mf!"Encountered {inferredType} expression when {expectedType} expected."
+        logErrorMF exprLoc mf!"Encountered {inferredType} expression when {expectedType} expected."
         return args
       assert! ea.size = ia.size
       unifyTypeVectors b argLevel0 ea tctx exprSyntax ia args
-    | ih => do
-      logErrorMF exprSyntax mf!"Encountered {ih} expression when {expectedType} expected."
+    | ih =>
+      logErrorMF exprLoc mf!"Encountered {ih} expression when {expectedType} expected."
       return args
-  | .bvar idx => do
+  | .bvar idx =>
     let .isTrue idxP := inferInstanceAs (Decidable (idx < argLevel))
       | return panic! "Invalid index"
     let typeLevel := argLevel - (idx + 1)
@@ -390,21 +392,25 @@ partial def unifyTypes
 
     match args[typeLevel] with
     | none => do
-      let einfo : ElabInfo := { stx := exprSyntax, inputCtx := tctx }
-      let info : TypeInfo := { toElabInfo := einfo, typeExpr := inferredType, isInferred := true }
+      let info : TypeInfo := {
+        loc := exprLoc
+        inputCtx := tctx
+        typeExpr := inferredType
+        isInferred := true
+      }
       return args.set typeLevel (some (.node (.ofTypeInfo info) #[]))
     | some t => do
       let .ofTypeInfo info := t.info
         | panic! "Expected type info"
       if !(← checkExpressionType tctx inferredType info.typeExpr) then
-        logErrorMF exprSyntax mf!"Expression has type {withBindings tctx.bindings (mformat inferredType)} when {withBindings tctx.bindings (mformat info.typeExpr)} expected."
+        logErrorMF exprLoc mf!"Expression has type {withBindings tctx.bindings (mformat inferredType)} when {withBindings tctx.bindings (mformat info.typeExpr)} expected."
       pure args
   | .arrow ea er =>
     match inferredType with
-    | .ident .. | .bvar _ | .fvar .. => do
-      logErrorMF exprSyntax mf!"Expected {expectedType} when {inferredType} found"
+    | .ident .. | .bvar .. | .fvar .. =>
+      logErrorMF exprLoc mf!"Expected {expectedType} when {inferredType} found"
       pure args
-    | .arrow ia ir => do
+    | .arrow ia ir =>
       let res ← unifyTypes b argLevel0 ea tctx exprSyntax ia args
       unifyTypes b argLevel0 er tctx exprSyntax ir res
 
@@ -420,12 +426,18 @@ private def elabManyElement (f : TypingContext → Syntax → ElabM Tree)
   pure (args.push t, rtctx)
 
 def elabOption (f : ElabArgFn) : ElabArgFn := fun tctx stx =>
-  let info : OptionInfo := { stx := stx, inputCtx := tctx }
-  if stx.matchesNull 0 then
+  if stx.matchesNull 0 then do
+    let some loc := mkSourceRange? stx
+      | panic! "elabOption missing source location"
+    let info : OptionInfo := { loc := loc, inputCtx := tctx }
     pure <| .node (.ofOptionInfo info) #[]
   else do
     assert! stx.matchesNull 1
-    let tree ← f tctx (stx.getArg 0)
+    let astx := stx.getArg 0
+    let some loc := mkSourceRange? stx
+      | panic! "elabOption missing source location"
+    let info : OptionInfo := { loc := loc, inputCtx := tctx }
+    let tree ← f tctx astx
     pure <| .node (.ofOptionInfo info) #[tree]
 
 def evalBindingNameIndex (trees : Vector Tree n) (idx : DebruijnIndex n) : String :=
@@ -439,18 +451,18 @@ resulting context of `tree` after the initial number of bindings given by
 `initialScope`.
 -/
 def collectNewBindingsM [Monad m] (initialScope : Nat) (tree : Tree)
-    (f : Syntax → Binding → m α) : m (Array α) := do
+    (f : SourceRange → Binding → m α) : m (Array α) := do
   assert! (initialScope ≤ tree.info.inputCtx.bindings.size)
-  let stx := tree.info.stx
+  let loc := tree.info.loc
   let bindings := tree.resultContext.bindings.toArray
   let init : Array α := .mkEmpty (bindings.size - initialScope)
-  bindings.foldlM (init := init) (start := initialScope) fun r b => r.push <$> f stx b
+  bindings.foldlM (init := init) (start := initialScope) fun r b => r.push <$> f loc b
 
 def elabArgIndex {α} {n}
     (initialScope : Nat)
     (trees : Vector Tree n)
     (argsIndex : Option (DebruijnIndex n))
-    (f : Syntax → Binding → ElabM α) :
+    (f : SourceRange → Binding → ElabM α) :
     ElabM (Array α) := do
   match argsIndex with
   | none => pure #[]
@@ -533,8 +545,8 @@ theorem flattenTypeApp_size (arg : Tree) (args : Array Tree) :
           omega
   termination_by sizeOf arg
 
-def logInternalError [ElabClass m] (stx : Syntax) (msg : String) : m Unit :=
-  logError stx msg
+def logInternalError {m} [ElabClass m] (loc : SourceRange) (msg : String) : m Unit :=
+  logError loc msg
 
 /--
 Evaluate the tree as a type expression.
@@ -545,27 +557,31 @@ partial def translateSyntaxCat (tree : Tree) : ElabM SyntaxCat := do
         match argInfo with
         | .ofOperationInfo info => info.op.name
         | _ => panic! s!"translateBindingTypeExpr expected operator, type or cat {repr argInfo}"
-  match op, argChildren with
-  | q`Init.TypeIdent, #[ident] => do
-    let tpId := translateQualifiedIdent ident
-    let some (qname, decl) ← resolveTypeOrCat ident.info.stx tpId
+  match op with
+  | q`Init.TypeIdent => do
+    assert! argChildren.size = 1
+    let nameTree := argChildren[0]!
+    let tpId := translateQualifiedIdent nameTree
+    let nameLoc := nameTree.info.loc
+    assert! !nameLoc.isNone
+    let some (name, decl) ← resolveTypeOrCat nameLoc tpId
       | return default
     match decl with
     | .syncat decl =>
-      checkArgSize argInfo.stx qname decl.argNames.size args
-      let r : SyntaxCat := .atom qname
+      checkArgSize argInfo.loc name decl.argNames.size args
+      let r : SyntaxCat := .atom name
       args.attach.foldlM (init := r) fun r ⟨a, _⟩ => do
         have p : sizeOf a < sizeOf args := by decreasing_tactic
         return .app r (← translateSyntaxCat a)
     | _ =>
-      logError ident.info.stx s!"Expected category"; pure default
+      logError nameLoc s!"Expected category"; pure default
 
-  | q`StrataDDL.TypeFn, _ => do
-    logError argInfo.stx s!"Expected category"
+  | q`StrataDDL.TypeFn => do
+    logError argInfo.loc s!"Expected category"
     return default
 
-  | _, _ =>
-    logInternalError argInfo.stx s!"translateSyntaxCat given invalid op {op}"
+  | _ =>
+    logInternalError argInfo.loc s!"translateSyntaxCat given invalid op {op}"
     return default
 
 /--
@@ -584,27 +600,28 @@ def translateTypeExpr (tree : Tree) : ElabM TypeExpr := do
     have q := Array.sizeOf_min argChildren
     simp [feq] at p
     omega
-  let op :=
+  let opInfo :=
         match argInfo with
-        | .ofOperationInfo info => info.op.name
+        | .ofOperationInfo info => info
         | _ => panic! s!"translateBindingTypeExpr expected operator, type or cat {repr argInfo}"
+  let op := opInfo.op.name
   match op with
   | q`Init.TypeIdent => do
     let isTrue p := inferInstanceAs (Decidable (argChildren.size = 1))
       | return panic! "Invalid arguments to Init.TypeIdent"
     let ident := argChildren[0]
     let tpId := translateQualifiedIdent ident
-    let some (qname, decl) ← resolveTypeOrCat ident.info.stx tpId
+    let some (qname, decl) ← resolveTypeOrCat ident.info.loc tpId
       | return default
     match decl with
     | .type decl =>
-      checkArgSize argInfo.stx qname decl.argNames.size args
+      checkArgSize opInfo.loc qname decl.argNames.size args
       let args ← args.attach.mapM fun ⟨a, _⟩ =>
         have p : sizeOf a < sizeOf args := by decreasing_tactic
         translateTypeExpr a
       return .ident qname args
     | _ =>
-      logError ident.info.stx s!"Expected type"; pure default
+      logError ident.info.loc s!"Expected type"; pure default
   | q`Init.TypeArrow => do
     let isTrue p := inferInstanceAs (Decidable (argChildren.size = 2))
       | return panic! "Invalid arguments to Init.TypeArrow"
@@ -614,10 +631,10 @@ def translateTypeExpr (tree : Tree) : ElabM TypeExpr := do
     let rType ← translateTypeExpr rTree
     return .arrow aType rType
   | q`StrataDDL.TypeFn =>
-    logError argInfo.stx s!"Macros not supported"
+    logError opInfo.loc s!"Macros not supported"
     return default
   | nm =>
-    logInternalError argInfo.stx s!"translateTypeExpr given unknown constructor {nm}"
+    logInternalError opInfo.loc s!"translateTypeExpr given unknown constructor {nm}"
     return default
   termination_by tree
   decreasing_by
@@ -632,36 +649,38 @@ Evaluate the tree as a type expression.
 -/
 partial def translateBindingKind (tree : Tree) : ElabM BindingKind := do
   let (⟨argInfo, argChildren⟩, args) := flattenTypeApp tree #[]
-  let op :=
+  let opInfo :=
         match argInfo with
-        | .ofOperationInfo info => info.op.name
+        | .ofOperationInfo info => info
         | _ => panic! s!"translateBindingTypeExpr expected operator, type or cat {repr argInfo}"
-  match op, argChildren with
-  | q`Init.TypeIdent, #[ident] => do
-    let tpId := translateQualifiedIdent ident
-    let stx := ident.info.stx
-    let some (qname, decl) ← resolveTypeOrCat stx tpId
+  let op := opInfo.op.name
+  match opInfo.op.name, szp : argChildren.size with
+  | q`Init.TypeIdent, 1 => do
+    let nameTree := argChildren[0]
+    let tpId := translateQualifiedIdent nameTree
+    let nameLoc := nameTree.info.loc
+    let some (name, decl) ← resolveTypeOrCat nameLoc tpId
       | return default
     match decl with
     | .type decl =>
-      checkArgSize argInfo.stx qname decl.argNames.size args
+      checkArgSize argInfo.loc name decl.argNames.size args
       let args ← args.mapM translateTypeExpr
-      return .expr (.ident qname args)
+      return .expr (.ident name args)
     | .syncat decl =>
-      checkArgSize argInfo.stx qname decl.argNames.size args
-      let r : SyntaxCat := .atom qname
+      checkArgSize argInfo.loc name decl.argNames.size args
+      let r : SyntaxCat := .atom name
       let r ← args.foldlM (init := r) fun r a => do
         return .app r (← translateSyntaxCat a)
       return .cat r
-  | q`Init.TypeArrow, #[aTree, rTree] => do
-    let aType ← translateTypeExpr aTree
-    let rType ← translateTypeExpr rTree
+  | q`Init.TypeArrow, 2 => do
+    let aType ← translateTypeExpr argChildren[0]
+    let rType ← translateTypeExpr argChildren[1]
     pure <| .expr <| .arrow aType rType
   | q`StrataDDL.TypeFn, _ => do
-    logError argInfo.stx s!"Macros not supported"
+    logError argInfo.loc s!"Macros not supported"
     pure default
   | _, _ =>
-    logInternalError argInfo.stx s!"translateArgDeclKind given invalid kind {op}"
+    logInternalError argInfo.loc s!"translateArgDeclKind given invalid kind {opInfo.op.name}"
     return default
 
 /--
@@ -676,12 +695,12 @@ def evalBindingSpec
   match b with
   | .value b =>
     let ident := evalBindingNameIndex args b.nameIndex
-    let (bindings, success) ← runChecked <| elabArgIndex initSize args b.argsIndex fun stx b =>
+    let (bindings, success) ← runChecked <| elabArgIndex initSize args b.argsIndex fun argLoc b =>
           match b.kind with
           | .expr tp =>
-            return (b.ident, tp)
-          | .type _ _ | .cat _ => do
-            logError stx "Expecting expressions in variable binding"
+            pure (b.ident, tp)
+          | .type .. | .cat _ => do
+            logError argLoc "Expecting expressions in variable binding"
             pure default
     if !success then
       return default
@@ -707,12 +726,12 @@ def evalBindingSpec
     pure { ident, kind }
   | .type b =>
     let ident := evalBindingNameIndex args b.nameIndex
-    let params ← elabArgIndex initSize args b.argsIndex fun stx b => do
+    let params ← elabArgIndex initSize args b.argsIndex fun argLoc b => do
           match b.kind with
           | .type [] _ =>
             pure ()
-          | .type _ _ | .expr _ | .cat _ => do
-            logError stx s!"{b.ident} must be have type Type instead of {repr b.kind}."
+          | .type .. | .expr _ | .cat _ => do
+            logError argLoc s!"{b.ident} must be have type Type instead of {repr b.kind}."
           return b.ident
     let value : Option TypeExpr :=
           match b.defIndex with
@@ -812,15 +831,15 @@ partial def translateTypeTree (arg : Tree) : ElabM Tree := do
     | q`Init.TypeArrow, #[aTree, rTree] => do
       let aType ← translateTypeTree aTree
       let .ofTypeInfo aInfo := aType.info
-        | logError aType.info.stx s!"Expected type"; return default
+        | logError aType.info.loc s!"Expected type"; return default
       let rType ← translateTypeTree rTree
       let .ofTypeInfo rInfo := rType.info
-        | logError rType.info.stx s!"Expected type"; return default
+        | logError rType.info.loc s!"Expected type"; return default
       let tp := .arrow aInfo.typeExpr rInfo.typeExpr
       let info : TypeInfo := { toElabInfo := info.toElabInfo, typeExpr := tp, isInferred := false }
       return .node (.ofTypeInfo info) #[aType, rType]
     | _, _ =>
-      logInternalError arg.info.stx s!"translateTypeTree given invalid operation {repr op}"
+      logInternalError arg.info.loc s!"translateTypeTree given invalid operation {repr op}"
       return default
   | _ =>
     panic! s!"translateTypeExpr expected operator {repr arg}"
@@ -828,8 +847,10 @@ partial def translateTypeTree (arg : Tree) : ElabM Tree := do
 mutual
 
 partial def elabOperation (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
+  let some loc := mkSourceRange? stx
+    | panic! s!"elabOperation missing source location {repr stx}"
   if stx.getKind = `choice then
-    logError stx s!"Parsing ambiguity {stx}"
+    logError loc s!"Parsing ambiguity {stx}"
     return default
   let some i := qualIdentKind stx
     | return panic! s!"Unknown command {stx.getKind}"
@@ -847,7 +868,7 @@ partial def elabOperation (tctx : TypingContext) (stx : Syntax) : ElabM Tree := 
   let resultCtx ← newBindings.foldlM (init := newCtx) <| fun ctx spec => do
     ctx.push <$> evalBindingSpec initSize spec args
   let op : Operation := { name := i, args := args.toArray.map (·.arg) }
-  let info : OperationInfo := { stx := stx, inputCtx := tctx, op, resultCtx }
+  let info : OperationInfo := { loc := loc, inputCtx := tctx, op, resultCtx }
   return .node (.ofOperationInfo info) args.toArray
 
 partial def runSyntaxElaborator
@@ -885,7 +906,7 @@ partial def runSyntaxElaborator
             Tree.arg <$> trees[argLevel - i - 1]!
         match expandMacros dialects expectedType resolveArg with
         | .error () =>
-          logError astx s!"Could not infer type."
+          panic! "Could not infer type."
         | .ok expectedType => do
           trees ← unifyTypes b ⟨argLevel, argLevelP⟩ expectedType tctx astx inferredType trees
           assert! trees[argLevel].isNone
@@ -918,7 +939,7 @@ partial def elabType (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
   | .ofTypeInfo _ =>
     pure ()
   | _ =>
-    logErrorMF stx mf!"Expected a type."
+    logErrorMF tree.info.loc mf!"Expected a type."
   pure tree
 
 partial def catElaborator (c : SyntaxCat) : TypingContext → Syntax → ElabM Tree :=
@@ -926,31 +947,39 @@ partial def catElaborator (c : SyntaxCat) : TypingContext → Syntax → ElabM T
   | .atom q`Init.Expr =>
     elabExpr
   | .atom q`Init.Ident =>
-    fun tctx stx =>
-      let info : IdentInfo := { inputCtx := tctx, stx := stx, val := stx.getId.toString }
+    fun tctx stx => do
+      let some loc := mkSourceRange? stx
+        | panic! "ident missing source location"
+      let info : IdentInfo := { inputCtx := tctx, loc := loc, val := stx.getId.toString }
       pure <| .node (.ofIdentInfo info) #[]
   | .atom q`Init.Num =>
-    fun tctx stx =>
+    fun tctx stx => do
+      let some loc := mkSourceRange? stx
+        | panic! "num missing source location"
       match stx.isNatLit? with
       | some v =>
-        let info : NumInfo := { inputCtx := tctx, stx := stx, val := v }
+        let info : NumInfo := { inputCtx := tctx, loc := loc, val := v }
         pure <| .node (.ofNumInfo info) #[]
       | none =>
         panic! s!"Invalid Init.Num {repr stx}"
   | .atom q`Init.Decimal =>
-    fun tctx stx =>
+    fun tctx stx => do
+      let some loc := mkSourceRange? stx
+        | panic! "decimal missing source location"
       match stx.isScientificLit? with
       | some (m, eIsNeg, e) =>
         let d : Decimal := { mantissa := m, exponent := if eIsNeg then .negOfNat e else .ofNat e }
-        let info : DecimalInfo := { inputCtx := tctx, stx := stx, val := d }
+        let info : DecimalInfo := { inputCtx := tctx, loc := loc, val := d }
         pure <| .node (.ofDecimalInfo info) #[]
       | none =>
         panic! s!"Invalid Init.Num {repr stx}"
   | .atom q`Init.Str =>
-    fun tctx stx =>
+    fun tctx stx => do
+      let some loc := mkSourceRange? stx
+        | panic! "str missing source location"
       match stx.isStrLit? with
       | some s =>
-        let info : StrlitInfo := { inputCtx := tctx, stx := stx, val := s }
+        let info : StrlitInfo := { inputCtx := tctx, loc := loc, val := s }
         pure <| .node (.ofStrlitInfo info) #[]
       | none =>
         panic! s!"String not supported {stx} {stx.isStrLit?}"
@@ -969,102 +998,110 @@ partial def catElaborator (c : SyntaxCat) : TypingContext → Syntax → ElabM T
               | .ofCatInfo info => info.cat = .atom q`Init.Type
               | _ => false
         if !ok then
-          logErrorMF stx mf!"Expected a type or Type instead of {c}"
+          logErrorMF tree.info.loc mf!"Expected a type or Type instead of {c}"
         pure tree
   | .app (.atom q`Init.Option) a =>
     elabOption (catElaborator a)
   | .app (.atom q`Init.Seq) a =>
     let f := elabManyElement (catElaborator a)
     fun tctx stx => do
+      let some loc := mkSourceRange? stx
+        | panic! "seq missing source location"
       let (args, resultCtx) ← stx.getArgs.foldlM f (#[], tctx)
-      let info : SeqInfo := { inputCtx := tctx, stx := stx, args := args.map (·.arg), resultCtx }
+      let info : SeqInfo := { inputCtx := tctx, loc := loc, args := args.map (·.arg), resultCtx }
       pure <| .node (.ofSeqInfo info) args
   | .app (.atom q`Init.CommaSepBy) a =>
     let f := elabManyElement (catElaborator a)
     fun tctx stx => do
+      let some loc := mkSourceRange? stx
+        | panic! s!"commaSepBy missing source location {repr stx}"
       let (args, resultCtx) ← stx.getSepArgs.foldlM f (#[], tctx)
-      let info : CommaSepInfo := { inputCtx := tctx, stx := stx, args := args.map (·.arg), resultCtx }
+      let info : CommaSepInfo := { inputCtx := tctx, loc := loc, args := args.map (·.arg), resultCtx }
       pure <| .node (.ofCommaSepInfo info) args
   | .atom _ =>
     elabOperation
   | _ =>
     panic! s!"Unsupport category {eformat c}"
 
-partial def elabExpr (tctx : TypingContext) (stx : Syntax) : ElabM Tree :=
+partial def elabExpr (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
   match stx.getKind with
   | `Init.exprParen =>
     elabExpr tctx stx[1]
   | `Init.exprIdent =>
+    let some loc := mkSourceRange? stx
+      | panic! "exprIdent missing source location"
+    let einfo : ElabInfo := { loc := loc, inputCtx := tctx }
     let name := elabIdent stx[0]
-    if let some binding := tctx.lookupVar name then
-      let einfo : ElabInfo := { stx, inputCtx := tctx }
-      match binding with
-      | .bvar idx k => do
-        match k with
-        | .expr _ =>
-          let info : ExprInfo := { toElabInfo := einfo, expr := .bvar idx }
-          return .node (.ofExprInfo info) #[]
-        | .type _params _ =>
-          logErrorMF stx mf!"{name} is a type when an expression is required."
+    let some binding := tctx.lookupVar name
+      | logError loc s!"Unknown expr identifier {name}"
+        return default
+    match binding with
+    | .bvar idx k => do
+      match k with
+      | .expr _ =>
+        let info : ExprInfo := { toElabInfo := einfo, expr := .bvar idx }
+        return .node (.ofExprInfo info) #[]
+      | .type _params _ =>
+        logErrorMF loc mf!"{name} is a type when an expression is required."
+        return default
+      | .cat c =>
+        logErrorMF loc mf!"{name} has category {c} when an expression is required."
+        return default
+    | .fvar idx k =>
+      let .expr _ := k
+        | logError loc s!"{name} is a type when expression required."
           return default
-        | .cat c =>
-          logErrorMF stx mf!"{name} has category {c} when an expression is required."
-          return default
-      | .fvar idx k =>
-        match k with
-        | .expr _ =>
-          let info : ExprInfo := { toElabInfo := einfo, expr := .fvar idx }
-          return .node (.ofExprInfo info) #[]
-        | _ => do
-          logError stx s!"{name} is a type when expression required."
-          return default
-    else do
-      logError stx s!"Unknown expr identifier {name}"
-      return default
+      let info : ExprInfo := { toElabInfo := einfo, expr := .fvar idx }
+      return .node (.ofExprInfo info) #[]
   | `Init.exprApp => do
+    let some loc := mkSourceRange? stx
+      | panic! "exprApp missing source location"
+    let einfo : ElabInfo := { loc := loc, inputCtx := tctx }
+    let some fnLoc := mkSourceRange? stx[0]
+      | panic! "exprApp fn missing source location"
     let fn := elabIdent stx[0]
     let args := stx[2].getSepArgs
-    let ((fvar, bindings), success) ← runChecked <| do
-          match tctx.lookupVar fn with
-          | some (.fvar idx k) =>
-            match k with
-            | .expr tp =>
-              let tctx : TypingContext := .empty tctx.globalContext
-              match tctx.applyNArgs tp args.size with
-              | .ok (argTypes, r) =>
-                let b := Array.ofFn fun (i : Fin args.size) => {
-                  ident := ""
-                  kind := .type (.ofType argTypes[i])
-                }
-                pure (idx, b)
-              | .error (a, r) =>
-                if a.size = 0 then
-                  logError stx[0] s!"Expected function"
-                else
-                  logError stx[0] s!"Expected function with {a.size} arguments."
-                return default
-            | .type _ _ =>
-              logError stx[0] s!"Expression expected."
-              return default
-          | some (.bvar idx tp) =>
-            logError stx[0] s!"Bound functions not yet supported."
-            return default
-          | none =>
-            logError stx[0] s!"Unknown variable {fn}"
-            return default
-    if !success then
-      return default
+    let (fvar, k) ←
+      match tctx.lookupVar fn with
+      | some (.fvar idx k) =>
+        pure (Expr.fvar idx, k)
+      | some (.bvar idx tp) =>
+        logError fnLoc s!"Bound functions not yet supported."
+        return default
+      | none =>
+        logError fnLoc s!"Unknown variable {fn}"
+        return default
+    let .expr tp := k
+      | logError fnLoc s!"Expression expected."
+        return default
+    let (argTypes, r) ← do
+      let tctx := TypingContext.empty tctx.globalContext
+      match tctx.applyNArgs tp args.size with
+      | .error (a, r) =>
+        if a.size = 0 then
+          logError fnLoc s!"Expected function"
+        else
+          logError fnLoc s!"Expected function with {a.size} arguments."
+        return default
+      | .ok p =>
+        pure p
+    let mkArgDecl (tp : TypeExpr) : ArgDecl :=
+          { ident := "", kind := .type (.ofType tp) }
+    let argDecls := argTypes.map mkArgDecl
     let se : SyntaxElaborator := {
             argElaborators := Array.ofFn fun (⟨lvl, _⟩ : Fin args.size) =>
                { syntaxLevel := lvl, argLevel := lvl }
             resultScope := none
           }
-    let (args, _) ← runSyntaxElaborator se bindings tctx args
-    let e : Expr := Expr.fvar fvar
-    let e := args.toArray.foldl (init := e) fun e t => .app e t.arg
-    let info : ExprInfo := { stx := stx, inputCtx := tctx, expr := e }
+    let (args, _) ← runSyntaxElaborator se argDecls.toArray tctx args
+    let e := args.toArray.foldl (init := fvar) fun e t =>
+      .app e t.arg
+    let info : ExprInfo := { toElabInfo := einfo, expr := e }
     return .node (.ofExprInfo info) args.toArray
   | _ => do
+    let some loc := mkSourceRange? stx
+      | panic! "evalExpr missing source location"
+    let einfo : ElabInfo := { loc := loc, inputCtx := tctx }
     let some i := qualIdentKind stx
       | return panic! s!"Unknown expression {stx}"
     let some d := (←read).dialects[i.dialect]?
@@ -1077,7 +1114,7 @@ partial def elabExpr (tctx : TypingContext) (stx : Syntax) : ElabM Tree :=
     if !success then
       return default
     let e := args.toArray.foldl (init := Expr.fn i) fun e t => .app e t.arg
-    let info : ExprInfo := { stx := stx, inputCtx := tctx, expr := e }
+    let info : ExprInfo := { toElabInfo := einfo, expr := e }
     return .node (.ofExprInfo info) args.toArray
 
 end
@@ -1117,7 +1154,7 @@ partial def elabCommand (leanEnv : Lean.Environment) : DeclM (Option Tree) := do
           q`Init.Command
   if leanParserState.hasError then
     for (pos, stk, err) in leanParserState.allErrors do
-      logErrorMessage stk.back <| Lean.mkErrorMessage inputContext pos stk err
+      logErrorMessage <| Lean.mkErrorMessage inputContext pos stk err
     return none
   if leanParserState.stxStack.size == 0 then
     panic! "Cmmand state is empty"

--- a/Strata/DDM/Elab/Tree.lean
+++ b/Strata/DDM/Elab/Tree.lean
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 import Strata.DDM.Format
+set_option autoImplicit false
 
 open Lean (Syntax)
 
@@ -27,7 +28,7 @@ over the parameters.
 Variable belongs to the particular category below.
 -/
 | cat (k : SyntaxCat)
-deriving BEq, Inhabited, Repr
+deriving Inhabited, Repr
 
 namespace BindingKind
 
@@ -60,7 +61,7 @@ all have the same type and metadata.
 structure Binding where
   ident : Var
   kind : BindingKind
-deriving Inhabited, Repr, BEq
+deriving Inhabited, Repr
 
 /--
 A sequence of bindings.
@@ -71,7 +72,6 @@ index of the binder for them.
 structure Bindings where
   ofArray ::
   toArray : Array Binding
-  deriving BEq
 
 namespace Bindings
 
@@ -183,12 +183,13 @@ end TypingContext
 -----------------------------------------------------------------------
 -- ElabInfo/Tree
 
+/--
+Common information for each node in the Strata info tree.
+-/
 structure ElabInfo where
-  /-- The piece of syntax that the elaborator created this info for.
-  Note that this also implicitly stores the code position in the syntax's SourceInfo. -/
-  stx : Syntax
-  /-- The piece of syntax that the elaborator created this info for.
-  Note that this also implicitly stores the code position in the syntax's SourceInfo. -/
+  /-- Source location information. -/
+  loc : SourceRange
+  /-- The typing context for node. -/
   inputCtx : TypingContext
 deriving Inhabited, Repr
 
@@ -292,7 +293,7 @@ def elabInfo (info : Info) : ElabInfo :=
 
 def inputCtx (info : Info) : TypingContext := info.elabInfo.inputCtx
 
-def stx (info : Info) : Syntax := info.elabInfo.stx
+def loc (info : Info) : SourceRange := info.elabInfo.loc
 
 end Info
 
@@ -403,7 +404,7 @@ def binding! (tree : Tree) : IdentInfo × Tree × Option Tree := Id.run do
   assert! tree.isSpecificOp q`StrataDDL.mkBinding
   assert! tree.children.size = 3
   let .ofIdentInfo nameInfo := tree[0]!.info
-    | panic! s!"Expected identifier {repr tree.info.stx.getKind}"
+    | panic! s!"Expected identifier {repr tree.info}"
   let some mdTree := tree[2]!.asOption?
       | panic! s!"Expected metadata to be option."
   return (nameInfo, tree[1]!.asBindingType!, mdTree)

--- a/Strata/DDM/Parser.lean
+++ b/Strata/DDM/Parser.lean
@@ -53,18 +53,18 @@ open Parser (
     getNext
     runLongestMatchParser
     longestMatchStep
+    noFirstTokenInfo
+    manyFn
     manyNoAntiquot
-    many1NoAntiquot
-    maxPrec
     mkAtomicInfo
     mkEmptySubstringAt
     mkIdent
     nodeInfo
-    optionalNoAntiquot
+    optionalInfo
     quotedCharFn
     quotedStringFn
-    sepByNoAntiquot
-    sepBy1NoAntiquot
+    sepByInfo
+    sepByFn
     setLhsPrec
     symbolInfo
     takeUntilFn
@@ -79,16 +79,47 @@ export Lean.Parser (
     Parser
     maxPrec
     minPrec
-    node
     skip
     )
+
+def nodeFn (n : SyntaxNodeKind) (p : ParserFn) : ParserFn := fun c s =>
+  let iniSz := s.stackSize
+  let s     := p c s
+  s.mkNode n iniSz
+
+private def emptySourceInfo (c : ParserContext) (pos : String.Pos) : SourceInfo :=
+  let empty := mkEmptySubstringAt c.input pos
+  .original empty pos empty pos
+
+private def optionalFn (p : ParserFn) : ParserFn := fun c s =>
+  let iniSz  := s.stackSize
+  let iniPos := s.pos
+  let s      := p c s
+  let s      := if s.hasError && s.pos == iniPos then s.restore iniSz iniPos else s
+  if s.stackSize == iniSz then
+    if s.pos != iniPos then
+      @panic _ ⟨s⟩ "Unexpected position"
+    else
+      s.pushSyntax <| .node (emptySourceInfo c s.pos) nullKind #[]
+  else
+    s.mkNode nullKind iniSz
+
+private def optionalNoAntiquot (p : Parser) : Parser := {
+  info := optionalInfo p.info
+  fn   := optionalFn p.fn
+}
+
+private def node (n : SyntaxNodeKind) (p : Parser) : Parser := {
+  info := nodeInfo n p.info,
+  fn   := nodeFn n p.fn
+}
 
 /--
 Create an input context from a string.
 -/
-def stringInputContext (contents : String) : InputContext where
+def stringInputContext (fileName : System.FilePath) (contents : String) : InputContext where
   input    := contents
-  fileName := "placeholder"
+  fileName := fileName.toString
   fileMap  := FileMap.ofString contents
 
 private def isIdFirstOrBeginEscape (c : Char) : Bool :=
@@ -526,10 +557,6 @@ def indexed {α : Type} (map : TokenMap α) (c : ParserContext) (s : ParserState
   | .ok _             => (s, [])
   | .error s'         => (s', [])
 
-private def mkResult (s : ParserState) (iniSz : Nat) : ParserState :=
-  if s.stackSize == iniSz + 1 then s
-  else s.mkNode nullKind iniSz -- throw error instead?
-
 def longestMatchMkResult (startSize : Nat) (s : ParserState) : ParserState :=
   if s.stackSize > startSize + 1 then s.mkNode choiceKind startSize else s
 
@@ -565,7 +592,10 @@ def leadingParserAux (cat : QualifiedIdent) (tables : PrattParsingTables) (behav
       return s
     return s.mkUnexpectedTokenError cat.fullName
   let s := longestMatchFn none ps c s
-  mkResult s iniSz
+  if s.stackSize == iniSz + 1 then
+    s
+  else
+    s.setError (panic! "Unexpected stack size")
 
 partial def trailingLoop (cat : QualifiedIdent) (tables : PrattParsingTables) (c : ParserContext) (s : ParserState) : ParserState := Id.run do
   let iniSz  := s.stackSize
@@ -709,15 +739,49 @@ def atomCatParser (ctx : ParsingContext) (cat : QualifiedIdent) : Parser :=
   else
     dynamicParser cat
 
+private def sepByParser (p sep : Parser) (allowTrailingSep : Bool := false) : Parser := {
+  info := sepByInfo p.info sep.info
+  fn   := fun c s =>
+    let s := sepByFn allowTrailingSep p.fn sep.fn c s
+    if s.hasError then
+      s
+    else
+      match s.stxStack.back with
+      | .node .none k args =>
+        if args.isEmpty then
+          s.popSyntax.pushSyntax (.node (emptySourceInfo c s.pos) k args)
+        else
+          s
+      | _ =>
+        s
+}
+
+def manyParser (p : Parser) : Parser := {
+  info := noFirstTokenInfo p.info
+  fn   := fun c s =>
+    let s := manyFn p.fn c s
+    if s.hasError then
+      s
+    else
+      match s.stxStack.back with
+      | .node .none k args =>
+        if args.isEmpty then
+          s.popSyntax.pushSyntax (.node (emptySourceInfo c s.pos) k args)
+        else
+          s
+      | _ =>
+        s
+}
+
 /-- Parser function for given syntax category -/
 def catParser (ctx : ParsingContext) (cat : SyntaxCat) : Except SyntaxCat Parser :=
   match cat with
   | .app (.atom (q`Init.CommaSepBy)) c =>
-    (sepByNoAntiquot · (symbolNoAntiquot ",")) <$> catParser ctx c
+    (sepByParser · (symbolNoAntiquot ",")) <$> catParser ctx c
   | .app (.atom (q`Init.Option)) c =>
     optionalNoAntiquot <$> catParser ctx c
   | .app (.atom (q`Init.Seq)) c =>
-    manyNoAntiquot <$> catParser ctx c
+    manyParser <$> catParser ctx c
   | .atom c =>
     .ok (atomCatParser ctx c)
   | c =>
@@ -776,11 +840,13 @@ def opSyntaxParser (ctx : ParsingContext)
       parser := trailingNode n prec minLeftPrec p
     }
   | .isLeading [] =>
+    let fn (c : ParserContext) (s : ParserState) : ParserState :=
+      s.pushSyntax (.atom (emptySourceInfo c s.pos) "")
     pure {
       category,
       outerPrec := prec,
       isLeading := true,
-      parser := node n { fn := fun _ s => s.pushSyntax (.atom .none "") } >> setLhsPrec prec
+      parser := node n { fn := fn } >> setLhsPrec prec
     }
   | .isLeading args =>
     let p := liftToKind ctx args argDecls

--- a/StrataTest/DDM/LoadDialect.lean
+++ b/StrataTest/DDM/LoadDialect.lean
@@ -20,7 +20,7 @@ error: Could not find file INVALID!
 
 -- This tests that dialects must be loaded in order.
 /--
-error: 5 error(s) reading ../../Examples/dialects/Arith.dialect.st:
+error: 5 error(s) in ../../Examples/dialects/Arith.dialect.st:
   2:7: Unknown dialect Bool
   11:27: Undeclared type or category Bool.
   12:27: Undeclared type or category Bool.

--- a/StrataVerify.lean
+++ b/StrataVerify.lean
@@ -101,7 +101,7 @@ def main (args : List String) : IO UInt32 := do
           return 1
     -- Strata.Elab.elabProgram
     | .error errors =>
-      for (_, e) in errors do
+      for e in errors do
         let msg ← e.toString
         println! s!"Error: {msg}"
       println! f!"Finished with {errors.size} errors."


### PR DESCRIPTION
This introduces a datatype for a range of characters in a source file.  It will be used for embedding source information in the AST for #112 , but is currently only being added to info trees.

This PR also removes the extra syntax elements from error handling as messages contain source information.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
