### PR TITLE
Fix warning in StrataToCBMC for unused error message.

### DIFF
--- a/StrataToCBMC.lean
+++ b/StrataToCBMC.lean
@@ -39,5 +39,5 @@ def main (args : List String) : IO Unit := do
             | _ => IO.println "Error: expected boogie procedure"
         else
           IO.println "Error: Unrecognized file extension"
-    | .error e => IO.println s!"Error: parsing"
+    | .error e => IO.println s!"Error: Parsing : {e.toList.map (λ p => p.fst)}"
   | _ => IO.println "Error: incorrect usage. Usage: StrataToCBMC filename or StrataToCBMC test"


### PR DESCRIPTION
Fix warning in StrataToCBMC for unused error message.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
