### PR TITLE
Fix build error from error messages.

### DIFF
--- a/StrataToCBMC.lean
+++ b/StrataToCBMC.lean
@@ -39,5 +39,8 @@ def main (args : List String) : IO Unit := do
             | _ => IO.println "Error: expected boogie procedure"
         else
           IO.println "Error: Unrecognized file extension"
-    | .error e => IO.println s!"Error: Parsing : {e.toList.map (λ p => p.fst)}"
+    | .error errors =>
+      for e in errors do
+        let msg ← e.toString
+        println! s!"Error: {msg}"
   | _ => IO.println "Error: incorrect usage. Usage: StrataToCBMC filename or StrataToCBMC test"


### PR DESCRIPTION
This fixes a build error not caught in merge due to merge queue skipped from lack of conflict.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
