### PR TITLE
Introduce astExpr! macro

### DIFF
--- a/Strata/DDM/Integration/Lean/ToExpr.lean
+++ b/Strata/DDM/Integration/Lean/ToExpr.lean
@@ -4,66 +4,61 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 
+import Lean.Elab.Term
 import Strata.DDM.AST
-import Lean.Elab.App
 
 namespace Strata
 
 open Lean
 
+namespace QualifiedIdent
 
 instance : ToExpr QualifiedIdent where
   toTypeExpr := mkConst ``QualifiedIdent
   toExpr i := mkApp2 (mkConst ``QualifiedIdent.mk) (toExpr i.dialect) (toExpr i.name)
 
-namespace TypeExpr
+end QualifiedIdent
 
-protected def typeExpr : Lean.Expr := mkConst ``TypeExpr
+section
 
-protected def toExpr : TypeExpr → Lean.Expr
-| .ident nm a =>
-  mkApp2
-    (mkConst ``TypeExpr.ident)
-    (toExpr nm)
-    (arrayToExpr TypeExpr.typeExpr (a.map (·.toExpr)))
-| .bvar idx => mkApp (mkConst ``TypeExpr.bvar) (toExpr idx)
-| .fvar idx a =>
-  mkApp2
-    (mkConst ``TypeExpr.fvar)
-    (toExpr idx)
-    (arrayToExpr TypeExpr.typeExpr (a.map (·.toExpr)))
-| .arrow a r => mkApp2 (mkConst ``arrow) a.toExpr r.toExpr
+open Lean.Elab
 
-instance : ToExpr TypeExpr where
-  toTypeExpr := TypeExpr.typeExpr
-  toExpr := TypeExpr.toExpr
+private def rootIdent (name : Name) : Ident :=
+  .mk (.ident .none name.toString.toSubstring name [.decl name []])
 
-end TypeExpr
+private def emptyLevel : Lean.Expr := mkApp (mkConst ``List.nil [.zero]) (mkConst ``Level)
 
-namespace PreType
+/--
+Lift a DDM AST constructor that takes a polymorphic annotation value to
+the expression level with the correct number of arguments.
 
-protected def typeExpr : Lean.Expr := mkConst ``PreType
+For example, `astExpr! ArgF.ident ann` returns a function that expects one
+Lean expression and returns another.
+-/
+syntax:max (name := astExprElab) "astExpr!" ident : term
 
-protected def toExpr : PreType → Lean.Expr
-| .ident nm a =>
-  mkApp2
-    (mkConst ``ident)
-    (toExpr nm)
-    (arrayToExpr  PreType.typeExpr (a.map (·.toExpr)))
-| .bvar idx => mkApp (mkConst ``bvar) (toExpr idx)
-| .fvar idx a =>
-  mkApp2
-    (mkConst ``fvar)
-    (toExpr idx)
-    (arrayToExpr  PreType.typeExpr (a.map (·.toExpr)))
-| .arrow a r => mkApp2 (mkConst ``arrow) a.toExpr r.toExpr
-| .funMacro i r => mkApp2 (mkConst ``funMacro) (toExpr i) r.toExpr
+@[term_elab astExprElab]
+def astExprElabImpl : Term.TermElab := fun stx _expectedType => do
+  match stx with
+  | `(astExpr! $ident) => do
+    let ctor ← realizeGlobalConstNoOverloadWithInfo ident
+    let cv ← getConstVal ctor
+    let argc := cv.type.getForallBinderNames.length
+    let ctorExpr := mkApp2 (mkConst ``mkConst) (toExpr ctor) emptyLevel
+    if argc = 0 then
+      return ctorExpr
+    else if argc > 10 then
+      throwError s!"astExpr! does not support constructors with more than 10 arguments."
+    let mkAppName : Name :=
+      if argc = 1 then
+        `Lean |>.str s!"mkApp"
+      else
+        `Lean |>.str s!"mkApp{argc}"
+    return mkApp (mkConst mkAppName) ctorExpr
+  | _ => do
+    throwUnsupportedSyntax
 
-instance : ToExpr PreType where
-  toTypeExpr := mkConst ``PreType
-  toExpr := PreType.toExpr
-
-end PreType
+end
 
 namespace SyntaxCat
 
@@ -77,6 +72,28 @@ instance : ToExpr SyntaxCat where
 
 end SyntaxCat
 
+namespace TypeExpr
+
+protected def typeExpr : Lean.Expr := mkConst ``TypeExpr
+
+protected def toExpr : TypeExpr → Lean.Expr
+| .ident nm a =>
+  let ae := arrayToExpr TypeExpr.typeExpr (a.map (·.toExpr))
+  astExpr! ident (toExpr nm) ae
+| .bvar idx =>
+  astExpr! bvar (toExpr idx)
+| .fvar idx a =>
+  let ae := arrayToExpr TypeExpr.typeExpr (a.map (·.toExpr))
+  astExpr! fvar (toExpr idx) ae
+| .arrow a r =>
+  astExpr! arrow a.toExpr r.toExpr
+
+instance  : ToExpr TypeExpr where
+  toTypeExpr := TypeExpr.typeExpr
+  toExpr := TypeExpr.toExpr
+
+end TypeExpr
+
 protected def Expr.typeExpr := mkConst ``Expr
 
 protected def Arg.typeExpr := mkConst ``Arg
@@ -86,30 +103,33 @@ protected def Operation.typeExpr := mkConst ``Operation
 mutual
 
 protected def Expr.toExpr : Expr → Lean.Expr
-| .bvar i => mkApp (mkConst ``Expr.bvar) (toExpr i)
-| .fvar idx => mkApp (mkConst ``Expr.fvar) (toExpr idx)
-| .fn ident => mkApp (mkConst ``Expr.fn) (toExpr ident)
-| .app f a => mkApp2 (mkConst ``Expr.app) f.toExpr a.toExpr
+| .bvar i => astExpr!  Expr.bvar (toExpr i)
+| .fvar idx => astExpr! Expr.fvar (toExpr idx)
+| .fn ident => astExpr! Expr.fn (toExpr ident)
+| .app f a => astExpr! Expr.app f.toExpr a.toExpr
 termination_by e => sizeOf e
 
 def Arg.toExpr : Arg → Lean.Expr
-| .op o => mkApp (mkConst ``Arg.op) o.toExpr
-| .expr e     => mkApp (mkConst ``Arg.expr)  (e.toExpr)
-| .type e     => mkApp (mkConst ``Arg.type)  (toExpr e)
-| .cat e      => mkApp (mkConst ``Arg.cat)   (toExpr e)
-| .ident e    => mkApp (mkConst ``Arg.ident) (toExpr e)
-| .num e      => mkApp (mkConst ``Arg.num) (toExpr e)
-| .decimal e  => mkApp (mkConst ``Arg.decimal) (toExpr e)
-| .strlit e    => mkApp (mkConst ``Arg.strlit) (toExpr e)
-| .option a => mkApp (mkConst ``Arg.option) (optionToExpr Arg.typeExpr (a.attach.map (fun ⟨e, _⟩ => e.toExpr)))
-| .seq a => mkApp (mkConst ``Arg.seq) (arrayToExpr Arg.typeExpr (a.map (·.toExpr)))
-| .commaSepList a => mkApp (mkConst ``Arg.commaSepList) (arrayToExpr Arg.typeExpr (a.map (·.toExpr)))
+| .op o => astExpr! Arg.op o.toExpr
+| .expr e => astExpr! Arg.expr (e.toExpr)
+| .type e => astExpr! Arg.type  (toExpr e)
+| .cat e => astExpr! Arg.cat (toExpr e)
+| .ident e => astExpr! Arg.ident (toExpr e)
+| .num e => astExpr! Arg.num (toExpr e)
+| .decimal e => astExpr! Arg.decimal (toExpr e)
+| .strlit e => astExpr! Arg.strlit (toExpr e)
+| .option a => astExpr! Arg.option (optionToExpr Arg.typeExpr (a.attach.map (fun ⟨e, _⟩ => e.toExpr)))
+| .seq a => astExpr! Arg.seq (arrayToExpr Arg.typeExpr (a.map (·.toExpr)))
+| .commaSepList a => astExpr! Arg.commaSepList (arrayToExpr Arg.typeExpr (a.map (·.toExpr)))
 termination_by a => sizeOf a
 
 protected def Operation.toExpr (op : Operation) : Lean.Expr :=
   let args := arrayToExpr Arg.typeExpr (op.args.map (·.toExpr))
-  mkApp2 (mkConst ``Operation.mk) (toExpr op.name) args
+  astExpr! Operation.mk (toExpr op.name) args
 termination_by sizeOf op
+decreasing_by
+  simp only [Operation.sizeOf_spec]
+  decreasing_tactic
 
 end
 
@@ -125,17 +145,40 @@ instance Operation.instToExpr : ToExpr Operation where
   toTypeExpr := Operation.typeExpr
   toExpr := Operation.toExpr
 
+namespace PreType
+
+protected def typeExpr : Lean.Expr := mkConst ``PreType
+
+protected def toExpr : PreType → Lean.Expr
+| .ident nm a =>
+  let args := arrayToExpr  PreType.typeExpr (a.map (·.toExpr))
+  astExpr! ident (toExpr nm) args
+| .bvar idx => astExpr! bvar (toExpr idx)
+| .fvar idx a =>
+    let args := arrayToExpr  PreType.typeExpr (a.map (·.toExpr))
+    astExpr! fvar (toExpr idx) args
+| .arrow a r =>
+  astExpr! arrow a.toExpr r.toExpr
+| .funMacro i r =>
+  astExpr! funMacro (toExpr i) r.toExpr
+
+instance : ToExpr PreType where
+  toTypeExpr := mkConst ``PreType
+  toExpr := PreType.toExpr
+
+end PreType
+
 namespace MetadataArg
 
 protected def typeExpr := mkConst ``MetadataArg
 
 protected def toExpr : MetadataArg → Lean.Expr
-| .bool b   => mkApp (mkConst ``bool) (toExpr b)
-| .num n    => mkApp (mkConst ``num) (toExpr n)
-| .catbvar n => mkApp (mkConst ``catbvar) (toExpr n)
+| .bool b => astExpr! bool (toExpr b)
+| .num n => astExpr! num (toExpr n)
+| .catbvar n => astExpr! catbvar (toExpr n)
 | .option ma =>
   let maExpr := optionToExpr MetadataArg.typeExpr (ma.attach.map fun ⟨a, _⟩ => a.toExpr)
-  mkApp (mkConst ``MetadataArg.option) maExpr
+  astExpr! option maExpr
 
 instance : ToExpr MetadataArg where
   toTypeExpr := MetadataArg.typeExpr
@@ -145,19 +188,19 @@ end MetadataArg
 
 instance MetadataAttr.instToExpr : ToExpr MetadataAttr where
   toTypeExpr := mkConst ``MetadataAttr
-  toExpr a := mkAppN (mkConst ``MetadataAttr.mk) #[toExpr a.ident, toExpr a.args]
+  toExpr a := astExpr! MetadataAttr.mk (toExpr a.ident) (toExpr a.args)
 
 instance Metadata.instToExpr : ToExpr Metadata where
   toTypeExpr := mkConst ``Metadata
-  toExpr m := mkAppN (mkConst ``Metadata.ofArray) #[toExpr m.toArray]
+  toExpr m := astExpr! Metadata.ofArray (toExpr m.toArray)
 
 namespace ArgDeclKind
 
 instance : ToExpr ArgDeclKind where
   toTypeExpr := mkConst ``ArgDeclKind
   toExpr
-  | .cat c => mkApp (mkConst ``cat) (toExpr c)
-  | .type tp => mkApp (mkConst ``type) (toExpr tp)
+  | .cat c => astExpr! cat (toExpr c)
+  | .type tp => astExpr! type (toExpr tp)
 
 end ArgDeclKind
 
@@ -165,7 +208,7 @@ namespace ArgDecl
 
 instance : ToExpr ArgDecl where
   toTypeExpr := mkConst ``ArgDecl
-  toExpr  b := mkAppN (mkConst ``mk) #[toExpr b.ident, toExpr b.kind, toExpr b.metadata]
+  toExpr  b := astExpr! mk (toExpr b.ident) (toExpr b.kind) (toExpr b.metadata)
 
 end ArgDecl
 
@@ -174,9 +217,11 @@ namespace SyntaxDefAtom
 protected def typeExpr : Lean.Expr := mkConst ``SyntaxDefAtom
 
 protected def toExpr : SyntaxDefAtom → Lean.Expr
-| .ident v p => mkAppN (mkConst ``ident) #[toExpr v, toExpr p]
-| .str l     => mkAppN (mkConst ``str) #[toExpr l]
-| .indent n a => mkAppN (mkConst ``indent) #[toExpr n, arrayToExpr SyntaxDefAtom.typeExpr (a.map (·.toExpr))]
+| .ident v p => astExpr! ident (toExpr v) (toExpr p)
+| .str l     => astExpr! str (toExpr l)
+| .indent n a =>
+  let args := arrayToExpr SyntaxDefAtom.typeExpr (a.map (·.toExpr))
+  astExpr! indent (toExpr n) args
 
 instance : ToExpr SyntaxDefAtom where
   toTypeExpr := SyntaxDefAtom.typeExpr
@@ -188,87 +233,114 @@ namespace SyntaxDef
 
 instance : ToExpr SyntaxDef where
   toTypeExpr := mkConst ``SyntaxDef
-  toExpr s := mkApp2 (mkConst ``SyntaxDef.mk) (toExpr s.atoms) (toExpr s.prec)
+  toExpr s := astExpr! mk (toExpr s.atoms) (toExpr s.prec)
 
 end SyntaxDef
 
 instance SynCatDecl.instToExpr : ToExpr SynCatDecl where
   toTypeExpr := mkConst ``SynCatDecl
-  toExpr d := mkAppN (mkConst ``SynCatDecl.mk) #[toExpr d.name, toExpr d.argNames]
+  toExpr d := astExpr! mk (toExpr d.name) (toExpr d.argNames)
 
 namespace DebruijnIndex
 
-def ofNat {n : Nat} [NeZero n] (a : Nat) : DebruijnIndex n :=
+protected def ofNat {n : Nat} [NeZero n] (a : Nat) : DebruijnIndex n :=
   ⟨a % n, Nat.mod_lt _ (Nat.pos_of_neZero n)⟩
 
-instance : ToExpr (DebruijnIndex n) where
+instance {n} : ToExpr (DebruijnIndex n) where
   toTypeExpr := .app (mkConst ``DebruijnIndex) (toExpr n)
   toExpr a :=
-    mkApp3 (.const ``DebruijnIndex.ofNat [])
+    astExpr! DebruijnIndex.ofNat
         (toExpr n)
         (.app (.const ``Nat.instNeZeroSucc []) (mkNatLit (n-1)))
         (mkRawNatLit a.val)
 
 end DebruijnIndex
 
-protected
-def ValueBindingSpec.toExpr {bindings} (b : ValueBindingSpec bindings) (bindingsExpr : Lean.Expr) : Lean.Expr :=
-  mkAppN (mkConst ``ValueBindingSpec.mk) #[
-    bindingsExpr,
-    toExpr b.nameIndex,
-    toExpr b.argsIndex,
-    toExpr b.typeIndex,
-    toExpr b.allowCat
-  ]
+namespace ValueBindingSpec
 
-protected
-def TypeBindingSpec.toExpr (b : TypeBindingSpec bindings) (bindingsExpr : Lean.Expr) : Lean.Expr :=
-  mkAppN (mkConst ``TypeBindingSpec.mk) #[
-    bindingsExpr,
-    toExpr b.nameIndex,
-    toExpr b.argsIndex,
-    toExpr b.defIndex
-  ]
+protected def toExpr {argDecls} (b : ValueBindingSpec argDecls) (argDeclsExpr : Lean.Expr) : Lean.Expr :=
+  astExpr! mk
+    argDeclsExpr
+    (toExpr b.nameIndex)
+    (toExpr b.argsIndex)
+    (toExpr b.typeIndex)
+    (toExpr b.allowCat)
+
+end ValueBindingSpec
+
+namespace TypeBindingSpec
+
+protected def toExpr {argDecls} (b : TypeBindingSpec argDecls) (argDeclsExpr : Lean.Expr) : Lean.Expr :=
+  astExpr! mk
+    argDeclsExpr
+    (toExpr b.nameIndex)
+    (toExpr b.argsIndex)
+    (toExpr b.defIndex)
+
+end TypeBindingSpec
 
 namespace BindingSpec
 
-def typeExpr (bindingsExpr : Lean.Expr) : Lean.Expr := mkApp (mkConst ``BindingSpec) bindingsExpr
+def typeExpr (argDeclsExpr : Lean.Expr) : Lean.Expr := mkApp (mkConst ``BindingSpec) argDeclsExpr
 
-def toExpr (bi : BindingSpec bindings) (bindingsExpr : Lean.Expr) : Lean.Expr :=
+/--
+Converts a bindings specification to a Lean expression.
+
+To avoid recomputations, this takes the argDecls and its representation as an expression.
+-/
+def toExpr {argDecls} (bi : BindingSpec argDecls) (argDeclsExpr : Lean.Expr) : Lean.Expr :=
   match bi with
-  | .value b => mkApp2 (mkConst ``value) bindingsExpr (b.toExpr bindingsExpr)
-  | .type b => mkApp2 (mkConst ``type) bindingsExpr (b.toExpr bindingsExpr)
+  | .value b => astExpr! value argDeclsExpr (b.toExpr argDeclsExpr)
+  | .type b => astExpr! type argDeclsExpr (b.toExpr argDeclsExpr)
 
 end BindingSpec
 
-instance OpDecl.instToExpr : ToExpr OpDecl where
+namespace OpDecl
+
+instance : ToExpr OpDecl where
   toTypeExpr := mkConst ``OpDecl
   toExpr d :=
     let be := toExpr d.argDecls
-    mkAppN (mkConst ``OpDecl.mk) #[
-      toExpr d.name,
-      be,
-      toExpr d.category,
-      toExpr d.syntaxDef,
-      toExpr d.metadata,
-      arrayToExpr (BindingSpec.typeExpr be) (d.newBindings.map (·.toExpr be))
-    ]
+    let bindings := arrayToExpr (BindingSpec.typeExpr be) (d.newBindings.map (·.toExpr be))
+    astExpr! mk
+      (toExpr d.name)
+      be
+      (toExpr d.category)
+      (toExpr d.syntaxDef)
+      (toExpr d.metadata)
+      bindings
 
-instance TypeDecl.instToExpr : ToExpr TypeDecl where
+end OpDecl
+
+namespace TypeDecl
+
+instance : ToExpr TypeDecl where
   toTypeExpr := mkConst ``TypeDecl
-  toExpr d := mkApp2 (mkConst ``TypeDecl.mk) (toExpr d.name) (toExpr d.argNames)
+  toExpr d := astExpr! mk (toExpr d.name) (toExpr d.argNames)
 
-instance FunctionDecl.instToExpr : ToExpr FunctionDecl where
+end TypeDecl
+
+namespace FunctionDecl
+
+instance : ToExpr FunctionDecl where
   toTypeExpr := mkConst ``FunctionDecl
-  toExpr d := mkAppN (mkConst ``FunctionDecl.mk) #[toExpr d.name, toExpr d.argDecls, toExpr d.result, toExpr d.syntaxDef, toExpr d.metadata]
+  toExpr d :=
+    astExpr! mk
+      (toExpr d.name)
+      (toExpr d.argDecls)
+      (toExpr d.result)
+      (toExpr d.syntaxDef)
+      (toExpr d.metadata)
+
+end FunctionDecl
 
 namespace MetadataArgType
 
 protected def toExpr : MetadataArgType → Lean.Expr
-| .bool      => mkConst ``bool
-| .num      => mkConst ``num
-| .ident    => mkConst ``ident
-| .opt tp => mkApp (mkConst ``opt) tp.toExpr
+| .bool => astExpr! bool
+| .num => astExpr! num
+| .ident => astExpr! ident
+| .opt tp => astExpr! opt tp.toExpr
 
 instance : ToExpr MetadataArgType where
   toTypeExpr := mkConst ``MetadataArgType
@@ -278,42 +350,44 @@ end MetadataArgType
 
 instance MetadataArgDecl.instToExpr : ToExpr MetadataArgDecl where
   toTypeExpr := mkConst ``MetadataArgDecl
-  toExpr d := mkApp2 (mkConst ``MetadataArgDecl.mk) (toExpr d.ident) (toExpr d.type)
+  toExpr d := astExpr! MetadataArgDecl.mk (toExpr d.ident) (toExpr d.type)
 
 instance MetadataDecl.instToExpr : ToExpr MetadataDecl where
   toTypeExpr := mkConst ``MetadataDecl
-  toExpr d := mkApp2 (mkConst ``MetadataDecl.mk) (toExpr d.name) (toExpr d.args)
+  toExpr d := astExpr! MetadataDecl.mk (toExpr d.name) (toExpr d.args)
+
+namespace Decl
 
 instance Decl.instToExpr : ToExpr Decl where
   toTypeExpr := mkConst ``Decl
   toExpr
-  | .syncat d   => mkApp (mkConst ``Decl.syncat)   (toExpr d)
-  | .op d       => mkApp (mkConst ``Decl.op)       (toExpr d)
-  | .type d     => mkApp (mkConst ``Decl.type)     (toExpr d)
-  | .function d => mkApp (mkConst ``Decl.function) (toExpr d)
-  | .metadata d => mkApp (mkConst ``Decl.metadata) (toExpr d)
+  | .syncat d   => astExpr! syncat (toExpr d)
+  | .op d       => astExpr! op (toExpr d)
+  | .type d     => astExpr! type (toExpr d)
+  | .function d => astExpr! function (toExpr d)
+  | .metadata d => astExpr! metadata (toExpr d)
+
+end Decl
 
 instance Dialect.instToExpr : ToExpr Dialect where
   toTypeExpr := mkConst ``Dialect
   toExpr d :=
-    mkApp3 (mkConst ``Dialect.ofArray)
-           (toExpr d.name)
-           (toExpr d.imports)
-           (toExpr d.declarations)
+    astExpr! Dialect.ofArray (toExpr d.name) (toExpr d.imports) (toExpr d.declarations)
 
 namespace DialectMap
 
 instance : ToExpr DialectMap where
   toTypeExpr := mkConst ``DialectMap
-  toExpr d := mkApp (mkConst ``DialectMap.ofList!) (toExpr d.toList)
+  toExpr d := astExpr! ofList! (toExpr d.toList)
 
 end DialectMap
 
 instance Program.instToExpr : ToExpr Program where
   toTypeExpr := mkConst ``Program
-  toExpr ms := mkApp3 (mkConst ``Program.create)
-    (toExpr ms.dialects)
-    (toExpr ms.dialect)
-    (toExpr ms.commands)
+  toExpr ms :=
+    astExpr! Program.create
+      (toExpr ms.dialects)
+      (toExpr ms.dialect)
+      (toExpr ms.commands)
 
 end Strata


### PR DESCRIPTION
This is designed to improve type safety of DDM ToExpr instances.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
