### PR TITLE
Replace Identifier with `String x Metadata`

### DIFF
--- a/Strata/DL/Lambda/Identifiers.lean
+++ b/Strata/DL/Lambda/Identifiers.lean
@@ -19,24 +19,38 @@ section Identifiers
 /--
 Identifiers, optionally with their inferred monotype.
 -/
-abbrev IdentT (Identifier : Type) := Identifier × Option LMonoTy
-abbrev IdentTs (Identifier : Type) := List (IdentT Identifier)
+structure Identifier (IDMeta : Type) : Type where
+  name : String
+  metadata : IDMeta
+deriving Repr, DecidableEq, Inhabited
 
-instance {Identifier : Type} [ToFormat Identifier] : ToFormat (IdentT Identifier) where
+instance : ToFormat (Identifier IDMeta) where
+  format i := i.name
+
+instance : ToString (Identifier IDMeta) where
+  toString i := i.name
+
+instance {IDMeta} [Inhabited IDMeta] : Coe String (Identifier IDMeta) where
+  coe s := ⟨s, Inhabited.default⟩
+
+abbrev IdentT (IDMeta : Type) := (Identifier IDMeta) × Option LMonoTy
+abbrev IdentTs (IDMeta : Type) := List (IdentT IDMeta)
+
+instance {IDMeta : Type} : ToFormat (IdentT IDMeta) where
   format i := match i.snd with
     | none => f!"{i.fst}"
     | some ty => f!"({i.fst} : {ty})"
 
-def IdentT.ident (x : (IdentT Identifier)) : Identifier :=
+def IdentT.ident (x : (IdentT IDMeta)) : Identifier IDMeta :=
   x.fst
 
-def IdentT.monoty? (x : (IdentT Identifier)) : Option LMonoTy :=
+def IdentT.monoty? (x : (IdentT IDMeta)) : Option LMonoTy :=
   x.snd
 
-def IdentTs.idents (xs : (IdentTs Identifier)) : List Identifier :=
+def IdentTs.idents (xs : (IdentTs IDMeta)) : List (Identifier IDMeta) :=
   xs.map Prod.fst
 
-def IdentTs.monotys? (xs : (IdentTs Identifier)) : List (Option LMonoTy) :=
+def IdentTs.monotys? (xs : (IdentTs IDMeta)) : List (Option LMonoTy) :=
   xs.map Prod.snd
 
 ---------------------------------------------------------------------

--- a/Strata/DL/Lambda/IntBoolFactory.lean
+++ b/Strata/DL/Lambda/IntBoolFactory.lean
@@ -19,37 +19,37 @@ open LExpr LTy
 
 section IntBoolFactory
 
-def unaryOp [Coe String Ident]
-            (n : Ident)
+def unaryOp[Coe String (Identifier IDMeta)]
+            (n : Identifier IDMeta)
             (ty : LMonoTy)
-            (ceval : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
+            (ceval : Option (LExpr LMonoTy IDMeta → List (LExpr LMonoTy IDMeta) → LExpr LMonoTy IDMeta)) : LFunc IDMeta :=
   { name := n,
     inputs := [("x", ty)],
     output := ty,
     concreteEval := ceval }
 
-def binaryOp [Coe String Ident]
-             (n : Ident)
+def binaryOp [Coe String (Identifier IDMeta)]
+             (n : Identifier IDMeta)
              (ty : LMonoTy)
-             (ceval : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
+             (ceval : Option (LExpr LMonoTy IDMeta → List (LExpr LMonoTy IDMeta) → LExpr LMonoTy IDMeta)) : LFunc IDMeta :=
   { name := n,
     inputs := [("x", ty), ("y", ty)],
     output := ty,
     concreteEval := ceval }
 
-def binaryPredicate [Coe String Ident]
-                    (n : Ident)
+def binaryPredicate [Coe String (Identifier IDMeta)]
+                    (n : Identifier IDMeta)
                     (ty : LMonoTy)
-                    (ceval : Option (LExpr LMonoTy Ident → List (LExpr LMonoTy Ident) → LExpr LMonoTy Ident)) : LFunc Ident :=
+                    (ceval : Option (LExpr LMonoTy IDMeta → List (LExpr LMonoTy IDMeta) → LExpr LMonoTy IDMeta)) : LFunc IDMeta :=
   { name := n,
     inputs := [("x", ty), ("y", ty)],
     output := .bool,
     concreteEval := ceval }
 
-def unOpCeval  {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
-                (cevalInTy : (LExpr LMonoTy Identifier) → Option InTy) (op : InTy → OutTy)
+def unOpCeval  {IDMeta : Type} (InTy OutTy : Type) [ToString OutTy]
+                (cevalInTy : (LExpr LMonoTy IDMeta) → Option InTy) (op : InTy → OutTy)
                 (ty : LMonoTy) :
-                (LExpr LMonoTy Identifier) → List (LExpr LMonoTy Identifier) → (LExpr LMonoTy Identifier) :=
+                (LExpr LMonoTy IDMeta) → List (LExpr LMonoTy IDMeta) → (LExpr LMonoTy IDMeta) :=
   (fun e args => match args with
    | [e1] =>
      let e1i := cevalInTy e1
@@ -58,10 +58,10 @@ def unOpCeval  {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
      | _ => e
    | _ => e)
 
-def binOpCeval {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
-                (cevalInTy : (LExpr LMonoTy Identifier) → Option InTy) (op : InTy → InTy → OutTy)
+def binOpCeval {IDMeta : Type} (InTy OutTy : Type) [ToString OutTy]
+                (cevalInTy : (LExpr LMonoTy IDMeta) → Option InTy) (op : InTy → InTy → OutTy)
                 (ty : LMonoTy) :
-                (LExpr LMonoTy Identifier) → List (LExpr LMonoTy Identifier) → (LExpr LMonoTy Identifier) :=
+                (LExpr LMonoTy IDMeta) → List (LExpr LMonoTy IDMeta) → (LExpr LMonoTy IDMeta) :=
   (fun e args => match args with
    | [e1, e2] =>
      let e1i := cevalInTy e1
@@ -73,7 +73,7 @@ def binOpCeval {Identifier : Type} (InTy OutTy : Type) [ToString OutTy]
 
 -- We hand-code a denotation for `Int.Div` to leave the expression
 -- unchanged if we have `0` for the denominator.
-def cevalIntDiv (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : LExpr LMonoTy Ident :=
+def cevalIntDiv (e : LExpr LMonoTy IDMeta) (args : List (LExpr LMonoTy IDMeta)) : LExpr LMonoTy IDMeta :=
   match args with
   | [e1, e2] =>
     let e1i := LExpr.denoteInt e1
@@ -86,7 +86,7 @@ def cevalIntDiv (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : 
 
 -- We hand-code a denotation for `Int.Mod` to leave the expression
 -- unchanged if we have `0` for the denominator.
-def cevalIntMod (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : LExpr LMonoTy Ident :=
+def cevalIntMod (e : LExpr LMonoTy IDMeta) (args : List (LExpr LMonoTy IDMeta)) : LExpr LMonoTy IDMeta :=
   match args with
   | [e1, e2] =>
     let e1i := LExpr.denoteInt e1
@@ -99,68 +99,68 @@ def cevalIntMod (e : LExpr LMonoTy Ident) (args : List (LExpr LMonoTy Ident)) : 
 
 /- Integer Arithmetic Operations -/
 
-def intAddFunc [Coe String Ident] : LFunc Ident :=
+def intAddFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Int.Add" .int
   (some (binOpCeval Int Int LExpr.denoteInt Int.add .int))
 
-def intSubFunc [Coe String Ident] : LFunc Ident :=
+def intSubFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Int.Sub" .int
   (some (binOpCeval Int Int LExpr.denoteInt Int.sub .int))
 
-def intMulFunc [Coe String Ident] : LFunc Ident :=
+def intMulFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Int.Mul" .int
   (some (binOpCeval Int Int LExpr.denoteInt Int.mul .int))
 
-def intDivFunc [Coe String Ident] : LFunc Ident :=
+def intDivFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Int.Div" .int
   (some cevalIntDiv)
 
-def intModFunc [Coe String Ident] : LFunc Ident :=
+def intModFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Int.Mod" .int
   (some cevalIntMod)
 
-def intNegFunc [Coe String Ident] : LFunc Ident :=
+def intNegFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   unaryOp "Int.Neg" .int
   (some (unOpCeval Int Int LExpr.denoteInt Int.neg .int))
 
-def intLtFunc [Coe String Ident] : LFunc Ident :=
+def intLtFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryPredicate "Int.Lt" .int
   (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x < y) .bool))
 
-def intLeFunc [Coe String Ident] : LFunc Ident :=
+def intLeFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryPredicate "Int.Le" .int
   (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x <= y) .bool))
 
-def intGtFunc [Coe String Ident] : LFunc Ident :=
+def intGtFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta:=
   binaryPredicate "Int.Gt" .int
   (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x > y) .bool))
 
-def intGeFunc [Coe String Ident] : LFunc Ident :=
+def intGeFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryPredicate "Int.Ge" .int
   (some (binOpCeval Int Bool LExpr.denoteInt (fun x y => x >= y) .bool))
 
 /- Boolean Operations -/
-def boolAndFunc [Coe String Ident] : LFunc Ident :=
+def boolAndFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Bool.And" .bool
   (some (binOpCeval Bool Bool LExpr.denoteBool Bool.and .bool))
 
-def boolOrFunc [Coe String Ident] : LFunc Ident :=
+def boolOrFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Bool.Or" .bool
   (some (binOpCeval Bool Bool LExpr.denoteBool Bool.or .bool))
 
-def boolImpliesFunc [Coe String Ident] : LFunc Ident :=
+def boolImpliesFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Bool.Implies" .bool
   (some (binOpCeval Bool Bool LExpr.denoteBool (fun x y => ((not x) || y)) .bool))
 
-def boolEquivFunc [Coe String Ident] : LFunc Ident :=
+def boolEquivFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   binaryOp "Bool.Equiv" .bool
   (some (binOpCeval Bool Bool LExpr.denoteBool (fun x y => (x == y)) .bool))
 
-def boolNotFunc [Coe String Ident] : LFunc Ident :=
+def boolNotFunc [Coe String (Identifier IDMeta)] : LFunc IDMeta :=
   unaryOp "Bool.Not" .bool
   (some (unOpCeval Bool Bool LExpr.denoteBool Bool.not .bool))
 
-def IntBoolFactory : @Factory String :=
+def IntBoolFactory : @Factory Unit :=
   open LTy.Syntax in #[
     intAddFunc,
     intSubFunc,

--- a/Strata/DL/Lambda/LExpr.lean
+++ b/Strata/DL/Lambda/LExpr.lean
@@ -41,43 +41,43 @@ user-allowed type annotations (optional), and `Identifier` for allowed
 identifiers. For a fully annotated AST, see `LExprT` that is created after the
 type inference transform.
 -/
-inductive LExpr (TypeType : Type) (Identifier : Type) : Type where
+inductive LExpr (TypeType : Type) (IDMeta : Type) : Type where
   /-- `.const c ty`: constants (in the sense of literals). -/
   | const   (c : String) (ty : Option TypeType)
   /-- `.op c ty`: operation names. -/
-  | op      (o : Identifier) (ty : Option TypeType)
+  | op      (o : Identifier IDMeta) (ty : Option TypeType)
   /-- `.bvar deBruijnIndex`: bound variable. -/
   | bvar    (deBruijnIndex : Nat)
   /-- `.fvar name ty`: free variable, with an option (mono)type annotation. -/
-  | fvar    (name : Identifier) (ty : Option TypeType)
-  | mdata   (info : Info) (e : LExpr TypeType Identifier)
+  | fvar    (name : Identifier IDMeta) (ty : Option TypeType)
+  | mdata   (info : Info) (e : LExpr TypeType IDMeta)
   /-- `.abs ty e`: abstractions; `ty` the is type of bound variable. -/
-  | abs     (ty : Option TypeType) (e : LExpr TypeType Identifier)
+  | abs     (ty : Option TypeType) (e : LExpr TypeType IDMeta)
   /-- `.quant k ty tr e`: quantified expressions; `ty` the is type of bound variable, and `tr` the trigger. -/
-  | quant   (k : QuantifierKind) (ty : Option TypeType) (trigger: LExpr TypeType Identifier) (e : LExpr TypeType Identifier)
+  | quant   (k : QuantifierKind) (ty : Option TypeType) (trigger: LExpr TypeType IDMeta) (e : LExpr TypeType IDMeta)
   /-- `.app fn e`: function application. -/
-  | app     (fn e : LExpr TypeType Identifier)
+  | app     (fn e : LExpr TypeType IDMeta)
   /-- `.ite c t e`: if-then-else expression. -/
-  | ite     (c t e : LExpr TypeType Identifier)
+  | ite     (c t e : LExpr TypeType IDMeta)
   /-- `.eq e1 e2`: equality expression. -/
-  | eq      (e1 e2 : LExpr TypeType Identifier)
+  | eq      (e1 e2 : LExpr TypeType IDMeta)
   deriving Repr, DecidableEq
 
-def LExpr.noTrigger {TypeType: Type} {Identifier : Type} : LExpr TypeType Identifier := .bvar 0
-def LExpr.allTr {TypeType: Type} {Identifier : Type} (ty : Option TypeType) := @LExpr.quant TypeType Identifier .all ty
-def LExpr.all {TypeType: Type} {Identifier : Type} (ty : Option TypeType) := @LExpr.quant TypeType Identifier .all ty LExpr.noTrigger
-def LExpr.existTr {TypeType: Type} {Identifier : Type} (ty : Option TypeType) := @LExpr.quant TypeType Identifier .exist ty
-def LExpr.exist {TypeType: Type} {Identifier : Type} (ty : Option TypeType) := @LExpr.quant TypeType Identifier .exist ty LExpr.noTrigger
+def LExpr.noTrigger {TypeType: Type} {IDMeta : Type} : LExpr TypeType IDMeta := .bvar 0
+def LExpr.allTr {TypeType: Type} {IDMeta : Type} (ty : Option TypeType) := @LExpr.quant TypeType IDMeta .all ty
+def LExpr.all {TypeType: Type} {IDMeta : Type} (ty : Option TypeType) := @LExpr.quant TypeType IDMeta .all ty LExpr.noTrigger
+def LExpr.existTr {TypeType: Type} {IDMeta : Type} (ty : Option TypeType) := @LExpr.quant TypeType IDMeta .exist ty
+def LExpr.exist {TypeType: Type} {IDMeta : Type} (ty : Option TypeType) := @LExpr.quant TypeType IDMeta .exist ty LExpr.noTrigger
 
-abbrev LExpr.absUntyped {TypeType: Type} {Identifier : Type} := @LExpr.abs TypeType Identifier .none
-abbrev LExpr.allUntypedTr {TypeType: Type} {Identifier : Type} := @LExpr.quant TypeType Identifier .all .none
-abbrev LExpr.allUntyped {TypeType: Type} {Identifier : Type} := @LExpr.quant TypeType Identifier .all .none LExpr.noTrigger
-abbrev LExpr.existUntypedTr {TypeType: Type} {Identifier : Type} := @LExpr.quant TypeType Identifier .exist .none
-abbrev LExpr.existUntyped {TypeType: Type} {Identifier : Type} := @LExpr.quant TypeType Identifier .exist .none LExpr.noTrigger
+abbrev LExpr.absUntyped {TypeType: Type} {IDMeta : Type} := @LExpr.abs TypeType IDMeta .none
+abbrev LExpr.allUntypedTr {TypeType: Type} {IDMeta : Type} := @LExpr.quant TypeType IDMeta .all .none
+abbrev LExpr.allUntyped {TypeType: Type} {IDMeta : Type} := @LExpr.quant TypeType IDMeta .all .none LExpr.noTrigger
+abbrev LExpr.existUntypedTr {TypeType: Type} {IDMeta : Type} := @LExpr.quant TypeType IDMeta .exist .none
+abbrev LExpr.existUntyped {TypeType: Type} {IDMeta : Type} := @LExpr.quant TypeType IDMeta .exist .none LExpr.noTrigger
 
 
-def LExpr.sizeOf {TypeType: Type}  [SizeOf Identifier]
-  | LExpr.mdata (TypeType:=TypeType) (Identifier:=Identifier) _ e => 2 + sizeOf e
+def LExpr.sizeOf {TypeType: Type}  [SizeOf IDMeta]
+  | LExpr.mdata (TypeType:=TypeType) (IDMeta:=IDMeta) _ e => 2 + sizeOf e
   | LExpr.abs   _ e => 2 + sizeOf e
   | LExpr.quant _ _ tr e => 3 + sizeOf e + sizeOf tr
   | LExpr.app fn e => 3 + sizeOf fn + sizeOf e
@@ -85,16 +85,16 @@ def LExpr.sizeOf {TypeType: Type}  [SizeOf Identifier]
   | LExpr.eq  e1 e2 => 3 + sizeOf e1 + sizeOf e2
   | _ => 1
 
-instance  : SizeOf (LExpr TypeType Identifier) where
+instance  : SizeOf (LExpr TypeType IDMeta) where
   sizeOf := LExpr.sizeOf
 ---------------------------------------------------------------------
 
 namespace LExpr
 
-instance : Inhabited (LExpr TypeType Identifier) where
+instance : Inhabited (LExpr TypeType IDMeta) where
   default := .const "false" none
 
-def LExpr.getVars (e : (LExpr TypeType Identifier)) := match e with
+def LExpr.getVars (e : (LExpr TypeType IDMeta)) := match e with
   | .const _ _ => [] | .bvar _ => [] | .op _ _ => []
   | .fvar y _ => [y]
   | .mdata _ e' => LExpr.getVars e'
@@ -104,28 +104,28 @@ def LExpr.getVars (e : (LExpr TypeType Identifier)) := match e with
   | .ite c t e => LExpr.getVars c ++ LExpr.getVars t ++ LExpr.getVars e
   | .eq e1 e2 => LExpr.getVars e1 ++ LExpr.getVars e2
 
-def getFVarName? (e : (LExpr TypeType Identifier)) : Option Identifier :=
+def getFVarName? (e : (LExpr TypeType IDMeta)) : Option (Identifier IDMeta) :=
   match e with
   | .fvar name _ => some name
   | _ => none
 
-def isConst (e : (LExpr TypeType Identifier)) : Bool :=
+def isConst (e : (LExpr TypeType IDMeta)) : Bool :=
   match e with
   | .const _ _ => true
   | _ => false
 
 @[match_pattern]
-protected def true : (LExpr LMonoTy Identifier) := .const "true"  (some (.tcons "bool" []))
+protected def true : (LExpr LMonoTy IDMeta) := .const "true"  (some (.tcons "bool" []))
 
 @[match_pattern]
-protected def false : (LExpr LMonoTy Identifier) := .const "false"  (some (.tcons "bool" []))
+protected def false : (LExpr LMonoTy IDMeta) := .const "false"  (some (.tcons "bool" []))
 
-def isTrue (e : (LExpr TypeType Identifier)) : Bool :=
+def isTrue (e : (LExpr TypeType IDMeta)) : Bool :=
   match e with
   | .const "true" _ => true
   | _ => false
 
-def isFalse (e : (LExpr TypeType Identifier)) : Bool :=
+def isFalse (e : (LExpr TypeType IDMeta)) : Bool :=
   match e with
   | .const "false" _ => true
   | _ => false
@@ -134,7 +134,7 @@ def isFalse (e : (LExpr TypeType Identifier)) : Bool :=
 If `e` is an `LExpr` boolean, then denote that into a Lean `Bool`.
 Note that we are type-agnostic here.
 -/
-def denoteBool (e : (LExpr LMonoTy Identifier)) : Option Bool :=
+def denoteBool (e : (LExpr LMonoTy IDMeta)) : Option Bool :=
   match e with
   | .const "true"  (some (.tcons "bool" [])) => some true
   | .const "true"  none => some true
@@ -146,7 +146,7 @@ def denoteBool (e : (LExpr LMonoTy Identifier)) : Option Bool :=
 If `e` is an `LExpr` integer, then denote that into a Lean `Int`.
 Note that we are type-agnostic here.
 -/
-def denoteInt (e : (LExpr LMonoTy Identifier)) : Option Int :=
+def denoteInt (e : (LExpr LMonoTy IDMeta)) : Option Int :=
   match e with
   | .const x (some (.tcons "int" [])) => x.toInt?
   | .const x none => x.toInt?
@@ -156,7 +156,7 @@ def denoteInt (e : (LExpr LMonoTy Identifier)) : Option Int :=
 If `e` is an `LExpr` real, then denote that into a Lean `String`.
 Note that we are type-agnostic here.
 -/
-def denoteReal (e : (LExpr LMonoTy Identifier)) : Option String :=
+def denoteReal (e : (LExpr LMonoTy IDMeta)) : Option String :=
   match e with
   | .const x (some (.tcons "real" [])) => .some x
   | .const x none => .some x
@@ -166,7 +166,7 @@ def denoteReal (e : (LExpr LMonoTy Identifier)) : Option String :=
 If `e` is an `LExpr` bv<n>, then denote that into a Lean `BitVec n`.
 Note that we are type-agnostic here.
 -/
-def denoteBitVec (n : Nat) (e : (LExpr LMonoTy Identifier)) : Option (BitVec n) :=
+def denoteBitVec (n : Nat) (e : (LExpr LMonoTy IDMeta)) : Option (BitVec n) :=
   match e with
   | .const x (.some (.bitvec n')) =>
     if n == n' then .map (.ofNat n) x.toNat? else none
@@ -177,12 +177,12 @@ def denoteBitVec (n : Nat) (e : (LExpr LMonoTy Identifier)) : Option (BitVec n) 
 If `e` is an _annotated_ `LExpr` string, then denote that into a Lean `String`.
 Note that unannotated strings are not denoted.
 -/
-def denoteString (e : (LExpr LMonoTy Identifier)) : Option String :=
+def denoteString (e : (LExpr LMonoTy IDMeta)) : Option String :=
   match e with
   | .const c  (some (.tcons "string" [])) => some c
   | _ => none
 
-def mkApp (fn : (LExpr TypeType Identifier)) (args : List (LExpr TypeType Identifier)) : (LExpr TypeType Identifier) :=
+def mkApp (fn : (LExpr TypeType IDMeta)) (args : List (LExpr TypeType IDMeta)) : (LExpr TypeType IDMeta) :=
   match args with
   | [] => fn
   | a :: rest =>
@@ -191,7 +191,7 @@ def mkApp (fn : (LExpr TypeType Identifier)) (args : List (LExpr TypeType Identi
 /--
 Does `e` have a metadata annotation? We don't check for nested metadata in `e`.
 -/
-def isMData (e : (LExpr TypeType Identifier)) : Bool :=
+def isMData (e : (LExpr TypeType IDMeta)) : Bool :=
   match e with
   | .mdata _ _ => true
   | _ => false
@@ -199,7 +199,7 @@ def isMData (e : (LExpr TypeType Identifier)) : Bool :=
 /--
 Remove the outermost metadata annotation in `e`, if any.
 -/
-def removeMData1 (e : (LExpr TypeType Identifier)) : (LExpr TypeType Identifier) :=
+def removeMData1 (e : (LExpr TypeType IDMeta)) : (LExpr TypeType IDMeta) :=
   match e with
   | .mdata _ e => e
   | _ => e
@@ -207,7 +207,7 @@ def removeMData1 (e : (LExpr TypeType Identifier)) : (LExpr TypeType Identifier)
 /--
 Remove all metadata annotations in `e`, included nested ones.
 -/
-def removeAllMData (e : (LExpr TypeType Identifier)) : (LExpr TypeType Identifier) :=
+def removeAllMData (e : (LExpr TypeType IDMeta)) : (LExpr TypeType IDMeta) :=
   match e with
   | .const _ _ | .op _ _ | .fvar _ _ | .bvar _ => e
   | .mdata _ e1 => removeAllMData e1
@@ -223,7 +223,7 @@ Compute the size of `e` as a tree.
 Not optimized for execution efficiency, but can be used for termination
 arguments.
 -/
-def size (e : (LExpr TypeType Identifier)) : Nat :=
+def size (e : (LExpr TypeType IDMeta)) : Nat :=
   match e with
   | .const _ _ => 1
   | .op _ _ => 1
@@ -239,7 +239,7 @@ def size (e : (LExpr TypeType Identifier)) : Nat :=
 /--
 Erase all type annotations from `e`.
 -/
-def eraseTypes (e : (LExpr TypeType Identifier)) : (LExpr TypeType Identifier) :=
+def eraseTypes (e : (LExpr TypeType IDMeta)) : (LExpr TypeType IDMeta) :=
   match e with
   | .const c _ => .const c none
   | .op o _ => .op o none
@@ -256,10 +256,10 @@ def eraseTypes (e : (LExpr TypeType Identifier)) : (LExpr TypeType Identifier) :
 
 /- Formatting and Parsing of Lambda Expressions -/
 
-instance (Identifier : Type) [Repr Identifier] [Repr TypeType] : ToString (LExpr TypeType Identifier) where
+instance (IDMeta : Type) [Repr IDMeta] [Repr TypeType] : ToString (LExpr TypeType IDMeta) where
    toString a := toString (repr a)
 
-private def formatLExpr [ToFormat Identifier] [ToFormat TypeType] (e : (LExpr TypeType Identifier)) :
+private def formatLExpr [ToFormat TypeType] (e : (LExpr TypeType IDMeta)) :
     Format :=
   match e with
   | .const c ty =>
@@ -286,7 +286,7 @@ private def formatLExpr [ToFormat Identifier] [ToFormat TypeType] (e : (LExpr Ty
                        ++ formatLExpr e)
   | .eq e1 e2 => Format.paren (formatLExpr e1 ++ " == " ++ formatLExpr e2)
 
-instance [ToFormat Identifier] [ToFormat TypeType] : ToFormat (LExpr TypeType Identifier) where
+instance [ToFormat TypeType] : ToFormat (LExpr TypeType IDMeta) where
   format := formatLExpr
 
 /-
@@ -296,7 +296,7 @@ Syntax for conveniently building `LExpr` terms with `LMonoTy`, scoped under the 
 namespace SyntaxMono
 open Lean Elab Meta
 
-class MkIdent (Identifier : Type) where
+class MkIdent (IDMeta : Type) where
   elabIdent : Lean.Syntax → MetaM Expr
   toExpr : Expr
 
@@ -320,54 +320,54 @@ scoped syntax "#" noWs ident : lconstmono
 scoped syntax "(" lconstmono ":" lmonoty ")" : lconstmono
 scoped syntax lconstmono : lexprmono
 
-def elabLConstMono (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLConstMono (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lconstmono| #$n:num)  => do
     let none ← mkNone (mkConst ``LMonoTy)
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit (toString n.getNat), none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit (toString n.getNat), none]
   | `(lconstmono| (#$n:num : $ty:lmonoty)) => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit (toString n.getNat), lmonoty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit (toString n.getNat), lmonoty]
   | `(lconstmono| #-$n:num) => do
     let none ← mkNone (mkConst ``LMonoTy)
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit ("-" ++ (toString n.getNat)), none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit ("-" ++ (toString n.getNat)), none]
   | `(lconstmono| (#-$n:num : $ty:lmonoty)) => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit ("-" ++ (toString n.getNat)), lmonoty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit ("-" ++ (toString n.getNat)), lmonoty]
   | `(lconstmono| #true)    => do
     let none ← mkNone (mkConst ``LMonoTy)
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "true", none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "true", none]
   | `(lconstmono| (#true : $ty:lmonoty))    => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "true", lmonoty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "true", lmonoty]
   | `(lconstmono| #false)   =>  do
     let none ← mkNone (mkConst ``LMonoTy)
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "false", none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "false", none]
   | `(lconstmono| (#false : $ty:lmonoty))    => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "false", lmonoty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "false", lmonoty]
   | `(lconstmono| #$s:ident) => do
     let none ← mkNone (mkConst ``LMonoTy)
     let s := toString s.getId
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit s, none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit s, none]
   | `(lconstmono| (#$s:ident : $ty:lmonoty)) => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
     let s := toString s.getId
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit s, lmonoty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit s, lmonoty]
   | _ => throwUnsupportedSyntax
 
 declare_syntax_cat lopmono
@@ -375,24 +375,24 @@ scoped syntax "~" noWs lidentmono : lopmono
 scoped syntax "(" lopmono ":" lmonoty ")" : lopmono
 scoped syntax lopmono : lexprmono
 
-def elabLOpMono (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLOpMono (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lopmono| ~$s:lidentmono)  => do
     let none ← mkNone (mkConst ``LMonoTy)
-    let ident ← MkIdent.elabIdent Identifier s
+    let ident ← MkIdent.elabIdent IDMeta s
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.op []) #[typeTypeExpr, MkIdent.toExpr Identifier, ident, none]
+    return mkAppN (.const ``LExpr.op []) #[typeTypeExpr, MkIdent.toExpr IDMeta, ident, none]
   | `(lopmono| (~$s:lidentmono : $ty:lmonoty)) => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-    mkAppM ``LExpr.op #[← MkIdent.elabIdent Identifier s, lmonoty]
+    mkAppM ``LExpr.op #[← MkIdent.elabIdent IDMeta s, lmonoty]
   | _ => throwUnsupportedSyntax
 
 declare_syntax_cat lbvarmono
 scoped syntax "%" noWs num : lbvarmono
-def elabLBVarMono (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLBVarMono (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lbvarmono| %$n:num) =>
     let typeTypeExpr := mkConst ``LMonoTy
-    return mkAppN (.const ``LExpr.bvar []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkNatLit n.getNat]
+    return mkAppN (.const ``LExpr.bvar []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkNatLit n.getNat]
   | _ => throwUnsupportedSyntax
 scoped syntax lbvarmono : lexprmono
 
@@ -400,14 +400,14 @@ declare_syntax_cat lfvarmono
 scoped syntax lidentmono : lfvarmono
 scoped syntax "(" lidentmono ":" lmonoty ")" : lfvarmono
 
-def elabLFVarMono (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLFVarMono (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lfvarmono| $i:lidentmono) => do
     let none ← mkNone (mkConst ``LMonoTy)
-    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent Identifier i, none]
+    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent IDMeta i, none]
   | `(lfvarmono| ($i:lidentmono : $ty:lmonoty)) => do
     let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy ty
     let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent Identifier i, lmonoty]
+    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent IDMeta i, lmonoty]
   | _ => throwUnsupportedSyntax
 scoped syntax lfvarmono : lexprmono
 
@@ -448,80 +448,80 @@ All type annotations in `LExpr` are for monotypes, not polytypes. It's the
 user's responsibility to ensure correct usage of type variables (i.e., they're
 unique).
 -/
-partial def elabLExprMono (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
-  | `(lexprmono| $c:lconstmono) => elabLConstMono Identifier c
-  | `(lexprmono| $o:lopmono) => elabLOpMono Identifier o
-  | `(lexprmono| $b:lbvarmono) => elabLBVarMono Identifier b
-  | `(lexprmono| $f:lfvarmono) => elabLFVarMono Identifier f
+partial def elabLExprMono (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
+  | `(lexprmono| $c:lconstmono) => elabLConstMono IDMeta c
+  | `(lexprmono| $o:lopmono) => elabLOpMono IDMeta o
+  | `(lexprmono| $b:lbvarmono) => elabLBVarMono IDMeta b
+  | `(lexprmono| $f:lfvarmono) => elabLFVarMono IDMeta f
   | `(lexprmono| λ $e:lexprmono) => do
-     let e' ← elabLExprMono Identifier e
+     let e' ← elabLExprMono IDMeta e
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.absUntyped []) #[typeTypeExpr, MkIdent.toExpr Identifier, e']
+     return mkAppN (.const ``LExpr.absUntyped []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e']
   | `(lexprmono| λ ($mty:lmonoty): $e:lexprmono) => do
      let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy mty
      let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-     let e' ← elabLExprMono Identifier e
+     let e' ← elabLExprMono IDMeta e
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.abs []) #[typeTypeExpr, MkIdent.toExpr Identifier, lmonoty, e']
+     return mkAppN (.const ``LExpr.abs []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lmonoty, e']
   | `(lexprmono| ∀ $e:lexprmono) => do
-     let e' ← elabLExprMono Identifier e
+     let e' ← elabLExprMono IDMeta e
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.allUntyped []) #[typeTypeExpr, MkIdent.toExpr Identifier, e']
+     return mkAppN (.const ``LExpr.allUntyped []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e']
   | `(lexprmono| ∀ {$tr}$e:lexprmono) => do
-     let e' ← elabLExprMono Identifier e
-     let tr' ← elabLExprMono Identifier tr
+     let e' ← elabLExprMono IDMeta e
+     let tr' ← elabLExprMono IDMeta tr
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.allUntypedTr []) #[typeTypeExpr, MkIdent.toExpr Identifier, tr', e']
+     return mkAppN (.const ``LExpr.allUntypedTr []) #[typeTypeExpr, MkIdent.toExpr IDMeta, tr', e']
   | `(lexprmono| ∀ ($mty:lmonoty): $e:lexprmono) => do
      let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy mty
      let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-     let e' ← elabLExprMono Identifier e
+     let e' ← elabLExprMono IDMeta e
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.all []) #[typeTypeExpr, MkIdent.toExpr Identifier, lmonoty, e']
+     return mkAppN (.const ``LExpr.all []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lmonoty, e']
   | `(lexprmono| ∀ ($mty:lmonoty):{$tr} $e:lexprmono) => do
      let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy mty
      let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-     let e' ← elabLExprMono Identifier e
-     let tr' ← elabLExprMono Identifier tr
+     let e' ← elabLExprMono IDMeta e
+     let tr' ← elabLExprMono IDMeta tr
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.allTr []) #[typeTypeExpr, MkIdent.toExpr Identifier, lmonoty, tr', e']
+     return mkAppN (.const ``LExpr.allTr []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lmonoty, tr', e']
   | `(lexprmono| ∃ ($mty:lmonoty): $e:lexprmono) => do
      let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy mty
      let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-     let e' ← elabLExprMono Identifier e
+     let e' ← elabLExprMono IDMeta e
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.exist []) #[typeTypeExpr, MkIdent.toExpr Identifier, lmonoty, e']
+     return mkAppN (.const ``LExpr.exist []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lmonoty, e']
   | `(lexprmono| ∃ ($mty:lmonoty):{$tr} $e:lexprmono) => do
      let lmonoty ← Lambda.LTy.Syntax.elabLMonoTy mty
      let lmonoty ← mkSome (mkConst ``LMonoTy) lmonoty
-     let e' ← elabLExprMono Identifier e
-     let tr' ← elabLExprMono Identifier tr
+     let e' ← elabLExprMono IDMeta e
+     let tr' ← elabLExprMono IDMeta tr
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.existTr []) #[typeTypeExpr, MkIdent.toExpr Identifier, lmonoty, tr', e']
+     return mkAppN (.const ``LExpr.existTr []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lmonoty, tr', e']
   | `(lexprmono| ∃ $e:lexprmono) => do
-     let e' ← elabLExprMono Identifier e
+     let e' ← elabLExprMono IDMeta e
      mkAppM ``LExpr.existUntyped #[e']
   | `(lexprmono| ∃{$tr} $e:lexprmono) => do
-     let e' ← elabLExprMono Identifier e
-     let tr' ← elabLExprMono Identifier tr
+     let e' ← elabLExprMono IDMeta e
+     let tr' ← elabLExprMono IDMeta tr
      mkAppM ``LExpr.existUntypedTr #[tr', e']
   | `(lexprmono| ($e1:lexprmono $e2:lexprmono)) => do
-     let e1' ← elabLExprMono Identifier e1
-     let e2' ← elabLExprMono Identifier e2
+     let e1' ← elabLExprMono IDMeta e1
+     let e2' ← elabLExprMono IDMeta e2
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.app []) #[typeTypeExpr, MkIdent.toExpr Identifier, e1', e2']
+     return mkAppN (.const ``LExpr.app []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e1', e2']
   | `(lexprmono| $e1:lexprmono == $e2:lexprmono) => do
-     let e1' ← elabLExprMono Identifier e1
-     let e2' ← elabLExprMono Identifier e2
+     let e1' ← elabLExprMono IDMeta e1
+     let e2' ← elabLExprMono IDMeta e2
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.eq []) #[typeTypeExpr, MkIdent.toExpr Identifier, e1', e2']
+     return mkAppN (.const ``LExpr.eq []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e1', e2']
   | `(lexprmono| if $e1:lexprmono then $e2:lexprmono else $e3:lexprmono) => do
-     let e1' ← elabLExprMono Identifier e1
-     let e2' ← elabLExprMono Identifier e2
-     let e3' ← elabLExprMono Identifier e3
+     let e1' ← elabLExprMono IDMeta e1
+     let e2' ← elabLExprMono IDMeta e2
+     let e3' ← elabLExprMono IDMeta e3
      let typeTypeExpr := mkConst ``LMonoTy
-     return mkAppN (.const ``LExpr.ite []) #[typeTypeExpr, MkIdent.toExpr Identifier, e1', e2', e3']
-  | `(lexprmono| ($e:lexprmono)) => elabLExprMono Identifier e
+     return mkAppN (.const ``LExpr.ite []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e1', e2', e3']
+  | `(lexprmono| ($e:lexprmono)) => elabLExprMono IDMeta e
   | _ => throwUnsupportedSyntax
 
 scoped syntax ident : lidentmono
@@ -529,38 +529,38 @@ scoped syntax ident : lidentmono
 def elabStrIdent : Lean.Syntax → MetaM Expr
   | `(lidentmono| $s:ident) => do
     let s := s.getId
-    return mkStrLit s.toString
+    return mkAppN (.const `Lambda.Identifier.mk []) #[.const ``Unit [], mkStrLit s.toString, .const ``Unit.unit []]
   | _ => throwUnsupportedSyntax
 
-instance : MkIdent String where
+instance : MkIdent Unit where
   elabIdent := elabStrIdent
-  toExpr := .const ``String []
+  toExpr := .const ``Unit []
 
-elab "esM[" e:lexprmono "]" : term => elabLExprMono (Identifier:=String) e
+elab "esM[" e:lexprmono "]" : term => elabLExprMono (IDMeta:=Unit) e
 
 open LTy.Syntax
 
-/-- info: (bvar 0).absUntyped.app (const "5" none) : LExpr LMonoTy String -/
+/-- info: (bvar 0).absUntyped.app (const "5" none) : LExpr LMonoTy Unit -/
 #guard_msgs in
 #check esM[((λ %0) #5)]
 
-/-- info: (abs (some (LMonoTy.tcons "bool" [])) (bvar 0)).app (const "true" none) : LExpr LMonoTy String -/
+/-- info: (abs (some (LMonoTy.tcons "bool" [])) (bvar 0)).app (const "true" none) : LExpr LMonoTy Unit -/
 #guard_msgs in
 #check esM[((λ (bool): %0) #true)]
 
-/-- info: ((bvar 0).eq (const "5" none)).allUntyped : LExpr LMonoTy String -/
+/-- info: ((bvar 0).eq (const "5" none)).allUntyped : LExpr LMonoTy Unit -/
 #guard_msgs in
 #check esM[(∀ %0 == #5)]
 
-/-- info: ((bvar 0).eq (const "5" none)).existUntyped : LExpr LMonoTy String -/
+/-- info: ((bvar 0).eq (const "5" none)).existUntyped : LExpr LMonoTy Unit -/
 #guard_msgs in
 #check esM[(∃ %0 == #5)]
 
-/-- info: exist (some (LMonoTy.tcons "int" [])) ((bvar 0).eq (const "5" none)) : LExpr LMonoTy String -/
+/-- info: exist (some (LMonoTy.tcons "int" [])) ((bvar 0).eq (const "5" none)) : LExpr LMonoTy Unit -/
 #guard_msgs in
 #check esM[(∃ (int): %0 == #5)]
 
-/-- info: fvar "x" (some (LMonoTy.tcons "bool" [])) : LExpr LMonoTy String -/
+/-- info: fvar { name := "x", metadata := () } (some (LMonoTy.tcons "bool" [])) : LExpr LMonoTy Unit -/
 #guard_msgs in
 #check esM[(x : bool)]
 
@@ -569,13 +569,13 @@ open LTy.Syntax
 info: all (some (LMonoTy.tcons "Map" [LMonoTy.ftvar "k", LMonoTy.ftvar "v"]))
   (all (some (LMonoTy.ftvar "k"))
     (all (some (LMonoTy.ftvar "v"))
-      ((((op "select"
+      ((((op { name := "select", metadata := () }
                     (some
                       (LMonoTy.tcons "Map"
                         [LMonoTy.ftvar "k",
                           LMonoTy.tcons "arrow"
                             [LMonoTy.ftvar "v", LMonoTy.tcons "arrow" [LMonoTy.ftvar "k", LMonoTy.ftvar "v"]]]))).app
-                ((((op "update"
+                ((((op { name := "update", metadata := () }
                               (some
                                 (LMonoTy.tcons "Map"
                                   [LMonoTy.ftvar "k",
@@ -590,7 +590,7 @@ info: all (some (LMonoTy.tcons "Map" [LMonoTy.ftvar "k", LMonoTy.ftvar "v"]))
                       (bvar 1)).app
                   (bvar 0))).app
             (bvar 1)).eq
-        (bvar 0)))) : LExpr LMonoTy String
+        (bvar 0)))) : LExpr LMonoTy Unit
 -/
 #guard_msgs in
 #check
@@ -611,7 +611,7 @@ Syntax for conveniently building `LExpr` terms with `LTy`, scoped under the name
 namespace Syntax
 open Lean Elab Meta
 
-class MkIdent (Identifier : Type) where
+class MkIdent (IDMeta : Type) where
   elabIdent : Lean.Syntax → MetaM Expr
   toExpr : Expr
 
@@ -635,54 +635,54 @@ scoped syntax "#" noWs ident : lconst
 scoped syntax "(" lconst ":" lty ")" : lconst
 scoped syntax lconst : lexpr
 
-def elabLConst (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLConst (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lconst| #$n:num)  => do
     let none ← mkNone (mkConst ``LTy)
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit (toString n.getNat), none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit (toString n.getNat), none]
   | `(lconst| (#$n:num : $ty:lty)) => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit (toString n.getNat), lty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit (toString n.getNat), lty]
   | `(lconst| #-$n:num) => do
     let none ← mkNone (mkConst ``LTy)
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit ("-" ++ (toString n.getNat)), none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit ("-" ++ (toString n.getNat)), none]
   | `(lconst| (#-$n:num : $ty:lty)) => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit ("-" ++ (toString n.getNat)), lty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit ("-" ++ (toString n.getNat)), lty]
   | `(lconst| #true)    => do
     let none ← mkNone (mkConst ``LTy)
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "true", none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "true", none]
   | `(lconst| (#true : $ty:lty))    => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "true", lty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "true", lty]
   | `(lconst| #false)   =>  do
     let none ← mkNone (mkConst ``LTy)
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "false", none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "false", none]
   | `(lconst| (#false : $ty:lty))    => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit "false", lty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit "false", lty]
   | `(lconst| #$s:ident) => do
     let none ← mkNone (mkConst ``LTy)
     let s := toString s.getId
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit s, none]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit s, none]
   | `(lconst| (#$s:ident : $ty:lty)) => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
     let s := toString s.getId
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkStrLit s, lty]
+    return mkAppN (.const ``LExpr.const []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkStrLit s, lty]
   | _ => throwUnsupportedSyntax
 
 declare_syntax_cat lop
@@ -690,24 +690,24 @@ scoped syntax "~" noWs lident : lop
 scoped syntax "(" lop ":" lty ")" : lop
 scoped syntax lop : lexpr
 
-def elabLOp (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLOp (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lop| ~$s:lident)  => do
     let none ← mkNone (mkConst ``LTy)
-    let ident ← MkIdent.elabIdent Identifier s
+    let ident ← MkIdent.elabIdent IDMeta s
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.op []) #[typeTypeExpr, MkIdent.toExpr Identifier, ident, none]
+    return mkAppN (.const ``LExpr.op []) #[typeTypeExpr, MkIdent.toExpr IDMeta, ident, none]
   | `(lop| (~$s:lident : $ty:lty)) => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
-    mkAppM ``LExpr.op #[← MkIdent.elabIdent Identifier s, lty]
+    mkAppM ``LExpr.op #[← MkIdent.elabIdent IDMeta s, lty]
   | _ => throwUnsupportedSyntax
 
 declare_syntax_cat lbvar
 scoped syntax "%" noWs num : lbvar
-def elabLBVar (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLBVar (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lbvar| %$n:num) =>
     let typeTypeExpr := mkConst ``LTy
-    return mkAppN (.const ``LExpr.bvar []) #[typeTypeExpr, MkIdent.toExpr Identifier, mkNatLit n.getNat]
+    return mkAppN (.const ``LExpr.bvar []) #[typeTypeExpr, MkIdent.toExpr IDMeta, mkNatLit n.getNat]
   | _ => throwUnsupportedSyntax
 scoped syntax lbvar : lexpr
 
@@ -715,14 +715,14 @@ declare_syntax_cat lfvar
 scoped syntax lident : lfvar
 scoped syntax "(" lident ":" lty ")" : lfvar
 
-def elabLFVar (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
+def elabLFVar (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
   | `(lfvar| $i:lident) => do
     let none ← mkNone (mkConst ``LTy)
-    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent Identifier i, none]
+    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent IDMeta i, none]
   | `(lfvar| ($i:lident : $ty:lty)) => do
     let lty ← Lambda.LTy.Syntax.elabLTy ty
     let lty ← mkSome (mkConst ``LTy) lty
-    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent Identifier i, lty]
+    mkAppM ``LExpr.fvar #[← MkIdent.elabIdent IDMeta i, lty]
   | _ => throwUnsupportedSyntax
 scoped syntax lfvar : lexpr
 
@@ -762,80 +762,80 @@ open LTy.Syntax in
 It's the user's responsibility to ensure correct usage of type variables (i.e., they're
 unique).
 -/
-partial def elabLExpr (Identifier : Type) [MkIdent Identifier] : Lean.Syntax → MetaM Expr
-  | `(lexpr| $c:lconst) => elabLConst Identifier c
-  | `(lexpr| $o:lop) => elabLOp Identifier o
-  | `(lexpr| $b:lbvar) => elabLBVar Identifier b
-  | `(lexpr| $f:lfvar) => elabLFVar Identifier f
+partial def elabLExpr (IDMeta : Type) [MkIdent IDMeta] : Lean.Syntax → MetaM Expr
+  | `(lexpr| $c:lconst) => elabLConst IDMeta c
+  | `(lexpr| $o:lop) => elabLOp IDMeta o
+  | `(lexpr| $b:lbvar) => elabLBVar IDMeta b
+  | `(lexpr| $f:lfvar) => elabLFVar IDMeta f
   | `(lexpr| λ $e:lexpr) => do
-     let e' ← elabLExpr Identifier e
+     let e' ← elabLExpr IDMeta e
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.absUntyped []) #[typeTypeExpr, MkIdent.toExpr Identifier, e']
+     return mkAppN (.const ``LExpr.absUntyped []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e']
   | `(lexpr| λ ($mty:lty): $e:lexpr) => do
      let lty ← Lambda.LTy.Syntax.elabLTy mty
      let lty ← mkSome (mkConst ``LTy) lty
-     let e' ← elabLExpr Identifier e
+     let e' ← elabLExpr IDMeta e
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.abs []) #[typeTypeExpr, MkIdent.toExpr Identifier, lty, e']
+     return mkAppN (.const ``LExpr.abs []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lty, e']
   | `(lexpr| ∀ $e:lexpr) => do
-     let e' ← elabLExpr Identifier e
+     let e' ← elabLExpr IDMeta e
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.allUntyped []) #[typeTypeExpr, MkIdent.toExpr Identifier, e']
+     return mkAppN (.const ``LExpr.allUntyped []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e']
   | `(lexpr| ∀{$tr}$e:lexpr) => do
-     let e' ← elabLExpr Identifier e
-     let tr' ← elabLExpr Identifier tr
+     let e' ← elabLExpr IDMeta e
+     let tr' ← elabLExpr IDMeta tr
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.allUntypedTr []) #[typeTypeExpr, MkIdent.toExpr Identifier, tr', e']
+     return mkAppN (.const ``LExpr.allUntypedTr []) #[typeTypeExpr, MkIdent.toExpr IDMeta, tr', e']
   | `(lexpr| ∀ ($mty:lty): $e:lexpr) => do
      let lty ← Lambda.LTy.Syntax.elabLTy mty
      let lty ← mkSome (mkConst ``LTy) lty
-     let e' ← elabLExpr Identifier e
+     let e' ← elabLExpr IDMeta e
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.all []) #[typeTypeExpr, MkIdent.toExpr Identifier, lty, e']
+     return mkAppN (.const ``LExpr.all []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lty, e']
   | `(lexpr| ∀ ($mty:lty): {$tr}$e:lexpr) => do
      let lty ← Lambda.LTy.Syntax.elabLTy mty
      let lty ← mkSome (mkConst ``LTy) lty
-     let e' ← elabLExpr Identifier e
-     let tr' ← elabLExpr Identifier tr
+     let e' ← elabLExpr IDMeta e
+     let tr' ← elabLExpr IDMeta tr
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.allTr []) #[typeTypeExpr, MkIdent.toExpr Identifier, lty, tr', e']
+     return mkAppN (.const ``LExpr.allTr []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lty, tr', e']
   | `(lexpr| ∃ ($mty:lty): $e:lexpr) => do
      let lty ← Lambda.LTy.Syntax.elabLTy mty
      let lty ← mkSome (mkConst ``LTy) lty
-     let e' ← elabLExpr Identifier e
+     let e' ← elabLExpr IDMeta e
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.exist []) #[typeTypeExpr, MkIdent.toExpr Identifier, lty, e']
+     return mkAppN (.const ``LExpr.exist []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lty, e']
   | `(lexpr| ∃ ($mty:lty): {$tr}$e:lexpr) => do
      let lty ← Lambda.LTy.Syntax.elabLTy mty
      let lty ← mkSome (mkConst ``LTy) lty
-     let e' ← elabLExpr Identifier e
-     let tr' ← elabLExpr Identifier tr
+     let e' ← elabLExpr IDMeta e
+     let tr' ← elabLExpr IDMeta tr
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.existTr []) #[typeTypeExpr, MkIdent.toExpr Identifier, lty, tr', e']
+     return mkAppN (.const ``LExpr.existTr []) #[typeTypeExpr, MkIdent.toExpr IDMeta, lty, tr', e']
   | `(lexpr| ∃ $e:lexpr) => do
-     let e' ← elabLExpr Identifier e
+     let e' ← elabLExpr IDMeta e
      mkAppM ``LExpr.existUntyped #[e']
   | `(lexpr| ∃ {$tr} $e:lexpr) => do
-     let e' ← elabLExpr Identifier e
-     let tr' ← elabLExpr Identifier tr
+     let e' ← elabLExpr IDMeta e
+     let tr' ← elabLExpr IDMeta tr
      mkAppM ``LExpr.existUntypedTr #[tr', e']
   | `(lexpr| ($e1:lexpr $e2:lexpr)) => do
-     let e1' ← elabLExpr Identifier e1
-     let e2' ← elabLExpr Identifier e2
+     let e1' ← elabLExpr IDMeta e1
+     let e2' ← elabLExpr IDMeta e2
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.app []) #[typeTypeExpr, MkIdent.toExpr Identifier, e1', e2']
+     return mkAppN (.const ``LExpr.app []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e1', e2']
   | `(lexpr| $e1:lexpr == $e2:lexpr) => do
-     let e1' ← elabLExpr Identifier e1
-     let e2' ← elabLExpr Identifier e2
+     let e1' ← elabLExpr IDMeta e1
+     let e2' ← elabLExpr IDMeta e2
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.eq []) #[typeTypeExpr, MkIdent.toExpr Identifier, e1', e2']
+     return mkAppN (.const ``LExpr.eq []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e1', e2']
   | `(lexpr| if $e1:lexpr then $e2:lexpr else $e3:lexpr) => do
-     let e1' ← elabLExpr Identifier e1
-     let e2' ← elabLExpr Identifier e2
-     let e3' ← elabLExpr Identifier e3
+     let e1' ← elabLExpr IDMeta e1
+     let e2' ← elabLExpr IDMeta e2
+     let e3' ← elabLExpr IDMeta e3
      let typeTypeExpr := mkConst ``LTy
-     return mkAppN (.const ``LExpr.ite []) #[typeTypeExpr, MkIdent.toExpr Identifier, e1', e2', e3']
-  | `(lexpr| ($e:lexpr)) => elabLExpr Identifier e
+     return mkAppN (.const ``LExpr.ite []) #[typeTypeExpr, MkIdent.toExpr IDMeta, e1', e2', e3']
+  | `(lexpr| ($e:lexpr)) => elabLExpr IDMeta e
   | _ => throwUnsupportedSyntax
 
 scoped syntax ident : lident
@@ -843,38 +843,38 @@ scoped syntax ident : lident
 def elabStrIdent : Lean.Syntax → MetaM Expr
   | `(lident| $s:ident) => do
     let s := s.getId
-    return mkStrLit s.toString
+    return mkAppN (.const `Lambda.Identifier.mk []) #[.const ``Unit [], mkStrLit s.toString, .const ``Unit.unit []]
   | _ => throwUnsupportedSyntax
 
-instance : MkIdent String where
+instance : MkIdent Unit where
   elabIdent := elabStrIdent
-  toExpr := .const ``String []
+  toExpr := .const ``Unit []
 
-elab "es[" e:lexpr "]" : term => elabLExpr (Identifier:=String) e
+elab "es[" e:lexpr "]" : term => elabLExpr (IDMeta:=Unit) e
 
 open LTy.Syntax
 
-/-- info: (bvar 0).absUntyped.app (const "5" none) : LExpr LTy String -/
+/-- info: (bvar 0).absUntyped.app (const "5" none) : LExpr LTy Unit -/
 #guard_msgs in
 #check es[((λ %0) #5)]
 
-/-- info: (abs (some (LTy.forAll [] (LMonoTy.tcons "bool" []))) (bvar 0)).app (const "true" none) : LExpr LTy String -/
+/-- info: (abs (some (LTy.forAll [] (LMonoTy.tcons "bool" []))) (bvar 0)).app (const "true" none) : LExpr LTy Unit -/
 #guard_msgs in
 #check es[((λ (bool): %0) #true)]
 
-/-- info: ((bvar 0).eq (const "5" none)).allUntyped : LExpr LTy String -/
+/-- info: ((bvar 0).eq (const "5" none)).allUntyped : LExpr LTy Unit -/
 #guard_msgs in
 #check es[(∀ %0 == #5)]
 
-/-- info: ((bvar 0).eq (const "5" none)).existUntyped : LExpr LTy String -/
+/-- info: ((bvar 0).eq (const "5" none)).existUntyped : LExpr LTy Unit -/
 #guard_msgs in
 #check es[(∃ %0 == #5)]
 
-/-- info: exist (some (LTy.forAll [] (LMonoTy.tcons "int" []))) ((bvar 0).eq (const "5" none)) : LExpr LTy String -/
+/-- info: exist (some (LTy.forAll [] (LMonoTy.tcons "int" []))) ((bvar 0).eq (const "5" none)) : LExpr LTy Unit -/
 #guard_msgs in
 #check es[(∃ (int): %0 == #5)]
 
-/-- info: fvar "x" (some (LTy.forAll [] (LMonoTy.tcons "bool" []))) : LExpr LTy String -/
+/-- info: fvar { name := "x", metadata := () } (some (LTy.forAll [] (LMonoTy.tcons "bool" []))) : LExpr LTy Unit -/
 #guard_msgs in
 #check es[(x : bool)]
 
@@ -883,14 +883,14 @@ open LTy.Syntax
 info: all (some (LTy.forAll [] (LMonoTy.tcons "Map" [LMonoTy.ftvar "k", LMonoTy.ftvar "v"])))
   (all (some (LTy.forAll [] (LMonoTy.ftvar "k")))
     (all (some (LTy.forAll [] (LMonoTy.ftvar "v")))
-      ((((op "select"
+      ((((op { name := "select", metadata := () }
                     (some
                       (LTy.forAll []
                         (LMonoTy.tcons "Map"
                           [LMonoTy.ftvar "k",
                             LMonoTy.tcons "arrow"
                               [LMonoTy.ftvar "v", LMonoTy.tcons "arrow" [LMonoTy.ftvar "k", LMonoTy.ftvar "v"]]])))).app
-                ((((op "update"
+                ((((op { name := "update", metadata := () }
                               (some
                                 (LTy.forAll []
                                   (LMonoTy.tcons "Map"
@@ -906,7 +906,7 @@ info: all (some (LTy.forAll [] (LMonoTy.tcons "Map" [LMonoTy.ftvar "k", LMonoTy.
                       (bvar 1)).app
                   (bvar 0))).app
             (bvar 1)).eq
-        (bvar 0)))) : LExpr LTy String
+        (bvar 0)))) : LExpr LTy Unit
 -/
 #guard_msgs in
 #check

--- a/Strata/DL/Lambda/LExprEval.lean
+++ b/Strata/DL/Lambda/LExprEval.lean
@@ -19,13 +19,12 @@ open Std (ToFormat Format format)
 
 namespace LExpr
 
-variable {Identifier : Type} [DecidableEq Identifier] [ToFormat Identifier]
-
+variable {IDMeta : Type} [DecidableEq IDMeta]
 /--
 Check for boolean equality of two expressions `e1` and `e2` after erasing any
 type annotations.
 -/
-def eqModuloTypes (e1 e2 : (LExpr LMonoTy Identifier)) : Bool :=
+def eqModuloTypes (e1 e2 : (LExpr LMonoTy IDMeta)) : Bool :=
   e1.eraseTypes == e2.eraseTypes
 
 /--
@@ -34,7 +33,7 @@ Canonical values of `LExpr`s.
 Equality is simply `==` (or more accurately, `eqModuloTypes`) for these
 `LExpr`s. Also see `eql` for a version that can tolerate nested metadata.
 -/
-def isCanonicalValue (e : (LExpr LMonoTy Identifier)) : Bool :=
+def isCanonicalValue (e : (LExpr LMonoTy IDMeta)) : Bool :=
   match e with
   | .const _ _ => true
   | .abs _ _ =>
@@ -51,7 +50,7 @@ Equality of canonical values `e1` and `e2`.
 
 We can tolerate nested metadata here.
 -/
-def eql (e1 e2 : (LExpr LMonoTy Identifier))
+def eql (e1 e2 : (LExpr LMonoTy IDMeta))
   (_h1 : isCanonicalValue e1) (_h2 : isCanonicalValue e2) : Bool :=
   if eqModuloTypes e1 e2 then
     true
@@ -60,7 +59,7 @@ def eql (e1 e2 : (LExpr LMonoTy Identifier))
     let e2' := removeAllMData e2
     eqModuloTypes e1' e2'
 
-instance : ToFormat (Except Format (LExpr LMonoTy Identifier)) where
+instance : ToFormat (Except Format (LExpr LMonoTy IDMeta)) where
   format x := match x with
               | .ok e => format e
               | .error err => err
@@ -71,9 +70,9 @@ eta-expansion.
 
 E.g., `mkAbsOfArity 2 core` will give `λxλy ((core y) x)`.
 -/
-def mkAbsOfArity (arity : Nat) (core : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def mkAbsOfArity (arity : Nat) (core : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   go 0 arity core
-  where go (bvarcount arity : Nat) (core : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+  where go (bvarcount arity : Nat) (core : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   match arity with
   | 0 => core
   | n + 1 =>
@@ -91,7 +90,7 @@ We prefer Curry-style semantics because they separate the type system from
 evaluation, allowing us to potentially apply different type systems with our
 expressions, along with supporting dynamically-typed languages.
 -/
-def eval (n : Nat) (σ : (LState Identifier)) (e : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def eval (n : Nat) (σ : (LState IDMeta)) (e : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   match n with
   | 0 => e
   | n' + 1 =>
@@ -123,7 +122,7 @@ def eval (n : Nat) (σ : (LState Identifier)) (e : (LExpr LMonoTy Identifier)) :
         -- Not a call of a factory function.
         evalCore n' σ e
 
-def evalCore (n' : Nat) (σ : (LState Identifier)) (e : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def evalCore (n' : Nat) (σ : (LState IDMeta)) (e : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   match e with
   | .const _ _  => e
   | .op _ _     => e
@@ -139,7 +138,7 @@ def evalCore (n' : Nat) (σ : (LState Identifier)) (e : (LExpr LMonoTy Identifie
   | .eq  e1 e2 => evalEq n' σ e1 e2
   | .ite c t f => evalIte n' σ c t f
 
-def evalIte (n' : Nat) (σ : (LState Identifier)) (c t f : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def evalIte (n' : Nat) (σ : (LState IDMeta)) (c t f : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   let c' := eval n' σ c
   match c' with
   | .const "true" _ => eval n' σ t
@@ -155,7 +154,7 @@ def evalIte (n' : Nat) (σ : (LState Identifier)) (c t f : (LExpr LMonoTy Identi
     let f' := substFvarsFromState σ f
     ite c' t' f'
 
-def evalEq (n' : Nat) (σ : (LState Identifier)) (e1 e2 : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def evalEq (n' : Nat) (σ : (LState IDMeta)) (e1 e2 : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   open LTy.Syntax in
   let e1' := eval n' σ e1
   let e2' := eval n' σ e2
@@ -169,7 +168,7 @@ def evalEq (n' : Nat) (σ : (LState Identifier)) (e1 e2 : (LExpr LMonoTy Identif
   else
     .eq e1' e2'
 
-def evalApp (n' : Nat) (σ : (LState Identifier)) (e e1 e2 : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def evalApp (n' : Nat) (σ : (LState IDMeta)) (e e1 e2 : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   let e1' := eval n' σ e1
   let e2' := eval n' σ e2
   match e1' with

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -28,7 +28,7 @@ open Std (ToFormat Format format)
 namespace LExpr
 open LTy
 
-variable {Identifier : Type} [DecidableEq Identifier]
+variable {IDMeta : Type} [DecidableEq IDMeta]
 
 /--
 Close `ty` by `x`, i.e., add `x` as a bound type variable.
@@ -54,8 +54,8 @@ Typing relation for `LExpr`s.
 
 (TODO) Add the introduction and elimination rules for `.tcons`.
 -/
-inductive HasType {Identifier : Type} [DecidableEq Identifier]:
-  (TContext Identifier) → (LExpr LMonoTy Identifier) → LTy → Prop where
+inductive HasType {IDMeta : Type} [DecidableEq IDMeta]:
+  (TContext IDMeta) → (LExpr LMonoTy IDMeta) → LTy → Prop where
   | tmdata : ∀ Γ info e ty, HasType Γ e ty →
                             HasType Γ (.mdata info e) ty
 
@@ -125,7 +125,7 @@ inductive HasType {Identifier : Type} [DecidableEq Identifier]:
 If `LExpr e` is well-typed, then it is well-formed, i.e., contains no dangling
 bound variables.
 -/
-theorem HasType.regularity (h : HasType (Identifier:=Identifier) Γ e ty) :
+theorem HasType.regularity (h : HasType (IDMeta:=IDMeta) Γ e ty) :
   LExpr.WF e := by
   open LExpr in
   induction h
@@ -160,8 +160,8 @@ example : LExpr.HasType {} esM[#-1] t[int] := by
   simp +ground
 
 example : LExpr.HasType { types := [[("x", t[∀a. %a])]]} esM[x] t[int] := by
-  have h_tinst := @LExpr.HasType.tinst (Identifier := String) _ { types := [[("x", t[∀a. %a])]]} esM[x] t[∀a. %a] t[int] "a" mty[int]
-  have h_tvar := @LExpr.HasType.tvar (Identifier := String) _ { types := [[("x", t[∀a. %a])]]} "x" t[∀a. %a]
+  have h_tinst := @LExpr.HasType.tinst (IDMeta := Unit) _ { types := [[("x", t[∀a. %a])]]} esM[x] t[∀a. %a] t[int] "a" mty[int]
+  have h_tvar := @LExpr.HasType.tvar (IDMeta := Unit) _ { types := [[("x", t[∀a. %a])]]} "x" t[∀a. %a]
   simp +ground at h_tvar
   simp [h_tvar] at h_tinst
   simp +ground at h_tinst
@@ -180,13 +180,13 @@ example : LExpr.HasType { types := [[("m", t[∀a. %a → int])]]}
   done
 
 example : LExpr.HasType {} esM[λ %0] t[∀a. %a → %a] := by
-  have h_tabs := @LExpr.HasType.tabs (Identifier := String) _ {} ("a", none) t[%a] esM[%0] t[%a]
+  have h_tabs := @LExpr.HasType.tabs (IDMeta := Unit) _ {} ("a", none) t[%a] esM[%0] t[%a]
   simp +ground at h_tabs
-  have h_tvar := @LExpr.HasType.tvar (Identifier := String) _ { types := [[("a", t[%a])]] }
+  have h_tvar := @LExpr.HasType.tvar (IDMeta := Unit) _ { types := [[("a", t[%a])]] }
                  "a" t[%a]
   simp [Maps.find?, Map.find?] at h_tvar
   simp [h_tvar, LTy.toMonoType] at h_tabs
-  have h_tgen := @LExpr.HasType.tgen (Identifier := String) _ {} esM[λ %0] "a"
+  have h_tgen := @LExpr.HasType.tgen (IDMeta := Unit) _ {} esM[λ %0] "a"
                  t[%a → %a]
                  h_tabs
   simp +ground [Maps.find?] at h_tgen

--- a/Strata/DL/Lambda/LExprWF.lean
+++ b/Strata/DL/Lambda/LExprWF.lean
@@ -21,13 +21,13 @@ open Std (ToFormat Format format)
 
 namespace LExpr
 
-variable {Identifier : Type} [DecidableEq Identifier]
+variable {IDMeta : Type} [DecidableEq IDMeta]
 
 /--
 Compute the free variables in an `LExpr`, which are simply all the `LExpr.fvar`s
 in it.
 -/
-def freeVars (e : LExpr LMonoTy Identifier) : IdentTs Identifier :=
+def freeVars (e : LExpr LMonoTy IDMeta) : IdentTs IDMeta :=
   match e with
   | .const _ _ => []
   | .op _ _ => []
@@ -43,45 +43,45 @@ def freeVars (e : LExpr LMonoTy Identifier) : IdentTs Identifier :=
 /--
 Is `x` is a fresh variable w.r.t. `e`?
 -/
-def fresh (x : IdentT Identifier) (e : LExpr LMonoTy Identifier) : Bool :=
+def fresh (x : IdentT IDMeta) (e : LExpr LMonoTy IDMeta) : Bool :=
   x ∉ (freeVars e)
 
 /-- An expression `e` is closed if has no free variables. -/
-def closed (e : LExpr LMonoTy Identifier) : Bool :=
+def closed (e : LExpr LMonoTy IDMeta) : Bool :=
   freeVars e |>.isEmpty
 
 @[simp]
 theorem fresh_abs :
-  fresh (Identifier:=Identifier) x (.abs ty e) = fresh x e := by
+  fresh (IDMeta:=IDMeta) x (.abs ty e) = fresh x e := by
   simp [fresh, freeVars]
 
 @[simp]
 theorem fresh_mdata :
-  fresh (Identifier:=Identifier) x (.mdata info e) = fresh x e := by
+  fresh (IDMeta:=IDMeta) x (.mdata info e) = fresh x e := by
   simp [fresh, freeVars]
 
-omit [DecidableEq Identifier] in
+omit [DecidableEq IDMeta] in
 @[simp]
 theorem freeVars_abs :
-  freeVars (Identifier:=Identifier) (.abs ty e) = freeVars e := by
+  freeVars (IDMeta:=IDMeta) (.abs ty e) = freeVars e := by
   simp [freeVars]
 
-omit [DecidableEq Identifier] in
+omit [DecidableEq IDMeta] in
 @[simp]
 theorem freeVars_mdata :
-  freeVars (Identifier:=Identifier) (.mdata info e) = freeVars e := by
+  freeVars (IDMeta:=IDMeta) (.mdata info e) = freeVars e := by
   simp [freeVars]
 
-omit [DecidableEq Identifier] in
+omit [DecidableEq IDMeta] in
 @[simp]
 theorem closed_abs :
-  closed (Identifier:=Identifier) (.abs ty e) = closed e := by
+  closed (IDMeta:=IDMeta) (.abs ty e) = closed e := by
   simp [closed]
 
-omit [DecidableEq Identifier] in
+omit [DecidableEq IDMeta] in
 @[simp]
 theorem closed_mdata :
-  closed (Identifier:=Identifier) (.mdata info e) = closed e := by
+  closed (IDMeta:=IDMeta) (.mdata info e) = closed e := by
   simp [closed]
 
 ---------------------------------------------------------------------
@@ -95,7 +95,7 @@ This function replaces some bound variables in `e` by an arbitrary expression
 `substK k s e` keeps track of the number `k` of abstractions that have passed
 by; it replaces all leaves of the form `(.bvar k)` with `s`.
 -/
-def substK (k : Nat) (s : LExpr LMonoTy Identifier) (e : LExpr LMonoTy Identifier) : LExpr LMonoTy Identifier :=
+def substK (k : Nat) (s : LExpr LMonoTy IDMeta) (e : LExpr LMonoTy IDMeta) : LExpr LMonoTy IDMeta :=
   match e with
   | .const c ty => .const c ty
   | .op o ty => .op o ty
@@ -129,7 +129,7 @@ to avoid such issues:
 
 `(λλ 1 0) (λ b) --β--> (λ (λ b) 0)`
 -/
-def subst (s : LExpr LMonoTy Identifier) (e : LExpr LMonoTy Identifier) : LExpr LMonoTy Identifier :=
+def subst (s : LExpr LMonoTy IDMeta) (e : LExpr LMonoTy IDMeta) : LExpr LMonoTy IDMeta :=
   substK 0 s e
 
 /--
@@ -140,7 +140,7 @@ with `(.fvar x)`.
 
 Note that `x` is expected to be a fresh variable w.r.t. `e`.
 -/
-def varOpen (k : Nat) (x : IdentT Identifier) (e : LExpr LMonoTy Identifier) : LExpr LMonoTy Identifier :=
+def varOpen (k : Nat) (x : IdentT IDMeta) (e : LExpr LMonoTy IDMeta) : LExpr LMonoTy IDMeta :=
   substK k (.fvar x.fst x.snd) e
 
 /--
@@ -149,7 +149,7 @@ abstraction, given its body. `varClose k x e` keeps track of the number `k`
 of abstractions that have passed by; it replaces all `(.fvar x)` with
 `(.bvar k)`.
 -/
-def varClose (k : Nat) (x : IdentT Identifier) (e : LExpr LMonoTy Identifier) : LExpr LMonoTy Identifier :=
+def varClose (k : Nat) (x : IdentT IDMeta) (e : LExpr LMonoTy IDMeta) : LExpr LMonoTy IDMeta :=
   match e with
   | .const c ty => .const c ty
   | .op o ty => .op o ty
@@ -165,7 +165,7 @@ def varClose (k : Nat) (x : IdentT Identifier) (e : LExpr LMonoTy Identifier) : 
 
 
 theorem varClose_of_varOpen (h : fresh x e) :
-  varClose (Identifier:=Identifier) i x (varOpen i x e) = e := by
+  varClose (IDMeta:=IDMeta) i x (varOpen i x e) = e := by
   induction e generalizing i x
   all_goals try simp_all [fresh, varOpen, LExpr.substK, varClose, freeVars]
   case bvar j =>
@@ -187,7 +187,7 @@ variables.
 
 Example of a term that is not locally closed: `(.abs "x" (.bvar 1))`.
 -/
-def lcAt (k : Nat) (e : LExpr LMonoTy Identifier) : Bool :=
+def lcAt (k : Nat) (e : LExpr LMonoTy IDMeta) : Bool :=
   match e with
   | .const _ _ => true
   | .op _ _ => true
@@ -202,7 +202,7 @@ def lcAt (k : Nat) (e : LExpr LMonoTy Identifier) : Bool :=
 
 theorem varOpen_varClose_when_lcAt
   (h1 : lcAt k e) (h2 : k <= i) :
-  (varOpen i x (varClose (Identifier:=Identifier) i x e)) = e := by
+  (varOpen i x (varClose (IDMeta:=IDMeta) i x e)) = e := by
   induction e generalizing k i x
   case const c ty =>
     simp! [lcAt, varOpen, substK]
@@ -282,11 +282,11 @@ An `LExpr e` is well-formed if it has no dangling bound variables.
 We expect the type system to guarantee the well-formedness of an `LExpr`, i.e.,
 we will prove a _regularity_ lemma; see lemma `HasType.regularity`.
 -/
-def WF (e : LExpr LMonoTy Identifier) : Bool :=
+def WF (e : LExpr LMonoTy IDMeta) : Bool :=
   lcAt 0 e
 
 theorem varOpen_of_varClose (h : LExpr.WF e) :
-  varOpen i x (varClose (Identifier:=Identifier) i x e) = e := by
+  varOpen i x (varClose (IDMeta:=IDMeta) i x e) = e := by
   simp_all [LExpr.WF]
   rw [varOpen_varClose_when_lcAt (k:=0) h]
   omega
@@ -303,8 +303,8 @@ and `varOpen`, this function is agnostic of types.
 Also see function `subst`, where `subst s e` substitutes the outermost _bound_
 variable in `e` with `s`.
 -/
-def substFvar {Identifier: Type} [DecidableEq Identifier] (e : LExpr LMonoTy Identifier) (fr : Identifier) (to : LExpr LMonoTy Identifier)
-  : (LExpr LMonoTy Identifier) :=
+def substFvar {IDMeta: Type} [DecidableEq IDMeta] (e : LExpr LMonoTy IDMeta) (fr : Identifier IDMeta) (to : LExpr LMonoTy IDMeta)
+  : (LExpr LMonoTy IDMeta) :=
   match e with
   | .const _ _ => e | .bvar _ => e | .op _ _ => e
   | .fvar  name _ => if name == fr then to else e
@@ -315,8 +315,8 @@ def substFvar {Identifier: Type} [DecidableEq Identifier] (e : LExpr LMonoTy Ide
   | .ite   c t e' => .ite (substFvar c fr to) (substFvar t fr to) (substFvar e' fr to)
   | .eq    e1 e2 => .eq (substFvar e1 fr to) (substFvar e2 fr to)
 
-def substFvars {Identifier: Type} [DecidableEq Identifier] (e : LExpr LMonoTy Identifier) (sm : Map Identifier (LExpr LMonoTy Identifier))
-  : LExpr LMonoTy Identifier :=
+def substFvars {IDMeta: Type} [DecidableEq IDMeta] (e : LExpr LMonoTy IDMeta) (sm : Map (Identifier IDMeta) (LExpr LMonoTy IDMeta))
+  : LExpr LMonoTy IDMeta :=
   List.foldl (fun e (var, s) => substFvar e var s) e sm
 
 ---------------------------------------------------------------------

--- a/Strata/DL/Lambda/LState.lean
+++ b/Strata/DL/Lambda/LState.lean
@@ -16,7 +16,7 @@ namespace Lambda
 
 open Std (ToFormat Format format)
 
-variable {Identifier : Type} [DecidableEq Identifier] [ToFormat Identifier]
+variable {IDMeta : Type} [DecidableEq IDMeta]
 ---------------------------------------------------------------------
 
 /-
@@ -28,13 +28,13 @@ We rely on the parser disallowing Lambda variables to begin with `$__`, which is
 reserved for internal use. Also see `TEnv.genExprVar` used during type inference
 and `LState.genVar` used during evaluation.
 -/
-structure EvalConfig (Identifier : Type) where
-  factory : @Factory Identifier
+structure EvalConfig (IDMeta : Type) where
+  factory : @Factory IDMeta
   fuel : Nat := 200
   varPrefix : String := "$__"
   gen : Nat := 0
 
-instance : ToFormat (EvalConfig Identifier) where
+instance : ToFormat (EvalConfig IDMeta) where
   format c :=
     f!"Eval Depth: {(repr c.fuel)}" ++ Format.line ++
     f!"Variable Prefix: {c.varPrefix}" ++ Format.line ++
@@ -42,15 +42,15 @@ instance : ToFormat (EvalConfig Identifier) where
     f!"Factory Functions:" ++ Format.line ++
     Std.Format.joinSep c.factory.toList f!"{Format.line}"
 
-def EvalConfig.init : (EvalConfig Identifier) :=
-  { factory := @Factory.default Identifier,
+def EvalConfig.init : (EvalConfig IDMeta) :=
+  { factory := @Factory.default IDMeta,
     fuel := 200,
     gen := 0 }
 
-def EvalConfig.incGen (c : (EvalConfig Identifier)) : (EvalConfig Identifier) :=
+def EvalConfig.incGen (c : (EvalConfig IDMeta)) : (EvalConfig IDMeta) :=
     { c with gen := c.gen + 1 }
 
-def EvalConfig.genSym (x : String) (c : (EvalConfig String)) : String × (EvalConfig String) :=
+def EvalConfig.genSym (x : String) (c : (EvalConfig Unit)) : String × (EvalConfig Unit) :=
   let new_idx := c.gen
   let c := c.incGen
   let new_var := c.varPrefix ++ x ++ toString new_idx
@@ -59,24 +59,24 @@ def EvalConfig.genSym (x : String) (c : (EvalConfig String)) : String × (EvalCo
 ---------------------------------------------------------------------
 
 /-- The Lambda evaluation state. -/
-structure LState (Identifier : Type) where
-  config : (EvalConfig Identifier)
-  state : (Scopes Identifier)
+structure LState (IDMeta : Type) where
+  config : (EvalConfig IDMeta)
+  state : (Scopes IDMeta)
 
 -- scoped notation (name := lstate) "Σ" => LState
 
-def LState.init : (LState Identifier) :=
+def LState.init : (LState IDMeta) :=
   { state := [],
     config := EvalConfig.init }
 
 /-- An empty `LState` -/
-instance : EmptyCollection (LState Identifier) where
+instance : EmptyCollection (LState IDMeta) where
   emptyCollection := LState.init
 
-instance : Inhabited (LState Identifier) where
+instance : Inhabited (LState IDMeta) where
   default := LState.init
 
-instance : ToFormat (LState Identifier) where
+instance : ToFormat (LState IDMeta) where
   format s :=
     let { state, config }  := s
     format f!"State:{Format.line}{state}{Format.line}{Format.line}\
@@ -87,7 +87,7 @@ instance : ToFormat (LState Identifier) where
 Add function `func` to the existing factory of functions in `σ`. Redefinitions
 are not allowed.
 -/
-def LState.addFactoryFunc (σ : LState Identifier) (func : (LFunc Identifier)) : Except Format (LState Identifier) := do
+def LState.addFactoryFunc (σ : LState IDMeta) (func : (LFunc IDMeta)) : Except Format (LState IDMeta) := do
   let F ← σ.config.factory.addFactoryFunc func
   .ok { σ with config := { σ.config with factory := F }}
 
@@ -95,7 +95,7 @@ def LState.addFactoryFunc (σ : LState Identifier) (func : (LFunc Identifier)) :
 Append `Factory f` to the existing factory of functions in `σ`, checking for
 redefinitions.
 -/
-def LState.addFactory (σ : (LState Identifier)) (F : @Factory Identifier) : Except Format (LState Identifier) := do
+def LState.addFactory (σ : (LState IDMeta)) (F : @Factory IDMeta) : Except Format (LState IDMeta) := do
   let oldF := σ.config.factory
   let newF ← oldF.addFactory F
   .ok { σ with config := { σ.config with factory := newF } }
@@ -103,9 +103,9 @@ def LState.addFactory (σ : (LState Identifier)) (F : @Factory Identifier) : Exc
 /--
 Get all the known variables from the scopes in state `σ`.
 -/
-def LState.knownVars (σ : (LState Identifier)) : List Identifier :=
+def LState.knownVars (σ : (LState IDMeta)) : List (Identifier IDMeta) :=
   go σ.state []
-  where go (s : Scopes Identifier) (acc : List Identifier) :=
+  where go (s : Scopes IDMeta) (acc : List (Identifier IDMeta)) :=
   match s with
   | [] => acc
   | m :: rest => go rest (acc ++ m.keys)
@@ -114,30 +114,31 @@ def LState.knownVars (σ : (LState Identifier)) : List Identifier :=
 Generate a fresh (internal) identifier with the base name
 `x`; i.e., `σ.config.varPrefix ++ x`.
 -/
-def LState.genVar (x : String) (σ : (LState String)) : (String × (LState String)) :=
+def LState.genVar (x : String) (σ : (LState Unit)) : (String × (LState Unit)) :=
   let (new_var, config) := σ.config.genSym x
   let σ := { σ with config := config }
   let known_vars := LState.knownVars σ
+  let new_var := ⟨ new_var, ()⟩
   if new_var ∈ known_vars then
     panic s!"[LState.genVar] Generated variable {new_var} is not fresh!\n\
              Known variables: {σ.knownVars}"
   else
-    (new_var, σ)
+    (new_var.name, σ)
 
 /--
 Generate fresh identifiers, each with the base name in `xs`.
 -/
-def LState.genVars (xs : List String) (σ : (LState String)) : (List String × (LState String)) :=
+def LState.genVars (xs : List String) (σ : (LState Unit)) : (List String × (LState Unit)) :=
   let (vars, σ') := go xs σ []
   (vars.reverse, σ')
-  where go (xs : List String) (σ : LState String) (acc : List String) :=
+  where go (xs : List String) (σ : LState Unit) (acc : List String) :=
     match xs with
     | [] => (acc, σ)
     | x :: rest =>
       let (x', σ) := LState.genVar x σ
       go rest σ (x' :: acc)
 
-instance : ToFormat (Identifier × LState Identifier) where
+instance : ToFormat (Identifier IDMeta × LState IDMeta) where
   format im :=
     f!"New Variable: {im.fst}{Format.line}\
        Gen in EvalConfig: {im.snd.config.gen}{Format.line}\
@@ -148,7 +149,7 @@ instance : ToFormat (Identifier × LState Identifier) where
 /--
 Substitute `.fvar`s in `e` by looking up their values in `σ`.
 -/
-def LExpr.substFvarsFromState (σ : (LState Identifier)) (e : (LExpr LMonoTy Identifier)) : (LExpr LMonoTy Identifier) :=
+def LExpr.substFvarsFromState (σ : (LState IDMeta)) (e : (LExpr LMonoTy IDMeta)) : (LExpr LMonoTy IDMeta) :=
   let sm := σ.state.toSingleMap.map (fun (x, (_, v)) => (x, v))
   Lambda.LExpr.substFvars e sm
 

--- a/Strata/DL/Lambda/Lambda.lean
+++ b/Strata/DL/Lambda/Lambda.lean
@@ -26,16 +26,16 @@ See module `Strata.DL.Lambda.LExpr` for the formalization of expressions,
 `Strata.DL.Lambda.LExprEval` for the partial evaluator.
 -/
 
-variable {Identifier : Type} [ToString Identifier] [DecidableEq Identifier] [ToFormat Identifier] [HasGen Identifier]
+variable {IDMeta : Type} [ToString IDMeta] [DecidableEq IDMeta] [HasGen IDMeta]
 
 /--
 Top-level type checking and partial evaluation function for the Lambda
 dialect.
 -/
 def typeCheckAndPartialEval
-  (f : Factory (Identifier:=Identifier) := Factory.default)
-  (e : (LExpr LMonoTy Identifier)) :
-  Except Std.Format (LExpr LMonoTy Identifier) := do
+  (f : Factory (IDMeta:=IDMeta) := Factory.default)
+  (e : (LExpr LMonoTy IDMeta)) :
+  Except Std.Format (LExpr LMonoTy IDMeta) := do
   let T := TEnv.default.addFactoryFunctions f
   let (et, _T) ← LExpr.annotate T e
   dbg_trace f!"Annotated expression:{Format.line}{et}{Format.line}"

--- a/Strata/Languages/Boogie/Axiom.lean
+++ b/Strata/Languages/Boogie/Axiom.lean
@@ -24,7 +24,7 @@ the responsibility of the user to ensure that they are consistent.
 
 structure Axiom where
   name : BoogieLabel
-  e : LExpr LMonoTy BoogieIdent
+  e : LExpr LMonoTy Visibility
 
 instance : ToFormat Axiom where
   format a := f!"axiom {a.name}: {a.e};"

--- a/Strata/Languages/Boogie/BoogieGen.lean
+++ b/Strata/Languages/Boogie/BoogieGen.lean
@@ -20,7 +20,7 @@ open Boogie Lambda Imperative
 namespace Names
 
 def initVarValue (id : BoogieIdent) : Expression.Expr :=
-  .fvar ("init_" ++ id.2) none
+  .fvar ("init_" ++ id.name) none
 
 end Names
 
@@ -48,7 +48,7 @@ def BoogieGenState.emp : BoogieGenState := { cs := .emp, generated := [] }
     -/
 def BoogieGenState.gen (pf : BoogieIdent) (σ : BoogieGenState)
   : BoogieIdent × BoogieGenState :=
-  let (s, cs') := StringGenState.gen pf.2 σ.cs
+  let (s, cs') := StringGenState.gen pf.name σ.cs
   let newState : BoogieGenState := { cs := cs', generated := (.temp s) :: σ.generated }
   ((.temp s), newState)
 
@@ -67,9 +67,9 @@ theorem BoogieGenState.WFMono' :
   unfold BoogieGenState.WF at Hwf
   simp [gen] at Hgen
   simp [← Hgen]
-  generalize h1 : (StringGenState.gen pf.snd s.cs).fst = st
-  generalize h2 : (StringGenState.gen pf.snd s.cs).snd = stg
-  have Hstrgen: StringGenState.gen pf.snd s.cs = (st, stg) := by simp [← h1, ← h2]
+  generalize h1 : (StringGenState.gen pf.name s.cs).fst = st
+  generalize h2 : (StringGenState.gen pf.name s.cs).snd = stg
+  have Hstrgen: StringGenState.gen pf.name s.cs = (st, stg) := by simp [← h1, ← h2]
   have Hwf':= StringGenState.WFMono Hwf.left Hstrgen
   simp [StringGenState.gen] at Hstrgen
   constructor <;> simp [*]

--- a/Strata/Languages/Boogie/Examples/DDMAxiomsExtraction.lean
+++ b/Strata/Languages/Boogie/Examples/DDMAxiomsExtraction.lean
@@ -36,7 +36,7 @@ def extractAxiomsDecl (prg: Boogie.Program) : (List Boogie.Decl) :=
 /--
   Extract the body LExpr from the axiom declaration
 -/
-def extractExpr (axDecl: Boogie.Decl): (Lambda.LExpr Lambda.LMonoTy Boogie.BoogieIdent) :=
+def extractExpr (axDecl: Boogie.Decl): (Lambda.LExpr Lambda.LMonoTy Boogie.Visibility) :=
   match axDecl with
     | .ax a _ => a.e
     | _ => panic "Can be called only on axiom declaration"
@@ -61,7 +61,7 @@ def transformSimpleTypeToFreeVariable (ty: Lambda.LMonoTy) (to_replace: List Str
   Transform all occurences of types of the form LMonoTy.tcons name [] into ftvar name, if name is in to_replace
   in the given expression
 -/
-def replaceTypesByFTV (expr: Lambda.LExpr Lambda.LMonoTy Boogie.BoogieIdent) (to_replace: List String): Lambda.LExpr Lambda.LMonoTy Boogie.BoogieIdent :=
+def replaceTypesByFTV (expr: Lambda.LExpr Lambda.LMonoTy Boogie.Visibility) (to_replace: List String): Lambda.LExpr Lambda.LMonoTy Boogie.Visibility :=
   match expr with
     | .const c oty => .const c (oty.map (fun t => transformSimpleTypeToFreeVariable t to_replace))
     | .op o oty => .op o (oty.map (fun t => transformSimpleTypeToFreeVariable t to_replace))
@@ -78,7 +78,7 @@ def replaceTypesByFTV (expr: Lambda.LExpr Lambda.LMonoTy Boogie.BoogieIdent) (to
   Extract all axioms from the given environment by first translating it into a Boogie Program.
   It then extracts LExpr body from the axioms, and replace all occurences of the typeArgs by a ftvar with the same name
 -/
-def extractAxiomsWithFreeTypeVars (pgm: Program) (typeArgs: List String): (List (Lambda.LExpr Lambda.LMonoTy Boogie.BoogieIdent)) :=
+def extractAxiomsWithFreeTypeVars (pgm: Program) (typeArgs: List String): (List (Lambda.LExpr Lambda.LMonoTy Boogie.Visibility)) :=
   let prg: Boogie.Program := (TransM.run (translateProgram pgm)).fst
   let axiomsDecls := extractAxiomsDecl prg
   let axioms := axiomsDecls.map extractExpr
@@ -253,7 +253,7 @@ info: [Lambda.LExpr.quant
          (Lambda.LExpr.app
            (Lambda.LExpr.app
              (Lambda.LExpr.op
-               u:select
+               { name := "select", metadata := Boogie.Visibility.unres }
                (some (Lambda.LMonoTy.tcons
                   "arrow"
                   [Lambda.LMonoTy.tcons "Map" [Lambda.LMonoTy.ftvar "k", Lambda.LMonoTy.ftvar "v"],
@@ -262,7 +262,7 @@ info: [Lambda.LExpr.quant
                (Lambda.LExpr.app
                  (Lambda.LExpr.app
                    (Lambda.LExpr.op
-                     u:update
+                     { name := "update", metadata := Boogie.Visibility.unres }
                      (some (Lambda.LMonoTy.tcons
                         "arrow"
                         [Lambda.LMonoTy.tcons "Map" [Lambda.LMonoTy.ftvar "k", Lambda.LMonoTy.ftvar "v"],
@@ -298,7 +298,7 @@ info: [Lambda.LExpr.quant
            (Lambda.LExpr.app
              (Lambda.LExpr.app
                (Lambda.LExpr.op
-                 u:select
+                 { name := "select", metadata := Boogie.Visibility.unres }
                  (some (Lambda.LMonoTy.tcons
                     "arrow"
                     [Lambda.LMonoTy.tcons "Map" [Lambda.LMonoTy.ftvar "k", Lambda.LMonoTy.ftvar "v"],
@@ -307,7 +307,7 @@ info: [Lambda.LExpr.quant
                  (Lambda.LExpr.app
                    (Lambda.LExpr.app
                      (Lambda.LExpr.op
-                       u:update
+                       { name := "update", metadata := Boogie.Visibility.unres }
                        (some (Lambda.LMonoTy.tcons
                           "arrow"
                           [Lambda.LMonoTy.tcons "Map" [Lambda.LMonoTy.ftvar "k", Lambda.LMonoTy.ftvar "v"],
@@ -325,7 +325,7 @@ info: [Lambda.LExpr.quant
            (Lambda.LExpr.app
              (Lambda.LExpr.app
                (Lambda.LExpr.op
-                 u:select
+                 { name := "select", metadata := Boogie.Visibility.unres }
                  (some (Lambda.LMonoTy.tcons
                     "arrow"
                     [Lambda.LMonoTy.tcons "Map" [Lambda.LMonoTy.ftvar "k", Lambda.LMonoTy.ftvar "v"],

--- a/Strata/Languages/Boogie/Expressions.lean
+++ b/Strata/Languages/Boogie/Expressions.lean
@@ -17,11 +17,11 @@ open Std (ToFormat Format format)
 
 abbrev Expression : Imperative.PureExpr :=
    { Ident := BoogieIdent,
-     Expr := Lambda.LExpr Lambda.LMonoTy BoogieIdent,
+     Expr := Lambda.LExpr Lambda.LMonoTy Visibility,
      Ty := Lambda.LTy,
-     TyEnv := @Lambda.TEnv BoogieIdent,
-     EvalEnv := Lambda.LState BoogieIdent
-     EqIdent := instDecidableEqBoogieIdent }
+     TyEnv := @Lambda.TEnv Visibility,
+     EvalEnv := Lambda.LState Visibility
+     EqIdent := inferInstanceAs (DecidableEq (Lambda.Identifier _))}
 
 instance : Imperative.HasVarsPure Expression Expression.Expr where
   getVars := Lambda.LExpr.LExpr.getVars

--- a/Strata/Languages/Boogie/Function.lean
+++ b/Strata/Languages/Boogie/Function.lean
@@ -17,17 +17,17 @@ open Lambda
 
 /-! # Boogie Functions -/
 
-abbrev Function := Lambda.LFunc BoogieIdent
+abbrev Function := Lambda.LFunc Visibility
 
 open LTy.Syntax LExpr.SyntaxMono in
 /-- info: ok: ∀[a, b]. (arrow int (arrow a (arrow b (arrow a a)))) -/
 #guard_msgs in
-#eval do let type ← LFunc.type (Identifier:=BoogieIdent)
-                     ({ name := (.unres, "Foo"),
+#eval do let type ← LFunc.type (IDMeta:=Visibility)
+                     ({ name := (BoogieIdent.unres "Foo"),
                         typeArgs := ["a", "b"],
-                        inputs := [((.locl, "w"), mty[int]), ((.locl, "x"), mty[%a]), ((.locl, "y"), mty[%b]), ((.locl, "z"), mty[%a])],
+                        inputs := [((BoogieIdent.locl "w"), mty[int]), ((BoogieIdent.locl "x"), mty[%a]), ((BoogieIdent.locl "y"), mty[%b]), ((BoogieIdent.locl "z"), mty[%a])],
                         output := mty[%a],
-                        body := some (.fvar (.locl, "x") none) } : Function)
+                        body := some (.fvar (BoogieIdent.locl "x") none) } : Function)
          return format type
 
 ---------------------------------------------------------------------

--- a/Strata/Languages/Boogie/Identifiers.lean
+++ b/Strata/Languages/Boogie/Identifiers.lean
@@ -49,17 +49,23 @@ instance : ToFormat Visibility where
   | .locl => "l:"
   | .temp => "t:"
 
-def BoogieIdent := Visibility × String
+instance : ToString Visibility where
+  toString v := toString $ ToFormat.format v
+
+abbrev BoogieIdent := Lambda.Identifier Visibility
 abbrev BoogieLabel := String
 
+def BoogieIdentDec : DecidableEq BoogieIdent := inferInstanceAs (DecidableEq (Lambda.Identifier Visibility))
+
+
 @[match_pattern]
-def BoogieIdent.unres (s : String) := (Visibility.unres, s)
+def BoogieIdent.unres (s : String) : BoogieIdent := ⟨s, Visibility.unres⟩
 @[match_pattern]
-def BoogieIdent.glob (s : String) := (Visibility.glob, s)
+def BoogieIdent.glob (s : String) : BoogieIdent := ⟨s, Visibility.glob⟩
 @[match_pattern]
-def BoogieIdent.locl (s : String) := (Visibility.locl, s)
+def BoogieIdent.locl (s : String) : BoogieIdent := ⟨s, Visibility.locl⟩
 @[match_pattern]
-def BoogieIdent.temp (s : String) := (Visibility.temp, s)
+def BoogieIdent.temp (s : String) : BoogieIdent := ⟨s, Visibility.temp⟩
 
 def BoogieIdent.isUnres (id : BoogieIdent) : Bool := match id with
   | .unres _ => true | _ => false
@@ -76,12 +82,12 @@ def BoogieIdent.isGlobOrLocl (id : BoogieIdent) : Bool :=
 instance : Coe String BoogieIdent where
   coe | s => .unres s
 
-instance : DecidableEq BoogieIdent := instDecidableEqProd
+-- instance : DecidableEq BoogieIdent := instDecidableEqProd
 
 /-- The pretty-printer for Boogie Identifiers.
   We ignore the visibility part so that the output can be parsed again -/
 def BoogieIdent.toPretty (x : BoogieIdent) : String :=
-  match x with | (_, s) => s
+  match x with | ⟨s, _⟩ => s
 
 /-- The pretty-printer for Boogie Identifiers.
   We ignore the visibility part so that the output can be parsed again -/
@@ -98,15 +104,15 @@ instance : ToFormat BoogieIdent where
   string representation fairly easily by overriding the method, if needed.
 -/
 instance : ToString BoogieIdent where
-  toString | (v, s) => (toString $ ToFormat.format v) ++ (toString $ ToFormat.format s)
+  toString | ⟨s, v⟩ => (toString $ ToFormat.format v) ++ (toString $ ToFormat.format s)
 
 instance : Repr BoogieIdent where
-  reprPrec | (v, s), _  => (ToFormat.format v) ++ (ToFormat.format s)
+  reprPrec | ⟨s, v⟩, _  => (ToFormat.format v) ++ (ToFormat.format s)
 
 instance : Inhabited BoogieIdent where
-  default := (.unres, "_")
+  default := ⟨"_", .unres⟩
 
-instance : Lambda.HasGen BoogieIdent where
+instance : Lambda.HasGen Visibility where
   genVar T := let (sym, state') := (Lambda.TState.genExprSym T.state)
               (BoogieIdent.temp sym, { T with state := state' })
 
@@ -122,26 +128,26 @@ def elabBoogieIdent : Syntax → MetaM Expr
     return ← mkAppM ``BoogieIdent.unres #[mkStrLit s]
   | _ => throwUnsupportedSyntax
 
-instance : MkIdent BoogieIdent where
+instance : MkIdent Visibility where
   elabIdent := elabBoogieIdent
-  toExpr := .const ``BoogieIdent []
+  toExpr := .const ``Visibility []
 
-elab "eb[" e:lexprmono "]" : term => elabLExprMono (Identifier:=BoogieIdent) e
+elab "eb[" e:lexprmono "]" : term => elabLExprMono (IDMeta:=Visibility) e
 
-/-- info: Lambda.LExpr.op (BoogieIdent.unres "old") none : Lambda.LExpr Lambda.LMonoTy BoogieIdent -/
+/-- info: Lambda.LExpr.op (BoogieIdent.unres "old") none : Lambda.LExpr Lambda.LMonoTy Visibility -/
 #guard_msgs in
 #check eb[~old]
 
 /--
 info: (Lambda.LExpr.op (BoogieIdent.unres "old") none).app
-  (Lambda.LExpr.fvar (BoogieIdent.unres "a") none) : Lambda.LExpr Lambda.LMonoTy BoogieIdent
+  (Lambda.LExpr.fvar (BoogieIdent.unres "a") none) : Lambda.LExpr Lambda.LMonoTy Visibility
 -/
 #guard_msgs in
 #check eb[(~old a)]
 
 open Lambda.LTy.Syntax in
 /-- info: Lambda.LExpr.fvar (BoogieIdent.unres "x")
-  (some (Lambda.LMonoTy.tcons "bool" [])) : Lambda.LExpr Lambda.LMonoTy (Visibility × String)  -/
+  (some (Lambda.LMonoTy.tcons "bool" [])) : Lambda.LExpr Lambda.LMonoTy Visibility  -/
 #guard_msgs in
 #check eb[(x : bool)]
 

--- a/Strata/Languages/Boogie/OldExpressions.lean
+++ b/Strata/Languages/Boogie/OldExpressions.lean
@@ -57,7 +57,7 @@ def oldExpr
   {tyold : Option Lambda.LMonoTy}
   (e : Expression.Expr)
   : Expression.Expr
-  := .app (.op (.unres "old") tyold) e
+  := .app (.op (BoogieIdent.unres "old") tyold) e
 
 @[match_pattern]
 def oldVar
@@ -161,7 +161,7 @@ This function is agnostic of old expression normalization (see
 -/
 def containsOldExpr (e : Expression.Expr) : Bool :=
   match e with
-  | .op (.unres "old") _ => true
+  | .op (BoogieIdent.unres "old") _ => true
   | .op _ _ => false
   | .const _ _ | .bvar _ | .fvar _ _ => false
   | .mdata _ e' => containsOldExpr e'
@@ -191,8 +191,8 @@ def extractOldExprVars (expr : Expression.Expr)
   | .abs _ e => extractOldExprVars e
   | .quant _ _ tr e => extractOldExprVars tr ++ extractOldExprVars e
   | .app e1 e2 => match e1, e2 with
-    | .op (.unres "old") _, .fvar v _ => [v]
-    | .op (.unres "old") _, _ => panic! s!"Old expression {expr} not normalized"
+    | .op (BoogieIdent.unres "old") _, .fvar v _ => [v]
+    | .op (BoogieIdent.unres "old") _, _ => panic! s!"Old expression {expr} not normalized"
     | e1', e2' => extractOldExprVars e1' ++ extractOldExprVars e2'
   | .ite c t e => extractOldExprVars c ++ extractOldExprVars t ++ extractOldExprVars e
   | .eq  e1 e2 => extractOldExprVars e1 ++ extractOldExprVars e2
@@ -213,7 +213,7 @@ def substOld (var : Expression.Ident) (s e : Expression.Expr) :
   | .quant qk ty tr' e' => .quant qk ty (substOld var s tr') (substOld var s e')
   | .app e1 e2 =>
     match e1, e2 with
-    | .op (.unres "old") _, .fvar x _ =>
+    | .op (BoogieIdent.unres "old") _, .fvar x _ =>
       -- NOTE: We rely on the typeChecker to normalize `e` ensure that `old` is
       -- only used with an `fvar`.
       if x == var
@@ -239,7 +239,7 @@ def substsOldExpr (sm : Map Expression.Ident Expression.Expr) (e : Expression.Ex
   | .quant qk ty tr' e' => .quant qk ty (substsOldExpr sm tr') (substsOldExpr sm e')
   | .app e1 e2 =>
     match e1, e2 with
-    | .op (.unres "old") _, .fvar x _ =>
+    | .op (BoogieIdent.unres "old") _, .fvar x _ =>
       match sm.find? x with
       | some s => s
       | none => e

--- a/Strata/Languages/Boogie/Procedure.lean
+++ b/Strata/Languages/Boogie/Procedure.lean
@@ -21,8 +21,8 @@ open Lambda
 structure Procedure.Header where
   name     : BoogieIdent
   typeArgs : List TyIdentifier
-  inputs   : @LMonoTySignature BoogieIdent
-  outputs  : @LMonoTySignature BoogieIdent
+  inputs   : @LMonoTySignature Visibility
+  outputs  : @LMonoTySignature Visibility
   deriving Repr, DecidableEq, Inhabited
 
 instance : ToFormat Procedure.Header where

--- a/Strata/Languages/Boogie/ProgramType.lean
+++ b/Strata/Languages/Boogie/ProgramType.lean
@@ -68,7 +68,7 @@ def typeCheck (T : Boogie.Expression.TyEnv) (program : Program) :
           .error f!"Type declaration of the same name already exists!\n\
                     {decl}"
         | none =>
-          if td.name.snd ∈ T.knownTypes.keywords then
+          if td.name.name ∈ T.knownTypes.keywords then
             .error f!"This type declaration's name is reserved!\n\
                       {td}\n\
                       KnownTypes' names:\n\

--- a/Strata/Languages/Boogie/SMTEncoder.lean
+++ b/Strata/Languages/Boogie/SMTEncoder.lean
@@ -117,7 +117,7 @@ def convertQuantifierKind : Lambda.QuantifierKind -> Strata.SMT.QuantifierKind
 
 mutual
 
-partial def toSMTTerm (E : Env) (bvs : BoundVars) (e : LExpr LMonoTy BoogieIdent) (ctx : SMT.Context)
+partial def toSMTTerm (E : Env) (bvs : BoundVars) (e : LExpr LMonoTy Visibility) (ctx : SMT.Context)
   : Except Format (Term × SMT.Context) := do
   match e with
   | .const "true" _ => .ok ((Term.bool true), ctx)
@@ -202,7 +202,7 @@ partial def toSMTTerm (E : Env) (bvs : BoundVars) (e : LExpr LMonoTy BoogieIdent
   | .app _ _ =>
     appToSMTTerm E bvs e [] ctx
 
-partial def appToSMTTerm (E : Env) (bvs : BoundVars) (e : (LExpr LMonoTy BoogieIdent)) (acc : List Term) (ctx : SMT.Context) :
+partial def appToSMTTerm (E : Env) (bvs : BoundVars) (e : (LExpr LMonoTy Visibility)) (acc : List Term) (ctx : SMT.Context) :
   Except Format (Term × SMT.Context) := do
   match e with
   | .app (.app fn e1) e2 => do
@@ -237,7 +237,7 @@ partial def toSMTOp (E : Env) (fn : BoogieIdent) (fnty : LMonoTy) (ctx : SMT.Con
   match E.factory.getFactoryLFunc fn with
   | none => .error f!"Cannot find function {fn} in Boogie's Factory!"
   | some func =>
-    match func.name.2 with
+    match func.name.name with
     | "Bool.And"     => .ok (.app Op.and,        .bool,   ctx)
     | "Bool.Or"      => .ok (.app Op.or,         .bool,   ctx)
     | "Bool.Not"     => .ok (.app Op.not,        .bool,   ctx)
@@ -430,7 +430,7 @@ partial def toSMTOp (E : Env) (fn : BoogieIdent) (fnty : LMonoTy) (ctx : SMT.Con
           .ok (acc_map.insert tyVar smtTy)
         ) Map.empty
         -- Add all axioms for this function to the context, with types binding for the type variables in the expr
-        let ctx ← func.axioms.foldlM (fun acc_ctx (ax: LExpr LMonoTy BoogieIdent) => do
+        let ctx ← func.axioms.foldlM (fun acc_ctx (ax: LExpr LMonoTy Visibility) => do
           let current_axiom_ctx := acc_ctx.addSubst smt_ty_inst
             let (axiom_term, new_ctx) ← toSMTTerm E [] ax current_axiom_ctx
             .ok (new_ctx.addAxiom axiom_term)
@@ -441,7 +441,7 @@ partial def toSMTOp (E : Env) (fn : BoogieIdent) (fnty : LMonoTy) (ctx : SMT.Con
         .ok (.app (Op.uf uf), smt_outty, ctx)
 end
 
-def toSMTTerms (E : Env) (es : List (LExpr LMonoTy BoogieIdent)) (ctx : SMT.Context) :
+def toSMTTerms (E : Env) (es : List (LExpr LMonoTy Visibility)) (ctx : SMT.Context) :
   Except Format ((List Term) × SMT.Context) := do
   match es with
   | [] => .ok ([], ctx)
@@ -462,7 +462,7 @@ def ProofObligation.toSMTTerms (E : Env)
 ---------------------------------------------------------------------
 
 /-- Convert an expression of type LExpr to a String representation in SMT-Lib syntax, for testing. -/
-def toSMTTermString (e : (LExpr LMonoTy BoogieIdent)) (E : Env := Env.init) (ctx : SMT.Context := SMT.Context.default)
+def toSMTTermString (e : (LExpr LMonoTy Visibility)) (E : Env := Env.init) (ctx : SMT.Context := SMT.Context.default)
   : IO String := do
   let smtctx := toSMTTerm E [] e ctx
   match smtctx with

--- a/Strata/Languages/Boogie/StatementEval.lean
+++ b/Strata/Languages/Boogie/StatementEval.lean
@@ -39,10 +39,10 @@ a `.call` statement.
 def callConditions (proc : Procedure)
                    (condType : CondType)
                    (conditions : ListMap String Procedure.Check)
-                   (subst :  Map (Lambda.IdentT BoogieIdent) Expression.Expr) :
+                   (subst :  Map (Lambda.IdentT Visibility) Expression.Expr) :
                    ListMap String Procedure.Check :=
   let names := List.map
-               (fun k => s!"(Origin_{proc.header.name.2}_{condType}){k}")
+               (fun k => s!"(Origin_{proc.header.name.name}_{condType}){k}")
                conditions.keys
   let exprs := List.map
                 (fun p =>
@@ -75,7 +75,7 @@ def Command.evalCall (E : Env) (old_var_subst : SubstMap)
   | some proc =>
     -- Create a mapping from the formals to the evaluated actuals.
     let args' := List.map (fun a => E.exprEval (OldExpressions.substsOldExpr old_var_subst a)) args
-    let formal_tys := proc.header.inputs.keys.map (fun k => ((k, none) : (Lambda.IdentT BoogieIdent)))
+    let formal_tys := proc.header.inputs.keys.map (fun k => ((k, none) : (Lambda.IdentT Visibility)))
     let formal_arg_subst := List.zip formal_tys args'
     -- Generate fresh variables for the LHS, and then create a mapping
     -- from the procedure's return variables to these LHS fresh
@@ -85,7 +85,7 @@ def Command.evalCall (E : Env) (old_var_subst : SubstMap)
       (fun l => (E.exprEnv.state.findD l (none, .fvar l none)).fst)
     let lhs_typed := lhs.zip lhs_tys
     let (lhs_fvars, E) := E.genFVars lhs_typed
-    let return_tys := proc.header.outputs.keys.map (fun k => ((k, none) : (Lambda.IdentT BoogieIdent)))
+    let return_tys := proc.header.outputs.keys.map (fun k => ((k, none) : (Lambda.IdentT Visibility)))
     let return_lhs_subst := List.zip return_tys lhs_fvars
     -- The LHS fresh variables reflect the values of these variables
     -- in the post-call state.

--- a/Strata/Languages/Boogie/StatementType.lean
+++ b/Strata/Languages/Boogie/StatementType.lean
@@ -25,8 +25,8 @@ Type checker for Boogie commands.
 Note that this function needs the entire program to type-check `call`
 commands by looking up the corresponding procedure's information.
 -/
-def typeCheckCmd (T : (TEnv BoogieIdent)) (P : Program) (c : Command) :
-  Except Format (Command × (TEnv BoogieIdent)) := do
+def typeCheckCmd (T : (TEnv Visibility)) (P : Program) (c : Command) :
+  Except Format (Command × (TEnv Visibility)) := do
   match c with
   | .cmd c =>
     let (c, T) ← Imperative.Cmd.typeCheck T c
@@ -69,12 +69,12 @@ def typeCheckCmd (T : (TEnv BoogieIdent)) (P : Program) (c : Command) :
            .ok (s', T)
 
 
-def typeCheckAux (T : (TEnv BoogieIdent)) (P : Program) (op : Option Procedure) (ss : List Statement) :
-  Except Format (List Statement × (TEnv BoogieIdent)) :=
+def typeCheckAux (T : (TEnv Visibility)) (P : Program) (op : Option Procedure) (ss : List Statement) :
+  Except Format (List Statement × (TEnv Visibility)) :=
   go T ss []
 where
-  go (T : TEnv BoogieIdent) (ss : List Statement) (acc : List Statement) :
-    Except Format (List Statement × (TEnv BoogieIdent)) :=
+  go (T : TEnv Visibility) (ss : List Statement) (acc : List Statement) :
+    Except Format (List Statement × (TEnv Visibility)) :=
     match ss with
     | [] => .ok (acc.reverse, T)
     | s :: srest => do

--- a/Strata/Languages/C_Simp/C_Simp.lean
+++ b/Strata/Languages/C_Simp/C_Simp.lean
@@ -23,12 +23,12 @@ namespace C_Simp
 
 -- Our expression language is `DL/Lambda`
 abbrev Expression : Imperative.PureExpr := {
-  Ident := String,
-  Expr := Lambda.LExpr Lambda.LMonoTy String,
+  Ident := Lambda.Identifier Unit,
+  Expr := Lambda.LExpr Lambda.LMonoTy Unit,
   Ty := Lambda.LTy,
   TyEnv := Lambda.TEnv String,
   EvalEnv := Lambda.LState String,
-  EqIdent := String.decEq
+  EqIdent := Lambda.instDecidableEqIdentifier
 }
 
 

--- a/Strata/Transform/CallElim.lean
+++ b/Strata/Transform/CallElim.lean
@@ -41,7 +41,7 @@ def createFvars (ident : List Expression.Ident)
 
 def genIdent (ident : Expression.Ident) (pf : String → String)
   : BoogieGenM Expression.Ident :=
-    BoogieGenState.gen (pf ident.2)
+    BoogieGenState.gen (pf ident.name)
 
 /--
 Generate identifiers in the form of arg_... that can be used to reduce argument expressions to temporary variables.
@@ -107,7 +107,7 @@ returned list has the shape
 ((generated_name, ty), original_expr)
 -/
 def genArgExprIdentsTrip
-  (inputs : @Lambda.LTySignature BoogieIdent)
+  (inputs : @Lambda.LTySignature Visibility)
   (args : List Expression.Expr)
   : CallElimM (List ((Expression.Ident × Lambda.LTy) × Expression.Expr))
   := do
@@ -120,7 +120,7 @@ returned list has the shape
 `((generated_name, ty), original_name)`
 -/
 def genOutExprIdentsTrip
-  (outputs : @Lambda.LTySignature BoogieIdent)
+  (outputs : @Lambda.LTySignature Visibility)
   (lhs : List Expression.Ident)
   : CallElimM (List ((Expression.Ident × Expression.Ty) × Expression.Ident)) := do
   if outputs.length ≠ lhs.length then throw "output length and lhs length mismatch"

--- a/Strata/Transform/LoopElim.lean
+++ b/Strata/Transform/LoopElim.lean
@@ -27,7 +27,7 @@ def Statement.removeLoopsM (s : Boogie.Statement) : StateM Nat Boogie.Statement 
     let invariant := invariant?.getD LExpr.true
     let loop_num ← StateT.get
     let neg_guard : Expression.Expr := .app boolNotOp guard
-    let assigned_vars := (Stmts.modifiedVars body.ss).map (λ s => s.2)
+    let assigned_vars := (Stmts.modifiedVars body.ss).map (λ s => s.name)
     let havocd : Statement :=
       .block s!"loop_havoc_{loop_num}" {
         ss := assigned_vars.map (λ n => Statement.havoc (Coe.coe n) {})

--- a/StrataTest/Backends/CBMC/LambdaToCProverGOTO.lean
+++ b/StrataTest/Backends/CBMC/LambdaToCProverGOTO.lean
@@ -19,7 +19,7 @@ def LMonoTy.toGotoType (ty : LMonoTy) : Except Format CProverGOTO.Ty :=
   | .string => .ok .String
   | _ => .error f!"[toGotoType] Not yet implemented: {ty}"
 
-def LExprT.getGotoType {Identifier} (e : LExprT Identifier) :
+def LExprT.getGotoType {IDMeta} (e : LExprT IDMeta) :
     Except Format CProverGOTO.Ty := do
   let ty := toLMonoTy e
   ty.toGotoType
@@ -34,7 +34,7 @@ def fnToGotoID (fn : String) : Except Format CProverGOTO.Expr.Identifier :=
 Mapping `LExprT` (Lambda expressions obtained after the type inference
 transform) to GOTO expressions.
 -/
-def LExprT.toGotoExpr {Identifier} [ToString Identifier] (e : LExprT Identifier) :
+def LExprT.toGotoExpr {IDMeta} [ToString IDMeta] (e : LExprT IDMeta) :
     Except Format CProverGOTO.Expr :=
   open CProverGOTO in
   do match e with
@@ -69,7 +69,7 @@ def LExprT.toGotoExpr {Identifier} [ToString Identifier] (e : LExprT Identifier)
 /--
 Mapping `LExpr` to GOTO expressions.
 -/
-def LExpr.toGotoExpr {Identifier} [ToString Identifier] (e : LExpr LMonoTy Identifier) :
+def LExpr.toGotoExpr {IDMeta} [ToString IDMeta] (e : LExpr LMonoTy IDMeta) :
     Except Format CProverGOTO.Expr :=
   open CProverGOTO in
   do match e with

--- a/StrataTest/DL/Lambda/LExprEvalTests.lean
+++ b/StrataTest/DL/Lambda/LExprEvalTests.lean
@@ -61,13 +61,13 @@ open Std (ToFormat Format format)
 
 /-- info: ((λ %1) #true) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 ∅ (.app (.mdata ⟨"x"⟩ (.abs .none (.bvar 1))) (.const "true" none))
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 ∅ (.app (.mdata ⟨"x"⟩ (.abs .none (.bvar 1))) (.const "true" none))
 
 /- Tests for evaluation of BuiltInFunctions. -/
 
 open LTy.Syntax
 
-private def testBuiltIn : @Factory String :=
+private def testBuiltIn : @Factory Unit :=
   #[{ name := "Int.Add",
       inputs := [("x", mty[int]), ("y", mty[int])],
       output := mty[int],
@@ -109,7 +109,7 @@ private def testBuiltIn : @Factory String :=
       body := some esM[((~Int.Add x) y)]
     }]
 
-private def testState : LState String :=
+private def testState : LState Unit :=
   let ans := LState.addFactory LState.init testBuiltIn
   match ans with
   | .error e => panic s!"{e}"
@@ -117,79 +117,79 @@ private def testState : LState String :=
 
 /-- info: (#50 : int) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~IntAddAlias #20) #30)]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~IntAddAlias #20) #30)]
 
 /-- info: ((~Int.Add #20) x) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~IntAddAlias #20) x)]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~IntAddAlias #20) x)]
 
 /-- info: ((~Int.Add ((~Int.Add #5) #100)) x) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 LState.init esM[(( ((λλ (~Int.Add %1) %0)) ((λ ((~Int.Add %0) #100)) #5)) x)]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 LState.init esM[(( ((λλ (~Int.Add %1) %0)) ((λ ((~Int.Add %0) #100)) #5)) x)]
 
 /-- info: (#50 : int) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Add #20) #30)]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Add #20) #30)]
 
 /-- info: ((~Int.Add (#105 : int)) x) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((((λλ (~Int.Add %1) %0)) ((λ ((~Int.Add %0) #100)) #5)) x)]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((((λλ (~Int.Add %1) %0)) ((λ ((~Int.Add %0) #100)) #5)) x)]
 
 /-- info: ((#f #20) (#-5 : int)) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[( ((λλ (#f %1) %0) #20) ((λ (~Int.Neg %0)) (#5 : int)))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[( ((λλ (#f %1) %0) #20) ((λ (~Int.Neg %0)) (#5 : int)))]
 
 /-- info: ((~Int.Add #20) (~Int.Neg x)) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[( ((λλ (~Int.Add %1) %0) #20) ((λ (~Int.Neg %0)) x))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[( ((λλ (~Int.Add %1) %0) #20) ((λ (~Int.Neg %0)) x))]
 
 /-- info: ((~Int.Add #20) (~Int.Neg x)) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Add #20) (~Int.Neg x))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Add #20) (~Int.Neg x))]
 
 /-- info: ((~Int.Add x) (#-30 : int)) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Add x) (~Int.Neg #30))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Add x) (~Int.Neg #30))]
 
 /-- info: (#50 : int) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((λ %0) ((~Int.Add #20) #30))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((λ %0) ((~Int.Add #20) #30))]
 
 /-- info: (#100 : int) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Div #300) ((~Int.Add #2) #1))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Div #300) ((~Int.Add #2) #1))]
 
 /-- info: (#0 : int) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Add #3) (~Int.Neg #3))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Add #3) (~Int.Neg #3))]
 
 /-- info: (#0 : int) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Add (~Int.Neg #3)) #3)]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Add (~Int.Neg #3)) #3)]
 
 /-- info: ((~Int.Div #300) (#0 : int)) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Div #300) ((~Int.Add #3) (~Int.Neg #3)))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Div #300) ((~Int.Add #3) (~Int.Neg #3)))]
 
 /-- info: ((~Int.Div x) (#3 : int)) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 10 testState esM[((~Int.Div x) ((~Int.Add #2) #1))]
+#eval format $ LExpr.eval (IDMeta:=Unit) 10 testState esM[((~Int.Div x) ((~Int.Add #2) #1))]
 
 /-- info: ((~Int.Le (#100 : int)) x) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 200 testState
+#eval format $ LExpr.eval (IDMeta:=Unit) 200 testState
                 esM[((~Int.Le ((~Int.Div #300) ((~Int.Add #2) #1))) x)]
 
 /--
 info: ((~Int.Le ((~Int.Div #300) ((~Int.Add #2) y))) x)
 -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 200 testState
+#eval format $ LExpr.eval (IDMeta:=Unit) 200 testState
                 esM[((~Int.Le ((~Int.Div #300) ((~Int.Add #2) y))) x)]
 
 /-- info: ((~Int.Div x) x) -/
 #guard_msgs in
-#eval format $ LExpr.eval (Identifier:=String) 200 testState
+#eval format $ LExpr.eval (IDMeta:=Unit) 200 testState
                 esM[((~Int.Div x) x)]
 
 

--- a/StrataTest/DL/Lambda/LExprTTests.lean
+++ b/StrataTest/DL/Lambda/LExprTTests.lean
@@ -135,7 +135,7 @@ info: ok: (arrow (arrow $__ty2 (arrow $__ty8 $__ty9)) (arrow (arrow $__ty2 $__ty
                             esM[λλ(%1 (%0 %0))]
          return (format $ ans.fst)
 
-private def testIntFns : (@Factory String) :=
+private def testIntFns : (@Factory Unit) :=
   #[{ name := "unit",
       inputs := [],
       output := mty[unit]},

--- a/StrataTest/Languages/Boogie/ProcedureTypeTests.lean
+++ b/StrataTest/Languages/Boogie/ProcedureTypeTests.lean
@@ -58,7 +58,7 @@ body: g := (((~Int.Add : (arrow int (arrow int int))) (a : int)) (g : int))
 -/
 #guard_msgs in
 #eval do let ans ←
-              typeCheck { TEnv.default (Identifier:=BoogieIdent) with
+              typeCheck { TEnv.default (IDMeta:=Visibility) with
                               functions := Boogie.Factory,
                               context := { types := [[("g", t[int])]] }}
                         Program.init
@@ -85,7 +85,7 @@ body: g := (((~Int.Add : (arrow int (arrow int int))) (a : int)) (g : int))
 -/
 #guard_msgs in
 #eval do let ans ←
-              typeCheck { TEnv.default (Identifier:=BoogieIdent) with
+              typeCheck { TEnv.default (IDMeta:=Visibility) with
                               functions := Boogie.Factory,
                               context := { types := [[("g", t[int])]] }}
                         Program.init


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Redefines an `Identifier` as `String x IDMeta` and parameterizes `LExpr`, `LExprT`, etc with `IDMeta` rather than `Identifier`. This allows several important operations on  identifiers and expressions including:
- Generating arbitrary distinct identifiers (assuming `IDMeta` is `Inhabited`)
- Pattern matching on the name of a `.op` expression

Note: since the `ToFormat` instance of `BoogieIdent` (the only non-`String` identifier in use) simply gave the name, this implementation ignores `IDMeta` when converting `Identifiers` to `String` or `Format`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
