### PR TITLE
Create variables for old expressions in Boogie

### DIFF
--- a/Strata/DL/Lambda/Identifiers.lean
+++ b/Strata/DL/Lambda/Identifiers.lean
@@ -22,7 +22,7 @@ Identifiers with a name and additional metadata
 structure Identifier (IDMeta : Type) : Type where
   name : String
   metadata : IDMeta
-deriving Repr, DecidableEq, Inhabited
+deriving Repr, DecidableEq, Inhabited, Hashable, Ord
 
 instance : ToFormat (Identifier IDMeta) where
   format i := i.name

--- a/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
+++ b/Strata/Languages/Boogie/Examples/AdvancedMaps.lean
@@ -63,7 +63,10 @@ var (c : (Map int MapII)) := init_c_2
 modifies: [a, b, c]
 preconditions: (P_requires_3, ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) #0) == #0)) (P_requires_4, ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) #0) == (a : MapII)))
 postconditions: ⏎
-body: assert [c_0_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) #0) == (a : MapII))
+body: init (old$a : MapII) := (a : MapII)
+init (old$b : (Map bool int)) := (b : (Map bool int))
+init (old$c : (Map int MapII)) := (c : (Map int MapII))
+assert [c_0_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) #0) == (a : MapII))
 c := ((((~update : (arrow (Map int MapII) (arrow int (arrow MapII (Map int MapII))))) (c : (Map int MapII))) #1) (a : MapII))
 assert [c_1_eq_a] ((((~select : (arrow (Map int MapII) (arrow int MapII))) (c : (Map int MapII))) #1) == (a : MapII))
 assert [a0eq0] ((((~select : (arrow (Map int int) (arrow int int))) (a : MapII)) #0) == #0)

--- a/Strata/Languages/Boogie/Examples/FreeRequireEnsure.lean
+++ b/Strata/Languages/Boogie/Examples/FreeRequireEnsure.lean
@@ -77,6 +77,7 @@ modifies: [g]
 preconditions: (g_eq_15, ((g : int) == #15) (Attribute: Boogie.Procedure.CheckAttr.Free))
 postconditions: (g_lt_10, (((~Int.Lt : (arrow int (arrow int bool))) (g : int)) #10) (Attribute: Boogie.Procedure.CheckAttr.Free))
 body: assume [g_eq_15] ($__g0 == #15)
+init (old$g : int) := $__g0
 assert [g_gt_10_internal] ((~Int.Gt $__g0) #10)
 g := ((~Int.Add $__g0) #1)
 #[<[g_lt_10]: (((~Int.Lt : (arrow int (arrow int bool))) (g : int)) #10)>,

--- a/Strata/Languages/Boogie/Examples/SimpleProc.lean
+++ b/Strata/Languages/Boogie/Examples/SimpleProc.lean
@@ -15,12 +15,15 @@ program Boogie;
 var g : bool;
 procedure Test(x : bool) returns (y : bool)
 spec {
+  modifies g;
   ensures (y == x);
   ensures (x == y);
   ensures (g == old(g));
 }
 {
+  g := g && true;
   y := x || x;
+  assert g == old(g);
 };
 #end
 
@@ -34,10 +37,13 @@ spec {
 /--
 info: var (g : bool) := init_g_0
 (procedure Test :  ((x : bool)) → ((y : bool)))
-modifies: []
+modifies: [g]
 preconditions: ⏎
-postconditions: (Test_ensures_0, ((y : bool) == (x : bool))) (Test_ensures_1, ((x : bool) == (y : bool))) (Test_ensures_2, ((g : bool) == ((~old : (arrow a a)) (g : bool))))
-body: y := (((~Bool.Or : (arrow bool (arrow bool bool))) (x : bool)) (x : bool))
+postconditions: (Test_ensures_1, ((y : bool) == (x : bool))) (Test_ensures_2, ((x : bool) == (y : bool))) (Test_ensures_3, ((g : bool) == (~old (g : bool))))
+body: init (old$g : bool) := (g : bool)
+g := (((~Bool.And : (arrow bool (arrow bool bool))) (g : bool)) #true)
+y := (((~Bool.Or : (arrow bool (arrow bool bool))) (x : bool)) (x : bool))
+assert [assert_0] ((g : bool) == (old$g : bool))
 
 Errors: #[]
 -/
@@ -49,38 +55,50 @@ info: [Strata.Boogie] Type checking succeeded.
 
 
 VCs:
-Label: Test_ensures_0
+Label: assert_0
 Assumptions:
 
 
 Proof Obligation:
-(((~Bool.Or $__x0) $__x0) == $__x0)
+(((~Bool.And $__g0) #true) == $__g0)
 
 Label: Test_ensures_1
 Assumptions:
 
 
 Proof Obligation:
-($__x0 == ((~Bool.Or $__x0) $__x0))
+(((~Bool.Or $__x1) $__x1) == $__x1)
 
 Label: Test_ensures_2
 Assumptions:
 
 
 Proof Obligation:
-#true
+($__x1 == ((~Bool.Or $__x1) $__x1))
 
-Wrote problem to vcs/Test_ensures_0.smt2.
+Label: Test_ensures_3
+Assumptions:
+
+
+Proof Obligation:
+(((~Bool.And $__g0) #true) == $__g0)
+
+Wrote problem to vcs/assert_0.smt2.
 Wrote problem to vcs/Test_ensures_1.smt2.
+Wrote problem to vcs/Test_ensures_2.smt2.
+Wrote problem to vcs/Test_ensures_3.smt2.
 ---
 info:
-Obligation: Test_ensures_0
+Obligation: assert_0
 Result: verified
 
 Obligation: Test_ensures_1
 Result: verified
 
 Obligation: Test_ensures_2
+Result: verified
+
+Obligation: Test_ensures_3
 Result: verified
 -/
 #guard_msgs in

--- a/Strata/Languages/Boogie/Identifiers.lean
+++ b/Strata/Languages/Boogie/Identifiers.lean
@@ -40,7 +40,7 @@ inductive Visibility where
   | glob
   | locl
   | temp
-deriving DecidableEq, Repr
+deriving DecidableEq, Repr, Ord, Hashable
 
 instance : ToFormat Visibility where
   format


### PR DESCRIPTION
**Note:** I don't think this is quite done yet. Let's merge #213 first, at the very least.

Now each Boogie procedure includes one additional local variable for every global variable in its `modifies` clause, initialized to the initial value of the global at procedure entry. For each such variable `g`, all instances of `old(g)` in the procedure body are replaced with a reference to the new local that stores the old value of `g`. Postconditions still can contain `old(x)` sub-expressions, but they will always be normalized (i.e., `old` will be applied only to variables).

Code that interprets postconditions will need to do the appropriate substitution to replace `old` expressions with something else.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
