### PR TITLE
Change concrete eval to partial function

### DIFF
--- a/Strata/DL/Lambda/Factory.lean
+++ b/Strata/DL/Lambda/Factory.lean
@@ -94,7 +94,7 @@ structure LFunc (T : LExprParams) where
   -- (TODO): Add support for a fixed set of attributes (e.g., whether to inline
   -- a function, etc.).
   attr     : Array String := #[]
-  concreteEval : Option ((LExpr T.mono) → List (LExpr T.mono) → (LExpr T.mono)) := .none
+  concreteEval : Option ((LExpr T.mono) → List (LExpr T.mono) → Option (LExpr T.mono)) := .none
   axioms   : List (LExpr T.mono) := []  -- For axiomatic definitions
 
 instance [Inhabited T.Metadata] [Inhabited T.IDMeta] : Inhabited (LFunc T) where

--- a/Strata/DL/Lambda/IntBoolFactory.lean
+++ b/Strata/DL/Lambda/IntBoolFactory.lean
@@ -21,13 +21,18 @@ section IntBoolFactory
 
 variable {T : LExprParams} [Coe String T.Identifier]
 
-def unaryOp (n : T.Identifier)
+def cevalMkOpt (ceval:  Option (LExpr T.mono→ List (LExpr T.mono) → LExpr T.mono)) :  Option (LExpr T.mono → List (LExpr T.mono) → Option (LExpr T.mono)) :=
+  match ceval with
+  | none => none
+  | some f => some (fun x y => some (f x y))
+
+def unaryOp (n :T.Identifier)
             (ty : LMonoTy)
             (ceval : Option (LExpr T.mono → List (LExpr T.mono) → LExpr T.mono)) : LFunc T :=
   { name := n,
     inputs := [("x", ty)],
     output := ty,
-    concreteEval := ceval }
+    concreteEval := cevalMkOpt ceval }
 
 def binaryOp (n : T.Identifier)
              (ty : LMonoTy)
@@ -35,7 +40,7 @@ def binaryOp (n : T.Identifier)
   { name := n,
     inputs := [("x", ty), ("y", ty)],
     output := ty,
-    concreteEval := ceval }
+    concreteEval := cevalMkOpt ceval }
 
 def binaryPredicate (n : T.Identifier)
                     (ty : LMonoTy)
@@ -43,7 +48,7 @@ def binaryPredicate (n : T.Identifier)
   { name := n,
     inputs := [("x", ty), ("y", ty)],
     output := .bool,
-    concreteEval := ceval }
+    concreteEval := cevalMkOpt ceval }
 
 def unOpCeval (InTy OutTy : Type) [ToString OutTy]
                 (mkConst : T.Metadata → OutTy → LExpr T.mono)

--- a/Strata/DL/Lambda/LExprEval.lean
+++ b/Strata/DL/Lambda/LExprEval.lean
@@ -132,7 +132,11 @@ partial def eval (n : Nat) (σ : LState TBase) (e : (LExpr TBase.mono))
             -- We can, provided a denotation function, evaluate this function
             -- call.
             match lfunc.concreteEval with
-            | none => new_e | some ceval => eval n' σ (ceval new_e args)
+            | none => new_e
+            | some ceval =>
+              match (ceval new_e args) with
+              | some x => eval n' σ x
+              | none => new_e
           else
             -- At least one argument in the function call is symbolic.
             new_e

--- a/Strata/DL/Lambda/TypeFactory.lean
+++ b/Strata/DL/Lambda/TypeFactory.lean
@@ -228,7 +228,7 @@ Examples:
 
 -/
 def elimConcreteEval {T: LExprParams} [BEq T.Identifier] (d: LDatatype T.IDMeta) (m: T.Metadata) (elimName : Identifier T.IDMeta) :
-  (LExpr T.mono) → List (LExpr T.mono) → (LExpr T.mono) :=
+  (LExpr T.mono) → List (LExpr T.mono) → Option (LExpr T.mono) :=
   fun e args =>
     match args with
     | x :: xs =>

--- a/Strata/Languages/Boogie/Factory.lean
+++ b/Strata/Languages/Boogie/Factory.lean
@@ -111,16 +111,16 @@ def strLengthFunc : LFunc BoogieLParams :=
       typeArgs := [],
       inputs := [("x", mty[string])]
       output := mty[int],
-      concreteEval := some (unOpCeval (T:=BoogieLParams) String Int (.intConst (T:=BoogieLParams.mono)) (@LExpr.denoteString BoogieLParams)
-                            (fun s => (Int.ofNat (String.length s))))}
+      concreteEval := cevalMkOpt (some (unOpCeval (T:=BoogieLParams) String Int (.intConst (T:=BoogieLParams.mono)) (@LExpr.denoteString BoogieLParams)
+                            (fun s => (Int.ofNat (String.length s)))))}
 
 def strConcatFunc : LFunc BoogieLParams :=
     { name := "Str.Concat",
       typeArgs := [],
       inputs := [("x", mty[string]), ("y", mty[string])]
       output := mty[string],
-      concreteEval := some (binOpCeval String String (.strConst (T := BoogieLParams.mono))
-                            LExpr.denoteString String.append)}
+      concreteEval := cevalMkOpt (some (binOpCeval String String (.strConst (T := BoogieLParams.mono))
+                            LExpr.denoteString String.append))}
 
 def strSubstrFunc : LFunc BoogieLParams :=
     { name := "Str.Substr",

--- a/StrataTest/DL/Lambda/LExprEvalTests.lean
+++ b/StrataTest/DL/Lambda/LExprEvalTests.lean
@@ -81,7 +81,7 @@ private def testBuiltIn : @Factory TestParams :=
                           let e1i := LExpr.denoteInt e1
                           let e2i := LExpr.denoteInt e2
                           match e1i, e2i with
-                          | some x, some y => .intConst e1.metadata (x + y)
+                          | some x, some y => some (.intConst e1.metadata (x + y))
                           | _, _ => e
                         | _ => e) },
     { name := "Int.Div",
@@ -93,7 +93,7 @@ private def testBuiltIn : @Factory TestParams :=
                             let e2i := LExpr.denoteInt e2
                             match e1i, e2i with
                             | some x, some y =>
-                              if y == 0 then e else .intConst e1.metadata (x / y)
+                              if y == 0 then none else some (.intConst e1.metadata (x / y))
                             | _, _ => e
                           | _ => e) },
     { name := "Int.Neg",
@@ -103,7 +103,7 @@ private def testBuiltIn : @Factory TestParams :=
                               | [e1] =>
                                 let e1i := LExpr.denoteInt e1
                                 match e1i with
-                                | some x => .intConst e1.metadata (- x)
+                                | some x => some (.intConst e1.metadata (- x))
                                 | _ => e
                               | _ => e) },
 


### PR DESCRIPTION
As discussed in #223, we most likely want `concreteEval` to return an `option`. This capability will also be needed for certain extensions to inductive types in Strata. 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
