### PR TITLE
Refactor beq proofs to reduce duplication

### DIFF
--- a/Strata/DL/Imperative/MetaData.lean
+++ b/Strata/DL/Imperative/MetaData.lean
@@ -33,6 +33,7 @@ inductive MetaDataElem.Field (P : PureExpr) where
   | var (v : P.Ident)
   | label (l : String)
 
+@[grind]
 def MetaDataElem.Field.beq [BEq P.Ident] (f1 f2 : MetaDataElem.Field P) :=
   match f1, f2 with
   | .var v1, .var v2 => v1 == v2
@@ -42,17 +43,9 @@ def MetaDataElem.Field.beq [BEq P.Ident] (f1 f2 : MetaDataElem.Field P) :=
 instance [BEq P.Ident] : BEq (MetaDataElem.Field P) where
   beq f1 f2 := f1.beq f2
 
--- TODO: this is exactly the same proof as LExpr.beq_eq. Is there some existing
--- automation we could use?
 theorem MetaDataElem.Field.beq_eq {P : PureExpr} [DecidableEq P.Ident]
   (f1 f2 : MetaDataElem.Field P) : MetaDataElem.Field.beq f1 f2 = true ↔ f1 = f2 := by
-  constructor <;> intro h
-  case mp =>
-    -- Soundness: beq = true → e1 = e2
-    unfold beq at h; induction f1 generalizing f2 <;> (cases f2 <;> grind)
-  case mpr =>
-    -- Completeness: e1 = e2 → beq = true
-    rw[h]; induction f2 generalizing f1 <;> simp only [MetaDataElem.Field.beq] <;> grind
+  solve_beq f1 f2
 
 instance [DecidableEq P.Ident] : DecidableEq (MetaDataElem.Field P) :=
   beq_eq_DecidableEq MetaDataElem.Field.beq MetaDataElem.Field.beq_eq

--- a/Strata/DL/Lambda/LExpr.lean
+++ b/Strata/DL/Lambda/LExpr.lean
@@ -7,6 +7,7 @@
 import Strata.DL.Lambda.LTy
 import Strata.DL.Lambda.Identifiers
 import Strata.DL.Lambda.MetaData
+import Strata.DL.Util.DecidableEq
 
 /-! ## Lambda Expressions with Quantifiers
 
@@ -146,6 +147,7 @@ instance [Repr T.base.Metadata] [Repr T.TypeType] [Repr T.base.IDMeta] : Repr (L
     if prec > 0 then Std.Format.paren (go e) else go e
 
 -- Boolean equality function for LExpr
+@[grind]
 def LExpr.beq [BEq T.base.Metadata] [BEq T.TypeType] [BEq (Identifier T.base.IDMeta)] : LExpr T → LExpr T → Bool
   | .const m1 c1, e2 =>
     match e2 with
@@ -192,12 +194,7 @@ instance [BEq T.base.Metadata] [BEq T.TypeType] [BEq (Identifier T.base.IDMeta)]
 -- First, prove that beq is sound and complete
 theorem LExpr.beq_eq {T : LExprParamsT} [DecidableEq T.base.Metadata] [DecidableEq T.TypeType] [DecidableEq T.base.IDMeta]
   (e1 e2 : LExpr T) : LExpr.beq e1 e2 = true ↔ e1 = e2 := by
-  constructor
-  · -- Soundness: beq = true → e1 = e2
-    intro h; induction e1 generalizing e2 <;>
-    (unfold beq at h; cases e2 <;> grind)
-  · -- Completeness: e1 = e2 → beq = true
-    intros h; rw[h]; induction e2 generalizing e1 <;> simp only [LExpr.beq] <;> grind
+  solve_beq e1 e2
 
 -- Now use this theorem in DecidableEq
 instance {T: LExprParamsT} [DecidableEq T.base.Metadata] [DecidableEq T.TypeType] [DecidableEq T.base.IDMeta] : DecidableEq (LExpr T) :=

--- a/Strata/DL/Util/DecidableEq.lean
+++ b/Strata/DL/Util/DecidableEq.lean
@@ -15,3 +15,16 @@ def beq_eq_DecidableEq
       isTrue (eq.mp h)
     else
       isFalse (fun heq => h (eq.mpr heq))
+
+/--
+Solves goals of the form `beq e1 e2 = true ↔ e1 = e2` if `beq` is
+marked with `@[grind]`.
+-/
+syntax "solve_beq" ident ident  : tactic
+macro_rules
+  | `(tactic|solve_beq $e1:ident $e2:ident) =>
+  `(tactic|
+    constructor <;> intro h <;>
+    try (induction $e1:ident generalizing $e2 <;> cases $e2:ident <;> grind) <;>
+    (subst_vars; induction $e2:ident <;> grind)
+  )


### PR DESCRIPTION
Resolves TODO in #189 by removing duplication in beq proofs

Closes #234

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
