### PR TITLE
Add all executables to default targets

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "Strata"
 version = "0.1.0"
-defaultTargets = ["Strata", "StrataMain", "StrataVerify", "StrataToCBMC"]
+defaultTargets = ["Strata", "strata", "StrataMain", "StrataVerify", "StrataToCBMC", "BoogieToGoto"]
 testDriver = "StrataTest"
 
 [[lean_lib]]


### PR DESCRIPTION
**Description of changes:**
Adding ``strata`` and ``BoogieToGoto`` to default targets list. This ensures that all binaries are generated when running ``lake build``. My assumption here is that this was omitted by mistake, but feel free to discard this PR if that was intentional. 




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
