### PR TITLE
Update pyTranslate and pyAnalyze to use compile time Python dialect

### DIFF
--- a/Strata/DDM/Ion.lean
+++ b/Strata/DDM/Ion.lean
@@ -1299,4 +1299,19 @@ def fromIonFragment (f : Ion.Fragment) (dialects : DialectMap) (dialect : Dialec
     commands := commands
   }
 
+def fromIon (dialects : DialectMap) (dialect : DialectName) (bytes : ByteArray) : Except String Strata.Program := do
+  let (hdr, frag) ←
+    match Strata.Ion.Header.parse bytes with
+    | .error msg =>
+      throw msg
+    | .ok p =>
+      pure p
+  match hdr with
+  | .dialect _ =>
+    throw "Expected a Strata program instead of a dialect."
+  | .program name => do
+    if name != dialect then
+      throw s!"{name} program found when {dialect} expected."
+    fromIonFragment frag dialects dialect
+
 end Program


### PR DESCRIPTION
pyTranslate and pyAnalyze search for the Python dialect using a search path despite being known at compile time.  This changes Strata main to use the builtin version.