### PR TITLE
Fix pyAnalyze CI

### DIFF
--- a/StrataTest/Languages/Python/expected/test_datetime.expected
+++ b/StrataTest/Languages/Python/expected/test_datetime.expected
@@ -1,7 +1,7 @@
 
-ensure_timedelta_sign_matches: verified
-
 datetime_now_ensures_0: verified
+
+datetime_utcnow_ensures_0: verified
 
 ensures_str_strp_reverse: verified
 
@@ -20,4 +20,3 @@ py_assertion: unknown
 py_assertion: unknown
 
 py_assertion: unknown
-

--- a/StrataTest/Languages/Python/expected/test_function_def_calls.expected
+++ b/StrataTest/Languages/Python/expected/test_function_def_calls.expected
@@ -1,4 +1,10 @@
 
+datetime_now_ensures_0: verified
+
+datetime_utcnow_ensures_0: verified
+
+ensures_str_strp_reverse: verified
+
 assert_name_is_foo: verified
 
 assert_opt_name_none_or_str: verified
@@ -8,7 +14,7 @@ assert_opt_name_none_or_bar: verified
 ensures_maybe_except_none: verified
 
 test_helper_procedure_assert_name_is_foo_3: failed
-CEx: ($__s8, "")
+CEx: ($__s49, "")
 
 test_helper_procedure_assert_opt_name_none_or_str_4: verified
 

--- a/StrataTest/Languages/Python/expected/test_precondition_verification.expected
+++ b/StrataTest/Languages/Python/expected/test_precondition_verification.expected
@@ -1,4 +1,10 @@
 
+datetime_now_ensures_0: verified
+
+datetime_utcnow_ensures_0: verified
+
+ensures_str_strp_reverse: verified
+
 assert_name_is_foo: verified
 
 assert_opt_name_none_or_str: verified

--- a/StrataTest/Languages/Python/run_py_analyze.sh
+++ b/StrataTest/Languages/Python/run_py_analyze.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+failed=0
+
 for test_file in tests/test_*.py; do
     if [ -f "$test_file" ]; then
         base_name=$(basename "$test_file" .py)
@@ -14,7 +16,10 @@ for test_file in tests/test_*.py; do
             if ! echo "$output" | diff -q "$expected_file" - > /dev/null; then
                 echo "ERROR: Analysis output for $base_name does not match expected result"
                 echo "$output" | diff "$expected_file" -
+                failed=1
             fi
         fi
     fi
 done
+
+exit $failed

--- a/StrataTest/Languages/Python/tests/test_function_def_calls.py
+++ b/StrataTest/Languages/Python/tests/test_function_def_calls.py
@@ -2,7 +2,7 @@ import test_helper
 
 # Test function defs
 
-def my_f(s: str) -> None:
+def my_f(s: str):
     test_helper.procedure(s)
 
 def main():


### PR DESCRIPTION
Fix pyAnalyze CI. The CI was printing an error message, but not exiting with an error code.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
