### PR TITLE
Add destructor-constructor cancellation to partial evaluator

### DIFF
--- a/Strata/DL/Lambda/TypeFactory.lean
+++ b/Strata/DL/Lambda/TypeFactory.lean
@@ -468,7 +468,8 @@ def destructorFuncs {T} [BEq T.Identifier] [Inhabited T.IDMeta]  (d: LDatatype T
       typeArgs := d.typeArgs,
       inputs := [(arg, dataDefault d)],
       output := ty,
-      concreteEval := some (fun _ => destructorConcreteEval d c i)})
+      concreteEval := some (fun _ => destructorConcreteEval d c i),
+      attr := #[eval_if_constr_attr]})
 
 
 ---------------------------------------------------------------------

--- a/StrataTest/Languages/Core/Examples/DatatypeEval.lean
+++ b/StrataTest/Languages/Core/Examples/DatatypeEval.lean
@@ -9,7 +9,7 @@ import Strata.Languages.Core.Verifier
 ---------------------------------------------------------------------
 namespace Strata
 
-def smalltest :=
+def testerEx :=
 #strata
 program Core;
 
@@ -22,7 +22,48 @@ procedure test () returns ()
 {
   var b: bool;
   havoc b;
-  assert [constr_destr_cancel]: Any..isfrom_bool(from_bool(b));
+  assert [constr_tester_cancel]: Any..isfrom_bool(from_bool(b));
+};
+
+#end
+
+/-- info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: constr_tester_cancel
+Property: assert
+Assumptions:
+
+
+Proof Obligation:
+#true
+
+---
+info:
+Obligation: constr_tester_cancel
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval verify "cvc5" testerEx
+
+
+def destrEx :=
+#strata
+program Core;
+
+
+datatype Any () {
+  from_bool (as_bool : bool)
+};
+
+procedure test () returns ()
+{
+  var b: bool;
+  havoc b;
+  assume (b == true);
+  assert [constr_destr_cancel]: Any..as_bool(from_bool(b));
 };
 
 #end
@@ -34,10 +75,10 @@ VCs:
 Label: constr_destr_cancel
 Property: assert
 Assumptions:
-
+(assume_0, ($__b0 == #true))
 
 Proof Obligation:
-#true
+$__b0
 
 ---
 info:
@@ -46,6 +87,6 @@ Property: assert
 Result: ✅ pass
 -/
 #guard_msgs in
-#eval verify "cvc5" smalltest
+#eval verify "cvc5" destrEx
 
 end Strata


### PR DESCRIPTION
*Description of changes:* Destructor-constructor pairs now simplify in the partial evaluator


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
