### PR TITLE
Reduce # test cases of ExprEvalTest to 5

### DIFF
--- a/StrataTest/Languages/Core/ExprEvalTest.lean
+++ b/StrataTest/Languages/Core/ExprEvalTest.lean
@@ -189,7 +189,7 @@ open Lambda.LTy.Syntax
 
 
 -- This may take a while
-#eval (checkFactoryOps true)
+#eval (checkFactoryOps false)
 
 open Plausible TestGen
 


### PR DESCRIPTION
After this patch it takes around 1 minute:

```
lake test  5.91s user 61.03s system 92% cpu 1:12.51 total
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
