### PR TITLE
Add app builtin constructor to generated Init.Expr category

### DIFF
--- a/Strata/DDM/AST.lean
+++ b/Strata/DDM/AST.lean
@@ -223,9 +223,23 @@ end SepFormat
 mutual
 
 inductive ExprF (α : Type) : Type where
+  /--
+  A bound variable reference (de Bruijn index).
+
+  If this is a function, then the arguments are always value-level;
+  type arguments are omitted.
+  -/
 | bvar (ann : α) (idx : Nat)
+  /--
+  A free variable reference.
+
+  If this is a function, then the arguments are always value-level;
+  type arguments are omitted.
+  -/
 | fvar (ann : α) (idx : FreeVarIndex)
+  /-- A named dialect function. -/
 | fn (ann : α) (ident : QualifiedIdent)
+  /-- Function application. -/
 | app (ann : α) (e : ExprF α) (a : ArgF α)
 deriving Inhabited, Repr
 

--- a/StrataTest/DDM/Integration/Lean/Gen.lean
+++ b/StrataTest/DDM/Integration/Lean/Gen.lean
@@ -177,6 +177,7 @@ number of parameters: 1
 constructors:
 TestDialect.Expr.fvar : {α : Type} → α → Nat → Expr α
 TestDialect.Expr.bvar : {α : Type} → α → Nat → Expr α
+TestDialect.Expr.app : {α : Type} → α → Expr α → Expr α → Expr α
 TestDialect.Expr.trueExpr : {α : Type} → α → Expr α
 TestDialect.Expr.and : {α : Type} → α → Expr α → Expr α → Expr α
 TestDialect.Expr.lambda : {α : Type} → α → TestDialectType α → Bindings α → Expr α → Expr α
@@ -224,6 +225,8 @@ def testRoundTrip {β M} [h : Strata.IsAST β M] [BEq (β Unit)] (e : β Unit) :
 #guard testRoundTrip <|
   Expr.lambda () (.bool ()) (Bindings.mkBindings () ⟨(), #[]⟩) (.trueExpr ())
 #guard testRoundTrip <| Expr.fvar () 1
+#guard testRoundTrip <| Expr.app () (.fvar () 0) (.trueExpr ())
+#guard testRoundTrip <| Expr.app () (.app () (.fvar () 0) (.trueExpr ())) (.fvar () 1)
 
 open Strata (OfAstM)
 

--- a/StrataTest/DL/Imperative/DDMTranslate.lean
+++ b/StrataTest/DL/Imperative/DDMTranslate.lean
@@ -78,6 +78,7 @@ number of parameters: 1
 constructors:
 ArithPrograms.Expr.fvar : {α : Type} → α → Nat → Expr α
 ArithPrograms.Expr.bvar : {α : Type} → α → Nat → Expr α
+ArithPrograms.Expr.app : {α : Type} → α → Expr α → Expr α → Expr α
 ArithPrograms.Expr.numLit : {α : Type} → α → Strata.Ann Nat α → Expr α
 ArithPrograms.Expr.btrue : {α : Type} → α → Expr α
 ArithPrograms.Expr.bfalse : {α : Type} → α → Expr α
@@ -109,6 +110,7 @@ def translateExpr (bindings : TransBindings) (e : ArithPrograms.Expr α) : Trans
     let e1 ← translateExpr bindings e1
     let e2 ← translateExpr bindings e2
     return (.Eq e1 e2)
+  | .app .. => TransM.error "Unexpected app in ArithPrograms"
 
 /--
 info: inductive ArithPrograms.Label : Type → Type


### PR DESCRIPTION
## Summary
- Adds an `app` builtin constructor to the generated `Init.Expr` category in `#strata_gen`, alongside `fvar` and `bvar`
- Fixes a bug where `ofAst` silently discarded arguments when `bvar`/`fvar` appeared as the head of an HNF-flattened application chain
- The `app` constructor uses `Expr α` (not `ArgF α`) for both arguments — `toAst` wraps the arg with `ArgF.expr`, and `ofAst` folds HNF args back into `Expr.app` chains

## Test plan
- [x] Round-trip tests for `Expr.app` in `StrataTest/DDM/Integration/Lean/Gen.lean`
- [x] Updated `#guard_msgs` for `#print Expr` in Gen.lean and DDMTranslate.lean
- [x] `lake build` passes
- [x] Investigate polymorphic function calls (type args on fvar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)