### PR TITLE
Document #strata_gen and Lean integration in DDM manual

### DIFF
--- a/Examples/Lean/AssertLangGen.lean
+++ b/Examples/Lean/AssertLangGen.lean
@@ -1,0 +1,103 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+-- Generate Lean types for an AssertLang dialect (based on the DDM manual).
+-- Used to produce trace output for documentation.
+import Strata.DDM.Integration.Lean
+
+namespace Strata
+
+#dialect
+dialect BoolDialect;
+type BoolType;
+fn true_lit : BoolType => "true";
+fn false_lit : BoolType => "false";
+fn not_expr (a : BoolType) : BoolType => "-" a;
+fn and (a : BoolType, b : BoolType) : BoolType => @[prec(10), leftassoc] a " && " b;
+fn or (a : BoolType, b : BoolType) : BoolType => @[prec(8), leftassoc] a " || " b;
+fn imp (a : BoolType, b : BoolType) : BoolType => @[prec(8), leftassoc] a " ==> " b;
+fn equal (tp : Type, a : tp, b : tp) : BoolType => @[prec(15)] a " == " b;
+fn not_equal (tp : Type, a : tp, b : tp) : BoolType => @[prec(15)] a " != " b;
+#end
+
+#dialect
+dialect Arith;
+import BoolDialect;
+type Int;
+fn neg_expr (a : Int) : Int => "- " a;
+fn add_expr (a : Int, b : Int) : Int => @[prec(25), leftassoc] a " + " b;
+fn sub_expr (a : Int, b : Int) : Int => @[prec(25), leftassoc] a " - " b;
+fn mul_expr (a : Int, b : Int) : Int => @[prec(30), leftassoc] a " * " b;
+fn exp_expr (a : Int, b : Int) : Int => @[prec(32), rightassoc] a " ^ " b;
+fn le (a : Int, b : Int) : BoolType => @[prec(15)] a " <= " b;
+fn lt (a : Int, b : Int) : BoolType => @[prec(15)] a " < " b;
+fn ge (a : Int, b : Int) : BoolType => @[prec(15)] a " >= " b;
+fn gt (a : Int, b : Int) : BoolType => @[prec(15)] a " > " b;
+#end
+
+#dialect
+dialect AssertLang;
+import Arith;
+op assert (b : BoolType) : Command => "assert " b ";";
+category ArgDecl;
+@[declare(var, tp)]
+op decl (var : Ident, tp : Type) : ArgDecl => var " : " tp;
+category ArgDecls;
+op decls (l : CommaSepBy ArgDecl) : ArgDecls => "(" l ")";
+@[declareFn(name, args, tp)]
+op defFun (name : Ident, args : ArgDecls, tp : Type, @[scope(args)] value : tp)
+  : Command => "def " name args "=" value ";";
+fn forall_expr (args : ArgDecls, @[scope(args)] b : BoolType) : BoolType =>
+  "forall " args ", " b;
+fn exists_expr (args : ArgDecls, @[scope(args)] b : BoolType) : BoolType =>
+  "exists " args ", " b;
+#end
+
+namespace AssertLang
+
+/--
+trace: [Strata.generator] Generating AssertLangType
+---
+trace: [Strata.generator] Generating AssertLangType.toAst
+---
+trace: [Strata.generator] Generating AssertLangType.ofAst
+---
+trace: [Strata.generator] Generating ArgDecl
+---
+trace: [Strata.generator] Generating ArgDecl.toAst
+---
+trace: [Strata.generator] Generating ArgDecl.ofAst
+---
+trace: [Strata.generator] Generating ArgDecls
+---
+trace: [Strata.generator] Generating ArgDecls.toAst
+---
+trace: [Strata.generator] Generating ArgDecls.ofAst
+---
+trace: [Strata.generator] Generating Expr
+---
+trace: [Strata.generator] Generating Expr.toAst
+---
+trace: [Strata.generator] Generating Expr.ofAst
+---
+trace: [Strata.generator] Generating Command
+---
+trace: [Strata.generator] Generating Command.toAst
+---
+trace: [Strata.generator] Generating Command.ofAst
+---
+trace: [Strata.generator] Declarations group: [Init.Type]
+[Strata.generator] Declarations group: [AssertLang.ArgDecl]
+[Strata.generator] Declarations group: [AssertLang.ArgDecls]
+[Strata.generator] Declarations group: [Init.Expr]
+[Strata.generator] Declarations group: [Init.Command]
+-/
+#guard_msgs in
+set_option trace.Strata.generator true in
+#strata_gen AssertLang
+
+end AssertLang
+end Strata

--- a/docs/verso/DDMDoc.lean
+++ b/docs/verso/DDMDoc.lean
@@ -59,11 +59,11 @@ are five basic types of declarations:
  * A {deftech}_Type_ declaration declares a new builtin type for the dialect
    that all programs in a dialect may refer to.  Types declarations do not introduce
    new syntactic categories in a dialect, but rather extend a dialect `Init.Type`
-   with new types that may be refered to.  This allows Strata to support type variables
+   with new types that may be referred to.  This allows Strata to support type variables
    and polymorphism.
  * A {deftech}_Function_ declaration introduces a new function into Strata's
-   builtin expression syntactic category `Init.Expr`.  Functions have an user-
-   defineable syntax like operators, but can be polymorphic and are type checked
+   builtin expression syntactic category `Init.Expr`.  Functions have a user-
+   definable syntax like operators, but can be polymorphic and are type checked
    after parsing.
  * A {deftech}_Metadata_ declaration introduces a new attribute that may be attached
    to other Strata declarations.  There are builtin metadata attributes used to
@@ -75,34 +75,34 @@ are five basic types of declarations:
 As a simple example, we define a sequence of progressively more complex Strata
 dialects with Boolean and arithmetic expressions as well as a simple assertion
 language.  Each example provides just enough detail to help readers understand
-the example code.  The [Strata Dialect Language Reference](#reference)
+the example code.  The [Dialect Language Reference](#reference)
 contains additional detail on the commands.
 
 ```
-dialect Bool;
+dialect BoolDialect;
 // Introduce Boolean type
-type Bool;
+type BoolType;
 
 // Introduce literals as constants.
-fn true_lit : Bool => "true";
-fn false_lit : Bool => "false";
+fn true_lit : BoolType => "true";
+fn false_lit : BoolType => "false";
 
 // Introduce basic Boolean operations.
-fn not_expr (a : Bool) : Bool => "-" a;
-fn and (a : Bool, b : Bool) : Bool => @[prec(10), leftassoc] a " && " b;
-fn or (a : Bool, b : Bool) : Bool => @[prec(8), leftassoc] a " || " b;
-fn imp (a : Bool, b : Bool) : Bool => @[prec(8), leftassoc] a " ==> " b;
+fn not_expr (a : BoolType) : BoolType => "-" a;
+fn and (a : BoolType, b : BoolType) : BoolType => @[prec(10), leftassoc] a " && " b;
+fn or (a : BoolType, b : BoolType) : BoolType => @[prec(8), leftassoc] a " || " b;
+fn imp (a : BoolType, b : BoolType) : BoolType => @[prec(8), leftassoc] a " ==> " b;
 
 // Introduce equality operations that work for arbitrary types.
 // The type is inferred.
-fn equal (tp : Type, a : tp, b : tp) : Bool => @[prec(15)] a " == " b;
-fn not_equal (tp : Type, a : tp, b : tp) : Bool => @[prec(15)] a " != " b;
+fn equal (tp : Type, a : tp, b : tp) : BoolType => @[prec(15)] a " == " b;
+fn not_equal (tp : Type, a : tp, b : tp) : BoolType => @[prec(15)] a " != " b;
 ```
 
-We can then extend thse operations with an Integer type and operations.
+We can then extend these operations with an Integer type and operations.
 ```
 dialect Arith;
-import Bool;
+import BoolDialect;
 
 type Int;
 fn neg_expr (a : Int) : Int => "- " a;
@@ -111,10 +111,10 @@ fn sub_expr (a : Int, b : Int) : Int => @[prec(25), leftassoc] a " - " b;
 fn mul_expr (a : Int, b : Int) : Int => @[prec(30), leftassoc] a " * " b;
 fn exp_expr (a : Int, b : Int) : Int => @[prec(32), rightassoc] a " ^ " b;
 
-fn le (a : Int, b : Int) : Bool => @[prec(15)] a " <= " b;
-fn lt (a : Int, b : Int) : Bool => @[prec(15)] a " < " b;
-fn ge (a : Int, b : Int) : Bool => @[prec(15)] a " >= " b;
-fn gt (a : Int, b : Int) : Bool => @[prec(15)] a " > " b;
+fn le (a : Int, b : Int) : BoolType => @[prec(15)] a " <= " b;
+fn lt (a : Int, b : Int) : BoolType => @[prec(15)] a " < " b;
+fn ge (a : Int, b : Int) : BoolType => @[prec(15)] a " >= " b;
+fn gt (a : Int, b : Int) : BoolType => @[prec(15)] a " > " b;
 ```
 
 By itself, these dialects do not define a new language.  To define a
@@ -124,10 +124,10 @@ commands for assertions and defining functions:
 
 ```
 dialect AssertLang;
-import Arith; // Automatically imports Bool dependency of Arith
+import Arith; // Automatically imports BoolDialect dependency of Arith
 
 // This introduces a new operator into the Command category.
-op assert (b : Bool) : Command => "assert " b ";";
+op assert (b : BoolType) : Command => "assert " b ";";
 
 // Introduce a category for arguments.
 category ArgDecl;
@@ -135,16 +135,16 @@ category ArgDecl;
 op decl (var : Ident, tp : Type) : ArgDecl => var " : " tp;
 
 category ArgDecls;
-op decls (l : CommaSepBy ArgDecl) => "(" l ")";
+op decls (l : CommaSepBy ArgDecl) : ArgDecls => "(" l ")";
 
 @[declareFn(name, args, tp)]
 op defFun (name : Ident, args : ArgDecls, tp : Type, @[scope(args)] value : tp)
   : Command => "def " name args "=" value ";";
 
-// Now that we have binders, Introduce quantifiers
-fn forall (args : ArgDecls, @[scope(args)] b : bool) : bool =>
+// Now that we have binders, introduce quantifiers
+fn forall_expr (args : ArgDecls, @[scope(args)] b : BoolType) : BoolType =>
   "forall " args ", " b;
-fn exists (args : ArgDecls, @[scope(args)] b : bool) : bool =>
+fn exists_expr (args : ArgDecls, @[scope(args)] b : BoolType) : BoolType =>
   "exists " args ", " b;
 ```
 
@@ -165,7 +165,7 @@ assert forall (a : Int, b : Int, c : Int),
         b >= c ==> addMul(a, b, b) >= addMul(a, c, c);
 ```
 
-# Strata Dialect Language Reference
+# Dialect Language Reference
 %%%
 tag := "reference"
 %%%
@@ -219,7 +219,7 @@ Declares a new operator _name_ where
 
 * _md_ is optional metadata (see [Metadata](#metadata)).
 * `(`_id1_ `:` _k1_`,` _id2_ `:` _k2_`,` _..._`)` are optional bindings and may
-  be omited if the operator takes no arguments.  Each identifier _idN_ is the name
+  be omitted if the operator takes no arguments.  Each identifier _idN_ is the name
   of an argument while the _kN_ annotation may refer to a syntax category or type.
 * _cat_ is the syntax category that is extended by this operator.
 * _syntax_ is the [syntax definition](#syntaxdef).
@@ -231,7 +231,7 @@ A simple operator is an assert operator that takes a Boolean expression and exte
 a hypothetical `Statement` category.
 
 ```
-op assert (b : Bool) : Statement => "assert" b ";";
+op assert (b : BoolType) : Statement => "assert" b ";";
 ```
 
 For expressions, Strata supports polymorphic types.  An example operator that uses
@@ -278,10 +278,10 @@ creation of typed IRs in Strata.
 Declares a new type with optional parameters with names given by the identifiers
 _id1_, _id2_, ...
 
-The code below declares a type `Bool` and a polymorphic Map type.
+The code below declares a type `BoolType` and a polymorphic Map type.
 ```
-type Bool;
-type Map (dom : Type, range : Type);  -- Ex. Map Nat Bool
+type BoolType;
+type Map (dom : Type, range : Type);  -- Ex. Map Nat BoolType
 ```
 
 ### Expressions
@@ -293,7 +293,7 @@ This introduces a new function
 As an example, the code below introduces a polymorphic `if` expression.
 
 ```
-fn if (tp : Type, c : Bool, t : tp, f : tp) : tp =>
+fn if (tp : Type, c : BoolType, t : tp, f : tp) : tp =>
    "if " c " then " t "else " f;
 ```
 
@@ -302,12 +302,12 @@ fn if (tp : Type, c : Bool, t : tp, f : tp) : tp =>
 tag := "metadata"
 %%%
 
-The Stata `Init` dialect provides a builtin `Init.Metadata` category that allows metadata
+The Strata `Init` dialect provides a builtin `Init.Metadata` category that allows metadata
 to be declared and attached to other declarations in dialects.  Predefined metadata attributes
 are used in dialect definitions for
 [defining precedence and type checking](#parsing_typechecking), but additional metadata
 attributes can be declared in dialects to build new capabilities on top of Strata.  The goal
-of this is to provide an user-controllable extension mechanism to Strata dialects so that
+of this is to provide a user-controllable extension mechanism to Strata dialects so that
 dialects themselves may be repurposed to new use cases.
 
 `metadata` _name_ `(`_id1_ `:` _tp1_`,` _id2_ `:` _tp2_`,` _..._ `);`
@@ -317,24 +317,27 @@ Declares a new metadata operation with the given name.
 The type annotations in _tp1_ are currently restricted to `Ident`
 (for referencing arguments), natural numbers (`Num`) and optional versions of
 each (`Option Ident` and `Option Num`).  More general support for metadata will
-be added in a future relase.
+be added in a future release.
 
 ### Syntax Definitions
 %%%
 tag := "syntaxdef"
 %%%
 
-How operations and functions are represented in Strata depends on  {deftech}_syntax definitions_.
-Each syntax definition is a sequence of tokens that describe the syntax of the operator or function.
+How operations and functions are represented in Strata's textual format depends on
+{deftech}_syntax definitions_.  Each syntax definition is a sequence of tokens that
+describe the syntax of the operator or function.
 
-* A string literal such as `"assert "` outputs the literal text as a token.  Spacing should be used to ensure
-  whitespace appears after a token.
-* An argument name `arg` indicates the the associated argument to the function or operator appears in output.  The
-  precedence can be set with the syntax `arg:prec`.
-* For multiline declarations, the function `indent(`_n_`,` _tokens_`)` may be used.  The _tokens_ will appear
-  indented when they appear on new lines.
+* A string literal such as `"assert "` outputs the literal text as a token.
+  Spacing should be used to ensure whitespace appears after a token.
+* An argument name `arg` indicates the associated argument to the function
+  or operator appears in output.  The precedence can be set with the syntax
+  `arg:prec`.
+* For multiline declarations, the function `indent(`_n_`,` _tokens_`)` may
+  be used.  The _tokens_ will appear indented when they appear on new lines.
 
-There are three metadata annotations in the Strata dialect that may affect precedence in syntax definitions.
+There are three metadata annotations in the Strata dialect that may affect
+precedence in syntax definitions.
 
 ```
 metadata prec(p : Nat); -- Controls the precedence of the outermost operator
@@ -367,13 +370,15 @@ The changes to the context are controlled via metadata, and the Strata dialect m
 three declarations for affecting this.
 
 ```
--- Specify result scope of argument used to evaluate argument or following code.
+-- Specify result scope of argument used to evaluate
+-- argument or following code.
 metadata scope(name : Ident);
--- Declares a new variable in the resulting scope with no metadata
+-- Declares a new variable in the resulting scope.
 metadata declare(name : Ident, type : TypeOrCat);
--- Declares a new variable in the resulting scope with metadata determined
--- by an argument.
--- Marks a list argument as requiring at least one element
+-- Declares a function in the resulting scope with name,
+-- arguments, and return type determined by the given arguments.
+metadata declareFn(name : Ident, args : Ident, type : Ident);
+-- Marks a list argument as requiring at least one element.
 metadata nonempty;
 ```
 
@@ -402,7 +407,7 @@ op varStatement (dl : DeclList) : Statement => "var " dl ";";
 The `@[declareTVar]` annotation allows polymorphic function declarations
 where type parameters (like `<a, b>`)
 need to be in scope when parsing parameter types and return types.
-For example, function declarations in Strata.Core are defined as 
+For example, function declarations in Strata.Core are defined as
 the following:
 
 ```
@@ -438,7 +443,7 @@ be defined in user definable dialects.
   can be type checked after parsing.  See [Types and Expressions](#type_expression) for
   more details.
 
-* Syntactic categories that in dialects other than `Init` cannot currently cannot
+* Syntactic categories that in dialects other than `Init` currently cannot
   take additional parameters.  This support will be added in a future update, but
   to help users, the `Init` declares a few builtin parametric categories:
 
@@ -462,7 +467,7 @@ be defined in user definable dialects.
   For example: `@[nonempty] items : SpaceSepBy Item` will reject empty lists with a parse error.
 
 * Parsing for primitive literals and identifiers cannot be directly in syntax definitions.
-  To accomodate this, the `Init` dialect introduces the syntactic categories for this:
+  To accommodate this, the `Init` dialect introduces the syntactic categories for this:
 
   * `Init.Ident` represents identifiers.  These are alphanumeric sequences that start with
     a letter that are not otherwise used as keywords in a dialect.
@@ -477,14 +482,17 @@ be defined in user definable dialects.
 tag := "datatypes"
 %%%
 
-The DDM has special support for defining dialects with algebraic datatypes (ADTs) similar to those found in functional programming
-languages. Datatypes allow one to define custom types with multiple constructors, each of
-which can have zero or more fields (constructor arguments).
+The DDM has special support for defining dialects with algebraic datatypes
+(ADTs) similar to those found in functional programming languages.
+Datatypes allow one to define custom types with multiple constructors,
+each of which can have zero or more fields (constructor arguments).
 
 Datatypes differ from other language constructs (e.g. types, operators), since
 they define several operations simultaneously. For example, an
 SMT datatype declaration defines (in addition to the type itself and the
-constructors) _tester_ functions to identify to which constructor an instance belongs and _accessor_ functions to extract the fields of a constructor.
+constructors) _tester_ functions to identify to which constructor an
+instance belongs and _accessor_ functions to extract the fields of a
+constructor.
 Dafny datatypes additionally produce an ordering relation, while Lean inductive
 types produce _eliminator_ instances defining induction principles. The DDM
 enables automatic creation of (a subset of) these auxiliary functions via a
@@ -502,7 +510,8 @@ datatype IntList {
 };
 ```
 
-This declares a list type with two constructors (`Nil` and `Cons`) and two fields (`head` and `tail`). The Core dialect automatically generates:
+This declares a list type with two constructors (`Nil` and `Cons`) and two
+fields (`head` and `tail`). The Core dialect automatically generates:
 
 * Constructors: `Nil : IntList` and `Cons : int -> IntList -> IntList`
 * Testers: `IntList..isNil : IntList -> bool` and `IntList..isCons : IntList -> bool`
@@ -544,7 +553,8 @@ arguments
 
 #### Datatype Command
 
-The main datatype declaration uses `@[declareDatatype]` to tie everything together. It is best illustrated with an example (from the Core dialect):
+The main datatype declaration uses `@[declareDatatype]` to tie everything
+together. It is best illustrated with an example (from the Core dialect):
 
 ```
 @[declareDatatype(name, typeParams, constructors,
@@ -624,8 +634,378 @@ perConstructor([.datatype, .literal "$idx$", .constructor], [.datatype], .builti
 tag := "lean_integration"
 %%%
 
-This will be described in a later release.
+Strata provides two complementary ways to work with dialect ASTs in Lean.
+The _generic AST_ is a set of dialect-agnostic types that can represent
+programs in any dialect.  It is used by the DDM's parser, pretty-printer,
+serializer, and other infrastructure that must operate uniformly across
+dialects.  The `#strata_gen` command takes the opposite approach: given a
+specific dialect, it generates Lean inductive types with one constructor per
+operator, enabling direct pattern matching and type-safe construction.
+Conversion functions (`toAst`/`ofAst`) bridge the two representations.
 
+## The Generic AST
+
+The generic AST is defined in `Strata.DDM.AST`.  All types are parameterized
+by an annotation type `α` (typically `SourceRange` for source locations).
+
+The core types are listed below in the same order as the
+[dialect concepts](#Strata-Dialect-Concepts) they represent:
+
+* `SyntaxCatF α` — a reference to a syntactic category, identified by its
+  qualified name.
+* `OperationF α` — an application of a dialect operator.  Contains the
+  operator's qualified name and an array of arguments.
+* `ArgF α` — a single argument to an operation.  This is a sum type whose
+  variants cover all the kinds of data an operator can receive: nested
+  operations, expressions, types, identifiers, numeric literals, string
+  literals, decimal literals, byte arrays, category references, optional
+  values, and sequences.
+* `TypeExprF α` — a type expression.  Variants cover dialect-defined types
+  (`ident`), bound and polymorphic type variables (`bvar`, `tvar`), global
+  type references (`fvar`), and function types (`arrow`).
+* `ExprF α` — a typed expression.  Expressions are represented in curried
+  form: a head (`fn` for a named dialect function, `bvar` for a bound
+  variable, or `fvar` for a free variable) applied to arguments via `app`.
+  Type arguments found bound and free variables are implicit and omitted.
+
+For the common case where annotations are source locations, Strata defines
+abbreviations:
+
+```
+abbrev SyntaxCat := SyntaxCatF SourceRange
+abbrev Operation := OperationF SourceRange
+abbrev Arg       := ArgF SourceRange
+abbrev TypeExpr  := TypeExprF SourceRange
+abbrev Expr      := ExprF SourceRange
+```
+
+### How DDM Concepts Map to the Generic AST
+
+The following table summarizes how the DDM concepts described in earlier
+sections are represented in the generic AST.
+
+:::table +header
+ *
+   * DDM Concept
+   * Generic AST Type
+   * Notes
+ *
+   * Syntactic category
+   * `SyntaxCatF`
+   * Identified by qualified name (e.g. `Init.Expr`)
+ *
+   * Operator application
+   * `OperationF`
+   * Qualified name + array of `ArgF` arguments
+ *
+   * Type expression
+   * `TypeExprF`
+   * Concrete types, type variables, function types
+ *
+   * Expression
+   * `ExprF`
+   * Curried: head (`fn`/`bvar`/`fvar`) + `app` chain
+ *
+   * Identifier literal
+   * `ArgF.ident`
+   * e.g. variable names from `Ident` arguments
+ *
+   * Numeric literal
+   * `ArgF.num`
+   * From `Num` arguments
+ *
+   * String literal
+   * `ArgF.strlit`
+   * From `Str` arguments
+ *
+   * `CommaSepBy`/`Seq`
+   * `ArgF.seq`
+   * Array of `ArgF` with a separator format
+ *
+   * `Option`
+   * `ArgF.option`
+   * `Option (ArgF α)`
+:::
+
+The generic AST is dialect-agnostic: operators are identified by their
+`QualifiedIdent` (a dialect name paired with an operator name) rather than
+by distinct Lean constructors.  This uniformity makes it the natural
+representation for DDM infrastructure such as the parser, formatter, and
+serializer, but it means that working with a specific dialect requires
+string-based matching on operator names.
+
+## The `#strata_gen` Command
+%%%
+tag := "strata_gen"
+%%%
+
+The `#strata_gen` command bridges Strata dialect definitions and Lean by
+automatically generating Lean inductive types and conversion functions from a
+dialect definition.  This lets developers work with dialect ASTs as ordinary
+Lean values — constructing, pattern matching, and transforming them — while
+retaining the ability to convert back to the generic AST representation
+for serialization, pretty-printing, and cross-dialect interoperability.
+
+### Basic Syntax
+
+```
+import Strata.DDM.Integration.Lean
+
+namespace MyDialect
+#strata_gen MyDialect
+end MyDialect
+```
+
+`#strata_gen` requires `import Strata.DDM.Integration.Lean` and takes a single
+argument: the name of a dialect that has already been defined (via
+`#dialect ... #end` or `#load_dialect`).  The command should typically be placed
+inside a `namespace` block so that the generated types and functions are scoped
+under that namespace.
+
+#### Tracing
+
+To see what `#strata_gen` generates, enable the `Strata.generator` trace
+option immediately before the command:
+
+```
+set_option trace.Strata.generator true in
+#strata_gen MyDialect
+```
+
+This prints each generated definition (inductives, `toAst`, `ofAst`) and the
+dependency groups used to order them.  For example, running `#strata_gen` on the
+AssertLang dialect defined [earlier in this manual](#reference) produces:
+
+```
+[Strata.generator] Generating AssertLangType
+[Strata.generator] Generating AssertLangType.toAst
+[Strata.generator] Generating AssertLangType.ofAst
+[Strata.generator] Generating ArgDecl
+[Strata.generator] Generating ArgDecl.toAst
+[Strata.generator] Generating ArgDecl.ofAst
+[Strata.generator] Generating ArgDecls
+[Strata.generator] Generating ArgDecls.toAst
+[Strata.generator] Generating ArgDecls.ofAst
+[Strata.generator] Generating Expr
+[Strata.generator] Generating Expr.toAst
+[Strata.generator] Generating Expr.ofAst
+[Strata.generator] Generating Command
+[Strata.generator] Generating Command.toAst
+[Strata.generator] Generating Command.ofAst
+[Strata.generator] Declarations group: [Init.Type]
+[Strata.generator] Declarations group: [AssertLang.ArgDecl]
+[Strata.generator] Declarations group: [AssertLang.ArgDecls]
+[Strata.generator] Declarations group: [Init.Expr]
+[Strata.generator] Declarations group: [Init.Command]
+```
+
+Each category produces an inductive type, a `toAst` function, and an `ofAst`
+function.  The "Declarations group" lines show the topologically sorted groups
+in the order they are emitted to Lean.
+
+### What Gets Generated
+
+For each syntactic category used by a dialect, `#strata_gen` generates four
+things:
+
+1. An inductive type parameterized by an annotation type `α`.
+2. An `Inhabited` instance (when possible).
+3. A `toAst` function that converts from the generated type to Strata's
+   generic AST representation (`ExprF`, `TypeExprF`, or `OperationF`).
+4. An `ofAst` function that converts from the generic AST back to the
+   generated type (returning `OfAstM`, an error monad).
+
+Every generated constructor includes an `ann : α` field that carries
+source-location or other annotation data through transformations.
+
+#### Determining Which Categories Are Used
+
+Not every category in a dialect's transitive imports needs code generated for
+it.  `#strata_gen` computes the set of _used_ categories by starting from the
+categories and types directly declared or referenced in the dialect and
+following argument dependencies transitively.  For example, if a dialect
+declares only `op assert (b : BoolType) : Command => ...`, the generator will
+produce types for `Command`, `Expr` (since `BoolType` is a type in
+`Init.Expr`), and `Type` — but not for categories like `Binding` that are never
+referenced.
+
+Primitive categories (`Init.Ident`, `Init.Num`, `Init.Str`, etc.) map
+directly to Lean types (`String`, `Nat`, `String`, etc.) and do not produce
+their own inductive definitions.
+
+#### Handling Mutually Recursive Categories
+
+Categories can be mutually recursive.  For example:
+
+```
+category MutA;
+category MutB;
+op opA (b : MutB) : MutA => "opA " b;
+op opB (a : MutA) : MutB => "opB " a;
+```
+
+`#strata_gen` uses Tarjan's algorithm to identify strongly connected
+components — groups of categories that reference each other.  Each group is
+emitted as a Lean `mutual ... end` block so that the inductive types, `toAst`
+functions, and `ofAst` functions can refer to one another.  Groups are
+processed in topological order so that a group's dependencies are always
+defined before the group itself.
+
+### Example Walkthrough
+
+Consider a small SQL dialect:
+
+```
+dialect SQL;
+
+op create (name : Ident, c : CommaSepBy Ident) : Command =>
+  "CREATE " name "(" c ")" ";\n";
+
+op drop (name : Ident) : Command =>
+  "DROP " name ";\n";
+
+category Columns;
+op colStar : Columns => "*";
+op colList (c : CommaSepBy Ident) : Columns => c;
+
+op select (col : Columns, table : Ident) : Command =>
+  "SELECT " col " FROM " table ";\n";
+```
+
+After `#strata_gen SQL`, the generator produces two inductive types.
+
+`Command` gets one constructor per operation that targets it:
+
+```
+inductive Command (α : Type) : Type where
+  | create (ann : α) (name : Ann String α) (c : Ann (Array String) α) : Command α
+  | drop   (ann : α) (name : Ann String α) : Command α
+  | select (ann : α) (col : Columns α) (table : Ann String α) : Command α
+  deriving Repr
+```
+
+`Columns` gets its own constructors:
+
+```
+inductive Columns (α : Type) : Type where
+  | colStar (ann : α) : Columns α
+  | colList (ann : α) (c : Ann (Array String) α) : Columns α
+  deriving Repr
+```
+
+Notice that:
+
+* `Ident` arguments become `Ann String α` (a `String` carrying an annotation).
+* `CommaSepBy Ident` arguments become `Ann (Array String) α`.
+* The custom category `Columns` appears directly as a type in `Command.select`.
+
+The generated `toAst` function converts from the dialect-specific type to the
+generic AST, and `ofAst` converts back:
+
+```
+-- Convert generated type → generic AST
+Command.toAst : {α : Type} → [Inhabited α] → Command α → OperationF α
+
+-- Convert generic AST → generated type
+Command.ofAst : {α : Type} → [Inhabited α] → [Repr α]
+  → OperationF α → OfAstM (Command α)
+```
+
+#### Expression and Type Categories
+
+Dialects that declare types (via `type`) or functions (via `fn`) also get
+generated `Expr` and `Type` inductives.  These include builtin constructors
+in addition to dialect-defined ones.  For instance, the Arith dialect's
+generated `Expr` type includes:
+
+```
+inductive Expr (α : Type) : Type where
+  -- Builtin constructors (always present for Init.Expr)
+  | fvar  (ann : α) (idx : Nat) : Expr α
+  | bvar  (ann : α) (idx : Nat) : Expr α
+  | app   (ann : α) (fn : Expr α) (arg : Expr α) : Expr α
+  -- Dialect-defined constructors
+  | btrue   (ann : α) : Expr α
+  | bfalse  (ann : α) : Expr α
+  | intLit  (ann : α) (n : Ann Nat α) : Expr α
+  | add     (ann : α) (x : Expr α) (y : Expr α) : Expr α
+  | mul     (ann : α) (x : Expr α) (y : Expr α) : Expr α
+  -- ... (additional constructors omitted)
+  deriving Repr
+```
+
+The `fvar`, `bvar`, and `app` constructors correspond to free variables, bound
+variables (de Bruijn indices), and function application in Strata's core
+expression model.
+
+### Post-Generation Patterns
+
+After running `#strata_gen`, there are several common patterns for working
+with the generated types.
+
+#### Deriving Typeclass Instances
+
+Generated types automatically derive `Repr`.  Other instances can be derived
+after generation:
+
+```
+deriving instance BEq for Command, Columns
+```
+
+For larger dialects with many categories, this can be done in bulk:
+
+```
+deriving instance BEq for
+  SpecConstant, QualifiedIdent, Symbol,
+  SMTSort, Term, Command
+```
+
+Support for automatically deriving additional instances during generation
+will be added in a future release.
+
+#### Verifying Generated Types
+
+Use `#print` and `#check` to inspect what was generated:
+
+```
+#print Command    -- Shows inductive definition and constructors
+#print Columns
+#check Columns.colStar  -- Columns.colStar : {α : Type} → α → Columns α
+```
+
+#### Round-Trip Testing
+
+A simple round-trip test can verify that `toAst` and `ofAst` are inverses:
+
+```
+def testRoundTrip (e : Expr Unit) : Bool :=
+  match e |> Expr.toAst |> Expr.ofAst with
+  | .error _ => false
+  | .ok g => e == g
+
+#guard testRoundTrip <| Expr.btrue ()
+#guard testRoundTrip <| Expr.app () (.fvar () 0) (.btrue ())
+```
+
+#### Dependent Dialects
+
+When a dialect imports another, `#strata_gen` automatically resolves the full
+transitive closure of dependencies.  Each invocation generates its own set of
+types — if ArithChecker imports Arith and uses `Init.Expr`, it will produce a
+new `ArithChecker.Expr` that includes all of Arith's constructors.  The two
+Expr types are isomorphic but distinct:
+
+```
+namespace Arith
+#strata_gen Arith      -- Generates Arith.Expr, Arith.ArithType, ...
+end Arith
+
+namespace ArithChecker
+#strata_gen ArithChecker  -- Generates ArithChecker.Expr, ArithChecker.Command, ...
+end ArithChecker
+-- ArithChecker.Expr is isomorphic to Arith.Expr (same constructors)
+-- but they are separate types.
+```
 
 # Command Line Use
 %%%


### PR DESCRIPTION
## Summary

Complete the previously stubbed **Lean Integration** chapter in the DDM
manual and improve readability of the `#strata_gen` implementation.

## Details

The DDM manual documents how Strata dialects are defined, but the Lean
Integration chapter was a placeholder. This PR fills it in with two main
sections:

- **The Generic AST** — introduces the five core types (`SyntaxCatF`,
  `OperationF`, `ArgF`, `TypeExprF`, `ExprF`) that represent dialect
  programs in a dialect-agnostic way, with a mapping table showing how DDM
  concepts correspond to AST types.

- **The `#strata_gen` Command** — documents how the generator produces
  dialect-specific Lean inductive types from a dialect definition, including
  tracing, category filtering, mutual recursion handling (Tarjan SCC), an
  end-to-end SQL example, and post-generation patterns (deriving instances,
  round-trip testing, dependent dialects).

Supporting changes:

- Add `Examples/Lean/AssertLangGen.lean` with `#guard_msgs` to
  regression-test the trace output used in documentation.
- Add block comments and docstrings to `Gen.lean` explaining the category
  classification system (`declaredCategories`, `forbiddenCategories`,
  `abstractCategories`, `reservedCategories`) and key functions.
- Rename internal identifiers for clarity (`specialCategories` →
  `abstractCategories`, `reservedCats` → `reservedCategories`).
- Fix pre-existing typos and line-length issues in the reference sections.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.