### PR TITLE
Fix term_by_mem to avoid name shadowing issues

### DIFF
--- a/Strata/Util/Tactics.lean
+++ b/Strata/Util/Tactics.lean
@@ -69,8 +69,10 @@ TacticM Unit :=
             else none
         if let some lemmaName := lemmaName? then
           try
-            let hypTerm := mkIdent decl.userName
-            evalTactic (← `(tactic| have := $(mkIdent lemmaName) $hypTerm))
+            -- Use fvarId for unique name
+            let hypExpr := mkFVar decl.fvarId
+            let hypStx ← Term.exprToSyntax hypExpr
+            evalTactic (← `(tactic| have := $(mkIdent lemmaName) $hypStx))
           catch e => dbg_trace s!"add_mem_size_lemmas error: {← e.toMessageData.toString}"
 
 /-- Adds sizeOf lemmas for all `x ∈ xs` hypotheses in context -/


### PR DESCRIPTION
*Description of changes:* Fixes issue in `term_by_mem` where two hypothesis with same name (e.g. `this`) caused the wrong one to trigger and gave a type error.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
