### PR TITLE
Infrastructure changes from PR 385

### DIFF
--- a/Strata/DDM/AST.lean
+++ b/Strata/DDM/AST.lean
@@ -188,6 +188,7 @@ inductive SepFormat where
 | comma          -- Comma separator (CommaSepBy)
 | space          -- Space separator (SpaceSepBy)
 | spacePrefix    -- Space before each element (SpacePrefixSepBy)
+| newline        -- Newline separator (NewlineSepBy)
 deriving Inhabited, Repr, BEq
 
 namespace SepFormat
@@ -197,23 +198,15 @@ def toString : SepFormat → String
   | .comma => "commaSepBy"
   | .space => "spaceSepBy"
   | .spacePrefix => "spacePrefixSepBy"
+  | .newline => "newlineSepBy"
 
-def toIonName : SepFormat → String
-  | .none => "seq"
-  | .comma => "commaSepList"
-  | .space => "spaceSepList"
-  | .spacePrefix => "spacePrefixedList"
-
-def fromIonName? : String → Option SepFormat
-  | "seq" => some .none
-  | "commaSepList" => some .comma
-  | "spaceSepList" => some .space
-  | "spacePrefixedList" => some .spacePrefix
+def fromCategoryName? : QualifiedIdent → Option SepFormat
+  | q`Init.Seq => some .none
+  | q`Init.CommaSepBy => some .comma
+  | q`Init.SpaceSepBy => some .space
+  | q`Init.SpacePrefixSepBy => some .spacePrefix
+  | q`Init.NewlineSepBy => some .newline
   | _ => none
-
-theorem fromIonName_toIonName_roundtrip (sep : SepFormat) :
-  fromIonName? (toIonName sep) = some sep := by
-  cases sep <;> rfl
 
 instance : ToString SepFormat where
   toString := SepFormat.toString

--- a/Strata/DDM/BuiltinDialects/Init.lean
+++ b/Strata/DDM/BuiltinDialects/Init.lean
@@ -20,6 +20,7 @@ def SyntaxCat.mkSeq (c:SyntaxCat) : SyntaxCat := { ann := .none, name := q`Init.
 def SyntaxCat.mkCommaSepBy (c:SyntaxCat) : SyntaxCat := { ann := .none, name := q`Init.CommaSepBy, args := #[c] }
 def SyntaxCat.mkSpaceSepBy (c:SyntaxCat) : SyntaxCat := { ann := .none, name := q`Init.SpaceSepBy, args := #[c] }
 def SyntaxCat.mkSpacePrefixSepBy (c:SyntaxCat) : SyntaxCat := { ann := .none, name := q`Init.SpacePrefixSepBy, args := #[c] }
+def SyntaxCat.mkNewlineSepBy (c:SyntaxCat) : SyntaxCat := { ann := .none, name := q`Init.NewlineSepBy, args := #[c] }
 
 def initDialect : Dialect := BuiltinM.create! "Init" #[] do
   let Ident : ArgDeclKind := .cat <| .atom .none q`Init.Ident
@@ -55,6 +56,8 @@ def initDialect : Dialect := BuiltinM.create! "Init" #[] do
   declareCat q`Init.SpaceSepBy #["a"]
 
   declareCat q`Init.SpacePrefixSepBy #["a"]
+
+  declareCat q`Init.NewlineSepBy #["a"]
 
   let QualifiedIdent := q`Init.QualifiedIdent
   declareCat QualifiedIdent

--- a/Strata/DDM/Elab.lean
+++ b/Strata/DDM/Elab.lean
@@ -71,6 +71,11 @@ private partial def runCommand (leanEnv : Lean.Environment) (commands : Array Op
     return commands
   let (some tree, true) ← runChecked <| elabCommand leanEnv
     | return commands
+  -- Prevent infinite loop if parser makes no progress
+  let newPos := (←get).pos
+  if newPos <= iniPos then
+    logError { start := iniPos, stop := iniPos } "Syntax error: unrecognized syntax or unexpected token"
+    return commands
   let cmd := tree.info.asOp!.op
   let dialects := (← read).loader.dialects
   modify fun s => { s with

--- a/Strata/DDM/Elab/Core.lean
+++ b/Strata/DDM/Elab/Core.lean
@@ -1209,6 +1209,8 @@ partial def catElaborator (c : SyntaxCat) : TypingContext → Syntax → ElabM T
     elabSeqWith c .space "spaceSepBy" (·.getSepArgs)
   | q`Init.SpacePrefixSepBy =>
     elabSeqWith c .spacePrefix "spacePrefixSepBy" (·.getArgs)
+  | q`Init.NewlineSepBy =>
+    elabSeqWith c .newline "newlineSepBy" (·.getArgs)
   | _ =>
     assert! c.args.isEmpty
     elabOperation

--- a/Strata/DDM/Format.lean
+++ b/Strata/DDM/Format.lean
@@ -408,6 +408,13 @@ private partial def ArgF.mformatM {α} : ArgF α → FormatM PrecFormat
   | .spacePrefix =>
     .atom <$> entries.foldlM (init := .nil) fun p a =>
       return (p ++ " " ++ (← a.mformatM).format)
+  | .newline =>
+    if z : entries.size = 0 then
+      pure (.atom .nil)
+    else do
+      let f i q s := return s ++ "\n" ++ (← entries[i].mformatM).format
+      let a := (← entries[0].mformatM).format
+      .atom <$> entries.size.foldlM f (start := 1) a
 
 private partial def ppArgs (f : StrataFormat) (rargs : Array Arg) : FormatM PrecFormat :=
   if rargs.isEmpty then

--- a/Strata/DDM/Integration/Lean/Gen.lean
+++ b/Strata/DDM/Integration/Lean/Gen.lean
@@ -703,6 +703,9 @@ partial def genCatTypeTerm (annType : Ident) (c : SyntaxCat)
   | q`Init.SpacePrefixSepBy, 1 =>
     let inner := mkCApp ``Array #[args[0]]
     return if addAnn then mkCApp ``Ann #[inner, annType] else inner
+  | q`Init.NewlineSepBy, 1 =>
+    let inner := mkCApp ``Array #[args[0]]
+    return if addAnn then mkCApp ``Ann #[inner, annType] else inner
   | q`Init.Option, 1 =>
     let inner := mkCApp ``Option #[args[0]]
     return if addAnn then mkCApp ``Ann #[inner, annType] else inner
@@ -910,6 +913,8 @@ partial def toAstApplyArg (vn : Name) (cat : SyntaxCat)
     toAstApplyArgSeq v cat ``SepFormat.space
   | q`Init.SpacePrefixSepBy => do
     toAstApplyArgSeq v cat ``SepFormat.spacePrefix
+  | q`Init.NewlineSepBy => do
+    toAstApplyArgSeq v cat ``SepFormat.newline
   | q`Init.Seq => do
     toAstApplyArgSeq v cat ``SepFormat.none
   | q`Init.Option => do
@@ -1170,6 +1175,8 @@ partial def genOfAstArgTerm (varName : String) (cat : SyntaxCat)
     genOfAstSeqArgTerm varName cat e ``SepFormat.space
   | q`Init.SpacePrefixSepBy => do
     genOfAstSeqArgTerm varName cat e ``SepFormat.spacePrefix
+  | q`Init.NewlineSepBy => do
+    genOfAstSeqArgTerm varName cat e ``SepFormat.newline
   | q`Init.Seq => do
     genOfAstSeqArgTerm varName cat e ``SepFormat.none
   | q`Init.Option => do
@@ -1485,6 +1492,7 @@ def tryMakeInhabited (cat : QualifiedIdent) (ops : Array DefaultCtor)
         | q`Init.CommaSepBy => true
         | q`Init.SpaceSepBy => true
         | q`Init.SpacePrefixSepBy => true
+        | q`Init.NewlineSepBy => true
         | q`Init.Option => true
         | c => c ∈ inhabited
     if !argsInhabited then

--- a/Strata/DDM/Integration/Lean/ToExpr.lean
+++ b/Strata/DDM/Integration/Lean/ToExpr.lean
@@ -40,6 +40,7 @@ instance : ToExpr SepFormat where
     | .comma => mkConst ``SepFormat.comma
     | .space => mkConst ``SepFormat.space
     | .spacePrefix => mkConst ``SepFormat.spacePrefix
+    | .newline => mkConst ``SepFormat.newline
 
 end SepFormat
 

--- a/Strata/DDM/Ion.lean
+++ b/Strata/DDM/Ion.lean
@@ -82,6 +82,29 @@ end Ion.Ion
 
 namespace Strata
 
+namespace SepFormat
+
+def toIonName : SepFormat → String
+  | .none => "seq"
+  | .comma => "commaSepList"
+  | .space => "spaceSepList"
+  | .spacePrefix => "spacePrefixedList"
+  | .newline => "newlineSepList"
+
+def fromIonName? : String → Option SepFormat
+  | "seq" => some .none
+  | "commaSepList" => some .comma
+  | "spaceSepList" => some .space
+  | "spacePrefixedList" => some .spacePrefix
+  | "newlineSepList" => some .newline
+  | _ => none
+
+theorem fromIonName_toIonName_roundtrip (sep : SepFormat) :
+  fromIonName? (toIonName sep) = some sep := by
+  cases sep <;> rfl
+
+end SepFormat
+
 /--
 Represents an Ion value that is either a symbol/string or a non-empty
 s-expression. The size proof ensures termination in recursive deserialization.

--- a/Strata/DDM/Parser.lean
+++ b/Strata/DDM/Parser.lean
@@ -899,7 +899,7 @@ partial def catParser (ctx : ParsingContext) (cat : SyntaxCat) (metadata : Metad
     assert! cat.args.size = 1
     let isNonempty := q`StrataDDL.nonempty ∈ metadata
     commaSepByParserHelper isNonempty <$> catParser ctx cat.args[0]!
-  | q`Init.SpaceSepBy | q`Init.SpacePrefixSepBy | q`Init.Seq =>
+  | q`Init.SpaceSepBy | q`Init.SpacePrefixSepBy | q`Init.NewlineSepBy | q`Init.Seq =>
     assert! cat.args.size = 1
     let isNonempty := q`StrataDDL.nonempty ∈ metadata
     (if isNonempty then many1Parser else manyParser) <$> catParser ctx cat.args[0]!

--- a/Strata/DL/Lambda/LExprEval.lean
+++ b/Strata/DL/Lambda/LExprEval.lean
@@ -185,7 +185,7 @@ def eval (n : Nat) (σ : LState TBase) (e : (LExpr TBase.mono))
             -- At least one argument in the function call is symbolic.
             new_e
       | none =>
-        -- Not a call of a factory function.
+        -- Not a call of a factory function - go through evalCore
         evalCore n' σ e
 
 def evalCore  (n' : Nat) (σ : LState TBase) (e : LExpr TBase.mono) : LExpr TBase.mono :=

--- a/Strata/Languages/C_Simp/DDMTransform/Translate.lean
+++ b/Strata/Languages/C_Simp/DDMTransform/Translate.lean
@@ -408,7 +408,7 @@ partial def translateStmt (bindings : TransBindings) (arg : Arg) :
 partial def translateBlock (bindings : TransBindings) (arg : Arg) :
   TransM (List Statement) := do
   let args ← checkOpArg arg q`C_Simp.block 1
-  let .seq _ .none stmts := args[0]!
+  let .seq _ _ stmts := args[0]!
     | TransM.error s!"Invalid block {repr args[0]!}"
   let (a, _) ← stmts.foldlM (init := (#[], bindings)) fun (a, b) s => do
       let (s, b) ← translateStmt b s

--- a/Strata/Languages/Core/Env.lean
+++ b/Strata/Languages/Core/Env.lean
@@ -257,7 +257,7 @@ def Env.genFVar (E : Env) (xt : (Lambda.IdentT Lambda.LMonoTy Visibility)) :
   let (xid, E) := E.genVar xt.ident
   let xe := match xt.ty? with
             | none => .fvar () xid none
-            | some xty => .fvar () xid xty
+            | some xty => .fvar () xid (some xty)
   (xe, E)
 
 /--

--- a/StrataTest/DDM/Integration/Lean/Gen.lean
+++ b/StrataTest/DDM/Integration/Lean/Gen.lean
@@ -47,17 +47,17 @@ op cmd (tp : Type, a : tp) : Command => "cmd " a;
 
 
 /--
-trace: [Strata.generator] Generating EmptyExprDialectType
----
-trace: [Strata.generator] Generating EmptyExprDialectType.toAst
----
-trace: [Strata.generator] Generating EmptyExprDialectType.ofAst
----
 trace: [Strata.generator] Generating Expr
 ---
 trace: [Strata.generator] Generating Expr.toAst
 ---
 trace: [Strata.generator] Generating Expr.ofAst
+---
+trace: [Strata.generator] Generating EmptyExprDialectType
+---
+trace: [Strata.generator] Generating EmptyExprDialectType.toAst
+---
+trace: [Strata.generator] Generating EmptyExprDialectType.ofAst
 ---
 trace: [Strata.generator] Generating Command
 ---
@@ -65,8 +65,8 @@ trace: [Strata.generator] Generating Command.toAst
 ---
 trace: [Strata.generator] Generating Command.ofAst
 ---
-trace: [Strata.generator] Declarations group: [Init.Type]
-[Strata.generator] Declarations group: [Init.Expr]
+trace: [Strata.generator] Declarations group: [Init.Expr]
+[Strata.generator] Declarations group: [Init.Type]
 [Strata.generator] Declarations group: [Init.Command]
 -/
 #guard_msgs in

--- a/StrataTest/DL/Lambda/LExprWFTests.lean
+++ b/StrataTest/DL/Lambda/LExprWFTests.lean
@@ -1,0 +1,105 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.DL.Lambda.LExprWF
+
+namespace Lambda.LExpr.WFTests
+
+open Lambda
+
+-- Fix the type parameters so BEq resolves
+abbrev Params : LExprParams := ⟨Unit, Unit⟩
+abbrev MonoExpr := LExpr Params.mono
+
+-- Shorthand constructors with fixed type
+def c (n : Int) : MonoExpr := .const () (.intConst n)
+def bv (i : Nat) : MonoExpr := .bvar () i
+def fv (name : String) (ty : Option LMonoTy := .none) : MonoExpr := .fvar () name ty
+def lam (e : MonoExpr) : MonoExpr := .abs () .none e
+def ap (f a : MonoExpr) : MonoExpr := .app () f a
+def eq' (a b : MonoExpr) : MonoExpr := .eq () a b
+def ite' (c t f : MonoExpr) : MonoExpr := .ite () c t f
+def qa (e : MonoExpr) : MonoExpr := .quant () .all .none (bv 0) e
+
+/-! ### liftBVars tests -/
+
+-- Constant is identity
+#guard liftBVars 1 (c 5) == c 5
+
+-- fvar is identity
+#guard liftBVars 1 (fv "x" (.some .int)) == fv "x" (.some .int)
+
+-- bvar 0 with default cutoff 0, lift by 1 → bvar 1
+#guard liftBVars 1 (bv 0) == bv 1
+
+-- bvar 1, lift by 2 → bvar 3
+#guard liftBVars 2 (bv 1) == bv 3
+
+-- bvar below cutoff is not shifted
+#guard liftBVars 1 (bv 0) (cutoff := 1) == bv 0
+
+-- bvar at cutoff is shifted
+#guard liftBVars 1 (bv 1) (cutoff := 1) == bv 2
+
+-- abs increments cutoff: abs(bvar 0) stays (bound by abs)
+#guard liftBVars 1 (lam (bv 0)) == lam (bv 0)
+
+-- abs(bvar 1): free relative to abs, becomes 2
+#guard liftBVars 1 (lam (bv 1)) == lam (bv 2)
+
+-- Nested abs: abs(abs(bvar 2)) → abs(abs(bvar 3))
+#guard liftBVars 1 (lam (lam (bv 2))) == lam (lam (bv 3))
+
+-- Recurses into app
+#guard liftBVars 1 (ap (bv 0) (bv 1)) == ap (bv 1) (bv 2)
+
+-- Recurses into eq
+#guard liftBVars 1 (eq' (bv 0) (bv 1)) == eq' (bv 1) (bv 2)
+
+-- Recurses into ite
+#guard liftBVars 1 (ite' (bv 0) (bv 1) (bv 2)) == ite' (bv 1) (bv 2) (bv 3)
+
+/-! ### substFvarLifting tests -/
+
+-- Basic: replace fvar "x" with a constant
+#guard substFvarLifting (fv "x" (.some .int)) "x" (c 42) == c 42
+
+-- Non-matching fvar untouched
+#guard substFvarLifting (fv "y" (.some .int)) "x" (c 42) == fv "y" (.some .int)
+
+-- KEY TEST: substituting fvar with bvar under a binder lifts the bvar.
+-- substFvarLifting (abs(fvar "x")) "x" (bvar 0)
+-- Under abs, depth=1, so bvar 0 → bvar 1
+#guard substFvarLifting (lam (fv "x")) "x" (bv 0) == lam (bv 1)
+
+-- Compare with substFvar (no lifting) — bvar 0 stays 0 (captured by abs)
+#guard substFvar (lam (fv "x")) "x" (bv 0) == lam (bv 0)
+
+-- Double nesting: abs(abs(fvar "x")) with bvar 0
+-- depth=2, so bvar 0 → bvar 2
+#guard substFvarLifting (lam (lam (fv "x"))) "x" (bv 0) == lam (lam (bv 2))
+
+-- Top level (depth=0) does not lift
+#guard substFvarLifting (fv "x") "x" (bv 0) == bv 0
+
+-- Under quant also lifts
+#guard substFvarLifting (qa (fv "x")) "x" (bv 0) == qa (bv 1)
+
+-- In app (no binder) does not lift
+#guard substFvarLifting (ap (fv "x") (fv "x")) "x" (bv 0) == ap (bv 0) (bv 0)
+
+/-! ### substFvarsLifting tests -/
+
+-- Multiple substitutions under abs: both lifted by 1
+#guard substFvarsLifting
+    (lam (ap (fv "x") (fv "y")))
+    [("x", bv 0), ("y", bv 1)]
+    == lam (ap (bv 1) (bv 2))
+
+-- Empty substitution is identity
+#guard substFvarsLifting (fv "x") [] == fv "x"
+
+end Lambda.LExpr.WFTests

--- a/StrataTest/Languages/Core/Examples/Functions.lean
+++ b/StrataTest/Languages/Core/Examples/Functions.lean
@@ -73,3 +73,82 @@ Result: ✅ pass
 #eval verify funcPgm
 
 ---------------------------------------------------------------------
+
+/-! ## Multi-argument function test
+
+Tests that multi-argument functions are correctly encoded in SMT.
+Before the fix, only the first argument type was captured.
+-/
+
+def multiArgFuncPgm : Program :=
+#strata
+program Core;
+
+function add(x : int, y : int) : int { x + y }
+
+procedure testMultiArg(a : int, b : int) returns () {
+  assert [addComm]: (add(a, b) == add(b, a));
+};
+
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: addComm
+Property: assert
+Obligation:
+add($__a0, $__b1) == add($__b1, $__a0)
+
+---
+info:
+Obligation: addComm
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval verify multiArgFuncPgm
+
+---------------------------------------------------------------------
+
+/-! ## Function with body containing quantifier
+
+Tests that substFvarsLifting correctly lifts de Bruijn indices
+when substituting formals with bvars in function bodies that
+contain quantifiers.
+-/
+
+def quantBodyFuncPgm : Program :=
+#strata
+program Core;
+
+function allPositive(x : int) : bool { forall y : int :: y > 0 ==> y + x > 0 }
+
+procedure testQuantBody(n : int) returns () {
+  assert [quantOk]: (n > 0 ==> allPositive(n));
+};
+
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: quantOk
+Property: assert
+Obligation:
+$__n0 > 0 ==> allPositive($__n0)
+
+---
+info:
+Obligation: quantOk
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval verify quantBodyFuncPgm
+
+---------------------------------------------------------------------


### PR DESCRIPTION
Contains a subset of the changes from https://github.com/strata-org/Strata/pull/385, rebased on current main.

### DDM Infrastructure
- Add `NewlineSepBy` separator and `SyntaxDef.passthrough` variant
- Replace `fromIonName?`/`toIonName` with `fromCategoryName?` for category-based lookup
- Add newline formatting case in `ArgF.mformatM`
- Update Java/Lean codegen for new constructs
- Comment parsing fix in `Parser.lean`

### Lambda/SMT Bug Fixes
- Add `liftBVars` with cutoff parameter for correct de Bruijn index shifting
- Add `substFvarLifting`/`substFvarsLifting` for substitution under binders (doc comment clarifies that `to`'s bvars must refer to binders outside `e`)
- Fix multi-argument function SMT encoding (was hardcoded to unary)
- Add Map type to SMT Array encoding

### Testing
- `LExprWFTests.lean`: tests for `substFvarLifting`
- `SMTEncoderTests.lean`: updated for multi-arg encoding
- `Functions.lean`: multi-argument function test + quantifier-in-body test

### Review feedback addressed
- The `≤` → `<` precedence change from the previous version has been removed (it was incorrect)
- Doc comment added to `substFvarLifting` per review feedback

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.