### PR TITLE
Fix DDM precedence for single-argument wrapper ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,11 @@ jobs:
       - name: Build documentation
         run: ./generate.sh
         working-directory: docs/verso
+      - name: Check for broken links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --offline --no-progress --exclude-path '.*/find/.*' docs/verso/_out/
+          fail: true
 
   build_python:
     name: Build and test Python

--- a/Strata/DDM/Integration/Lean/ToExpr.lean
+++ b/Strata/DDM/Integration/Lean/ToExpr.lean
@@ -329,7 +329,7 @@ namespace SyntaxDefAtom
 private protected def typeExpr : Lean.Expr := mkConst ``SyntaxDefAtom
 
 private protected def toExpr : SyntaxDefAtom → Lean.Expr
-| .ident v p unwrap => astExpr! ident (toExpr v) (toExpr p) (toExpr unwrap)
+| .ident v p => astExpr! ident (toExpr v) (toExpr p)
 | .str l     => astExpr! str (toExpr l)
 | .indent n a =>
   let args := arrayToExpr .zero SyntaxDefAtom.typeExpr (a.map (·.toExpr))
@@ -345,7 +345,9 @@ namespace SyntaxDef
 
 instance : ToExpr SyntaxDef where
   toTypeExpr := private mkConst ``SyntaxDef
-  toExpr s := private astExpr! mk (toExpr s.atoms) (toExpr s.prec)
+  toExpr := private fun
+    | .std atoms prec => astExpr! std (Lean.toExpr atoms) (Lean.toExpr prec)
+    | .passthrough => astExpr! passthrough
 
 end SyntaxDef
 

--- a/Strata/Languages/C_Simp/DDMTransform/Parse.lean
+++ b/Strata/Languages/C_Simp/DDMTransform/Parse.lean
@@ -90,10 +90,10 @@ category Bindings;
 op mkBindings (bindings : CommaSepBy Binding) : Bindings => "(" bindings ")";
 
 category MeasureCat;
-op measure (e : int) : MeasureCat => "//@decreases" e;
+op measure (e : int) : MeasureCat => "//@decreases " e;
 
 category InvariantCat;
-op invariant (e : bool) : InvariantCat => "//@invariant" e;
+op invariant (e : bool) : InvariantCat => "//@invariant " e;
 
 op while_command (g : bool,
                   measure: Option MeasureCat,
@@ -110,8 +110,8 @@ op procedure (retType: Type,
               @[scope(b)] pre: bool,
               @[scope(b)] post: bool,
               @[scope(b)] body : Block) : Command => retType " procedure " name typeArgs b
-                                                     "//@pre" indent(2, pre) ";\n"
-                                                     "//@post" indent(2, post) ";\n"
+                                                     "//@pre " indent(2, pre) ";\n"
+                                                     "//@post " indent(2, post) ";\n"
                                                      indent(2, body);
 
 category Annotation;

--- a/StrataTest/DDM/Integration/Java/TestGen.lean
+++ b/StrataTest/DDM/Integration/Java/TestGen.lean
@@ -32,7 +32,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
           { ident := "value", kind := .cat (.atom .none ⟨"Init", "Num"⟩) }
         ]
         category := ⟨"Test", "Expr"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       },
       .op {
         name := "add"
@@ -41,7 +41,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
           { ident := "rhs", kind := .cat (.atom .none ⟨"Test", "Expr"⟩) }
         ]
         category := ⟨"Test", "Expr"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -65,7 +65,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
           { ident := "public", kind := .cat (.atom .none ⟨"Init", "Ident"⟩) }
         ]
         category := ⟨"Reserved", "Stmt"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -85,7 +85,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
         name := "Expr"
         argDecls := .ofArray #[]
         category := ⟨"Collision", "expr"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -102,10 +102,10 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
     declarations := #[
       .syncat { name := "A", argNames := #[] },
       .syncat { name := "B", argNames := #[] },
-      .op { name := "foo", argDecls := .ofArray #[], category := ⟨"Dup", "A"⟩, syntaxDef := { atoms := #[], prec := 0 } },
-      .op { name := "foo", argDecls := .ofArray #[], category := ⟨"Dup", "B"⟩, syntaxDef := { atoms := #[], prec := 0 } },  -- Duplicate
-      .op { name := "class", argDecls := .ofArray #[], category := ⟨"Dup", "A"⟩, syntaxDef := { atoms := #[], prec := 0 } },
-      .op { name := "class_", argDecls := .ofArray #[], category := ⟨"Dup", "B"⟩, syntaxDef := { atoms := #[], prec := 0 } }  -- Would clash after escaping
+      .op { name := "foo", argDecls := .ofArray #[], category := ⟨"Dup", "A"⟩, syntaxDef := .std #[] 0 },
+      .op { name := "foo", argDecls := .ofArray #[], category := ⟨"Dup", "B"⟩, syntaxDef := .std #[] 0 },  -- Duplicate
+      .op { name := "class", argDecls := .ofArray #[], category := ⟨"Dup", "A"⟩, syntaxDef := .std #[] 0 },
+      .op { name := "class_", argDecls := .ofArray #[], category := ⟨"Dup", "B"⟩, syntaxDef := .std #[] 0 }  -- Would clash after escaping
     ]
   }
   let files := (generateDialect testDialect "com.test").toOption.get!
@@ -120,7 +120,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
     imports := #[]
     declarations := #[
       .syncat { name := "Node", argNames := #[] },  -- Collides with base class
-      .op { name := "leaf", argDecls := .ofArray #[], category := ⟨"Base", "Node"⟩, syntaxDef := { atoms := #[], prec := 0 } }
+      .op { name := "leaf", argDecls := .ofArray #[], category := ⟨"Base", "Node"⟩, syntaxDef := .std #[] 0 }
     ]
   }
   let files := (generateDialect testDialect "com.test").toOption.get!
@@ -139,7 +139,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
         name := "my_operator"
         argDecls := .ofArray #[]
         category := ⟨"Snake", "my_category"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -168,7 +168,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
           { ident := "seq", kind := .cat ⟨.none, ⟨"Init", "Seq"⟩, #[.atom .none ⟨"Init", "Ident"⟩]⟩ }
         ]
         category := ⟨"Types", "Node"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -195,7 +195,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
         name := "test"
         argDecls := .ofArray #[]
         category := ⟨"FQN", "Node"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -218,7 +218,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
           { ident := "e", kind := .cat (.atom .none ⟨"Init", "Expr"⟩) }  -- References Init.Expr
         ]
         category := ⟨"Stub", "Stmt"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }
@@ -255,7 +255,7 @@ elab "#testCoreError" : command => do
           { ident := "b", kind := .cat (.atom .none ⟨"B", "Num"⟩) }
         ]
         category := ⟨"A", "Num"⟩
-        syntaxDef := { atoms := #[], prec := 0 }
+        syntaxDef := .std #[] 0
       }
     ]
   }

--- a/StrataTest/Languages/B3/DDMFormatDeclarationsTests.lean
+++ b/StrataTest/Languages/B3/DDMFormatDeclarationsTests.lean
@@ -666,7 +666,7 @@ info: B3: .program
             (.intLit () 0)))])]
 ---
 info:
-procedure withAutoinv(x : int autoinv x + y >= 0, y : int autoinv y >= -(x))
+procedure withAutoinv(x : int autoinv x + y >= 0, y : int autoinv y >= -x)
 {
   check x >= 0
 }

--- a/StrataTest/Languages/B3/Verifier/VerifierTests.lean
+++ b/StrataTest/Languages/B3/Verifier/VerifierTests.lean
@@ -313,7 +313,7 @@ procedure test_fail() {
 
 /--
 info: test_all_expressions: ✗ unknown
-  (0,127): check (false || true) && (if true true else false) && f(5) && notalwaystrue(1, 2) && 5 == 5 && !(3 == 4) && 2 < 3 && 2 <= 2 && 4 > 3 && 4 >= 4 && 1 + 2 == 4 && 5 - 2 == 3 && 3 * 4 == 12 && 10 div 2 == 5 && 7 mod 3 == 1 && -(5) == 0 - 5 && notalwaystrue(3, 4) && (true ==> true) && (forall y : int pattern f(y) f(y) || !f(y)) && (forall y : int y > 0 || y <= 0)
+  (0,127): check (false || true) && (if true true else false) && f(5) && notalwaystrue(1, 2) && 5 == 5 && !(3 == 4) && 2 < 3 && 2 <= 2 && 4 > 3 && 4 >= 4 && 1 + 2 == 4 && 5 - 2 == 3 && 3 * 4 == 12 && 10 div 2 == 5 && 7 mod 3 == 1 && -5 == 0 - 5 && notalwaystrue(3, 4) && (true ==> true) && (forall y : int pattern f(y) f(y) || !f(y)) && (forall y : int y > 0 || y <= 0)
   └─ (0,213): could not prove notalwaystrue(1, 2)
      under the assumptions
        forall x : int pattern f(x) f(x) == (x + 1 == 6)
@@ -480,7 +480,7 @@ procedure test_reach_diagnosis() {
 
 /--
 info: test_all_expressions: ✗ refuted
-  (0,127): reach (false || true) && (if true true else false) && f(5) && notalwaystrue(1, 2) && 5 == 5 && !(3 == 4) && 2 < 3 && 2 <= 2 && 4 > 3 && 4 >= 4 && 1 + 2 == 4 && 5 - 2 == 3 && 3 * 4 == 12 && 10 div 2 == 5 && 7 mod 3 == 1 && -(5) == 0 - 5 && notalwaystrue(3, 4) && (true ==> true) && (forall y : int pattern f(y) f(y) || !f(y)) && (forall y : int y > 0 || y <= 0)
+  (0,127): reach (false || true) && (if true true else false) && f(5) && notalwaystrue(1, 2) && 5 == 5 && !(3 == 4) && 2 < 3 && 2 <= 2 && 4 > 3 && 4 >= 4 && 1 + 2 == 4 && 5 - 2 == 3 && 3 * 4 == 12 && 10 div 2 == 5 && 7 mod 3 == 1 && -5 == 0 - 5 && notalwaystrue(3, 4) && (true ==> true) && (forall y : int pattern f(y) f(y) || !f(y)) && (forall y : int y > 0 || y <= 0)
   └─ (0,353): it is impossible that 1 + 2 == 4
      under the assumptions
        forall x : int pattern f(x) f(x) == (x + 1 == 6)

--- a/StrataTest/Languages/C_Simp/Examples/Coprime.lean
+++ b/StrataTest/Languages/C_Simp/Examples/Coprime.lean
@@ -37,20 +37,20 @@ bool procedure coprime (a: int, b: int)
 
 /--
 info: program C_Simp;
-bool procedure coprime(a:int, b:int)//@pre(a>(0))&&(b>(0));
-//@posttrue;
+bool procedure coprime(a:int, b:int)//@pre (a>0)&&(b>0);
+//@post true;
   ({
   vari:int;
   i=a;
   if(b<a){
   i=b;
   }
-  ()while(i>(1))
-  //@decreasesi//@invariant(true)({
-  if(((b%i)==(0))&&((a%i)==(0))){
+  ()while(i>1)
+  //@decreases i//@invariant true({
+  if(((b%i)==0)&&((a%i)==0)){
   returnfalse;
   }
-  ()i=i-(1);
+  ()i=i-1;
   }
   )returntrue;
   }

--- a/StrataTest/Languages/C_Simp/Examples/LinearSearch.lean
+++ b/StrataTest/Languages/C_Simp/Examples/LinearSearch.lean
@@ -36,17 +36,17 @@ bool procedure linearSearch (arr: intArr, e: int)
 
 /--
 info: program C_Simp;
-bool procedure linearSearch(arr:intArr, e:int)//@pretrue;
-//@posttrue;
+bool procedure linearSearch(arr:intArr, e:int)//@pre true;
+//@post true;
   ({
   varidx:int;
   idx=0;
   while(idx<(len(arr)))
-  //@decreases((len(arr))-idx)//@invariant(true)({
+  //@decreases ((len(arr))-idx)//@invariant true({
   if(e==(get(arr,idx))){
   returntrue;
   }
-  ()idx=idx+(1);
+  ()idx=idx+1;
   }
   )returnfalse;
   }

--- a/StrataTest/Languages/C_Simp/Examples/LoopSimple.lean
+++ b/StrataTest/Languages/C_Simp/Examples/LoopSimple.lean
@@ -35,19 +35,19 @@ int procedure loopSimple (n: int)
 
 /--
 info: program C_Simp;
-int procedure loopSimple(n:int)//@pren>=(0);
-//@posttrue;
+int procedure loopSimple(n:int)//@pre n>=0;
+//@post true;
   ({
   varsum:int;
   vari:int;
   sum=0;
   i=0;
   while(i<n)
-  //@decreases(n-i)//@invariant((i<=n)&&(((i*(i-(1)))/(2))==sum))({
+  //@decreases (n-i)//@invariant ((i<=n)&&(((i*(i-1))/2)==sum))({
   sum=sum+i;
-  i=i+(1);
+  i=i+1;
   }
-  )//@assert [sum_assert]((n*(n-(1)))/(2))==sum;
+  )//@assert [sum_assert]((n*(n-1))/2)==sum;
   returnsum;
   }
   )

--- a/StrataTest/Languages/C_Simp/Examples/LoopTrivial.lean
+++ b/StrataTest/Languages/C_Simp/Examples/LoopTrivial.lean
@@ -34,14 +34,14 @@ int procedure loopTrivial (n: int)
 
 /--
 info: program C_Simp;
-int procedure loopTrivial(n:int)//@pren>=(0);
-//@posttrue;
+int procedure loopTrivial(n:int)//@pre n>=0;
+//@post true;
   ({
   vari:int;
   i=0;
   while(i<n)
-  //@decreases(n-i)//@invariant(i<=n)({
-  i=i+(1);
+  //@decreases (n-i)//@invariant (i<=n)({
+  i=i+1;
   }
   )//@assert [i_eq_n]i==n;
   returni;

--- a/StrataTest/Languages/C_Simp/Examples/Min.lean
+++ b/StrataTest/Languages/C_Simp/Examples/Min.lean
@@ -26,8 +26,8 @@ int procedure min (a: int, b: int)
 
 /--
 info: program C_Simp;
-int procedure min(a:int, b:int)//@pretrue;
-//@posttrue;
+int procedure min(a:int, b:int)//@pre true;
+//@post true;
   ({
   if(a<b){
   returna;

--- a/StrataTest/Languages/C_Simp/Examples/SimpleTest.lean
+++ b/StrataTest/Languages/C_Simp/Examples/SimpleTest.lean
@@ -31,19 +31,19 @@ int procedure simpleTest (x: int, y: int)
 
 /--
 info: program C_Simp;
-int procedure simpleTest(x:int, y:int)//@prey>(0);
-//@posttrue;
+int procedure simpleTest(x:int, y:int)//@pre y>0;
+//@post true;
   ({
   varz:int;
   z=x+y;
   //@assert [test_assert]z>x;
-  if(z>(10)){
-  z=z-(1);
+  if(z>10){
+  z=z-1;
   }
   (else({
-  z=z+(1);
+  z=z+1;
   }
-  ))//@assume [test_assume]z>(0);
+  ))//@assume [test_assume]z>0;
   return0;
   }
   )

--- a/StrataTest/Languages/C_Simp/Examples/Trivial.lean
+++ b/StrataTest/Languages/C_Simp/Examples/Trivial.lean
@@ -22,8 +22,8 @@ bool procedure trivial ()
 
 /--
 info: program C_Simp;
-bool procedure trivial()//@pretrue;
-//@posttrue;
+bool procedure trivial()//@pre true;
+//@post true;
   ({
   returntrue;
   }

--- a/StrataTest/Languages/Core/Examples/AdvancedMaps.lean
+++ b/StrataTest/Languages/Core/Examples/AdvancedMaps.lean
@@ -76,8 +76,8 @@ spec {
   a := a[0:=1];
   assert [a0eq1]: a[0] == 1;
   assert [a0neq2]: !(a[0] == 2);
-  b := b[true:=-(1)];
-  assert [bTrueEqTrue]: b[true] == -(1);
+  b := b[true:=-1];
+  assert [bTrueEqTrue]: b[true] == -1;
   assert [mix]: a[1] == -(b[true]);
   };
 -/
@@ -143,7 +143,7 @@ Assumptions:
 P_requires_3: $__a0[0] == 0
 P_requires_4: $__c2[0] == $__a0
 Obligation:
-($__b1[true:=-(1)])[true] == -(1)
+($__b1[true:=-1])[true] == -1
 
 Label: mix
 Property: assert
@@ -151,7 +151,7 @@ Assumptions:
 P_requires_3: $__a0[0] == 0
 P_requires_4: $__c2[0] == $__a0
 Obligation:
-(($__a0[1:=1])[0:=1])[1] == -(($__b1[true:=-(1)])[true])
+(($__a0[1:=1])[0:=1])[1] == -(($__b1[true:=-1])[true])
 
 ---
 info:
@@ -249,7 +249,7 @@ Assumptions:
 P_requires_3: $__a0[0] == 0
 P_requires_4: $__c2[0] == $__a0
 Obligation:
-($__b1[true:=-(1)])[true] == -(1)
+($__b1[true:=-1])[true] == -1
 
 Label: mix
 Property: assert
@@ -257,7 +257,7 @@ Assumptions:
 P_requires_3: $__a0[0] == 0
 P_requires_4: $__c2[0] == $__a0
 Obligation:
-(($__a0[1:=1])[0:=1])[1] == -(($__b1[true:=-(1)])[true])
+(($__a0[1:=1])[0:=1])[1] == -(($__b1[true:=-1])[true])
 
 ---
 info:


### PR DESCRIPTION
## Summary

Reduce unnecessary parentheses in DDM pretty printing by overhauling syntax elaboration — convert `SyntaxDef` to an inductive type with `std`/`passthrough` variants, fix precedence for wrapper and string-literal ops, remove dead `unwrap` code, and rewrite the precedence documentation.

## Details

- Single string-literal syntax ops get `maxPrec + 1` (never parenthesized)
- Give `Nat` and `Decimal` literals `maxPrec + 1` so they are never spuriously
  parenthesized (e.g., `i + (1)` → `i + 1`)
- Remove unused `unwrap` field from `SyntaxDefAtom` and related dead code
  (`unwrapSpecs`, `unwrapTree`); unwrap is only used via metadata in Gen.lean
- Replace unsafe array indexing with bounds-checked access in Format.lean
- Fix missing whitespace in C_Simp `measure`/`invariant`/`pre`/`post` grammar

## Documentation

- Rewrite precedence section of DDM documentation; fix broken link, grammar,
  and section hierarchy
- Add lychee link checker to CI doc build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.