### PR TITLE
Refactor PySpec type infrastructure and fix correctness bugs

### DIFF
--- a/Strata/DDM/Util/SourceRange.lean
+++ b/Strata/DDM/Util/SourceRange.lean
@@ -5,6 +5,8 @@
 -/
 module
 
+public import Lean.Data.Position
+
 public section
 namespace Strata
 
@@ -33,6 +35,17 @@ def isNone (loc : SourceRange) : Bool := loc.start = 0 ∧ loc.stop = 0
 
 instance : Std.ToFormat SourceRange where
  format fr := f!"{fr.start}-{fr.stop}"
+
+/-- Format a SourceRange as a string using a FileMap for line:column conversion.
+    Renders location information in a format VSCode understands.
+    Returns "path:line:col-col" if on same line, otherwise "path:line:col". -/
+def format (loc : SourceRange) (path : System.FilePath) (fm : Lean.FileMap) : String :=
+  let spos := fm.toPosition loc.start
+  let epos := fm.toPosition loc.stop
+  if spos.line == epos.line then
+    s!"{path}:{spos.line}:{spos.column+1}-{epos.column+1}"
+  else
+    s!"{path}:{spos.line}:{spos.column+1}"
 
 end Strata.SourceRange
 end

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -12,6 +12,7 @@ import all    Strata.DDM.Util.Fin
 public import Strata.DDM.Util.SourceRange
 import        Strata.Languages.Python.ReadPython
 import        Strata.Languages.Python.Specs.DDM
+import        Strata.Languages.Python.Specs.PySpecM
 public import Strata.Languages.Python.Specs.Decls
 import        Strata.Util.DecideProp
 
@@ -61,11 +62,6 @@ added.
 -/
 inductive Iterable where
 | list
-
-public structure SpecError where
-  file : System.FilePath
-  loc : Strata.SourceRange
-  message : String
 
 /--
 A Python module name split into its dot-separated components.
@@ -177,7 +173,8 @@ def insert (sig : TypeSignature) (name : String) (m : Option (Std.HashMap String
 
 end TypeSignature
 
-def typeIdent (tp : PythonIdent) : SpecValue := .typeValue  (.ident tp)
+/-- Create a type value for prelude types that have no source location. -/
+def typeIdent (tp : PythonIdent) : SpecValue := .typeValue  (.ident default tp)
 
 def preludeSig :=
   TypeSignature.ofList [
@@ -222,15 +219,15 @@ structure PySpecContext where
   /-- Callback that takes a module name and provides filepath to module  -/
   moduleReader : ModuleReader
 
-def preludeAtoms : List (String × SpecType) := [
-  ("bool", .ident .builtinsBool),
-  ("bytearray", .ident .builtinsBytearray),
-  ("bytes", .ident .builtinsBytes),
-  ("complex", .ident .builtinsComplex),
-  ("dict", .ident .builtinsDict),
-  ("float", .ident .builtinsFloat),
-  ("int", .ident .builtinsInt),
-  ("str", .ident .builtinsStr),
+def preludeAtoms : List (String × PythonIdent) := [
+  ("bool", .builtinsBool),
+  ("bytearray", .builtinsBytearray),
+  ("bytes", .builtinsBytes),
+  ("complex", .builtinsComplex),
+  ("dict", .builtinsDict),
+  ("float", .builtinsFloat),
+  ("int", .builtinsInt),
+  ("str", .builtinsStr),
 ]
 
 structure PySpecState where
@@ -240,20 +237,13 @@ structure PySpecState where
   This maps global identifiers to their value.
   -/
   nameMap : Std.HashMap String SpecValue :=
-    preludeAtoms.foldl (init := {}) fun m (nm, tp) =>
-      m.insert nm (.typeValue tp)
+    preludeAtoms.foldl (init := {}) fun m (nm, pyIdent) =>
+      m.insert nm (.typeValue (.ident default pyIdent))
   typeReferences : Std.HashMap String ClassRef := {}
   /--
   Signatures being generated (declarations, functions, classes, etc).
   -/
   elements : Array Signature := #[]
-
-class PySpecMClass (m : Type → Type) where
-  specError (loc : SourceRange) (message : String) : m Unit
-  runChecked {α} (act : m α) : m (Bool × α)
-
-abbrev specError := @PySpecMClass.specError
-abbrev runChecked := @PySpecMClass.runChecked
 
 abbrev PySpecM := ReaderT PySpecContext (StateT PySpecState BaseIO)
 
@@ -316,7 +306,7 @@ def valueAsType (loc : SourceRange) (v : SpecValue) : PySpecM SpecType := do
   | .typeValue itp =>
     pure itp
   | .noneConst =>
-    return .ofAtom .noneType
+    return .ofAtom loc .noneType
   | .stringConst loc val =>
     -- Check if this is a known built-in type first
     match ← getNameValue? val with
@@ -324,7 +314,7 @@ def valueAsType (loc : SourceRange) (v : SpecValue) : PySpecM SpecType := do
       return tp
     | _ =>
       recordTypeRef loc val
-      return .ofAtom (.pyClass val #[])
+      return .ofAtom loc (.pyClass val #[])
   | _ =>
     specError loc s!"Expected type instead of {repr v}."
     return default
@@ -333,14 +323,14 @@ def fixedTranslator (t : PythonIdent) (arity : Nat) : TypeTranslator where
   callback := fun loc arg => do
     if arity = 1 then
       let tp ← valueAsType loc arg
-      return .ident t #[tp]
+      return .ident loc t #[tp]
     else
       let .tuple args := arg
         | specError loc s!"Expected multiple args instead of {repr arg}."; return default
       let some ⟨_⟩ ← checkEq loc (toString t) args arity
           | return default
       let args ← args.mapM (valueAsType loc)
-      return .ident t args
+      return .ident loc t args
 
 def unionTranslator : TypeTranslator where
   callback := fun loc arg => do
@@ -350,7 +340,7 @@ def unionTranslator : TypeTranslator where
       | specError loc s!"Union expects at least one argument."; return default
     let tp ← valueAsType loc args[0]
     args.foldlM (start := 1) (init := tp) fun tp v => do
-      return tp ||| (← valueAsType loc v)
+      return SpecType.union loc tp (← valueAsType loc v)
 
 def literalTranslator : TypeTranslator where
   callback := fun loc arg => do
@@ -369,7 +359,7 @@ def literalTranslator : TypeTranslator where
           | _ =>
             specError loc s!"Unsupported literal value {repr v}."
             pure default
-    return .ofArray (← args.mapM trans)
+    return .ofArray loc (← args.mapM trans)
 
 def metadataProcessor : MetadataType → TypeTranslator
 | .typingDict => fixedTranslator .typingDict 2
@@ -400,7 +390,7 @@ def translateCall (loc : SourceRange) (func : SpecValue)
     let fields := fieldsPairs |>.map (·.fst)
     let values ← fieldsPairs |>.mapM fun (_name, v) => do
       valueAsType loc v
-    return .typeValue <| .ofAtom <| .typedDict fields values total
+    return .typeValue <| .ofAtom loc <| .typedDict fields values total
   | _ =>
     specError loc s!"Unknown call {repr func}."
     return default
@@ -469,15 +459,14 @@ def pyKeywordValue (k : keyword SourceRange) : PySpecM (Option String × SpecVal
 termination_by 2 * sizeOf k
 decreasing_by
   cases k
-  simp [keyword.value]
-  decreasing_tactic
+  simp +arith [keyword.value]
 
 def pySpecValue (expr : expr SourceRange) : PySpecM SpecValue := do
   match h : expr with
   | .BinOp loc x op y => do
     match op with
     | .BitOr _ =>
-      return .typeValue <| (← pySpecType x) ||| (← pySpecType y)
+      return .typeValue <| .union loc (← pySpecType x) (← pySpecType y)
     | _ =>
       specError loc s!"Unsupported binary operator {repr op}"
       return default
@@ -571,7 +560,7 @@ def pySpecArg (usedNames : Std.HashSet String)
     | some cl =>
       if type.isSome then
         specError loc s!"Unexpected argument to {name.val}"
-      pure <| .pyClass cl #[]
+      pure <| .pyClass loc cl #[]
   assert! comment.val.isNone
   let hasDefault ←
     match de with
@@ -744,7 +733,7 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
   let argDecls : ArgDecls := { args := specArgs, kwonly := kwSpecArgs }
   let returnType : SpecType ←
         match returns with
-        | none => pure <| .ident .typingAny
+        | none => pure <| .ident fnLoc .typingAny
         | some tp => pySpecType tp
   let as ← collectAssertions argDecls returnType <| body.forM blockStmt
 
@@ -826,7 +815,7 @@ def signatureValueMap (mod : String) (sigs : Array Signature) :
             pythonModule := mod
             name := d.name
           }
-          m.insert d.name (.typeValue (.ident pyIdent))
+          m.insert d.name (.typeValue (.ident d.loc pyIdent))
         | .functionDecl .. | .typeDef .. | .externTypeDecl .. => m
   sigs.foldl (init := {}) addType
 
@@ -982,7 +971,7 @@ partial def translate (body : Array (Strata.Python.stmt Strata.SourceRange)) : P
       assert! typeParams.val.size = 0
       let (success, _) ← runChecked <| recordTypeDef loc className
       -- Add the class to nameMap so it can be used in forward references
-      setNameValue className (.typeValue (.pyClass className #[]))
+      setNameValue className (.typeValue (.pyClass loc className #[]))
       let d ← pySpecClassBody loc className stmts.val
       if success then
         pushSignature (.classDef d)
@@ -1007,13 +996,7 @@ def FileMaps.ppSourceRange (fmm : Strata.Python.Specs.FileMaps) (path : System.F
   | none =>
     panic! "Invalid path {file}"
   | some fm =>
-    let spos := fm.toPosition loc.start
-    let epos := fm.toPosition loc.stop
-    -- Render error location information in a format VSCode understands.
-    if spos.line == spos.line then
-      s!"{path}:{spos.line}:{spos.column+1}-{epos.column+1}"
-    else
-      s!"{path}:{spos.line}:{spos.column+1}"
+    loc.format path fm
 
 /-- Translates Python AST statements to PySpec signatures with dependency resolution. -/
 def translateModule

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -62,14 +62,14 @@ handling during type translation (e.g., parameterized types with specific
 arity requirements).
 -/
 inductive MetadataType where
-  | typingDict
-  | typingGenerator
-  | typingList
-  | typingLiteral
-  | typingMapping
-  | typingSequence
-  | typingUnion
-  deriving Repr
+| typingDict
+| typingGenerator
+| typingList
+| typingLiteral
+| typingMapping
+| typingSequence
+| typingUnion
+deriving Repr
 
 def MetadataType.ident : MetadataType -> PythonIdent
 | .typingDict => .typingDict
@@ -95,7 +95,6 @@ inductive SpecAtomType where
 | intLiteral (value : Int)
 /-- A string literal -/
 | stringLiteral (value : String)
-| noneType
 /-
 A typed dictionary with an array of fields and their types.  The arrays
 must be of the same length.
@@ -105,16 +104,95 @@ fields are optional.
 | typedDict (fields : Array String)
             (fieldTypes : Array SpecType)
             (isTotal : Bool)
-deriving BEq, Hashable, Inhabited, Ord, Repr
+deriving Inhabited, Repr
 
 /--
 A PySpec type is a union of atom types.
 -/
 structure SpecType where
   atoms : Array SpecAtomType
-deriving Inhabited, Ord
+  /-- Source location of this type. May be `.none` for builtin types. -/
+  loc : SourceRange
+deriving Inhabited
 
 end
+
+namespace SpecAtomType
+
+def noneType : SpecAtomType := .ident .noneType #[]
+
+end SpecAtomType
+
+/-- Heterogeneous lexicographic comparison of two arrays. Shorter arrays
+    compare as less than longer arrays when all shared elements are equal. -/
+@[specialize]
+def compareHLex {α β} (cmp : α → β → Ordering) (a₁ : Array α) (a₂ : Array β) : Ordering :=
+  go 0
+where go i :=
+  if h₁ : a₁.size <= i then
+    if a₂.size <= i then .eq else .lt
+  else
+    if h₂ : a₂.size <= i then
+      .gt
+    else cmp a₁[i] a₂[i] |>.then $ go (i + 1)
+termination_by a₁.size - i
+
+mutual
+
+/-- Compare two atom types by structure, ignoring `loc` in nested `SpecType`
+    values. Variants are ordered: ident < pyClass < intLiteral < stringLiteral
+    < typedDict. -/
+protected def SpecAtomType.compare (x y : SpecAtomType) : Ordering :=
+  match x, y with
+  | .ident xnm xargs, .ident ynm yargs =>
+    compare xnm ynm |>.then $
+      compareHLex (fun ⟨xe, _⟩ ye => xe.compare ye) xargs.attach yargs
+  | .ident .., _ => .lt
+  | _, .ident .. => .gt
+
+  | .pyClass xname xargs, .pyClass yname yargs =>
+    compare xname yname |>.then $
+      compareHLex (fun ⟨xe, _⟩ ye => xe.compare ye) xargs.attach yargs
+  | .pyClass .., _ => .lt
+  | _, .pyClass .. => .gt
+
+  | .intLiteral xval, .intLiteral yval => compare xval yval
+  | .intLiteral .., _ => .lt
+  | _, .intLiteral .. => .gt
+
+  | .stringLiteral xval, .stringLiteral yval => compare xval yval
+  | .stringLiteral .., _ => .lt
+  | _, .stringLiteral .. => .gt
+
+  | .typedDict xfields xfieldTypes xisTotal, .typedDict yfields yfieldTypes yisTotal =>
+    compare xfields yfields |>.then $
+    compareHLex (fun ⟨xe, _⟩ ye => xe.compare ye) xfieldTypes.attach yfieldTypes |>.then $
+    compare xisTotal yisTotal
+termination_by sizeOf x
+
+/-- Compare two types by their atoms arrays, ignoring `loc`. -/
+protected def SpecType.compare (x y : SpecType) : Ordering :=
+  compareHLex (fun ⟨xe, _⟩ y => xe.compare y )
+      x.atoms.attach y.atoms
+termination_by sizeOf x
+decreasing_by
+  cases x
+  case mk xl xa =>
+    decreasing_tactic
+
+end
+
+instance : BEq SpecAtomType where
+  beq x y := SpecAtomType.compare x y == .eq
+
+instance : BEq SpecType where
+  beq x y := SpecType.compare x y == .eq
+
+instance : Ord SpecAtomType where
+  compare := SpecAtomType.compare
+
+instance : Ord SpecType where
+  compare := SpecType.compare
 
 instance : LT SpecAtomType where
   lt x y := private compare x y = .lt
@@ -152,28 +230,53 @@ private partial def unionAux (x y : Array SpecAtomType) (i : Fin x.size) (j : Fi
   | .gt =>
     let j' := j.val + 1
     if yjp : j' < y.size then
-      unionAux x y i ⟨j', yjp⟩ (r.push xe)
+      unionAux x y i ⟨j', yjp⟩ (r.push ye)
     else
-      r.push xe ++ x.drop i.val
+      r.push ye ++ x.drop i.val
 
-instance : OrOp SpecType where
-  or x y := private
-    if xp : 0 < x.atoms.size then
-      if yp : 0 < y.atoms.size then
-        { atoms := unionAux x.atoms y.atoms ⟨0, xp⟩ ⟨0, yp⟩ #[] }
-      else
-        x
+/-- Union two SpecTypes with a specified location for the result -/
+def union (loc : SourceRange) (x y : SpecType) : SpecType :=
+  if xp : 0 < x.atoms.size then
+    if yp : 0 < y.atoms.size then
+      { loc := loc, atoms := unionAux x.atoms y.atoms ⟨0, xp⟩ ⟨0, yp⟩ #[] }
     else
-      y
+      x
+  else
+    y
 
-def ofAtom (atom : SpecAtomType) : SpecType := { atoms := #[atom] }
+def ofAtom (loc : SourceRange) (atom : SpecAtomType) : SpecType := { loc := loc, atoms := #[atom] }
 
-def ofArray (atoms : Array SpecAtomType) : SpecType := { atoms := atoms.qsort (· < ·) }
+@[specialize]
+private def removeAdjDupsAux {α} [BEq α] (a : Array α) (i : Nat) (r : Array α) (rne : r.size > 0) : Array α :=
+  if ilt : i < a.size then
+    if r.back == a[i] then
+      removeAdjDupsAux a (i+1) r rne
+    else
+      removeAdjDupsAux a (i+1) (r.push a[i]) (by simp +arith)
+  else
+    r
 
-def ident (i : PythonIdent) (args : Array SpecType := #[]) : SpecType :=
-  .ofAtom (.ident i args)
+/--
+Removes duplicate adjacent elements
+-/
+@[inline]
+private def removeAdjDups {α} [BEq α] (a : Array α) : Array α :=
+  if p : a.size = 0 then
+    #[]
+  else
+    removeAdjDupsAux a 1 #[a[0]] (by simp +arith)
 
-def pyClass (name : String) (params : Array SpecType) : SpecType := ofAtom <| .pyClass name params
+/-- Construct a `SpecType` from an array of atoms by sorting and
+    removing duplicates to produce a canonical representation. -/
+protected def ofArray (loc : SourceRange) (atoms : Array SpecAtomType) : SpecType :=
+  let elts := atoms.qsort (· < ·)
+  { loc := loc, atoms := removeAdjDups elts }
+
+def ident (loc : SourceRange) (i : PythonIdent) (args : Array SpecType := #[]) : SpecType :=
+  ofAtom loc (.ident i args)
+
+def pyClass (loc : SourceRange) (name : String) (params : Array SpecType) : SpecType :=
+  ofAtom loc (.pyClass name params)
 
 def asSingleton (tp : SpecType) : Option SpecAtomType := do
   if tp.atoms.size = 1 then

--- a/Strata/Languages/Python/Specs/PySpecM.lean
+++ b/Strata/Languages/Python/Specs/PySpecM.lean
@@ -1,0 +1,36 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.DDM.Util.SourceRange
+
+/-!
+# PySpec Monad
+
+This module defines the monad infrastructure for PySpec translation,
+including error reporting type class and error structures.
+-/
+
+public section
+namespace Strata.Python.Specs
+
+/-- An error encountered while processing a PySpec file. -/
+structure SpecError where
+  file : System.FilePath
+  loc : SourceRange
+  message : String
+
+/-- Type class for monads that support PySpec error reporting. -/
+class PySpecMClass (m : Type → Type) where
+  /-- Report an error at a specific source location. -/
+  specError (loc : SourceRange) (message : String) : m Unit
+  /-- Run an action and check if any new errors were reported. -/
+  runChecked {α} (act : m α) : m (Bool × α)
+
+export PySpecMClass (specError runChecked)
+
+end Strata.Python.Specs
+end

--- a/StrataTest/Languages/Python/Specs/DeclsTest.lean
+++ b/StrataTest/Languages/Python/Specs/DeclsTest.lean
@@ -1,0 +1,39 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+import Strata.Languages.Python.Specs.Decls
+
+open Strata.Python.Specs
+
+namespace DeclsTest
+
+private abbrev mk1 (a : SpecAtomType) : SpecType := ⟨#[a], ⟨0, 0⟩⟩
+private abbrev mk2 (a : SpecAtomType) : SpecType := ⟨#[a], ⟨⟨1⟩, ⟨2⟩⟩⟩
+
+-- Atom ordering: ident < pyClass < intLiteral < stringLiteral < typedDict
+#guard compare (SpecAtomType.ident .builtinsInt #[]) (.pyClass "Foo" #[]) == .lt
+#guard compare (SpecAtomType.pyClass "Foo" #[]) (.intLiteral 0) == .lt
+#guard compare (SpecAtomType.intLiteral 0) (.stringLiteral "a") == .lt
+
+-- Same variant compares by fields
+#guard compare (SpecAtomType.intLiteral 1) (.intLiteral 2) == .lt
+#guard compare (SpecAtomType.intLiteral 1) (.intLiteral 1) == .eq
+#guard compare (SpecAtomType.stringLiteral "a") (.stringLiteral "b") == .lt
+
+-- ident compares by PythonIdent then args
+#guard compare (SpecAtomType.ident .builtinsBool #[]) (.ident .builtinsInt #[]) == .lt
+
+-- SpecType comparison ignores loc
+#guard compare (mk1 (.intLiteral 1)) (mk2 (.intLiteral 1)) == .eq
+-- BEq also ignores loc (consistent with Ord)
+#guard mk1 (.intLiteral 1) == mk2 (.intLiteral 1)
+
+-- SpecType compares by atoms content
+#guard compare (mk1 (.intLiteral 1)) (mk1 (.intLiteral 2)) == .lt
+
+-- ofArray deduplicates
+#guard 1 == (SpecType.ofArray ⟨0, 0⟩ #[.intLiteral 0, .intLiteral 0] |>.atoms.size)
+
+end DeclsTest


### PR DESCRIPTION
## Summary

PySpec types (`SpecType`) had no source location tracking, making it
impossible to report precise error locations for type-related diagnostics.
This PR adds a `loc : SourceRange` field to `SpecType` so that error
messages can point back to the source that produced each type.

Adding `loc` required replacing the derived `Ord` and `BEq` instances with
custom ones that compare types semantically (ignoring provenance metadata).
While implementing this, two pre-existing bugs were found and fixed:

- **`unionAux`** pushed the wrong element in the `.gt` case, producing
  incorrectly ordered union arrays. This could cause `binSearchContains`
  membership checks to miss valid members.
- **`ppSourceRange`** compared `spos.line == spos.line` (always true)
  instead of `spos.line == epos.line`, so multi-line ranges always
  rendered in single-line format.

The `SpecError` and `PySpecMClass` types are extracted into a separate
`PySpecM.lean` module and the `noneType` atom variant is unified with the
existing `ident`-based representation, removing the redundant `typeNoneType`
DDM op.

**Note:** Existing `.pyspec.st.ion` cache files will need regeneration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.