### PR TITLE
Add AL2: skip comments

### DIFF
--- a/Strata/Languages/Core/FactoryWF.lean
+++ b/Strata/Languages/Core/FactoryWF.lean
@@ -30,6 +30,7 @@ Wellformedness of Factory
 -/
 theorem Factory_wf :
     FactoryWF Factory := by
+/- AL2: skip -/
   unfold Factory
   simp only [array_list_happend_toArray, List.cons_append, List.nil_append]
   apply FactoryWF.mk
@@ -74,4 +75,5 @@ theorem Factory_wf :
       · decide -- LFuncWF.inputs_typevars_in_typeArgs
       · decide -- LFuncWF.output_typevars_in_typeArgs
     )
+/- AL2: skip end -/
 end Core


### PR DESCRIPTION
These comment blocks will be replaced with `sorry` through this command:

```
find . -type f -name "*.lean" -exec sed -i '' '/\/- AL2: skip -\//,/\/- AL2: skip end -\//{
    /\/- AL2: skip -\//!{
        /\/- AL2: skip end -\//!d
    }
    /\/- AL2: skip end -\//s/.*/sorry/
    /\/- AL2: skip -\//d
}' {} \;
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
