### PR TITLE
Correct-by-construction WF proofs for factory functions

### DIFF
--- a/Strata/DL/Lambda/FactoryWF.lean
+++ b/Strata/DL/Lambda/FactoryWF.lean
@@ -36,6 +36,35 @@ abbrev LFuncWF {T : LExprParams} (f : LFunc T) :=
     (fun e => e.freeVars) -- getTyFreeVars
     f
 
+/-- An LFunc bundled with its well-formedness proof. -/
+structure WFLFunc (T : LExprParams) where
+  func : LFunc T
+  wf : LFuncWF func
+
+/-- The name of the underlying LFunc. -/
+def WFLFunc.name (f : WFLFunc T) : T.Identifier := f.func.name
+
+/-- The operator expression for the underlying LFunc. -/
+def WFLFunc.opExpr [Inhabited T.Metadata] (f : WFLFunc T) : LExpr T.mono :=
+  f.func.opExpr
+
+/-- An array of well-formed LFuncs with a proof that function
+    names are unique. -/
+structure WFLFactory (T : LExprParams) where
+  funcs : Array (WFLFunc T)
+  name_nodup : List.Nodup (funcs.toList.map (·.func.name.name))
+
+/-- Construct a `WFLFactory` from an array of `WFLFunc`s.
+    The `name_nodup` proof defaults to `by decide`. -/
+def WFLFactory.ofArray (funcs : Array (WFLFunc T))
+    (name_nodup : List.Nodup (funcs.toList.map (·.func.name.name)) := by decide)
+    : WFLFactory T :=
+  ⟨funcs, name_nodup⟩
+
+/-- Extract the underlying `Factory` from a `WFLFactory`. -/
+def WFLFactory.toFactory (wf : WFLFactory T) : @Factory T :=
+  wf.funcs.map (·.func)
+
 instance LFuncWF.arg_nodup_decidable {T : LExprParams} (f : LFunc T):
     Decidable (List.Nodup (f.inputs.map (·.1.name))) := by
   apply List.nodupDecidable

--- a/Strata/DL/Lambda/Preconditions.lean
+++ b/Strata/DL/Lambda/Preconditions.lean
@@ -17,7 +17,7 @@ from expressions that call functions with preconditions.
 namespace Lambda
 open Std (ToFormat Format format)
 
-variable {T : LExprParams} [DecidableEq T.IDMeta] [BEq T.IDMeta]
+variable {T : LExprParams} [Inhabited T.IDMeta] [DecidableEq T.IDMeta]
 
 /-- A well-formedness obligation generated from a function call -/
 structure WFObligation (T : LExprParams) where

--- a/Strata/Languages/Core/Factory.lean
+++ b/Strata/Languages/Core/Factory.lean
@@ -55,255 +55,182 @@ match ine with
     | .eq m e1 e2 => .eq m (ToCoreIdent e1) (ToCoreIdent e2)
 
 
-def bvBinaryOp (fn:∀ {n}, BitVec n → BitVec n → BitVec n)
-  (check:∀ {n}, BitVec n → BitVec n → Bool)
-  (m:CoreLParams.Metadata)
-  (ops:List (LExpr CoreLParams.mono))
-    : Option (LExpr CoreLParams.mono) :=
-  match ops with
-  | [.bitvecConst _ n1 b1, .bitvecConst _ n2 b2] =>
-    if h : n1 = n2 then
-      if check (h ▸ b1) b2 then
-        .some (.bitvecConst m n2 (fn (h ▸ b1) b2))
-      else .none
-    else .none
-  | _ => .none
+/-- Kind of bitvector evaluator, used to generate both the combinator name
+    and the concrete-evaluator syntax for each BV operation. -/
+private inductive BVEvalKind
+  /-- Unary: `unaryOp fn` -/
+  | unary (fn : Lean.Name)
+  /-- Binary: `binaryOp fn` or `binaryOp fn (· != 0)` -/
+  | binary (fn : Lean.Name) (divGuard : Bool)
+  /-- Shift: `binaryOp` with toNat conversion and size guard -/
+  | shift (fn : Lean.Name)
+  /-- Predicate: `binaryOp fn` -/
+  | pred (fn : Lean.Name) (swap : Bool)
 
-def bvShiftOp (fn:∀ {n}, BitVec n → Nat → BitVec n)
-  (m:CoreLParams.Metadata)
-  (ops:List (LExpr CoreLParams.mono))
-    : Option (LExpr CoreLParams.mono) :=
-  match ops with
-  | [.bitvecConst _ n1 b1, .bitvecConst _ n2 b2] =>
-    let i2 := BitVec.toNat b2
-    if n1 = n2 && i2 < n1 then
-      .some (.bitvecConst m n1 (fn b1 i2))
-    else .none
-  | _ => .none
+/-- Specification of a single bitvector operation for metaprogramming. -/
+private structure BVOpSpec where
+  opName : String
+  evalKind : BVEvalKind
 
-def bvUnaryOp (fn:∀ {n}, BitVec n → BitVec n)
-  (m:CoreLParams.Metadata)
-  (ops:List (LExpr CoreLParams.mono))
-    : Option (LExpr CoreLParams.mono) :=
-  match ops with
-  | [.bitvecConst _ n b] => .some (.bitvecConst m n (fn b))
-  | _ => .none
+/-- All bitvector operations, in canonical order.
+    This is the single source of truth: `ExpandBVOpFuncDefs`,
+    `ExpandBVOpFuncNames`, and `DefBVOpFuncExprs` all derive from it. -/
+private def BVOpSpecs : Array BVOpSpec := #[
+  -- Unary
+  ⟨"Neg", .unary ``BitVec.neg⟩,
+  -- Binary arithmetic
+  ⟨"Add",  .binary ``BitVec.add  false⟩,
+  ⟨"Sub",  .binary ``BitVec.sub  false⟩,
+  ⟨"Mul",  .binary ``BitVec.mul  false⟩,
+  ⟨"UDiv", .binary ``BitVec.udiv true⟩,
+  ⟨"UMod", .binary ``BitVec.umod true⟩,
+  ⟨"SDiv", .binary ``BitVec.sdiv true⟩,
+  ⟨"SMod", .binary ``BitVec.srem true⟩,
+  -- Unary bitwise
+  ⟨"Not", .unary ``BitVec.not⟩,
+  -- Binary bitwise
+  ⟨"And", .binary ``BitVec.and false⟩,
+  ⟨"Or",  .binary ``BitVec.or  false⟩,
+  ⟨"Xor", .binary ``BitVec.xor false⟩,
+  -- Shifts
+  ⟨"Shl",  .shift ``BitVec.shiftLeft⟩,
+  ⟨"UShr", .shift ``BitVec.ushiftRight⟩,
+  ⟨"SShr", .shift ``BitVec.sshiftRight⟩,
+  -- Predicates
+  ⟨"ULt", .pred ``BitVec.ult false⟩,
+  ⟨"ULe", .pred ``BitVec.ule false⟩,
+  ⟨"UGt", .pred ``BitVec.ult true⟩,
+  ⟨"UGe", .pred ``BitVec.ule true⟩,
+  ⟨"SLt", .pred ``BitVec.slt false⟩,
+  ⟨"SLe", .pred ``BitVec.sle false⟩,
+  ⟨"SGt", .pred ``BitVec.slt true⟩,
+  ⟨"SGe", .pred ``BitVec.sle true⟩
+]
 
-def bvBinaryPred (fn:∀ {n}, BitVec n → BitVec n → Bool)
-  (swap:Bool)
-  (m:CoreLParams.Metadata)
-  (ops:List (LExpr CoreLParams.mono))
-    : Option (LExpr CoreLParams.mono) :=
-  match ops with
-  | [.bitvecConst _ n1 b1, .bitvecConst _ n2 b2] =>
-    if h : n1 = n2 then
-      let res := if swap then fn b2 (h ▸ b1) else fn (h ▸ b1) b2
-      .some (.boolConst m res)
-    else .none
-  | _ => .none
-
-
-private def BVOpNames :=
-  ["Neg", "Add", "Sub", "Mul", "UDiv", "UMod", "SDiv", "SMod",
-   "Not", "And", "Or", "Xor", "Shl", "UShr", "SShr",
-   "ULt", "ULe", "UGt", "UGe",
-   "SLt", "SLe", "SGt", "SGe"]
-
-private def BVOpAritys :=
-  ["unaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp",
-   "unaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp", "binaryOp",
-   "binaryPredicate", "binaryPredicate", "binaryPredicate", "binaryPredicate",
-   "binaryPredicate", "binaryPredicate", "binaryPredicate", "binaryPredicate" ]
-
-/--
-info: [("Neg", "unaryOp"), ("Add", "binaryOp"), ("Sub", "binaryOp"), ("Mul", "binaryOp"), ("UDiv", "binaryOp"),
-  ("UMod", "binaryOp"), ("SDiv", "binaryOp"), ("SMod", "binaryOp"), ("Not", "unaryOp"), ("And", "binaryOp"),
-  ("Or", "binaryOp"), ("Xor", "binaryOp"), ("Shl", "binaryOp"), ("UShr", "binaryOp"), ("SShr", "binaryOp"),
-  ("ULt", "binaryPredicate"), ("ULe", "binaryPredicate"), ("UGt", "binaryPredicate"), ("UGe", "binaryPredicate"),
-  ("SLt", "binaryPredicate"), ("SLe", "binaryPredicate"), ("SGt", "binaryPredicate"), ("SGe", "binaryPredicate")]
--/
-#guard_msgs in
-#eval List.zip BVOpNames BVOpAritys
-
-private def BVOpEvals :=
-  [("Neg", Option.some (bvUnaryOp BitVec.neg)),
-   ("Add", .some (bvBinaryOp BitVec.add (λ_ _ => true))),
-   ("Sub", .some (bvBinaryOp BitVec.sub (λ_ _ => true))),
-   ("Mul", .some (bvBinaryOp BitVec.mul (λ_ _ => true))),
-   ("UDiv", .some (bvBinaryOp BitVec.udiv (λ_ y => y ≠ 0))),
-   ("UMod", .some (bvBinaryOp BitVec.umod (λ_ y => y ≠ 0))),
-   ("SDiv", .some (bvBinaryOp BitVec.sdiv (λ_ y => y ≠ 0))),
-   ("SMod", .some (bvBinaryOp BitVec.srem (λ_ y => y ≠ 0))),
-   ("Not", .some (bvUnaryOp BitVec.not)),
-   ("And", .some (bvBinaryOp BitVec.and (λ_ _ => true))),
-   ("Or", .some (bvBinaryOp BitVec.or (λ_ _ => true))),
-   ("Xor", .some (bvBinaryOp BitVec.xor (λ_ _ => true))),
-   ("Shl", .some (bvShiftOp BitVec.shiftLeft)),
-   ("UShr", .some (bvShiftOp BitVec.ushiftRight)),
-   ("SShr", .some (bvShiftOp BitVec.sshiftRight)),
-   ("ULt", .some (bvBinaryPred BitVec.ult false)),
-   ("ULe", .some (bvBinaryPred BitVec.ule false)),
-   ("UGt", .some (bvBinaryPred BitVec.ult true)),
-   ("UGe", .some (bvBinaryPred BitVec.ule true)),
-   ("SLt", .some (bvBinaryPred BitVec.slt false)),
-   ("SLe", .some (bvBinaryPred BitVec.sle false)),
-   ("SGt", .some (bvBinaryPred BitVec.slt true)),
-   ("SGe", .some (bvBinaryPred BitVec.sle true))]
+open Lean Elab Command in
+/-- Generate the full definition RHS for a BV operation.
+    Uses typeclass-based combinators for all operation kinds. -/
+private def BVEvalKind.toDefRHS (opName : TSyntax `str)
+    (sizeNum : TSyntax `num)
+    : BVEvalKind → CommandElabM (TSyntax `term)
+  | .unary fn =>
+    `(Lambda.unaryOp (InValTy := BitVec $sizeNum) $opName $(mkIdent fn))
+  | .binary fn false =>
+    `(Lambda.binaryOp (InValTy := BitVec $sizeNum) $opName $(mkIdent fn))
+  | .binary fn true =>
+    `(Lambda.binaryOp (InValTy := BitVec $sizeNum) $opName $(mkIdent fn) (· != 0))
+  | .shift fn =>
+    `(Lambda.binaryOp (InValTy := BitVec $sizeNum) $opName
+      (fun b1 b2 => $(mkIdent fn) b1 b2.toNat)
+      (fun b => decide (b.toNat < $sizeNum)))
+  | .pred fn false =>
+    `(Lambda.binaryOp (InValTy := BitVec $sizeNum) $opName $(mkIdent fn))
+  | .pred fn true =>
+    `(Lambda.binaryOp (InValTy := BitVec $sizeNum) $opName (fun x y => $(mkIdent fn) y x))
 
 open Lean Elab Command in
 elab "ExpandBVOpFuncDefs" "[" sizes:num,* "]" : command => do
   for size in sizes.getElems do
     let s := size.getNat.repr
-    for (op, arity) in List.zip BVOpNames BVOpAritys do
-      let funcName := mkIdent (.str .anonymous s!"bv{s}{op}Func")
-      let funcArity := mkIdent (.str (.str .anonymous "Lambda") arity)
-      let opName := Syntax.mkStrLit s!"Bv{s}.{op}"
-      let bvTypeName := Name.mkSimple s!"bv{s}"
-      let opStr := Syntax.mkStrLit op
-      elabCommand (← `(def $funcName : LFunc CoreLParams :=
-        $funcArity $opName mty[$(mkIdent bvTypeName):ident]
-        ((BVOpEvals.find? (fun (k,_) => k == $opStr)).bind (fun (_,w)=>w))))
+    let sizeNum := Syntax.mkNumLit s
+    for spec in BVOpSpecs do
+      let funcName := mkIdent (.str .anonymous s!"bv{s}{spec.opName}Func")
+      let opName := Syntax.mkStrLit s!"Bv{s}.{spec.opName}"
+      let rhs ← spec.evalKind.toDefRHS opName sizeNum
+      elabCommand (← `(def $funcName : Lambda.WFLFunc CoreLParams := $rhs))
 
 ExpandBVOpFuncDefs[1, 2, 8, 16, 32, 64]
 
 /- Real Arithmetic Operations -/
 
-def realAddFunc : LFunc CoreLParams := binaryOp "Real.Add" mty[real] none
-def realSubFunc : LFunc CoreLParams := binaryOp "Real.Sub" mty[real] none
-def realMulFunc : LFunc CoreLParams := binaryOp "Real.Mul" mty[real] none
-def realDivFunc : LFunc CoreLParams := binaryOp "Real.Div" mty[real] none
-def realNegFunc : LFunc CoreLParams := unaryOp "Real.Neg" mty[real] none
+def realAddFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Add" mty[real] mty[real] mty[real]
+def realSubFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Sub" mty[real] mty[real] mty[real]
+def realMulFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Mul" mty[real] mty[real] mty[real]
+def realDivFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Div" mty[real] mty[real] mty[real]
+def realNegFunc : WFLFunc CoreLParams :=
+  unaryFuncUneval "Real.Neg" mty[real] mty[real]
 
 /- Real Comparison Operations -/
-def realLtFunc : LFunc CoreLParams := binaryPredicate "Real.Lt" mty[real] none
-def realLeFunc : LFunc CoreLParams := binaryPredicate "Real.Le" mty[real] none
-def realGtFunc : LFunc CoreLParams := binaryPredicate "Real.Gt" mty[real] none
-def realGeFunc : LFunc CoreLParams := binaryPredicate "Real.Ge" mty[real] none
+
+def realLtFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Lt" mty[real] mty[real] mty[bool]
+def realLeFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Le" mty[real] mty[real] mty[bool]
+def realGtFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Gt" mty[real] mty[real] mty[bool]
+def realGeFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Real.Ge" mty[real] mty[real] mty[bool]
 
 /- String Operations -/
-def strLengthFunc : LFunc CoreLParams :=
-    { name := "Str.Length",
-      typeArgs := [],
-      inputs := [("x", mty[string])]
-      output := mty[int],
-      concreteEval := some (unOpCeval (T:=CoreLParams) String Int (.intConst (T:=CoreLParams.mono)) (@LExpr.denoteString CoreLParams)
-                            (fun s => (Int.ofNat (String.length s))))}
+def strLengthFunc : WFLFunc CoreLParams :=
+  unaryOp "Str.Length" (fun (s : String) => Int.ofNat s.length)
 
-def strConcatFunc : LFunc CoreLParams :=
-    { name := "Str.Concat",
-      typeArgs := [],
-      inputs := [("x", mty[string]), ("y", mty[string])]
-      output := mty[string],
-      concreteEval := some (binOpCeval String String (.strConst (T := CoreLParams.mono))
-                            LExpr.denoteString String.append)}
+def strConcatFunc : WFLFunc CoreLParams :=
+  binaryOp "Str.Concat" String.append
 
-def strSubstrFunc : LFunc CoreLParams :=
-    { name := "Str.Substr",
-      typeArgs := [],
-      -- longest substring of `x` of length at most `n` starting at position `i`.
-      inputs := [("x", mty[string]), ("i", mty[int]), ("n", mty[int])]
-      output := mty[string] }
+def strSubstrFunc : WFLFunc CoreLParams :=
+  polyUneval "Str.Substr" []
+    [("x", mty[string]), ("i", mty[int]), ("n", mty[int])] mty[string]
 
-def strToRegexFunc : LFunc CoreLParams :=
-    { name := "Str.ToRegEx",
-      typeArgs := [],
-      inputs := [("x", mty[string])]
-      output := mty[regex] }
+def strToRegexFunc : WFLFunc CoreLParams :=
+  unaryFuncUneval "Str.ToRegEx" mty[string] mty[regex]
 
-def strInRegexFunc : LFunc CoreLParams :=
-    { name := "Str.InRegEx",
-      typeArgs := [],
-      inputs := [("x", mty[string]), ("y", mty[regex])]
-      output := mty[bool] }
+def strInRegexFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Str.InRegEx" mty[string] mty[regex] mty[bool]
 
-def reAllCharFunc : LFunc CoreLParams :=
-    { name := "Re.AllChar",
-      typeArgs := [],
-      inputs := []
-      output := mty[regex] }
+def reAllCharFunc : WFLFunc CoreLParams :=
+  nullaryUneval "Re.AllChar" mty[regex]
 
-def reAllFunc : LFunc CoreLParams :=
-    { name := "Re.All",
-      typeArgs := [],
-      inputs := []
-      output := mty[regex] }
+def reAllFunc : WFLFunc CoreLParams :=
+  nullaryUneval "Re.All" mty[regex]
 
-def reRangeFunc : LFunc CoreLParams :=
-    { name := "Re.Range",
-      typeArgs := [],
-      inputs := [("x", mty[string]), ("y", mty[string])]
-      output := mty[regex] }
+def reRangeFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Re.Range" mty[string] mty[string] mty[regex]
 
-def reConcatFunc : LFunc CoreLParams :=
-    { name := "Re.Concat",
-      typeArgs := [],
-      inputs := [("x", mty[regex]), ("y", mty[regex])]
-      output := mty[regex] }
+def reConcatFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Re.Concat" mty[regex] mty[regex] mty[regex]
 
-def reStarFunc : LFunc CoreLParams :=
-    { name := "Re.Star",
-      typeArgs := [],
-      inputs := [("x", mty[regex])]
-      output := mty[regex] }
+def reStarFunc : WFLFunc CoreLParams :=
+  unaryFuncUneval "Re.Star" mty[regex] mty[regex]
 
-def rePlusFunc : LFunc CoreLParams :=
-    { name := "Re.Plus",
-      typeArgs := [],
-      inputs := [("x", mty[regex])]
-      output := mty[regex] }
+def rePlusFunc : WFLFunc CoreLParams :=
+  unaryFuncUneval "Re.Plus" mty[regex] mty[regex]
 
-def reLoopFunc : LFunc CoreLParams :=
-    { name := "Re.Loop",
-      typeArgs := [],
-      inputs := [("x", mty[regex]), ("n1", mty[int]), ("n2", mty[int])]
-      output := mty[regex] }
+def reLoopFunc : WFLFunc CoreLParams :=
+  polyUneval "Re.Loop" []
+    [("x", mty[regex]), ("n1", mty[int]), ("n2", mty[int])] mty[regex]
 
-def reUnionFunc : LFunc CoreLParams :=
-    { name := "Re.Union",
-      typeArgs := [],
-      inputs := [("x", mty[regex]), ("y", mty[regex])]
-      output := mty[regex] }
+def reUnionFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Re.Union" mty[regex] mty[regex] mty[regex]
 
-def reInterFunc : LFunc CoreLParams :=
-    { name := "Re.Inter",
-      typeArgs := [],
-      inputs := [("x", mty[regex]), ("y", mty[regex])]
-      output := mty[regex] }
+def reInterFunc : WFLFunc CoreLParams :=
+  binaryFuncUneval "Re.Inter" mty[regex] mty[regex] mty[regex]
 
-def reCompFunc : LFunc CoreLParams :=
-    { name := "Re.Comp",
-      typeArgs := [],
-      inputs := [("x", mty[regex])]
-      output := mty[regex] }
+def reCompFunc : WFLFunc CoreLParams :=
+  unaryFuncUneval "Re.Comp" mty[regex] mty[regex]
 
-def reNoneFunc : LFunc CoreLParams :=
-    { name := "Re.None",
-      typeArgs := [],
-      inputs := []
-      output := mty[regex] }
+def reNoneFunc : WFLFunc CoreLParams :=
+  nullaryUneval "Re.None" mty[regex]
 
 /- A polymorphic `old` function with type `∀a. a → a`. -/
-def polyOldFunc : LFunc CoreLParams :=
-    { name := "old",
-      typeArgs := ["a"],
-      inputs := [((CoreIdent.locl "x"), mty[%a])]
-      output := mty[%a]}
+def polyOldFunc : WFLFunc CoreLParams :=
+  polyUneval "old" ["a"] [("x", mty[%a])] mty[%a]
 
 /- A `Map` selection function with type `∀k, v. Map k v → k → v`. -/
-def mapSelectFunc : LFunc CoreLParams :=
-   { name := "select",
-     typeArgs := ["k", "v"],
-     inputs := [("m", mapTy mty[%k] mty[%v]), ("i", mty[%k])],
-     output := mty[%v] }
+def mapSelectFunc : WFLFunc CoreLParams :=
+  polyUneval "select" ["k", "v"]
+    [("m", mapTy mty[%k] mty[%v]), ("i", mty[%k])] mty[%v]
 
 /- A `Map` update function with type `∀k, v. Map k v → k → v → Map k v`. -/
-def mapUpdateFunc : LFunc CoreLParams :=
-   { name := "update",
-     typeArgs := ["k", "v"],
-     inputs := [("m", mapTy mty[%k] mty[%v]), ("i", mty[%k]), ("x", mty[%v])],
-     output := mapTy mty[%k] mty[%v],
-     axioms :=
-     [
+def mapUpdateFunc : WFLFunc CoreLParams :=
+  polyUneval "update" ["k", "v"]
+    [("m", mapTy mty[%k] mty[%v]), ("i", mty[%k]), ("x", mty[%v])]
+    (mapTy mty[%k] mty[%v])
+    (axioms := [
       -- updateSelect: forall m: Map k v, kk: k, vv: v :: m[kk := vv][kk] == vv
       ToCoreIdent esM[∀(Map %k %v):
           (∀ (%k):
@@ -329,61 +256,41 @@ def mapUpdateFunc : LFunc CoreLParams :=
                     ==
                     ((((~select : (Map %k %v) → %k → %v) %3) %2)))
                     ))))]
-     ]
-   }
+    ])
 
-def emptyTriggersFunc : LFunc CoreLParams :=
-    { name := "Triggers.empty",
-      typeArgs := [],
-      inputs := [],
-      output := mty[Triggers],
-      concreteEval := none }
+def emptyTriggersFunc : WFLFunc CoreLParams :=
+  nullaryUneval "Triggers.empty" mty[Triggers]
 
-def addTriggerGroupFunc : LFunc CoreLParams :=
-    { name := "Triggers.addGroup",
-      typeArgs := [],
-      inputs := [("g", mty[TriggerGroup]), ("t", mty[Triggers])],
-      output := mty[Triggers],
-      concreteEval := none }
+def addTriggerGroupFunc : WFLFunc CoreLParams :=
+  polyUneval "Triggers.addGroup" []
+    [("g", mty[TriggerGroup]), ("t", mty[Triggers])] mty[Triggers]
 
-def emptyTriggerGroupFunc : LFunc CoreLParams :=
-    { name := "TriggerGroup.empty",
-      typeArgs := [],
-      inputs := [],
-      output := mty[TriggerGroup],
-      concreteEval := none }
+def emptyTriggerGroupFunc : WFLFunc CoreLParams :=
+  nullaryUneval "TriggerGroup.empty" mty[TriggerGroup]
 
-def addTriggerFunc : LFunc CoreLParams :=
-    { name := "TriggerGroup.addTrigger",
-      typeArgs := ["a"],
-      inputs := [("x", mty[%a]), ("t", mty[TriggerGroup])],
-      output := mty[TriggerGroup],
-      concreteEval := none }
+def addTriggerFunc : WFLFunc CoreLParams :=
+  polyUneval "TriggerGroup.addTrigger" ["a"]
+    [("x", mty[%a]), ("t", mty[TriggerGroup])] mty[TriggerGroup]
 
 open Lean in
 macro "ExpandBVOpFuncNames" "[" sizes:num,* "]" : term => do
   let mut allOps := #[]
   for size in sizes.getElems do
     let s := size.getNat.repr
-    let ops := BVOpNames.map (mkIdent ∘ (.str (.str .anonymous "Core")) ∘ (s!"bv{s}" ++ · ++ "Func"))
-    allOps := allOps ++ ops.toArray
+    for spec in BVOpSpecs do
+      let name := s!"bv{s}" ++ spec.opName ++ "Func"
+      allOps := allOps.push (mkIdent (.str (.str .anonymous "Core") name))
   `([$(allOps),*])
 
-def bvConcatFunc (size : Nat) : LFunc CoreLParams :=
-  { name := s!"Bv{size}.Concat",
-    typeArgs := [],
-    inputs := [("x", .bitvec size), ("y", .bitvec size)]
-    output := .bitvec (size*2),
-    concreteEval := none }
+def bvConcatFunc (size : Nat) : WFLFunc CoreLParams :=
+  binaryFuncUneval s!"Bv{size}.Concat"
+    (.bitvec size) (.bitvec size) (.bitvec (size * 2)) rfl rfl rfl
 
-def bvExtractFunc (size hi lo: Nat) : LFunc CoreLParams :=
-  { name := s!"Bv{size}.Extract_{hi}_{lo}",
-    typeArgs := [],
-    inputs := [("x", .bitvec size)]
-    output := .bitvec (hi + 1 - lo),
-    concreteEval := none }
+def bvExtractFunc (size hi lo : Nat) : WFLFunc CoreLParams :=
+  unaryFuncUneval s!"Bv{size}.Extract_{hi}_{lo}"
+    (.bitvec size) (.bitvec (hi + 1 - lo)) rfl rfl
 
-def bv8ConcatFunc := bvConcatFunc 8
+def bv8ConcatFunc  := bvConcatFunc 8
 def bv16ConcatFunc := bvConcatFunc 16
 def bv32ConcatFunc := bvConcatFunc 32
 
@@ -397,22 +304,25 @@ def bv64Extract_31_0_Func  := bvExtractFunc 64 31  0
 def bv64Extract_15_0_Func  := bvExtractFunc 64 15  0
 def bv64Extract_7_0_Func   := bvExtractFunc 64  7  0
 
-def Factory : @Factory CoreLParams := #[
-  @intAddFunc CoreLParams _,
-  @intSubFunc CoreLParams _,
-  @intMulFunc CoreLParams _,
-  @intDivFunc CoreLParams _,
-  @intSafeDivFunc CoreLParams _ _,
-  @intModFunc CoreLParams _,
-  @intSafeModFunc CoreLParams _ _,
-  @intDivTFunc CoreLParams _,
-  @intModTFunc CoreLParams _,
-  @intNegFunc CoreLParams _,
+def WFFactory : Lambda.WFLFactory CoreLParams :=
+  -- (T := CoreLParams) annotations needed for IntBoolFactory
+  -- functions to resolve typeclass instances.
+  WFLFactory.ofArray (name_nodup := by native_decide) (#[
+  intAddFunc (T := CoreLParams),
+  intSubFunc (T := CoreLParams),
+  intMulFunc (T := CoreLParams),
+  intDivFunc (T := CoreLParams),
+  intSafeDivFunc (T := CoreLParams),
+  intModFunc (T := CoreLParams),
+  intSafeModFunc (T := CoreLParams),
+  intDivTFunc (T := CoreLParams),
+  intModTFunc (T := CoreLParams),
+  intNegFunc (T := CoreLParams),
 
-  @intLtFunc CoreLParams _,
-  @intLeFunc CoreLParams _,
-  @intGtFunc CoreLParams _,
-  @intGeFunc CoreLParams _,
+  intLtFunc (T := CoreLParams),
+  intLeFunc (T := CoreLParams),
+  intGtFunc (T := CoreLParams),
+  intGeFunc (T := CoreLParams),
 
   realAddFunc,
   realSubFunc,
@@ -424,11 +334,11 @@ def Factory : @Factory CoreLParams := #[
   realGtFunc,
   realGeFunc,
 
-  @boolAndFunc CoreLParams _,
-  @boolOrFunc CoreLParams _,
-  @boolImpliesFunc CoreLParams _,
-  @boolEquivFunc CoreLParams _,
-  @boolNotFunc CoreLParams _,
+  boolAndFunc (T := CoreLParams),
+  boolOrFunc (T := CoreLParams),
+  boolImpliesFunc (T := CoreLParams),
+  boolEquivFunc (T := CoreLParams),
+  boolNotFunc (T := CoreLParams),
 
   strLengthFunc,
   strConcatFunc,
@@ -469,15 +379,17 @@ def Factory : @Factory CoreLParams := #[
   bv64Extract_31_0_Func,
   bv64Extract_15_0_Func,
   bv64Extract_7_0_Func,
-] ++ (ExpandBVOpFuncNames [1,8,16,32,64])
+] ++ (ExpandBVOpFuncNames [1,8,16,32,64]))
+
+def Factory : @Factory CoreLParams := WFLFactory.toFactory WFFactory
 
 open Lean Elab Command in
 elab "DefBVOpFuncExprs" "[" sizes:num,* "]" : command => do
   for size in sizes.getElems do
     let s := size.getNat.repr
-    for op in BVOpNames do
-      let opName := mkIdent (.str .anonymous s!"bv{s}{op}Op")
-      let funcName := mkIdent (.str (.str .anonymous "Core") s!"bv{s}{op}Func")
+    for spec in BVOpSpecs do
+      let opName := mkIdent (.str .anonymous s!"bv{s}{spec.opName}Op")
+      let funcName := mkIdent (.str (.str .anonymous "Core") s!"bv{s}{spec.opName}Func")
       elabCommand (← `(def $opName : Expression.Expr := ($funcName).opExpr))
 
 instance : Inhabited CoreLParams.Metadata where
@@ -501,7 +413,7 @@ def bv64Extract_7_0_Op   := bv64Extract_7_0_Func.opExpr
 
 def emptyTriggersOp : Expression.Expr := emptyTriggersFunc.opExpr
 def addTriggerGroupOp : Expression.Expr := addTriggerGroupFunc.opExpr
-def emptyTriggerGroupOp : Expression.Expr :=  emptyTriggerGroupFunc.opExpr
+def emptyTriggerGroupOp : Expression.Expr := emptyTriggerGroupFunc.opExpr
 def addTriggerOp : Expression.Expr := addTriggerFunc.opExpr
 
 instance : Inhabited (⟨ExpressionMetadata, CoreIdent⟩: LExprParams).Metadata where

--- a/Strata/Languages/Core/StatementSemantics.lean
+++ b/Strata/Languages/Core/StatementSemantics.lean
@@ -46,7 +46,7 @@ instance : HasNot Core.Expression where
   not
   | Core.true => Core.false
   | Core.false => Core.true
-  | e => Lambda.LExpr.app () (Lambda.LFunc.opExpr (T:=CoreLParams) Lambda.boolNotFunc) e
+  | e => Lambda.LExpr.app () (Lambda.boolNotFunc (T:=CoreLParams)).opExpr e
 
 abbrev CoreEval := SemanticEval Expression
 abbrev CoreStore := SemanticStore Expression


### PR DESCRIPTION
Introduces well-formed Lambda functions (`WFLFunc`) as an abstraction that bundles each factory function with its well-formedness proof at construction time, simplifying the `Factory_wf` proof in `FactoryWF.lean` which triggered stack overflows as the factory grew.

## Details

- Each factory function now carries its own well-formedness proof, so the top-level `Factory_wf` proof no longer needs to unfold every function individually. The proof shrinks from ~40 lines to 8 generic lines.
- A new `LambdaLeanType` typeclass lets eval combinators infer types automatically, reducing most function definitions from ~6 lines to a single line.
- Functions without concrete evaluation use `Uneval` combinators (`polyUneval`, `nullaryUneval`, `unaryFuncUneval`, `binaryFuncUneval`, `ternaryFuncUneval`) that handle common arities and delegate to `polyUneval` for the well-formedness proof.
- Guarded and unguarded binary operations are unified into a single `binaryOp` combinator via an optional guard parameter.
- `binaryOp` also accepts optional preconditions, used by `intSafeDivFunc`/`intSafeModFunc` to express the `y ≠ 0` guard as a proof obligation.
- The three parallel BV operation lists that had to be kept in sync are replaced by a single `BVOpSpec` array that serves as the source of truth.
- The section variable constraint changes from `Coe String T.Identifier` to `Inhabited T.IDMeta`, which is needed for the argument-uniqueness proofs in the new combinators.
- `Preconditions.lean` gains `[Inhabited T.IDMeta]` (needed since `boolImpliesFunc`/`boolNotFunc` are now `WFLFunc`s) and drops unused `[BEq T.IDMeta]`.