### PR TITLE
Ion roundtrip tests + PreType.fvar removal

### DIFF
--- a/Strata/DDM/AST.lean
+++ b/Strata/DDM/AST.lean
@@ -435,6 +435,7 @@ private def ArgF.beq {α} [BEq α] (a1 a2 : ArgF α) : Bool :=
   | .num a1 n1, .num a2 n2 => a1 == a2 && n1 == n2
   | .decimal a1 v1, .decimal a2 v2 => a1 == a2 && v1 == v2
   | .strlit a1 i1, .strlit a2 i2 => a1 == a2 && i1 == i2
+  | .bytes a1 b1, .bytes a2 b2 => a1 == a2 && b1 == b2
   | .option a1 o1, .option a2 o2 => a1 == a2 &&
     match o1,o2 with
     | .none, .none => true
@@ -643,8 +644,6 @@ inductive PreType where
   /-- A polymorphic type variable (universally quantified).
       Used for polymorphic function type parameters -/
 | tvar (ann : SourceRange) (name : String)
-  /-- A reference to a global variable along with any arguments to ensure it is well-typed. -/
-| fvar (ann : SourceRange) (fvar : FreeVarIndex) (args : Array PreType)
   /-- A function type. -/
 | arrow (ann : SourceRange) (arg : PreType) (res : PreType)
   /-- A function created from a reference to bindings and a result type. -/
@@ -658,17 +657,8 @@ def ann : PreType → SourceRange
 | .ident ann _ _ => ann
 | .bvar ann _ => ann
 | .tvar ann _ => ann
-| .fvar ann _ _ => ann
 | .arrow ann _ _ => ann
 | .funMacro ann _ _ => ann
-
-def ofType : TypeExprF SourceRange → PreType
-| .ident loc name args => .ident loc name (args.map fun a => .ofType a)
-| .bvar loc idx => .bvar loc idx
-| .tvar loc name => .tvar loc name
-| .fvar loc idx args => .fvar loc idx (args.map fun a => .ofType a)
-| .arrow loc a r => .arrow loc (.ofType a) (.ofType r)
-termination_by tp => tp
 
 end PreType
 

--- a/Strata/DDM/AST/Lemmas.lean
+++ b/Strata/DDM/AST/Lemmas.lean
@@ -1,0 +1,28 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.DDM.AST
+
+import all Strata.DDM.AST
+
+public section
+namespace Strata.Program
+
+@[simp]
+theorem create_dialects (d : DialectMap) (dn : DialectName) (cmds : Array Operation) :
+    (create d dn cmds).dialects = d := by dsimp [create]
+
+@[simp]
+theorem create_dialect (d : DialectMap) (dn : DialectName) (cmds : Array Operation) :
+    (create d dn cmds).dialect = dn := by dsimp [create]
+
+@[simp]
+theorem create_commands (d : DialectMap) (dn : DialectName) (cmds : Array Operation) :
+    (create d dn cmds).commands = cmds := by dsimp [create]
+
+end Strata.Program
+end

--- a/Strata/DDM/Elab/Core.lean
+++ b/Strata/DDM/Elab/Core.lean
@@ -53,7 +53,6 @@ partial def expandMacros (m : DialectMap) (f : PreType) (args : Nat → Option A
   match f with
   | .ident loc i a => .ident loc i <$> a.mapM fun e => expandMacros m e args
   | .arrow loc a b => .arrow loc <$> expandMacros m a args <*> expandMacros m b args
-  | .fvar loc i a => .fvar loc i <$> a.mapM fun e => expandMacros m e args
   | .bvar loc idx => pure (.bvar loc idx)
   | .tvar loc name => pure (.tvar loc name)
   | .funMacro loc i r => do
@@ -386,7 +385,7 @@ mutual
 
 partial def unifyTypeVectors
   {argc : Nat}
-  (b : Vector ArgDecl argc)
+  (isTypeP : Fin argc → Bool)
   (argLevel0 : Fin argc)
   (ea : Array TypeExpr)
   (tctx : TypingContext)
@@ -397,7 +396,7 @@ partial def unifyTypeVectors
   assert! ea.size = ia.size
   let mut res := args
   for i in Fin.range ea.size do
-    res ← unifyTypes b argLevel0 ea[i] tctx exprSyntax ia[i]! res
+    res ← unifyTypes isTypeP argLevel0 ea[i] tctx exprSyntax ia[i]! res
   return res
 
 /--
@@ -405,7 +404,7 @@ This compares the inferred type against the expected type for an argument to che
 argument value is well-typed and determine if additional type variables can be automatically
 inferred.
 
-- `b` is the bindings for the expression/operator this is for.
+- `isTypeP` returns true if the argument at the given index is a type.
 - `argLevel` refers to the index of the argument in `args`
 - `expectedType` is the type of the argument for the operation/expression.  Bound
   variables in it may refer to args in `args` less than `argIndex`.
@@ -419,7 +418,7 @@ inferred.
 -/
 partial def unifyTypes
     {argc : Nat}
-    (b : Vector ArgDecl argc)
+    (isTypeP : Fin argc → Bool)
     (argLevel0 : Fin argc)
     (expectedType : TypeExpr)
     (tctx : TypingContext)
@@ -442,7 +441,7 @@ partial def unifyTypes
         logErrorMF exprLoc mf!"Encountered {inferredHead} expression when {expectedType} expected."
         return args
       assert! ea.size = ia.size
-      unifyTypeVectors b argLevel0 ea tctx exprSyntax ia args
+      unifyTypeVectors isTypeP argLevel0 ea tctx exprSyntax ia args
     | .tvar _ _ =>
       -- tvar inferred types are passed through; type inference will catch mismatches
       pure args
@@ -456,7 +455,7 @@ partial def unifyTypes
         logErrorMF exprLoc mf!"Encountered {inferredType} expression when {expectedType} expected."
         return args
       assert! ea.size = ia.size
-      unifyTypeVectors b argLevel0 ea tctx exprSyntax ia args
+      unifyTypeVectors isTypeP argLevel0 ea tctx exprSyntax ia args
     | .tvar _ _ =>
       -- tvar inferred types are passed through; type inference will catch mismatches
       pure args
@@ -468,7 +467,7 @@ partial def unifyTypes
       | return panic! "Invalid index"
     let typeLevel := argLevel - (idx + 1)
     -- Verify type level is a type parameter.
-    assert! b[typeLevel].kind.isType
+    assert! isTypeP ⟨typeLevel, by omega⟩
 
     match args[typeLevel] with
     | none => do
@@ -497,8 +496,8 @@ partial def unifyTypes
       -- tvar inferred types are passed through; type inference will catch mismatches
       pure args
     | .arrow _ ia ir =>
-      let res ← unifyTypes b argLevel0 ea tctx exprSyntax ia args
-      unifyTypes b argLevel0 er tctx exprSyntax ir res
+      let res ← unifyTypes isTypeP argLevel0 ea tctx exprSyntax ia args
+      unifyTypes isTypeP argLevel0 er tctx exprSyntax ir res
 
 end
 
@@ -982,6 +981,26 @@ def getSyntaxArgs (stx : Syntax) (ident : QualifiedIdent) (expected : Nat) : Ela
       return default
   return ⟨stxArgs, stxArgP⟩
 
+/-- The kind of elaboration to perform for an argument in `runSyntaxElaborator`.
+Unlike `ArgDeclKind`, this distinguishes pre-types (which need macro expansion)
+from already-resolved type expressions. -/
+inductive ElabArgKind where
+| preType (tp : PreType)
+| typeExpr (tp : TypeExpr)
+| cat (k : SyntaxCat)
+
+namespace ElabArgKind
+
+def isType : ElabArgKind → Bool
+| .cat c => c.isType
+| _ => false
+
+def ofArgDeclKind : ArgDeclKind → ElabArgKind
+| .type tp => .preType tp
+| .cat c => .cat c
+
+end ElabArgKind
+
 mutual
 
 partial def elabOperation (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
@@ -1003,7 +1022,9 @@ partial def elabOperation (tctx : TypingContext) (stx : Syntax) : ElabM Tree := 
   let (stxArgs, success) ← runChecked <| getSyntaxArgs stx i se.syntaxCount
   if not success then
     return default
-  let ((args, newCtx), success) ← runChecked <| runSyntaxElaborator argDecls se tctx stxArgs
+  let isType i := .ofArgDeclKind argDecls[i].kind
+  let ((args, newCtx), success) ← runChecked <|
+    runSyntaxElaborator (argc := argDecls.size) isType se tctx stxArgs
   if !success then
     return default
   let resultCtx ← decl.newBindings.foldlM (init := newCtx) <| fun ctx spec => do
@@ -1016,10 +1037,11 @@ partial def elabOperation (tctx : TypingContext) (stx : Syntax) : ElabM Tree := 
 
 partial def runSyntaxElaborator
   {argc : Nat}
-  (argDecls : Vector ArgDecl argc)
+  (getKind : Fin argc → ElabArgKind)
   (se : SyntaxElaborator)
   (tctx0 : TypingContext)
   (args : Vector Syntax se.syntaxCount) : ElabM (Vector Tree argc × TypingContext) := do
+  let isTypeP := fun i => (getKind i).isType
   let mut trees : Vector (Option Tree) argc := .replicate argc none
   for ⟨ae, sp⟩ in se.argElaborators do
     let argLevel := ae.argLevel
@@ -1070,12 +1092,9 @@ partial def runSyntaxElaborator
           | none => continue
         | none => pure tctx0
     let astx := args[ae.syntaxLevel]
-    let expectedKind := argDecls[argLevel].kind
-    match expectedKind with
-    | .type expectedType =>
+    match getKind ⟨argLevel, argLevelP⟩ with
+    | .preType expectedType =>
       let (tree, success) ← runChecked <| elabExpr tctx astx
-      -- If elaboration is successful, then we run type inference to see if we
-      -- can resolve additional type arguments.
       if success then
         let expr := tree.info.asExpr!.expr
         let inferredType ← inferType tctx expr
@@ -1087,13 +1106,23 @@ partial def runSyntaxElaborator
         | .error () =>
           panic! "Could not infer type."
         | .ok expectedType => do
-          trees ← unifyTypes argDecls ⟨argLevel, argLevelP⟩ expectedType tctx astx inferredType trees
+          trees ← unifyTypes isTypeP ⟨argLevel, argLevelP⟩
+            expectedType tctx astx inferredType trees
           assert! trees[argLevel].isNone
           trees := trees.set argLevel (some tree)
-      | .cat c =>
-        let (tree, success) ← runChecked <| catElaborator c tctx astx
-        if success then
-          trees := trees.set argLevel (some tree)
+    | .typeExpr expectedType =>
+      let (tree, success) ← runChecked <| elabExpr tctx astx
+      if success then
+        let expr := tree.info.asExpr!.expr
+        let inferredType ← inferType tctx expr
+        trees ← unifyTypes isTypeP ⟨argLevel, argLevelP⟩
+          expectedType tctx astx inferredType trees
+        assert! trees[argLevel].isNone
+        trees := trees.set argLevel (some tree)
+    | .cat c =>
+      let (tree, success) ← runChecked <| catElaborator c tctx astx
+      if success then
+        trees := trees.set argLevel (some tree)
   let treesr := trees.map (·.getD default)
   let mut tctx :=
     match se.resultScope with
@@ -1295,9 +1324,8 @@ partial def elabExpr (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
         return default
       | .ok p =>
         pure p
-    let mkArgDecl (tp : TypeExpr) : ArgDecl :=
-          { ident := "", kind := .type (.ofType tp) }
-    let argDecls := argTypes.map mkArgDecl
+    let getKind (i : Fin argTypes.size) : ElabArgKind :=
+          .typeExpr argTypes[i]
     let se : SyntaxElaborator := {
             syntaxCount := args.size
             argElaborators := Array.ofFn fun (⟨lvl, lvlp⟩ : Fin args.size) =>
@@ -1305,7 +1333,7 @@ partial def elabExpr (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
               ⟨e, lvlp⟩
             resultScope := none
           }
-    let (args, _) ← runSyntaxElaborator argDecls se tctx ⟨args, Eq.refl args.size⟩
+    let (args, _) ← runSyntaxElaborator getKind se tctx ⟨args, Eq.refl args.size⟩
     let e := args.toArray.foldl (init := fvar) fun e t =>
       .app { start := fnLoc.start, stop := t.info.loc.stop } e t.arg
     let info : ExprInfo := { toElabInfo := einfo, expr := e }
@@ -1326,7 +1354,10 @@ partial def elabExpr (tctx : TypingContext) (stx : Syntax) : ElabM Tree := do
     let (stxArgs, success) ← runChecked <| getSyntaxArgs stx i se.syntaxCount
     if !success then
       return default
-    let ((args, _), success) ← runChecked <| runSyntaxElaborator argDecls se tctx stxArgs
+    let getKind (i : Fin argDecls.size) :=
+      ElabArgKind.ofArgDeclKind argDecls[i].kind
+    let ((args, _), success) ← runChecked <|
+      runSyntaxElaborator getKind se tctx stxArgs
     if !success then
       return default
     -- N.B. Every subterm gets the function location.

--- a/Strata/DDM/Elab/DialectM.lean
+++ b/Strata/DDM/Elab/DialectM.lean
@@ -27,7 +27,6 @@ Note this does not return variables referenced by .funMacro.
 private def foldBoundTypeVars {α} (tp : PreType) (init : α) (f : α → Nat → α) : α :=
   match tp with
   | .ident _ _ a => a.attach.foldl (init := init) fun r ⟨e, _⟩ => e.foldBoundTypeVars r f
-  | .fvar _ _ a => a.attach.foldl (init := init) fun r ⟨e, _⟩ => e.foldBoundTypeVars r f
   | .bvar _ i => f init i
   | .tvar _ _ => init
   | .arrow _ a r => r.foldBoundTypeVars (a.foldBoundTypeVars init f) f

--- a/Strata/DDM/Format.lean
+++ b/Strata/DDM/Format.lean
@@ -288,7 +288,6 @@ private protected def mformat : PreType → StrataFormat
 | .ident _ tp a => a.attach.foldl (init := mformat tp) (fun m ⟨e, _⟩ => mf!"{m} {e.mformat}")
 | .bvar _ idx => .bvar idx
 | .tvar _ name => mf!"{name}"
-| .fvar _ idx a => a.attach.foldl (init := .fvar idx) (fun m ⟨e, _⟩ => mf!"{m} {e.mformat}")
 | .arrow _ a r => mf!"{a.mformat} -> {r.mformat}"
 | .funMacro _ idx r => mf!"fnOf({StrataFormat.bvar idx}, {r.mformat})"
 

--- a/Strata/DDM/Integration/Lean/ToExpr.lean
+++ b/Strata/DDM/Integration/Lean/ToExpr.lean
@@ -222,9 +222,6 @@ private protected def toExpr : PreType → Lean.Expr
   astExpr! ident (toExpr loc) (toExpr nm) args
 | .bvar loc idx => astExpr! bvar (toExpr loc) (toExpr idx)
 | .tvar loc name => astExpr! tvar (toExpr loc) (toExpr name)
-| .fvar loc idx a =>
-    let args := arrayToExpr .zero PreType.typeExpr (a.map (·.toExpr))
-    astExpr! fvar (toExpr loc) (toExpr idx) args
 | .arrow loc a r =>
   astExpr! arrow (toExpr loc) a.toExpr r.toExpr
 | .funMacro loc i r =>

--- a/StrataTest/DDM/Ion.lean
+++ b/StrataTest/DDM/Ion.lean
@@ -5,11 +5,10 @@
 -/
 module
 
+import Strata.DDM.AST.Lemmas
 import all Strata.DDM.Ion
 import Strata.DDM.BuiltinDialects.StrataDDL
 import Strata.DDM.Integration.Lean
-import StrataTest.DDM.DeclareFn
-meta import StrataTest.DDM.DeclareFn
 
 namespace Strata
 
@@ -25,12 +24,12 @@ def testDialectRoundTrip (d : Dialect) : Bool :=
   testRoundTrip Dialect.toIon d
 
 /-- Test that a `Program` can round-trip through Ion
-serialization without losing commands. -/
+serialization without losing data. -/
 private def testProgramRoundTrip (p : Program) : Bool :=
   let bs := p.toIon
   match Program.fromIon p.dialects p.dialect bs with
   | .error msg => @panic _ ⟨false⟩ msg
-  | .ok res  => res.commands.size == p.commands.size
+  | .ok res  => res == p
 
 -- Load the actual Bool dialect from Examples
 #load_dialect "../../Examples/dialects/Bool.dialect.st"
@@ -41,5 +40,221 @@ private def testProgramRoundTrip (p : Program) : Bool :=
 #guard testDialectRoundTrip initDialect
 #guard testDialectRoundTrip StrataDDL
 
--- Test we can serialize/deserialize programs with expressions
-#guard testProgramRoundTrip testDeclareFnPgm
+-- Ion roundtrip test dialect covering SepFormat variants, expressions, and bindings
+#dialect
+dialect TestIon;
+
+type mytype;
+type Pair(a : Type, b : Type);
+fn lit (n : Num) : mytype => n;
+// Arrow type in fn parameter (PreType.arrow in dialect)
+fn apply (f : mytype -> mytype, x : mytype) : mytype => f "(" x ")";
+op eval (tp : Type, e : tp) : Command => "eval " e " : " tp ";\n";
+op evalDec (d : Decimal) : Command => "dec " d ";\n";
+op evalStr (s : Str) : Command => "str " s ";\n";
+op evalBytes (b : ByteArray) : Command => "bytes " b ";\n";
+op evalIdent (name : Ident) : Command => "ident " name ";\n";
+// Bool metadata (MetadataArg.bool, MetadataArgType.bool)
+metadata myFlag (flag : Bool);
+@[myFlag(true)]
+op flaggedTrue (e : mytype) : Command => "flagT " e ";\n";
+// Option metadata (MetadataArg.option some/none)
+metadata myOpt (id : Ident, extra : Option Ident);
+@[myOpt(name, none)]
+op optNone (name : Ident) : Command => "optN " name ";\n";
+@[myOpt(name, some name)]
+op optSome (name : Ident) : Command => "optS " name ";\n";
+
+// Binding and scope support (for ExprF.bvar coverage)
+category Binding;
+@[declare(name, tp)]
+op mkBinding (name : Ident, tp : TypeP) : Binding => name ":" tp;
+
+category Bindings;
+@[scope(bindings)]
+op mkBindings (bindings : CommaSepBy Binding) : Bindings => "(" bindings ")";
+
+op evalScoped (b : Bindings, tp : Type, @[scope(b)] e : tp) : Command
+  => "evalScoped " b " " e " : " tp ";\n";
+
+// Lambda function (PreType.funMacro in dialect)
+fn lambda (tp : Type, b : Bindings, @[scope(b)] res : tp) : fnOf(b, tp)
+  => "fun " b " => " res;
+
+// Scoped type reference (TypeExprF.bvar in programs)
+op checkBoundType (b : Bindings, @[scope(b)] tp : Type) : Command
+  => "checkBound " b " " tp ";\n";
+
+// Top-level variable declaration (ExprF.fvar when referenced)
+@[declare(name, tp)]
+op declareVar (name : Ident, tp : Type) : Command => "declare " name " : " tp ";\n";
+
+// Type variable support (PreType.tvar, TypeExprF.tvar)
+category TypeVar;
+@[declareTVar(name)]
+op type_var (name : Ident) : TypeVar => name;
+
+category TypeArgs;
+@[scope(args)]
+op type_args (args : CommaSepBy TypeVar) : TypeArgs => "<" args ">";
+
+@[declareFn(name, b, r)]
+op command_fndecl (name : Ident,
+                   typeArgs : Option TypeArgs,
+                   @[scope(typeArgs)] b : Bindings,
+                   @[scope(typeArgs)] r : Type) : Command =>
+  "function " name typeArgs b ":" r ";\n";
+
+category Item;
+op item (n : Num) : Item => n;
+op testSeq (items : Seq Item) : Command => "seq(" items ")";
+op testComma (items : CommaSepBy Item) : Command => "comma(" items ")";
+op testSpace (items : SpaceSepBy Item) : Command => "space(" items ")";
+op testPrefix (items : SpacePrefixSepBy Item) : Command => "prefix(" items ")";
+op testOpt (item : Option Item) : Command => "opt(" item ")";
+// Indent syntax (SyntaxDefAtom.indent)
+op block (body : Seq Item) : Command => "block" indent(2, body) "end";
+// TypeP argument (ArgF.cat coverage)
+op checkTypeP (tp : TypeP) : Command => "checkTypeP " tp ";\n";
+#end
+
+namespace TestIon
+#strata_gen TestIon
+end TestIon
+
+def testIonPgm := #strata
+program TestIon;
+eval 1 : mytype;
+dec 1e0;
+str "hello";
+bytes b"abc";
+ident foo;
+evalScoped (x : mytype) x : mytype;
+function f<a>(x: a): a;
+eval f(1) : mytype;
+opt(1)
+opt()
+seq(1 2 3)
+comma(1, 2, 3)
+space(1 2 3)
+prefix(1 2 3)
+block 1 2 3 end
+eval fun (x: mytype) => x : mytype -> mytype;
+#end
+
+-- ExprF.fvar: `eval g` references a declared variable
+abbrev testIonFvarPgm := #strata
+program TestIon;
+declare g : mytype;
+eval g : mytype;
+#end
+
+-- `eval g` (command 1) references a declared variable via ExprF.fvar
+#guard
+  let cmd := testIonFvarPgm.commands[1]
+  match cmd.args[1]? with
+  | some (ArgF.expr (.fvar _ _)) => true
+  | _ => false
+
+#guard testProgramRoundTrip testIonFvarPgm
+
+-- ArgF.cat: `checkTypeP Type` passes a category as an argument
+abbrev testIonCatPgm := #strata
+program TestIon;
+checkTypeP Type;
+#end
+
+-- `checkTypeP Type` (command 0) passes a category via ArgF.cat
+#guard
+  let cmd := testIonCatPgm.commands[0]
+  match cmd.args[0]? with
+  | some (ArgF.cat _) => true
+  | _ => false
+
+#guard testProgramRoundTrip testIonCatPgm
+
+-- TypeExprF.bvar: `checkBound` references a scoped type variable
+abbrev testIonBvarPgm := #strata
+program TestIon;
+checkBound (T : Type) T;
+#end
+
+-- `checkBound` (command 0) references a scoped type variable via TypeExprF.bvar
+#guard
+  let cmd := testIonBvarPgm.commands[0]
+  match cmd.args[1]? with
+  | some (ArgF.type (.bvar _ _)) => true
+  | _ => false
+
+#guard testProgramRoundTrip testIonBvarPgm
+
+-- Verify the lambda function uses PreType.funMacro in the dialect
+#guard
+  TestIon.declarations.any fun d =>
+    match d with
+    | .function f => f.name == "lambda" && match f.result with
+      | .funMacro _ _ _ => true
+      | _ => false
+    | _ => false
+
+#guard testDialectRoundTrip TestIon
+#guard testProgramRoundTrip testIonPgm
+
+-- Dialect for testing FunctionTemplate Ion serialization
+#dialect
+dialect TestIonDatatypes;
+
+type bool;
+type mydt;
+
+category Binding;
+@[declare(name, tp)]
+op mkBinding (name : Ident, tp : TypeP) : Binding => name ":" tp;
+
+category Bindings;
+@[scope(bindings)]
+op mkBindings (bindings : CommaSepBy Binding) : Bindings => "(" bindings ")";
+
+category Constructor;
+category ConstructorList;
+
+@[constructor(name, fields)]
+op constructor_mk (name : Ident, fields : Option (CommaSepBy Binding))
+  : Constructor => name "(" fields ")";
+
+@[constructorListAtom(c)]
+op constructorListAtom (c : Constructor) : ConstructorList => c;
+
+@[constructorListPush(cl, c)]
+op constructorListPush (cl : ConstructorList, c : Constructor)
+  : ConstructorList => cl ", " c;
+
+metadata declareDatatype (name : Ident, typeParams : Ident,
+  constructors : Ident, testerTemplate : FunctionTemplate,
+  accessorTemplate : FunctionTemplate);
+
+@[declareDatatype(name, typeParams, constructors,
+    perConstructor([.datatype, .literal "..is", .constructor],
+                   [.datatype], .builtin "bool"),
+    perField([.field], [.datatype], .fieldType))]
+op command_datatype (name : Ident,
+                     typeParams : Option Bindings,
+                     @[scopeDatatype(name, typeParams)] constructors : ConstructorList)
+  : Command =>
+  "datatype " name typeParams " { " constructors " };\n";
+#end
+
+namespace TestIonDatatypes
+#strata_gen TestIonDatatypes
+end TestIonDatatypes
+
+-- Program with self-referencing datatype (TypeExprF.fvar)
+-- and parameterized datatype (TypeExprF.bvar via type parameter reference)
+def testIonDatatypesPgm := #strata
+program TestIonDatatypes;
+datatype MyList { MyNil(), MyCons(head: mydt, tail: MyList) };
+datatype Box(a: Type) { MkBox(val: a) };
+#end
+
+#guard testDialectRoundTrip TestIonDatatypes
+#guard testProgramRoundTrip testIonDatatypesPgm


### PR DESCRIPTION
## Summary

Ensures every Ion serialization path is covered by roundtrip tests and
removes dead code that the test investigation revealed.

## Details

- **Roundtrip test coverage for all Ion paths.** Two new test dialects
  (TestIon, TestIonDatatypes) exercise every `ArgF`, `ExprF`, `TypeExprF`,
  `PreType`, `SepFormat`, and metadata variant, so future serialization
  changes will break the build if they introduce regressions. These replace
  the old `DeclareFn`-based test program which only covered a handful of
  paths.
- **`PreType.fvar` and `PreType.ofType` removed.** While building tests
  we discovered `PreType.fvar` was only constructible through
  `PreType.ofType`, which converted `TypeExpr → PreType` solely to
  satisfy `runSyntaxElaborator`'s API. A small refactor to pass type
  information more precisely (`ElabArgKind`) eliminated the need for
  this conversion, making both definitions dead code.
- **Narrower elaboration APIs.** `runSyntaxElaborator` and `unifyTypes`
  now accept only the information they need rather than full `ArgDecl`
  vectors, reducing coupling between elaboration and the AST declaration
  types.
- **SepFormat serialization refactored.** `ArgF.toIon` now pattern-matches
  on `SepFormat` constructors directly instead of dispatching through
  `toIonName` strings, gaining exhaustiveness checking. `fromIonName?`
  moved from `AST.lean` to `Ion.lean` next to its serialization counterpart.
- **Fix missing `.bytes` case in `ArgF.beq`.** This pre-existing bug
  caused byte array arguments to always compare unequal, enabling
  strengthening `testProgramRoundTrip` to check full program equality
  instead of only command count.
- **`Program.create` simp lemmas.** New `Strata.DDM.AST.Lemmas` module
  provides `@[simp]` theorems for `Program.create` field projections,
  enabling safe (proof-carrying) array indexing in tests instead of `!`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.