### PR TITLE
Add additional code owners to the Laurel and Python pieces of the codebase

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,9 @@
 # Defaults owners for everything in the repo. unless a later match
 # takes precedence
 *       @strata-org/reviewers
+
+# Laurel language
+Strata/Languages/Laurel/     @strata-org/reviewers @keyboardDrummer @fabiomadge
+StrataTest/Languages/Laurel/ @strata-org/reviewers @keyboardDrummer @fabiomadge
+Strata/Languages/Python/     @strata-org/reviewers @keyboardDrummer @fabiomadge
+StrataTest/Languages/Python/ @strata-org/reviewers @keyboardDrummer @fabiomadge


### PR DESCRIPTION
### Changes
Add additional code owners to the Laurel and Python pieces of the codebase. Example PR that this change would allow either of us to review: https://github.com/strata-org/Strata/pull/481

### Testing
N/A

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
