### PR TITLE
ci: Include .st files in lake cache key to prevent stale Laurel .olean

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -52,8 +52,22 @@ jobs:
         run: |
           wget https://github.com/diffblue/cbmc/releases/download/cbmc-6.4.1/ubuntu-22.04-cbmc-6.4.1-Linux.deb
           sudo dpkg -i ubuntu-22.04-cbmc-6.4.1-Linux.deb
+      - name: Restore lake cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
+          restore-keys: |
+            lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}
       - name: Build Strata
         uses: leanprover/lean-action@v1
+        with:
+          use-github-cache: false
+      - name: Save lake cache
+        uses: actions/cache/save@v4
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.14'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,22 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
+      - name: Restore lake cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
+          restore-keys: |
+            lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}
       - name: Build and test Strata
         uses: leanprover/lean-action@v1
+        with:
+          use-github-cache: false
+      - name: Save lake cache
+        uses: actions/cache/save@v4
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
       - name: Build and run StrataVerify
         run: lake exe StrataVerify Examples/SimpleProc.core.st
       - name: Build BoogieToStrata


### PR DESCRIPTION
The `lean-action` default cache key does not include `.st` grammar files. When `.st` files change, Laurel `.olean` files can become stale, causing incorrect CI results where old compiled grammar is used.

This PR adds a custom lake cache step to both `ci.yml` and `cbmc.yml` that includes `hashFiles('**/*.st')` in the cache key, and disables `lean-action`'s built-in cache (`use-github-cache: false`) to avoid conflicts.

Tested by verifying CI passes with the custom cache in place.
