### PR TITLE
Switch Strata/DL/Util/List.lean to module

### DIFF
--- a/Strata/DL/Lambda/LTy.lean
+++ b/Strata/DL/Lambda/LTy.lean
@@ -115,7 +115,7 @@ def LMonoTys.destructArrow (mtys : LMonoTys) : LMonoTys :=
     mtys ++ mrest_tys
 end
 
-private theorem LMonoTy.destructArrow_non_empty (mty : LMonoTy) :
+public theorem LMonoTy.destructArrow_non_empty (mty : LMonoTy) :
   (mty.destructArrow) ≠ [] := by
   unfold destructArrow; split <;> simp_all
 

--- a/Strata/DL/Lambda/LTy.lean
+++ b/Strata/DL/Lambda/LTy.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 import Strata.DL.Util.Map
 import Lean.Elab.Term
+public import Lean.Elab.Term.TermElabM
+public meta import Lean.Meta.AppBuilder
 
 /-! ## Formalization of Mono- and Poly- Types in Lambda
 
@@ -18,6 +21,8 @@ do not have `let`s in `LExpr`, so we do not tackle let-polymorphism yet.
 
 namespace Lambda
 open Std (ToFormat Format format)
+
+public section
 
 
 /-- Type identifiers. For now, these are just strings. -/
@@ -40,39 +45,39 @@ inductive LMonoTy : Type where
 
 abbrev LMonoTys := List LMonoTy
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.bool : LMonoTy :=
   .tcons "bool" []
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.int : LMonoTy :=
   .tcons "int" []
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.real : LMonoTy :=
   .tcons "real" []
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.bv1 : LMonoTy :=
   .bitvec 1
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.bv8 : LMonoTy :=
   .bitvec 8
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.bv16 : LMonoTy :=
   .bitvec 16
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.bv32 : LMonoTy :=
   .bitvec 32
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.bv64 : LMonoTy :=
   .bitvec 64
 
-@[match_pattern]
+@[expose, match_pattern]
 def LMonoTy.string : LMonoTy :=
   .tcons "string" []
 
@@ -110,7 +115,7 @@ def LMonoTys.destructArrow (mtys : LMonoTys) : LMonoTys :=
     mtys ++ mrest_tys
 end
 
-theorem LMonoTy.destructArrow_non_empty (mty : LMonoTy) :
+private theorem LMonoTy.destructArrow_non_empty (mty : LMonoTy) :
   (mty.destructArrow) ≠ [] := by
   unfold destructArrow; split <;> simp_all
 
@@ -169,13 +174,13 @@ def LMonoTys.size (args : LMonoTys) : Nat :=
     | t :: rest => LMonoTy.size t + LMonoTys.size rest
 end
 
-theorem LMonoTy.size_gt_zero :
+public theorem LMonoTy.size_gt_zero :
   0 < LMonoTy.size ty := by
   induction ty <;>  simp_all [LMonoTy.size]
   unfold LMonoTys.size; split
   simp_all; omega
 
-theorem LMonoTy.size_lt_of_mem {ty: LMonoTy} {tys: LMonoTys} (h: ty ∈ tys):
+public theorem LMonoTy.size_lt_of_mem {ty: LMonoTy} {tys: LMonoTys} (h: ty ∈ tys):
   ty.size <= tys.size := by
   induction tys <;> simp only[LMonoTys.size]<;> grind
 
@@ -197,7 +202,7 @@ def LMonoTy.BEq (x y : LMonoTy) : Bool :=
     LMonoTy.BEq x y && go xrest yrest
 
 @[simp]
-theorem LMonoTy.BEq_refl : LMonoTy.BEq ty ty := by
+private theorem LMonoTy.BEq_refl : LMonoTy.BEq ty ty := by
   induction ty <;> simp_all [LMonoTy.BEq]
   rename_i name args ih
   induction args
@@ -277,7 +282,7 @@ def LMonoTys.freeVars (mtys : LMonoTys) : List TyIdentifier :=
 end
 
 @[simp]
-theorem LMonoTys.freeVars_of_cons :
+private theorem LMonoTys.freeVars_of_cons :
   LMonoTys.freeVars (x :: xs) = LMonoTy.freeVars x ++ LMonoTys.freeVars xs := by
   simp_all [LMonoTys.freeVars]
 
@@ -370,7 +375,7 @@ def LTy.toMonoTypeUnsafe (ty : LTy) : LMonoTy :=
 instance : ToString LMonoTy where
   toString x := toString (repr x)
 
-private def formatLMonoTy (lmonoty : LMonoTy) : Format :=
+def formatLMonoTy (lmonoty : LMonoTy) : Format :=
   match lmonoty with
   | .ftvar x => toString x
   | .bitvec n => f!"bv{n}"
@@ -424,7 +429,7 @@ scoped syntax tprim : tcons
 scoped syntax "(" lmonoty ")" : lmonoty
 
 open Lean Elab Meta in
-partial def elabLMonoTy : Lean.Syntax → MetaM Expr
+meta partial def elabLMonoTy : Lean.Syntax → MetaM Expr
   | `(lmonoty| %$f:ident) => do
      mkAppM ``LMonoTy.ftvar #[mkStrLit (toString f.getId)]
   | `(lmonoty| $ty1:lmonoty → $ty2:lmonoty) => do
@@ -464,7 +469,7 @@ scoped syntax "∀" (ident)* "." (lmonoty)* : lty
 scoped syntax "(" lty ")" : lty
 
 open Lean Elab Meta in
-partial def elabLTy : Lean.Syntax → MetaM Expr
+meta partial def elabLTy : Lean.Syntax → MetaM Expr
   | `(lty| ∀ $vars:ident* . $ty:lmonoty) => do
       let vars' := List.map (fun f => mkStrLit (toString f.getId)) vars.toList
       let varslist ← mkListLit (mkConst ``String) vars'
@@ -510,4 +515,5 @@ def LMonoTy.inputTypes (ty : LMonoTy) : List LMonoTy :=
 
 ---------------------------------------------------------------------
 
+end -- public section
 end Lambda

--- a/Strata/DL/Lambda/LTyUnify.lean
+++ b/Strata/DL/Lambda/LTyUnify.lean
@@ -3,10 +3,14 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 import Strata.DL.Lambda.LTy
+import all Strata.DL.Lambda.LTy
 import Strata.DL.Util.List
+import all Strata.DL.Util.List
 import Strata.DL.Util.Maps
+import all Strata.DL.Util.Maps
 
 /-!
 ## Type Substitution and Unification

--- a/Strata/DL/Lambda/LTyUnify.lean
+++ b/Strata/DL/Lambda/LTyUnify.lean
@@ -5,11 +5,11 @@
 -/
 module
 
-import Strata.DL.Lambda.LTy
+public import Strata.DL.Lambda.LTy
+public import Strata.DL.Util.List
+public import Strata.DL.Util.Maps
 import all Strata.DL.Lambda.LTy
-import Strata.DL.Util.List
 import all Strata.DL.Util.List
-import Strata.DL.Util.Maps
 import all Strata.DL.Util.Maps
 
 /-!
@@ -25,23 +25,25 @@ namespace Lambda
 
 open Std (ToFormat Format format)
 
+public section
+
 /-! ### Type Substitution -/
 
 /-- Substitution mapping type variables to `LMonoTy`. -/
-abbrev SubstOne := Map TyIdentifier LMonoTy
-abbrev SubstOne.empty : SubstOne := []
+@[expose] abbrev SubstOne := Map TyIdentifier LMonoTy
+@[expose] abbrev SubstOne.empty : SubstOne := []
 
 /--
 Substitution mapping type variables to `LMonoTy`, taking scopes into
 account. The oldest scope can be obtained via `Maps.oldest`.
 -/
-abbrev Subst := Maps TyIdentifier LMonoTy
-abbrev Subst.empty : Subst := []
+@[expose] abbrev Subst := Maps TyIdentifier LMonoTy
+@[expose] abbrev Subst.empty : Subst := []
 /--
 A `Subst` with an empty scope, typically meant for storing global type
 substitutions.
 -/
-abbrev Subst.emptyScope : Subst := [[]]
+@[expose] abbrev Subst.emptyScope : Subst := [[]]
 
 instance : ToFormat Subst where
   format := Maps.format'
@@ -49,7 +51,7 @@ instance : ToFormat Subst where
 /--
 Check if `Subst` contains only empty scopes.
 -/
-def Subst.hasEmptyScopes (S : Subst) : Bool :=
+@[expose] def Subst.hasEmptyScopes (S : Subst) : Bool :=
   S.all (fun s => s.isEmpty)
 
 @[simp]
@@ -68,7 +70,7 @@ every type in `S`.
 
 Note that we do not deduplicate the resulting list.
 -/
-def Subst.freeVars (S : Subst) : List TyIdentifier :=
+@[expose] def Subst.freeVars (S : Subst) : List TyIdentifier :=
   S.values.flatMap LMonoTy.freeVars
 
 @[simp]
@@ -93,7 +95,7 @@ theorem Subst.freeVars_of_find_subset (S : Subst) (hi : Maps.find? S i = some st
 A substitution map `S` is well-formed if no key appears in the free type
 variables of the values.
 -/
-def SubstWF (S : Subst) : Bool :=
+@[expose] def SubstWF (S : Subst) : Bool :=
   S.keys.all (fun k => k ∉ Subst.freeVars S)
 
 @[simp]
@@ -151,7 +153,7 @@ structure SubstInfo where
   isWF : SubstWF subst
   deriving Repr
 
-def SubstInfo.empty : SubstInfo :=
+@[expose] def SubstInfo.empty : SubstInfo :=
   { subst := Subst.empty,
     isWF := SubstWF_of_empty }
 
@@ -162,7 +164,7 @@ mutual
 /--
 Apply substitution `S` to monotype `mty`.
 -/
-def LMonoTy.subst (S : Subst) (mty : LMonoTy) : LMonoTy :=
+@[expose] def LMonoTy.subst (S : Subst) (mty : LMonoTy) : LMonoTy :=
   if Subst.hasEmptyScopes S then mty else
   match mty with
   | .ftvar x => match S.find? x with
@@ -173,13 +175,12 @@ def LMonoTy.subst (S : Subst) (mty : LMonoTy) : LMonoTy :=
 /--
 Apply substitution `S` to monotypes `mtys`.
 -/
-def LMonoTys.subst (S : Subst) (mtys : LMonoTys) : LMonoTys :=
-  if Subst.hasEmptyScopes S then mtys else substAux S mtys []
-where
-  substAux S mtys acc : LMonoTys :=
+@[expose] def LMonoTys.subst.substAux (S : Subst) (mtys : LMonoTys) (acc : LMonoTys) : LMonoTys :=
   match mtys with
   | [] => acc.reverse
-  | ty :: rest => substAux S rest (LMonoTy.subst S ty :: acc)
+  | ty :: rest => LMonoTys.subst.substAux S rest (LMonoTy.subst S ty :: acc)
+@[expose] def LMonoTys.subst (S : Subst) (mtys : LMonoTys) : LMonoTys :=
+  if Subst.hasEmptyScopes S then mtys else LMonoTys.subst.substAux S mtys []
 end
 
 /--
@@ -187,7 +188,7 @@ Non tail-recursive version of `LMonoTys.subst`, useful for proofs.
 
 See theorem `LMonoTys.subst_eq_substLogic`.
 -/
-def LMonoTys.substLogic (S : Subst) (mtys : LMonoTys) : LMonoTys :=
+@[expose] def LMonoTys.substLogic (S : Subst) (mtys : LMonoTys) : LMonoTys :=
   if S.hasEmptyScopes then mtys else
   match mtys with
   | [] => []
@@ -329,7 +330,7 @@ theorem LMonoTy.freeVars_of_subst_subset (S : Subst) (mty : LMonoTy) :
 /--
 Apply `new` to `old` substitution.
 -/
-def SubstOne.apply (new old : SubstOne) : SubstOne :=
+@[expose] def SubstOne.apply (new old : SubstOne) : SubstOne :=
   applyAux new old []
   where applyAux (new old acc : SubstOne) : SubstOne :=
   match old with
@@ -340,7 +341,7 @@ def SubstOne.apply (new old : SubstOne) : SubstOne :=
 /--
 Non tail-recursive version of `SubstOne.apply`, useful for proofs.
 -/
-def SubstOne.applyLogic (new old : SubstOne) : SubstOne :=
+@[expose] def SubstOne.applyLogic (new old : SubstOne) : SubstOne :=
   match old with
   | [] => []
   | (id, lty) :: rest =>
@@ -388,7 +389,7 @@ theorem SubstOne.keys_of_apply_eq :
 /--
 Apply the `new` substitution to the `old` one.
 -/
-def Subst.apply (new : SubstOne) (old : Subst) : Subst :=
+@[expose] def Subst.apply (new : SubstOne) (old : Subst) : Subst :=
   match old with
   | [] => old
   | o :: orest => SubstOne.apply new o :: (Subst.apply new orest)
@@ -528,7 +529,7 @@ theorem SubstWF.cons_of_subst_apply (S : SubstInfo) (id : TyIdentifier) (ty newt
 /--
 Apply substitution `S` to the free type variables in `ty`.
 -/
-def LTy.subst (S : Subst) (ty : LTy) : LTy :=
+@[expose] def LTy.subst (S : Subst) (ty : LTy) : LTy :=
   match ty with
   | .forAll xs ty =>
     let S' := go xs S
@@ -545,23 +546,23 @@ def LTy.subst (S : Subst) (ty : LTy) : LTy :=
 A type constraint `(ty1, ty2)` that records that `ty1` and `ty2` must
 have a common substitution instance.
 -/
-abbrev Constraint := (LMonoTy × LMonoTy)
+@[expose] abbrev Constraint := (LMonoTy × LMonoTy)
 /--
 A list of type constraints. These should really be viewed as a set.
 -/
-abbrev Constraints := List Constraint
+@[expose] abbrev Constraints := List Constraint
 
 /--
 Get the free type variables in the type constraint `c`.
 -/
-def Constraint.freeVars (c : Constraint) : List TyIdentifier :=
+@[expose] def Constraint.freeVars (c : Constraint) : List TyIdentifier :=
   let (t1, t2) := c
   LMonoTy.freeVars t1 ++ LMonoTy.freeVars t2
 
 /--
 Get the free type variables in type constraints `cs`.
 -/
-def Constraints.freeVars (cs : Constraints) : List TyIdentifier :=
+@[expose] def Constraints.freeVars (cs : Constraints) : List TyIdentifier :=
   match cs with
   | [] => []
   | c :: c_rest =>
@@ -643,7 +644,7 @@ theorem Constraints.freeVars_zip_dedup_length (h : args1.length = args2.length) 
 /--
 The size of a constraint, useful for termination arguments.
 -/
-def Constraint.size (c : Constraint) : Nat :=
+@[expose] def Constraint.size (c : Constraint) : Nat :=
   c.fst.size + c.snd.size
 
 @[simp]
@@ -655,7 +656,7 @@ theorem Constraint.size_gt_zero : 0 < Constraint.size c := by
 /--
 The size of a set of constraint, where each constituent type is sized as a tree.
 -/
-def Constraints.size (cs : Constraints) : Nat :=
+@[expose] def Constraints.size (cs : Constraints) : Nat :=
   match cs with
   | [] => 0
   | c :: rest => c.size + Constraints.size rest
@@ -693,7 +694,7 @@ theorem Constraints.size_zip_eq (h : args1.length = args2.length) :
 /--
 Apply substitution `S` to type constraints `cs`.
 -/
-def Constraints.subst (S : Subst) (cs : Constraints) : Constraints :=
+@[expose] def Constraints.subst (S : Subst) (cs : Constraints) : Constraints :=
   match cs with
   | [] => []
   | (lty1, lty2) :: rest =>
@@ -712,7 +713,7 @@ theorem Constraints.subst.length_same : (Constraints.subst S cs).length = cs.len
 Function encoding the property that the free variables in a substitution `newS`
 are a subset of those in constraints `cs` and substitution `oldS`.
 -/
-def Subst.freeVars_subset_prop (cs : Constraints) (newS oldS : SubstInfo) : Prop :=
+@[expose] def Subst.freeVars_subset_prop (cs : Constraints) (newS oldS : SubstInfo) : Prop :=
   Subst.freeVars newS.subst ⊆
   Constraints.freeVars cs ++ Subst.freeVars oldS.subst
 
@@ -1023,7 +1024,7 @@ inductive UnifyError where
   | FailedOccursCheck (tyvar : TyIdentifier) (ty : LMonoTy) (c : Constraint) (original : Option Constraint := .none)
   deriving Repr, Inhabited, DecidableEq
 
-def UnifyError.addOriginalConstraint (e : UnifyError) (o : Constraint) : UnifyError :=
+@[expose] def UnifyError.addOriginalConstraint (e : UnifyError) (o : Constraint) : UnifyError :=
   match e with
   | ImpossibleToUnify c _ => ImpossibleToUnify c o
   | FailedOccursCheck tyvar ty c _ => FailedOccursCheck tyvar ty c o
@@ -1054,7 +1055,7 @@ mutual
 Type unification for a single constraint `c` w.r.t. a well-formed type
 substitution `S`. See `Constraints.unify` for the top-level function.
 -/
-def Constraint.unifyOne (c : Constraint) (S : SubstInfo) :
+@[expose] def Constraint.unifyOne (c : Constraint) (S : SubstInfo) :
   Except UnifyError (ValidSubstRelation [c] S) :=
   let (t1, t2) := c
   if _h1: t1 == t2 then
@@ -1141,7 +1142,7 @@ def Constraint.unifyOne (c : Constraint) (S : SubstInfo) :
 Type unification for constraints `cs` w.r.t. a well-formed type
 substitution `S`. See `Constraints.unify` for the top-level function.
 -/
-def Constraints.unifyCore (cs : Constraints) (S : SubstInfo) :
+@[expose] def Constraints.unifyCore (cs : Constraints) (S : SubstInfo) :
     Except UnifyError (ValidSubstRelation cs S) := do
   match _h0 : cs with
   | [] => .ok { newS := S, goodSubset := by simp [Subst.freeVars_subset_prop_of_empty] }
@@ -1175,11 +1176,13 @@ failure would be the _first_ mismatching one, not necessarily the only one.
 
 Returns a well-formed `S` w.r.t. `cs` otherwise.
 -/
-def Constraints.unify (constraints : Constraints) (S : SubstInfo) :
+@[expose] def Constraints.unify (constraints : Constraints) (S : SubstInfo) :
     Except UnifyError SubstInfo := do
     let relS ← Constraints.unifyCore constraints S
     .ok relS.newS
 
 ---------------------------------------------------------------------
+
+end -- public section
 
 end Lambda

--- a/Strata/DL/Util/List.lean
+++ b/Strata/DL/Util/List.lean
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 /-! # List Utilities
 -/
@@ -20,7 +21,7 @@ theorem List.subset_append_cons_right {α : Type} [DecidableEq α] {a b c : List
 /--
 Remove duplicates in a list.
 -/
-def dedup {α : Type} [DecidableEq α] : List α → List α
+@[expose] public def dedup {α : Type} [DecidableEq α] : List α → List α
   | [] => []
   | a :: as =>
     let as := as.dedup
@@ -411,7 +412,7 @@ theorem length_dedup_of_subset_le {α : Type} [DecidableEq α] (l₁ l₂ : List
       simp_all [dedup]
       omega
 
-theorem subset_nodup_length {α} {s1 s2: List α} (hn: s1.Nodup) (hsub: s1 ⊆ s2) : s1.length ≤ s2.length := by
+public theorem subset_nodup_length {α} {s1 s2: List α} (hn: s1.Nodup) (hsub: s1 ⊆ s2) : s1.length ≤ s2.length := by
   induction s1 generalizing s2 with
   | nil => simp
   | cons x t IH =>
@@ -424,7 +425,7 @@ theorem subset_nodup_length {α} {s1 s2: List α} (hn: s1.Nodup) (hsub: s1 ⊆ s
 
 
 /-- Deduplicates l and counts the number of occurrences for each element. -/
-def occurrences {α : Type} [DecidableEq α] (l : List α) : List (α × Nat) :=
+@[expose] public def occurrences {α : Type} [DecidableEq α] (l : List α) : List (α × Nat) :=
   l.dedup.map (λ x => (x, l.count x))
 
 theorem occurrences_len_eq_dedup {α} [DecidableEq α]:

--- a/Strata/DL/Util/Map.lean
+++ b/Strata/DL/Util/Map.lean
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 -- [STOPGAP] Should be replaced by Std.HashMap.
 
@@ -15,9 +16,9 @@ open Std (ToFormat Format format)
 A simple Map-like type based on lists
 -/
 
-def Map (α : Type u) (β : Type v) := List (α × β)
+@[expose] public def Map (α : Type u) (β : Type v) := List (α × β)
 
-instance [BEq α] [BEq β] : BEq (Map α β) where
+public instance [BEq α] [BEq β] : BEq (Map α β) where
   beq m1 m2 := go m1 m2 where
   go m1 m2 :=
     match m1, m2 with
@@ -26,49 +27,49 @@ instance [BEq α] [BEq β] : BEq (Map α β) where
       x == y && go xrest yrest
     | _, _ => false
 
-instance : Inhabited (Map α β) where
+public instance : Inhabited (Map α β) where
   default := []
 
-instance : EmptyCollection (Map α β) where
+public instance : EmptyCollection (Map α β) where
   emptyCollection := []
 
-instance : HAppend (Map α β) (Map α β) (Map α β) where
+public instance : HAppend (Map α β) (Map α β) (Map α β) where
   hAppend := List.append
 
-instance [DecidableEq α] [DecidableEq β] [LawfulBEq α] [LawfulBEq β] : DecidableEq (Map α β) :=
+public instance [DecidableEq α] [DecidableEq β] [LawfulBEq α] [LawfulBEq β] : DecidableEq (Map α β) :=
   List.hasDecEq
 
-instance [x : Repr (List (α × β))] : Repr (Map α β) where
+public instance [x : Repr (List (α × β))] : Repr (Map α β) where
   reprPrec := x.reprPrec
 
-def Map.ofList (l : List (α × β)) : Map α β := l
+@[expose] public def Map.ofList (l : List (α × β)) : Map α β := l
 
-def Map.toList (m : Map α β) : List (α × β) := m
+@[expose] public def Map.toList (m : Map α β) : List (α × β) := m
 
-def Map.format' [ToFormat α] [ToFormat β] (m : Map α β) : Format :=
+public def Map.format' [ToFormat α] [ToFormat β] (m : Map α β) : Format :=
   match m with
   | [] => ""
   | [(k, v)] => (format f!"({k}, {v})")
   | (k, v) :: rest =>
     (format f!"({k}, {v}) ") ++ Map.format' rest
 
-instance [ToFormat α] [ToFormat β] : ToFormat (Map α β) where
+public instance [ToFormat α] [ToFormat β] : ToFormat (Map α β) where
   format := Map.format'
 
-def Map.union (m1 m2 : Map α β) : Map α β :=
+public def Map.union (m1 m2 : Map α β) : Map α β :=
   List.append m1 m2
 
-abbrev Map.empty : Map α β := []
+public abbrev Map.empty : Map α β := []
 
-def Map.find? [DecidableEq α] (m : Map α β) (a' : α) : Option β :=
+@[expose] public def Map.find? [DecidableEq α] (m : Map α β) (a' : α) : Option β :=
   match m with
   | [] => none
   | (a, b) :: m => if a = a' then some b else find? m a'
 
-def Map.contains [DecidableEq α] (m : Map α β) (a : α) : Bool :=
+@[expose] public def Map.contains [DecidableEq α] (m : Map α β) (a : α) : Bool :=
   m.find? a |>.isSome
 
-def Map.insert [DecidableEq α] (m : Map α β) (a' : α) (b' : β) : Map α β :=
+@[expose] public def Map.insert [DecidableEq α] (m : Map α β) (a' : α) (b' : β) : Map α β :=
   match m with
   | [] => [(a', b')]
   | (a, b) :: m => if a = a' then (a', b') :: m else (a, b) :: insert m a' b'
@@ -76,7 +77,7 @@ def Map.insert [DecidableEq α] (m : Map α β) (a' : α) (b' : β) : Map α β 
 /--
 Remove the first occurence of element with key `a'` in `m`.
 -/
-def Map.remove [DecidableEq α] (m : Map α β) (a' : α) : Map α β :=
+@[expose] public def Map.remove [DecidableEq α] (m : Map α β) (a' : α) : Map α β :=
   match m with
   | [] => []
   | (a, b) :: m => if a = a' then m else (a, b) :: remove m a'
@@ -84,34 +85,34 @@ def Map.remove [DecidableEq α] (m : Map α β) (a' : α) : Map α β :=
 /--
 Remove all occurences of elements with key `a'` in `m`.
 -/
-def Map.erase [DecidableEq α] (m : Map α β) (a' : α) : Map α β :=
+@[expose] public def Map.erase [DecidableEq α] (m : Map α β) (a' : α) : Map α β :=
   match m with
   | [] => []
   | (a, b) :: m => if a = a' then erase m a' else (a, b) :: erase m a'
 
-def Map.isEmpty (m : Map α β) : Bool :=
+@[expose] public def Map.isEmpty (m : Map α β) : Bool :=
   match m with
   | [] => true
   | _ => false
 
-def Map.size (m : Map α β) : Nat :=
+@[expose] public def Map.size (m : Map α β) : Nat :=
   m.length
 
-def Map.keys (m : Map α β) : List α :=
+@[expose] public def Map.keys (m : Map α β) : List α :=
   match m with
   | [] => []
   | (a, _) :: m => a :: keys m
 
-def Map.values (m : Map α β) : List β :=
+@[expose] public def Map.values (m : Map α β) : List β :=
   match m with
   | [] => []
   | (_, a) :: m => a :: values m
 
 /-- Are the keys of `m1` and `m2` disjoint? -/
-def Map.disjointp [DecidableEq α] (m1 m2 : Map α β) : Prop :=
+public def Map.disjointp [DecidableEq α] (m1 m2 : Map α β) : Prop :=
   ∀ k, (m1.find? k) = none ∨ (m2.find? k = none)
 
-def Map.fmap (f: β → γ) (m: Map α β) : Map α γ :=
+public def Map.fmap (f: β → γ) (m: Map α β) : Map α γ :=
   List.map (fun (x, y) => (x, f y)) m
 
 ---------------------------------------------------------------------
@@ -205,7 +206,7 @@ theorem Map.insert_values [DecidableEq α] (m : Map α β) :
       grind
   done
 
-theorem Map.findNone_eq_notmem_mapfst {m: Map α β} [DecidableEq α]: ¬ a ∈ List.map Prod.fst m ↔ Map.find? m a = none := by
+public theorem Map.findNone_eq_notmem_mapfst {m: Map α β} [DecidableEq α]: ¬ a ∈ List.map Prod.fst m ↔ Map.find? m a = none := by
   induction m <;> simp [Map.find?]
   constructor <;> intro H
   split <;> simp_all

--- a/Strata/DL/Util/Maps.lean
+++ b/Strata/DL/Util/Maps.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
+public import Strata.DL.Util.Map
+import all Strata.DL.Util.Map
 
-import Strata.DL.Util.Map
+public section
 
 open Std (ToFormat Format format)
 
@@ -191,7 +194,7 @@ def Maps.addInOldest [DecidableEq α] (ms : Maps α β) (xs : List α) (vs : Lis
 
 ---------------------------------------------------------------------
 
-theorem Maps.find?_mem_keys [DecidableEq α] (m : Maps α β)
+private theorem Maps.find?_mem_keys [DecidableEq α] (m : Maps α β)
   (h : Maps.find? m k = some v) :
   k ∈ Maps.keys m := by
   induction m with
@@ -207,7 +210,7 @@ theorem Maps.find?_mem_keys [DecidableEq α] (m : Maps α β)
       simp_all
   done
 
-theorem Maps.find?_mem_values [DecidableEq α] (m : Maps α β)
+private theorem Maps.find?_mem_values [DecidableEq α] (m : Maps α β)
   (h : Maps.find? m k = some v) :
   v ∈ Maps.values m := by
   induction m with
@@ -222,7 +225,7 @@ theorem Maps.find?_mem_values [DecidableEq α] (m : Maps α β)
       have := @Map.find?_mem_values α β k v _ head heq
       simp_all
 
-theorem Maps.find?_of_not_mem_values [DecidableEq α] (S : Maps α β)
+private theorem Maps.find?_of_not_mem_values [DecidableEq α] (S : Maps α β)
   (h1 : Maps.find? S i = none) : i ∉ Maps.keys S := by
   induction S; all_goals simp_all [Maps.keys]
   rename_i _ head tail ih
@@ -289,30 +292,30 @@ private theorem Maps.insert_key_update_subset_value [DecidableEq α] (ms : Maps 
       grind
   done
 
-theorem Maps.insert_keys_subset [DecidableEq α] (ms : Maps α β) :
+private theorem Maps.insert_keys_subset [DecidableEq α] (ms : Maps α β) :
   (Maps.insert ms key val).keys ⊆ key :: Maps.keys ms := by
   have h1 := @Maps.insert_fresh_key_subset _ _ key val _ ms
   have h2 := @Maps.insert_key_update_subset _ _ key val _ ms
   grind
   done
 
-theorem Maps.insert_values_subset [DecidableEq α] (ms : Maps α β) :
+private theorem Maps.insert_values_subset [DecidableEq α] (ms : Maps α β) :
   (Maps.insert ms key val).values ⊆ val :: Maps.values ms := by
   have h1 := @Maps.insert_fresh_key_subset_value _ _ key val _ ms
   have h2 := @Maps.insert_key_update_subset_value _ _ key val _ ms
   grind
 
 @[simp]
-theorem Maps.keys_of_push_empty :
+private theorem Maps.keys_of_push_empty :
   (Maps.push ms []).keys = ms.keys := by
   simp_all [Maps.push, Maps.keys, Map.keys]
 
 @[simp]
-theorem Maps.values_of_push_empty :
+private theorem Maps.values_of_push_empty :
   (Maps.push ms []).values = ms.values := by
   simp_all [Maps.push, Maps.values, Map.values]
 
-theorem Maps.mem_keys_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
+private theorem Maps.mem_keys_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
   (ms : Maps α β) (k1 k2 : α) (h : k2 ∈ (Maps.remove ms k1).keys) :
   k2 ∈ ms.keys := by
   induction ms
@@ -325,7 +328,7 @@ theorem Maps.mem_keys_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
       · simp [@Map.mem_keys_of_mem_keys_remove _ _ _ m k1 k2 (by assumption)]
       · simp_all
 
-theorem Maps.mem_values_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
+private theorem Maps.mem_values_of_mem_keys_remove [DecidableEq α] [BEq (Map α β)]
   (ms : Maps α β) (k : α) (v : β) (h : v ∈ (Maps.remove ms k).values) :
   v ∈ ms.values := by
   induction ms


### PR DESCRIPTION
Battery has two definitions that collide with Strata's ones:
* List.Disjoint (in Strata/DL/Util/ListUtils.lean)
* List.nodup_dedup (in Strata/DL/Util/List.lean)

To allow users to select visibility when importing these files, this patch switches the implementation to use the latest module system feature in Lean4.
In DRAFT: Only Strata/DL/Util/List.lean has been updated. To fix List.Disjoint, it seems lots of users of ListUtils.lean have to be switched to modules. There are quite a few places using List.Disjoint. Another possible option is to simply mark List.Disjoint as public.

Theorems are marked as private as much as possible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
