### PR TITLE
feat(laurel): Add direct operational semantics for Laurel IR

### DIFF
--- a/Strata.lean
+++ b/Strata.lean
@@ -24,6 +24,8 @@ import Strata.Languages.Core.FactoryWF
 import Strata.Languages.Core.StatementSemantics
 import Strata.Languages.Core.SarifOutput
 import Strata.Languages.Laurel.LaurelToCoreTranslator
+import Strata.Languages.Laurel.LaurelSemantics
+import Strata.Languages.Laurel.LaurelSemanticsProps
 
 /- Code Transforms -/
 import Strata.Transform.CallElimCorrect

--- a/Strata.lean
+++ b/Strata.lean
@@ -26,6 +26,7 @@ import Strata.Languages.Core.SarifOutput
 import Strata.Languages.Laurel.LaurelToCoreTranslator
 import Strata.Languages.Laurel.LaurelSemantics
 import Strata.Languages.Laurel.LaurelSemanticsProps
+import Strata.Languages.Laurel.LiftImperativeExpressionsCorrectness
 
 /- Code Transforms -/
 import Strata.Transform.CallElimCorrect

--- a/Strata/Languages/Core/StatementEval.lean
+++ b/Strata/Languages/Core/StatementEval.lean
@@ -402,6 +402,39 @@ def processExit : Statements → Option (Option String) → (Statements × Optio
 | rest, .none => (rest, .none)
 | _, .some exitLabel => ([], .some exitLabel) -- Skip all remaining statements
 
+/--
+Merge a list of `EnvWithNext` results that share the same `exitLabel` into
+a single result. This prevents path multiplication when an `ite` inside a
+block produces multiple paths (e.g., one branch exits and the other falls
+through) that converge after the block consumes the exit.
+
+Uses `Env.merge` pairwise with the distinguishing path condition extracted
+from each environment's newest path condition scope.
+-/
+private def mergeEnvWithNexts (ewns : List EnvWithNext) : List EnvWithNext :=
+  match ewns with
+  | [] => []
+  | [ewn] => [ewn]
+  | ewn1 :: rest =>
+    -- Fold remaining results into the first using Env.merge.
+    -- Extract the distinguishing condition from the newest path condition.
+    let merged := rest.foldl (fun acc ewn =>
+      let cond := match ewn.env.pathConditions.newest with
+        | (_, c) :: _ => c
+        | [] => LExpr.true ()
+      { acc with env := Env.merge cond acc.env ewn.env }
+    ) ewn1
+    [merged]
+
+/--
+Group `EnvWithNext` results by `exitLabel` and merge within each group,
+producing at most one result per distinct exit label.
+-/
+private def mergeByExitLabel (ewns : List EnvWithNext) : List EnvWithNext :=
+  let labels := ewns.map (·.exitLabel) |>.eraseDups
+  labels.flatMap fun label =>
+    mergeEnvWithNexts (ewns.filter (·.exitLabel == label))
+
 mutual
 def evalAuxGo (steps : Nat) (old_var_subst : SubstMap) (Ewn : EnvWithNext) (ss : Statements) (optExit : Option (Option String)) :
     List EnvWithNext :=
@@ -445,7 +478,10 @@ def evalAuxGo (steps : Nat) (old_var_subst : SubstMap) (Ewn : EnvWithNext) (ss :
                                               let ss' := ewn.stk.top
                                               let s' := Imperative.Stmt.block label ss' md
                                               orig_stk.appendToTop [s'] })
-            Ewns
+            -- After consuming exits, multiple paths may converge to the same
+            -- exit label (e.g., one branch exited and the other fell through).
+            -- Merge them to prevent path multiplication in subsequent evaluation.
+            mergeByExitLabel Ewns
 
           | .ite cond then_ss else_ss md =>
             let orig_stk := Ewn.stk

--- a/Strata/Languages/Core/StatementEval.lean
+++ b/Strata/Languages/Core/StatementEval.lean
@@ -403,37 +403,35 @@ def processExit : Statements → Option (Option String) → (Statements × Optio
 | _, .some exitLabel => ([], .some exitLabel) -- Skip all remaining statements
 
 /--
-Merge a list of `EnvWithNext` results that share the same `exitLabel` into
-a single result. This prevents path multiplication when an `ite` inside a
-block produces multiple paths (e.g., one branch exits and the other falls
-through) that converge after the block consumes the exit.
+Merge exactly two `EnvWithNext` results that share the same exit label after
+block exit consumption. Extracts the ite condition from the newest path
+condition scope (which is still intact since `Env.popScope` only pops
+expression state, not path conditions). The environment whose newest path
+condition is a positive condition (not negated) is treated as E1 (true branch).
 
-Uses `Env.merge` pairwise with the distinguishing path condition extracted
-from each environment's newest path condition scope.
--/
-private def mergeEnvWithNexts (ewns : List EnvWithNext) : List EnvWithNext :=
-  match ewns with
-  | [] => []
-  | [ewn] => [ewn]
-  | ewn1 :: rest =>
-    -- Fold remaining results into the first using Env.merge.
-    -- Extract the distinguishing condition from the newest path condition.
-    let merged := rest.foldl (fun acc ewn =>
-      let cond := match ewn.env.pathConditions.newest with
-        | (_, c) :: _ => c
-        | [] => LExpr.true ()
-      { acc with env := Env.merge cond acc.env ewn.env }
-    ) ewn1
-    [merged]
-
-/--
-Group `EnvWithNext` results by `exitLabel` and merge within each group,
-producing at most one result per distinct exit label.
+For 3+ paths converging to the same label, returns them unmerged to avoid
+corrupting the path-condition structure with repeated `Env.merge` calls.
 -/
 private def mergeByExitLabel (ewns : List EnvWithNext) : List EnvWithNext :=
   let labels := ewns.map (·.exitLabel) |>.eraseDups
   labels.flatMap fun label =>
-    mergeEnvWithNexts (ewns.filter (·.exitLabel == label))
+    let group := ewns.filter (·.exitLabel == label)
+    match group with
+    | [ewn1, ewn2] =>
+      -- Determine which is the true branch by checking if its newest path
+      -- condition is the positive (non-negated) ite condition.
+      -- The true branch's condition is `cond'`, the false branch's is
+      -- `ite cond' false true` (i.e., negation).
+      let (ewn_t, ewn_f, cond) := match ewn1.env.pathConditions.newest with
+        | (_, c) :: _ =>
+          match c with
+          | .ite _ inner (.false _) (.true _) =>
+            -- ewn1 has the negated condition, so it's the false branch
+            (ewn2, ewn1, inner)
+          | _ => (ewn1, ewn2, c)
+        | [] => (ewn1, ewn2, LExpr.true ())
+      [{ ewn_t with env := Env.merge cond ewn_t.env ewn_f.env }]
+    | _ => group
 
 mutual
 def evalAuxGo (steps : Nat) (old_var_subst : SubstMap) (Ewn : EnvWithNext) (ss : Statements) (optExit : Option (Option String)) :
@@ -479,8 +477,7 @@ def evalAuxGo (steps : Nat) (old_var_subst : SubstMap) (Ewn : EnvWithNext) (ss :
                                               let s' := Imperative.Stmt.block label ss' md
                                               orig_stk.appendToTop [s'] })
             -- After consuming exits, multiple paths may converge to the same
-            -- exit label (e.g., one branch exited and the other fell through).
-            -- Merge them to prevent path multiplication in subsequent evaluation.
+            -- exit label. Merge them to prevent path multiplication.
             mergeByExitLabel Ewns
 
           | .ite cond then_ss else_ss md =>
@@ -595,17 +592,31 @@ def processIteBranches (steps : Nat) (old_var_subst : SubstMap) (Ewn : EnvWithNe
                     .none
                     (orig_stk.appendToTop [s'])]
   | _, _ =>
-    let Ewns_t := Ewns_t.map
-                      (fun (ewn : EnvWithNext) =>
-                        let s' := Imperative.Stmt.ite (LExpr.true ()) ewn.stk.top [] md
-                        { ewn with env := ewn.env.popScope,
-                                   stk := orig_stk.appendToTop [s']})
-    let Ewns_f := Ewns_f.map
-                      (fun (ewn : EnvWithNext) =>
-                        let s' := Imperative.Stmt.ite (LExpr.false ()) [] ewn.stk.top md
-                        { ewn with env := ewn.env.popScope,
-                                   stk := orig_stk.appendToTop [s']})
-  Ewns_t ++ Ewns_f
+    -- Group results by exit label and merge true/false branches within each
+    -- group using the ite condition `cond'`. This happens *before* popping
+    -- the ite scope so that the path-condition structure is still intact.
+    let labels := (Ewns_t ++ Ewns_f).map (·.exitLabel) |>.eraseDups
+    let merged := labels.flatMap fun label =>
+      let ts := Ewns_t.filter (·.exitLabel == label)
+      let fs := Ewns_f.filter (·.exitLabel == label)
+      match ts, fs with
+      | [ewn_t], [ewn_f] =>
+        let s' := Imperative.Stmt.ite cond' ewn_t.stk.top ewn_f.stk.top md
+        [EnvWithNext.mk (Env.merge cond' ewn_t.env ewn_f.env).popScope
+                        label
+                        (orig_stk.appendToTop [s'])]
+      | _, _ =>
+        -- Unmatched paths: pop scope and pass through individually.
+        let ts' := ts.map fun ewn =>
+          let s' := Imperative.Stmt.ite (LExpr.true ()) ewn.stk.top [] md
+          { ewn with env := ewn.env.popScope,
+                     stk := orig_stk.appendToTop [s'] }
+        let fs' := fs.map fun ewn =>
+          let s' := Imperative.Stmt.ite (LExpr.false ()) [] ewn.stk.top md
+          { ewn with env := ewn.env.popScope,
+                     stk := orig_stk.appendToTop [s'] }
+        ts' ++ fs'
+    merged
   termination_by (steps, Imperative.Block.sizeOf then_ss + Imperative.Block.sizeOf else_ss)
 end
 

--- a/Strata/Languages/Core/StatementEval.lean
+++ b/Strata/Languages/Core/StatementEval.lean
@@ -403,14 +403,25 @@ def processExit : Statements → Option (Option String) → (Statements × Optio
 | _, .some exitLabel => ([], .some exitLabel) -- Skip all remaining statements
 
 /--
-Merge exactly two `EnvWithNext` results that share the same exit label after
-block exit consumption. Extracts the ite condition from the newest path
-condition scope (which is still intact since `Env.popScope` only pops
-expression state, not path conditions). The environment whose newest path
-condition is a positive condition (not negated) is treated as E1 (true branch).
+Merge `EnvWithNext` results that share the same exit label after block exit
+consumption.
 
-For 3+ paths converging to the same label, returns them unmerged to avoid
-corrupting the path-condition structure with repeated `Env.merge` calls.
+This function is safe to use even without enforced label uniqueness because it
+only merges paths that result from evaluating the same block's statements. All
+paths in the input list are siblings (they started from the same entry point),
+so if they converge to the same exit label, they represent different execution
+paths through the same code that should be merged.
+
+The function handles two cases:
+1. Exactly two paths with the same label: Merges them using the ite condition
+   extracted from their path conditions. The environment whose newest path
+   condition is positive (not negated) is treated as E1 (true branch).
+2. Other cases (1 path, or 3+ paths): Returns paths unmerged to avoid
+   corrupting the path-condition structure with repeated `Env.merge` calls.
+
+Note: This merging is essential to prevent path multiplication in the VCG.
+Without it, subsequent procedures would be verified once per path from the
+previous procedure, causing duplicate proof obligations (see issue #419).
 -/
 private def mergeByExitLabel (ewns : List EnvWithNext) : List EnvWithNext :=
   let labels := ewns.map (·.exitLabel) |>.eraseDups
@@ -478,6 +489,8 @@ def evalAuxGo (steps : Nat) (old_var_subst : SubstMap) (Ewn : EnvWithNext) (ss :
                                               orig_stk.appendToTop [s'] })
             -- After consuming exits, multiple paths may converge to the same
             -- exit label. Merge them to prevent path multiplication.
+            -- This is safe because all paths in Ewns are siblings (they all
+            -- result from evaluating the same block's statements).
             mergeByExitLabel Ewns
 
           | .ite cond then_ss else_ss md =>

--- a/Strata/Languages/Laurel/LaurelSemantics.lean
+++ b/Strata/Languages/Laurel/LaurelSemantics.lean
@@ -1,0 +1,399 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Laurel.Laurel
+
+/-!
+# Direct Operational Semantics for Laurel IR
+
+This file defines a standalone big-step operational semantics for Laurel's
+`StmtExpr` AST, independent of Core semantics (Option A from the design
+document `docs/designs/design-formal-semantics-for-laurel-ir.md`).
+
+## Design
+
+- **LaurelValue**: runtime values (int, bool, string, void, ref)
+- **LaurelStore**: variable store (`Identifier → Option LaurelValue`)
+- **LaurelHeap**: object heap (`Nat → Option (Identifier × (Identifier → Option LaurelValue))`)
+- **Outcome**: non-local control flow (normal, exit, return)
+- **EvalLaurelStmt / EvalLaurelBlock**: mutually inductive big-step relations
+
+The judgment form is: `δ, π, heap, σ, stmt ⊢ heap', σ', outcome`
+-/
+
+namespace Strata.Laurel
+
+/-! ## Values -/
+
+inductive LaurelValue where
+  | vInt    : Int → LaurelValue
+  | vBool   : Bool → LaurelValue
+  | vString : String → LaurelValue
+  | vVoid   : LaurelValue
+  | vRef    : Nat → LaurelValue
+  deriving Repr, BEq, Inhabited, DecidableEq
+
+/-! ## Store and Heap -/
+
+abbrev LaurelStore := Identifier → Option LaurelValue
+abbrev LaurelHeap := Nat → Option (Identifier × (Identifier → Option LaurelValue))
+abbrev LaurelEval := LaurelStore → StmtExpr → Option LaurelValue
+abbrev ProcEnv := Identifier → Option Procedure
+
+/-! ## Outcomes -/
+
+inductive Outcome where
+  | normal : LaurelValue → Outcome
+  | exit   : Identifier → Outcome
+  | ret    : Option LaurelValue → Outcome
+  deriving Repr, BEq, Inhabited, DecidableEq
+
+/-! ## Store Operations -/
+
+inductive UpdateStore : LaurelStore → Identifier → LaurelValue → LaurelStore → Prop where
+  | update :
+    σ x = .some v' →
+    σ' x = .some v →
+    (∀ y, x ≠ y → σ' y = σ y) →
+    UpdateStore σ x v σ'
+
+inductive InitStore : LaurelStore → Identifier → LaurelValue → LaurelStore → Prop where
+  | init :
+    σ x = none →
+    σ' x = .some v →
+    (∀ y, x ≠ y → σ' y = σ y) →
+    InitStore σ x v σ'
+
+/-! ## Heap Operations -/
+
+inductive AllocHeap : LaurelHeap → Identifier → Nat → LaurelHeap → Prop where
+  | alloc :
+    h addr = none →
+    h' addr = .some (typeName, fun _ => none) →
+    (∀ a, addr ≠ a → h' a = h a) →
+    AllocHeap h typeName addr h'
+
+def heapFieldRead (h : LaurelHeap) (addr : Nat) (field : Identifier) : Option LaurelValue :=
+  match h addr with
+  | some (_, fields) => fields field
+  | none => none
+
+inductive HeapFieldWrite : LaurelHeap → Nat → Identifier → LaurelValue → LaurelHeap → Prop where
+  | write :
+    h addr = .some (tag, fields) →
+    h' addr = .some (tag, fun f => if f == field then some v else fields f) →
+    (∀ a, addr ≠ a → h' a = h a) →
+    HeapFieldWrite h addr field v h'
+
+/-! ## Helpers -/
+
+def catchExit : Option Identifier → Outcome → Outcome
+  | some l, .exit l' => if l == l' then .normal .vVoid else .exit l'
+  | _, o => o
+
+def evalPrimOp (op : Operation) (args : List LaurelValue) : Option LaurelValue :=
+  match op, args with
+  | .And,     [.vBool a, .vBool b] => some (.vBool (a && b))
+  | .Or,      [.vBool a, .vBool b] => some (.vBool (a || b))
+  | .Not,     [.vBool a]           => some (.vBool (!a))
+  | .Implies, [.vBool a, .vBool b] => some (.vBool (!a || b))
+  | .Add, [.vInt a, .vInt b] => some (.vInt (a + b))
+  | .Sub, [.vInt a, .vInt b] => some (.vInt (a - b))
+  | .Mul, [.vInt a, .vInt b] => some (.vInt (a * b))
+  | .Neg, [.vInt a]          => some (.vInt (-a))
+  | .Div, [.vInt a, .vInt b] => if b != 0 then some (.vInt (a / b)) else none
+  | .Mod, [.vInt a, .vInt b] => if b != 0 then some (.vInt (a % b)) else none
+  | .Eq,  [.vInt a, .vInt b] => some (.vBool (a == b))
+  | .Neq, [.vInt a, .vInt b] => some (.vBool (a != b))
+  | .Lt,  [.vInt a, .vInt b] => some (.vBool (a < b))
+  | .Leq, [.vInt a, .vInt b] => some (.vBool (a ≤ b))
+  | .Gt,  [.vInt a, .vInt b] => some (.vBool (a > b))
+  | .Geq, [.vInt a, .vInt b] => some (.vBool (a ≥ b))
+  | .Eq,  [.vBool a, .vBool b] => some (.vBool (a == b))
+  | .Neq, [.vBool a, .vBool b] => some (.vBool (a != b))
+  | .Eq,       [.vString a, .vString b] => some (.vBool (a == b))
+  | .Neq,      [.vString a, .vString b] => some (.vBool (a != b))
+  | .StrConcat, [.vString a, .vString b] => some (.vString (a ++ b))
+  | .Eq,  [.vRef a, .vRef b] => some (.vBool (a == b))
+  | .Neq, [.vRef a, .vRef b] => some (.vBool (a != b))
+  | _, _ => none
+
+def getBody : Procedure → Option StmtExprMd
+  | { body := .Transparent b, .. } => some b
+  | { body := .Opaque _ (some b) _, .. } => some b
+  | _ => none
+
+def bindParams (σ : LaurelStore) (params : List Parameter) (vals : List LaurelValue)
+    : Option LaurelStore :=
+  match params, vals with
+  | [], [] => some σ
+  | p :: ps, v :: vs =>
+    if σ p.name = none then
+      bindParams (fun x => if x == p.name then some v else σ x) ps vs
+    else none
+  | _, _ => none
+
+def HighType.typeName : HighType → Identifier
+  | .UserDefined name => name
+  | _ => ""
+
+/-- Non-mutual argument evaluation using the expression evaluator δ. -/
+inductive EvalArgs : LaurelEval → LaurelStore → List StmtExprMd → List LaurelValue → Prop where
+  | nil  : EvalArgs δ σ [] []
+  | cons : δ σ e.val = some v → EvalArgs δ σ es vs → EvalArgs δ σ (e :: es) (v :: vs)
+
+/-! ## Main Semantic Relations -/
+
+mutual
+inductive EvalLaurelStmt :
+    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
+    StmtExprMd → LaurelHeap → LaurelStore → Outcome → Prop where
+
+  -- Literals
+
+  | literal_int :
+    EvalLaurelStmt δ π h σ ⟨.LiteralInt i, md⟩ h σ (.normal (.vInt i))
+
+  | literal_bool :
+    EvalLaurelStmt δ π h σ ⟨.LiteralBool b, md⟩ h σ (.normal (.vBool b))
+
+  | literal_string :
+    EvalLaurelStmt δ π h σ ⟨.LiteralString s, md⟩ h σ (.normal (.vString s))
+
+  -- Variables
+
+  | identifier :
+    σ name = some v →
+    EvalLaurelStmt δ π h σ ⟨.Identifier name, md⟩ h σ (.normal v)
+
+  -- Primitive Operations (uses non-mutual EvalArgs)
+
+  | prim_op :
+    EvalArgs δ σ args vals →
+    evalPrimOp op vals = some result →
+    EvalLaurelStmt δ π h σ ⟨.PrimitiveOp op args, md⟩ h σ (.normal result)
+
+  -- Control Flow
+
+  | ite_true :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h₁ σ₁ thenBr h₂ σ₂ outcome →
+    EvalLaurelStmt δ π h σ ⟨.IfThenElse c thenBr (some elseBr), md⟩ h₂ σ₂ outcome
+
+  | ite_false :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool false)) →
+    EvalLaurelStmt δ π h₁ σ₁ elseBr h₂ σ₂ outcome →
+    EvalLaurelStmt δ π h σ ⟨.IfThenElse c thenBr (some elseBr), md⟩ h₂ σ₂ outcome
+
+  | ite_true_no_else :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h₁ σ₁ thenBr h₂ σ₂ outcome →
+    EvalLaurelStmt δ π h σ ⟨.IfThenElse c thenBr none, md⟩ h₂ σ₂ outcome
+
+  | ite_false_no_else :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool false)) →
+    EvalLaurelStmt δ π h σ ⟨.IfThenElse c thenBr none, md⟩ h₁ σ₁ (.normal .vVoid)
+
+  | block_sem :
+    EvalLaurelBlock δ π h σ stmts h' σ' outcome →
+    catchExit label outcome = outcome' →
+    EvalLaurelStmt δ π h σ ⟨.Block stmts label, md⟩ h' σ' outcome'
+
+  | exit_sem :
+    EvalLaurelStmt δ π h σ ⟨.Exit target, md⟩ h σ (.exit target)
+
+  | return_some :
+    EvalLaurelStmt δ π h σ val h' σ' (.normal v) →
+    EvalLaurelStmt δ π h σ ⟨.Return (some val), md⟩ h' σ' (.ret (some v))
+
+  | return_none :
+    EvalLaurelStmt δ π h σ ⟨.Return none, md⟩ h σ (.ret none)
+
+  -- While Loop
+
+  | while_true :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h₁ σ₁ body h₂ σ₂ (.normal _) →
+    EvalLaurelStmt δ π h₂ σ₂ ⟨.While c invs dec body, md⟩ h₃ σ₃ outcome →
+    EvalLaurelStmt δ π h σ ⟨.While c invs dec body, md⟩ h₃ σ₃ outcome
+
+  | while_false :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool false)) →
+    EvalLaurelStmt δ π h σ ⟨.While c invs dec body, md⟩ h₁ σ₁ (.normal .vVoid)
+
+  | while_exit :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h₁ σ₁ body h₂ σ₂ (.exit label) →
+    EvalLaurelStmt δ π h σ ⟨.While c invs dec body, md⟩ h₂ σ₂ (.exit label)
+
+  | while_return :
+    EvalLaurelStmt δ π h σ c h₁ σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h₁ σ₁ body h₂ σ₂ (.ret rv) →
+    EvalLaurelStmt δ π h σ ⟨.While c invs dec body, md⟩ h₂ σ₂ (.ret rv)
+
+  -- Assignments
+
+  | assign_single :
+    EvalLaurelStmt δ π h σ value h₁ σ₁ (.normal v) →
+    σ₁ name = some _ →
+    UpdateStore σ₁ name v σ₂ →
+    EvalLaurelStmt δ π h σ ⟨.Assign [⟨.Identifier name, tmd⟩] value, md⟩ h₁ σ₂ (.normal .vVoid)
+
+  | local_var_init :
+    EvalLaurelStmt δ π h σ init h₁ σ₁ (.normal v) →
+    σ₁ name = none →
+    InitStore σ₁ name v σ₂ →
+    EvalLaurelStmt δ π h σ ⟨.LocalVariable name ty (some init), md⟩ h₁ σ₂ (.normal .vVoid)
+
+  | local_var_uninit :
+    σ name = none →
+    InitStore σ name .vVoid σ' →
+    EvalLaurelStmt δ π h σ ⟨.LocalVariable name ty none, md⟩ h σ' (.normal .vVoid)
+
+  -- Verification Constructs
+
+  | assert_true :
+    EvalLaurelStmt δ π h σ c h σ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h σ ⟨.Assert c, md⟩ h σ (.normal .vVoid)
+
+  | assume_true :
+    EvalLaurelStmt δ π h σ c h σ (.normal (.vBool true)) →
+    EvalLaurelStmt δ π h σ ⟨.Assume c, md⟩ h σ (.normal .vVoid)
+
+  -- Static Calls (arguments evaluated via δ for simplicity)
+
+  | static_call :
+    π callee = some proc →
+    EvalArgs δ σ args vals →
+    bindParams σ proc.inputs vals = some σBound →
+    getBody proc = some body →
+    EvalLaurelStmt δ π h σBound body h' σ' (.normal v) →
+    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal v)
+
+  | static_call_return :
+    π callee = some proc →
+    EvalArgs δ σ args vals →
+    bindParams σ proc.inputs vals = some σBound →
+    getBody proc = some body →
+    EvalLaurelStmt δ π h σBound body h' σ' (.ret (some v)) →
+    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal v)
+
+  -- OO Features
+
+  | new_obj :
+    AllocHeap h typeName addr h' →
+    EvalLaurelStmt δ π h σ ⟨.New typeName, md⟩ h' σ (.normal (.vRef addr))
+
+  | field_select :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    heapFieldRead h₁ addr fieldName = some v →
+    EvalLaurelStmt δ π h σ ⟨.FieldSelect target fieldName, md⟩ h₁ σ₁ (.normal v)
+
+  | pure_field_update :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    EvalLaurelStmt δ π h₁ σ₁ newVal h₂ σ₂ (.normal v) →
+    HeapFieldWrite h₂ addr fieldName v h₃ →
+    EvalLaurelStmt δ π h σ ⟨.PureFieldUpdate target fieldName newVal, md⟩ h₃ σ₂ (.normal (.vRef addr))
+
+  | reference_equals :
+    EvalLaurelStmt δ π h σ lhs h₁ σ₁ (.normal (.vRef a)) →
+    EvalLaurelStmt δ π h₁ σ₁ rhs h₂ σ₂ (.normal (.vRef b)) →
+    EvalLaurelStmt δ π h σ ⟨.ReferenceEquals lhs rhs, md⟩ h₂ σ₂ (.normal (.vBool (a == b)))
+
+  | instance_call :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    h₁ addr = some (typeName, _) →
+    π (typeName ++ "." ++ callee) = some proc →
+    EvalArgs δ σ₁ args vals →
+    bindParams σ₁ proc.inputs ((.vRef addr) :: vals) = some σBound →
+    getBody proc = some body →
+    EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.normal v) →
+    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal v)
+
+  | this_sem :
+    σ "this" = some v →
+    EvalLaurelStmt δ π h σ ⟨.This, md⟩ h σ (.normal v)
+
+  -- Type Operations
+
+  | is_type :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    h₁ addr = some (actualType, _) →
+    EvalLaurelStmt δ π h σ ⟨.IsType target ty, md⟩ h₁ σ₁
+      (.normal (.vBool (actualType == ty.val.typeName)))
+
+  | as_type :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal v) →
+    EvalLaurelStmt δ π h σ ⟨.AsType target ty, md⟩ h₁ σ₁ (.normal v)
+
+  -- Quantifiers (specification-only, delegated to δ)
+
+  | forall_sem :
+    δ σ (.Forall name ty body) = some v →
+    EvalLaurelStmt δ π h σ ⟨.Forall name ty body, md⟩ h σ (.normal v)
+
+  | exists_sem :
+    δ σ (.Exists name ty body) = some v →
+    EvalLaurelStmt δ π h σ ⟨.Exists name ty body, md⟩ h σ (.normal v)
+
+  -- Specification Constructs (delegated to δ)
+
+  | old_sem :
+    δ σ (.Old val) = some v →
+    EvalLaurelStmt δ π h σ ⟨.Old val, md⟩ h σ (.normal v)
+
+  | fresh_sem :
+    δ σ (.Fresh val) = some v →
+    EvalLaurelStmt δ π h σ ⟨.Fresh val, md⟩ h σ (.normal v)
+
+  | assigned_sem :
+    δ σ (.Assigned name) = some v →
+    EvalLaurelStmt δ π h σ ⟨.Assigned name, md⟩ h σ (.normal v)
+
+  | prove_by :
+    EvalLaurelStmt δ π h σ value h' σ' outcome →
+    EvalLaurelStmt δ π h σ ⟨.ProveBy value proof, md⟩ h' σ' outcome
+
+  | contract_of :
+    δ σ (.ContractOf ct func) = some v →
+    EvalLaurelStmt δ π h σ ⟨.ContractOf ct func, md⟩ h σ (.normal v)
+
+  -- Field Assignment
+
+  | assign_field :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    EvalLaurelStmt δ π h₁ σ₁ value h₂ σ₂ (.normal v) →
+    HeapFieldWrite h₂ addr fieldName v h₃ →
+    EvalLaurelStmt δ π h σ
+      ⟨.Assign [⟨.FieldSelect target fieldName, tmd⟩] value, md⟩ h₃ σ₂ (.normal .vVoid)
+
+inductive EvalLaurelBlock :
+    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
+    List StmtExprMd → LaurelHeap → LaurelStore → Outcome → Prop where
+
+  | nil :
+    EvalLaurelBlock δ π h σ [] h σ (.normal .vVoid)
+
+  | cons_normal :
+    EvalLaurelStmt δ π h σ s h₁ σ₁ (.normal v) →
+    EvalLaurelBlock δ π h₁ σ₁ rest h₂ σ₂ outcome →
+    EvalLaurelBlock δ π h σ (s :: rest) h₂ σ₂ outcome
+
+  | last_normal :
+    EvalLaurelStmt δ π h σ s h' σ' (.normal v) →
+    EvalLaurelBlock δ π h σ [s] h' σ' (.normal v)
+
+  | cons_exit :
+    EvalLaurelStmt δ π h σ s h' σ' (.exit label) →
+    EvalLaurelBlock δ π h σ (s :: _rest) h' σ' (.exit label)
+
+  | cons_return :
+    EvalLaurelStmt δ π h σ s h' σ' (.ret rv) →
+    EvalLaurelBlock δ π h σ (s :: _rest) h' σ' (.ret rv)
+
+end
+
+end Strata.Laurel

--- a/Strata/Languages/Laurel/LaurelSemantics.lean
+++ b/Strata/Languages/Laurel/LaurelSemantics.lean
@@ -22,6 +22,22 @@ document `docs/designs/design-formal-semantics-for-laurel-ir.md`).
 - **EvalLaurelStmt / EvalLaurelBlock**: mutually inductive big-step relations
 
 The judgment form is: `δ, π, heap, σ, stmt ⊢ heap', σ', outcome`
+
+## Intentionally Omitted Constructs
+
+The following `StmtExpr` constructors have no evaluation rules and will get stuck:
+- **`Abstract`**: Specification-level marker for abstract contracts. Not executable.
+- **`All`**: Specification-level reference to all heap objects (reads/modifies clauses).
+- **`Hole`**: Represents incomplete programs. Not executable by design.
+
+## Known Limitations
+
+- **Multi-target `Assign`**: Only single-target assignment (identifier or field) is
+  handled. Multi-target assignment (for procedures with multiple outputs) is not yet
+  supported. -- TODO: Add multi-target assign rules.
+- **Argument evaluation**: Call arguments are evaluated via the pure evaluator `δ`
+  rather than `EvalLaurelStmt`, so arguments with side effects will get stuck.
+  This is a workaround for Lean 4 mutual inductive limitations.
 -/
 
 namespace Strata.Laurel
@@ -126,15 +142,18 @@ def getBody : Procedure → Option StmtExprMd
   | { body := .Opaque _ (some b) _, .. } => some b
   | _ => none
 
-def bindParams (σ : LaurelStore) (params : List Parameter) (vals : List LaurelValue)
+/-- Bind parameters to values starting from an empty store (lexical scoping). -/
+def bindParams (params : List Parameter) (vals : List LaurelValue)
     : Option LaurelStore :=
-  match params, vals with
-  | [], [] => some σ
-  | p :: ps, v :: vs =>
-    if σ p.name = none then
-      bindParams (fun x => if x == p.name then some v else σ x) ps vs
-    else none
-  | _, _ => none
+  go (fun _ => none) params vals
+where
+  go (σ : LaurelStore) : List Parameter → List LaurelValue → Option LaurelStore
+    | [], [] => some σ
+    | p :: ps, v :: vs =>
+      if σ p.name = none then
+        go (fun x => if x == p.name then some v else σ x) ps vs
+      else none
+    | _, _ => none
 
 def HighType.typeName : HighType → Identifier
   | .UserDefined name => name
@@ -254,6 +273,10 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h σ ⟨.LocalVariable name ty none, md⟩ h σ' (.normal .vVoid)
 
   -- Verification Constructs
+  -- Note: assert_true and assume_true require the condition to be pure
+  -- (no side effects on heap or store). Conditions with side effects have
+  -- no derivation. This is intentional — assert/assume conditions should
+  -- be specification-level expressions, not effectful computations.
 
   | assert_true :
     EvalLaurelStmt δ π h σ c h σ (.normal (.vBool true)) →
@@ -264,11 +287,15 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h σ ⟨.Assume c, md⟩ h σ (.normal .vVoid)
 
   -- Static Calls (arguments evaluated via δ for simplicity)
+  -- Note: Arguments are evaluated via the pure evaluator δ rather than
+  -- EvalLaurelStmt due to Lean 4 mutual inductive limitations. This means
+  -- call arguments cannot have side effects (e.g., f(g(x)) where g modifies
+  -- the store will get stuck). See commit message for details.
 
   | static_call :
     π callee = some proc →
     EvalArgs δ σ args vals →
-    bindParams σ proc.inputs vals = some σBound →
+    bindParams proc.inputs vals = some σBound →
     getBody proc = some body →
     EvalLaurelStmt δ π h σBound body h' σ' (.normal v) →
     EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal v)
@@ -276,10 +303,18 @@ inductive EvalLaurelStmt :
   | static_call_return :
     π callee = some proc →
     EvalArgs δ σ args vals →
-    bindParams σ proc.inputs vals = some σBound →
+    bindParams proc.inputs vals = some σBound →
     getBody proc = some body →
     EvalLaurelStmt δ π h σBound body h' σ' (.ret (some v)) →
     EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal v)
+
+  | static_call_return_void :
+    π callee = some proc →
+    EvalArgs δ σ args vals →
+    bindParams proc.inputs vals = some σBound →
+    getBody proc = some body →
+    EvalLaurelStmt δ π h σBound body h' σ' (.ret none) →
+    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal .vVoid)
 
   -- OO Features
 
@@ -308,10 +343,30 @@ inductive EvalLaurelStmt :
     h₁ addr = some (typeName, _) →
     π (typeName ++ "." ++ callee) = some proc →
     EvalArgs δ σ₁ args vals →
-    bindParams σ₁ proc.inputs ((.vRef addr) :: vals) = some σBound →
+    bindParams proc.inputs ((.vRef addr) :: vals) = some σBound →
     getBody proc = some body →
     EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.normal v) →
     EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal v)
+
+  | instance_call_return :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    h₁ addr = some (typeName, _) →
+    π (typeName ++ "." ++ callee) = some proc →
+    EvalArgs δ σ₁ args vals →
+    bindParams proc.inputs ((.vRef addr) :: vals) = some σBound →
+    getBody proc = some body →
+    EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.ret (some v)) →
+    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal v)
+
+  | instance_call_return_void :
+    EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
+    h₁ addr = some (typeName, _) →
+    π (typeName ++ "." ++ callee) = some proc →
+    EvalArgs δ σ₁ args vals →
+    bindParams proc.inputs ((.vRef addr) :: vals) = some σBound →
+    getBody proc = some body →
+    EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.ret none) →
+    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal .vVoid)
 
   | this_sem :
     σ "this" = some v →
@@ -377,14 +432,15 @@ inductive EvalLaurelBlock :
   | nil :
     EvalLaurelBlock δ π h σ [] h σ (.normal .vVoid)
 
-  | cons_normal :
-    EvalLaurelStmt δ π h σ s h₁ σ₁ (.normal v) →
-    EvalLaurelBlock δ π h₁ σ₁ rest h₂ σ₂ outcome →
-    EvalLaurelBlock δ π h σ (s :: rest) h₂ σ₂ outcome
-
   | last_normal :
     EvalLaurelStmt δ π h σ s h' σ' (.normal v) →
     EvalLaurelBlock δ π h σ [s] h' σ' (.normal v)
+
+  | cons_normal :
+    EvalLaurelStmt δ π h σ s h₁ σ₁ (.normal _v) →
+    rest ≠ [] →
+    EvalLaurelBlock δ π h₁ σ₁ rest h₂ σ₂ outcome →
+    EvalLaurelBlock δ π h σ (s :: rest) h₂ σ₂ outcome
 
   | cons_exit :
     EvalLaurelStmt δ π h σ s h' σ' (.exit label) →

--- a/Strata/Languages/Laurel/LaurelSemantics.lean
+++ b/Strata/Languages/Laurel/LaurelSemantics.lean
@@ -88,6 +88,7 @@ inductive InitStore : LaurelStore → Identifier → LaurelValue → LaurelStore
 inductive AllocHeap : LaurelHeap → Identifier → Nat → LaurelHeap → Prop where
   | alloc :
     h addr = none →
+    (∀ a, a < addr → (h a).isSome) →
     h' addr = .some (typeName, fun _ => none) →
     (∀ a, addr ≠ a → h' a = h a) →
     AllocHeap h typeName addr h'

--- a/Strata/Languages/Laurel/LaurelSemantics.lean
+++ b/Strata/Languages/Laurel/LaurelSemantics.lean
@@ -450,6 +450,19 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h σ
       ⟨.Assign [⟨.FieldSelect target fieldName, tmd⟩] value, md⟩ h₃ σ₂ (.normal v)
 
+/-- Store-threading argument evaluation. Evaluates a list of arguments
+left-to-right using `EvalLaurelStmt`, threading heap and store through
+each argument. Each argument must evaluate to `.normal v`. -/
+inductive EvalStmtArgs :
+    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
+    List StmtExprMd → LaurelHeap → LaurelStore →
+    List LaurelValue → Prop where
+  | nil  : EvalStmtArgs δ π h σ [] h σ []
+  | cons :
+    EvalLaurelStmt δ π h σ e h₁ σ₁ (.normal v) →
+    EvalStmtArgs δ π h₁ σ₁ es h₂ σ₂ vs →
+    EvalStmtArgs δ π h σ (e :: es) h₂ σ₂ (v :: vs)
+
 inductive EvalLaurelBlock :
     LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
     List StmtExprMd → LaurelHeap → LaurelStore → Outcome → Prop where
@@ -474,19 +487,6 @@ inductive EvalLaurelBlock :
   | cons_return :
     EvalLaurelStmt δ π h σ s h' σ' (.ret rv) →
     EvalLaurelBlock δ π h σ (s :: _rest) h' σ' (.ret rv)
-
-/-- Store-threading argument evaluation. Evaluates a list of arguments
-left-to-right using `EvalLaurelStmt`, threading heap and store through
-each argument. Each argument must evaluate to `.normal v`. -/
-inductive EvalStmtArgs :
-    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
-    List StmtExprMd → LaurelHeap → LaurelStore →
-    List LaurelValue → Prop where
-  | nil  : EvalStmtArgs δ π h σ [] h σ []
-  | cons :
-    EvalLaurelStmt δ π h σ e h₁ σ₁ (.normal v) →
-    EvalStmtArgs δ π h₁ σ₁ es h₂ σ₂ vs →
-    EvalStmtArgs δ π h σ (e :: es) h₂ σ₂ (v :: vs)
 
 end
 

--- a/Strata/Languages/Laurel/LaurelSemantics.lean
+++ b/Strata/Languages/Laurel/LaurelSemantics.lean
@@ -85,6 +85,12 @@ inductive InitStore : LaurelStore → Identifier → LaurelValue → LaurelStore
 
 /-! ## Heap Operations -/
 
+/-- Heap allocation using a bump-allocator (smallest-free-address) model.
+The `alloc` constructor requires `addr` to be the smallest free address:
+all addresses below `addr` must be occupied (`(h a).isSome`).
+This invariant makes allocation deterministic but precludes heap deallocation.
+If Laurel ever needs a `free` operation, this must be relaxed to a free-list
+model, which would invalidate `AllocHeap_deterministic` and downstream proofs. -/
 inductive AllocHeap : LaurelHeap → Identifier → Nat → LaurelHeap → Prop where
   | alloc :
     h addr = none →

--- a/Strata/Languages/Laurel/LaurelSemantics.lean
+++ b/Strata/Languages/Laurel/LaurelSemantics.lean
@@ -19,9 +19,32 @@ document `docs/designs/design-formal-semantics-for-laurel-ir.md`).
 - **LaurelStore**: variable store (`Identifier → Option LaurelValue`)
 - **LaurelHeap**: object heap (`Nat → Option (Identifier × (Identifier → Option LaurelValue))`)
 - **Outcome**: non-local control flow (normal, exit, return)
-- **EvalLaurelStmt / EvalLaurelBlock**: mutually inductive big-step relations
+- **EvalLaurelStmt / EvalLaurelBlock / EvalStmtArgs**: mutually inductive big-step relations
 
 The judgment form is: `δ, π, heap, σ, stmt ⊢ heap', σ', outcome`
+
+## Argument Evaluation Model
+
+Arguments to `PrimitiveOp` and calls are evaluated left-to-right via
+`EvalStmtArgs`, which threads heap and store through each argument using
+`EvalLaurelStmt`. This supports effectful arguments (assignments, calls,
+blocks) in argument position. The judgment form is:
+
+  `δ, π, h, σ, [e₁, ..., eₙ] ⊢ h', σ', [v₁, ..., vₙ]`
+
+Each argument must evaluate to `.normal v`; non-local control flow in
+arguments (e.g., `f(return 5)`) has no derivation.
+
+The old `EvalArgs` inductive (pure, non-mutual) is retained for reasoning
+about pure sub-expressions.
+
+## Assignment Return Value
+
+`assign_single` and `assign_field` return `.normal v` (the assigned value)
+rather than `.normal .vVoid`. This models assignments as expressions (like
+C's `=` operator), which is needed for effectful argument evaluation where
+`x := 1` in expression position should evaluate to 1. Statement-level code
+discards the return value via `cons_normal`.
 
 ## Intentionally Omitted Constructs
 
@@ -35,9 +58,6 @@ The following `StmtExpr` constructors have no evaluation rules and will get stuc
 - **Multi-target `Assign`**: Only single-target assignment (identifier or field) is
   handled. Multi-target assignment (for procedures with multiple outputs) is not yet
   supported. -- TODO: Add multi-target assign rules.
-- **Argument evaluation**: Call arguments are evaluated via the pure evaluator `δ`
-  rather than `EvalLaurelStmt`, so arguments with side effects will get stuck.
-  This is a workaround for Lean 4 mutual inductive limitations.
 -/
 
 namespace Strata.Laurel
@@ -195,12 +215,12 @@ inductive EvalLaurelStmt :
     σ name = some v →
     EvalLaurelStmt δ π h σ ⟨.Identifier name, md⟩ h σ (.normal v)
 
-  -- Primitive Operations (uses non-mutual EvalArgs)
+  -- Primitive Operations (uses mutual EvalStmtArgs for effectful args)
 
   | prim_op :
-    EvalArgs δ σ args vals →
+    EvalStmtArgs δ π h σ args h' σ' vals →
     evalPrimOp op vals = some result →
-    EvalLaurelStmt δ π h σ ⟨.PrimitiveOp op args, md⟩ h σ (.normal result)
+    EvalLaurelStmt δ π h σ ⟨.PrimitiveOp op args, md⟩ h' σ' (.normal result)
 
   -- Control Flow
 
@@ -266,7 +286,7 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h σ value h₁ σ₁ (.normal v) →
     σ₁ name = some _ →
     UpdateStore σ₁ name v σ₂ →
-    EvalLaurelStmt δ π h σ ⟨.Assign [⟨.Identifier name, tmd⟩] value, md⟩ h₁ σ₂ (.normal .vVoid)
+    EvalLaurelStmt δ π h σ ⟨.Assign [⟨.Identifier name, tmd⟩] value, md⟩ h₁ σ₂ (.normal v)
 
   | local_var_init :
     EvalLaurelStmt δ π h σ init h₁ σ₁ (.normal v) →
@@ -293,35 +313,33 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h σ c h σ (.normal (.vBool true)) →
     EvalLaurelStmt δ π h σ ⟨.Assume c, md⟩ h σ (.normal .vVoid)
 
-  -- Static Calls (arguments evaluated via δ for simplicity)
-  -- Note: Arguments are evaluated via the pure evaluator δ rather than
-  -- EvalLaurelStmt due to Lean 4 mutual inductive limitations. This means
-  -- call arguments cannot have side effects (e.g., f(g(x)) where g modifies
-  -- the store will get stuck). See commit message for details.
+  -- Static Calls (arguments evaluated via EvalStmtArgs for effectful args)
+  -- The store after argument evaluation (σ₁) becomes the caller's store
+  -- after the call, consistent with the lifting pass model.
 
   | static_call :
     π callee = some proc →
-    EvalArgs δ σ args vals →
+    EvalStmtArgs δ π h σ args h₁ σ₁ vals →
     bindParams proc.inputs vals = some σBound →
     getBody proc = some body →
-    EvalLaurelStmt δ π h σBound body h' σ' (.normal v) →
-    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal v)
+    EvalLaurelStmt δ π h₁ σBound body h' σ' (.normal v) →
+    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ₁ (.normal v)
 
   | static_call_return :
     π callee = some proc →
-    EvalArgs δ σ args vals →
+    EvalStmtArgs δ π h σ args h₁ σ₁ vals →
     bindParams proc.inputs vals = some σBound →
     getBody proc = some body →
-    EvalLaurelStmt δ π h σBound body h' σ' (.ret (some v)) →
-    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal v)
+    EvalLaurelStmt δ π h₁ σBound body h' σ' (.ret (some v)) →
+    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ₁ (.normal v)
 
   | static_call_return_void :
     π callee = some proc →
-    EvalArgs δ σ args vals →
+    EvalStmtArgs δ π h σ args h₁ σ₁ vals →
     bindParams proc.inputs vals = some σBound →
     getBody proc = some body →
-    EvalLaurelStmt δ π h σBound body h' σ' (.ret none) →
-    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ (.normal .vVoid)
+    EvalLaurelStmt δ π h₁ σBound body h' σ' (.ret none) →
+    EvalLaurelStmt δ π h σ ⟨.StaticCall callee args, md⟩ h' σ₁ (.normal .vVoid)
 
   -- OO Features
 
@@ -349,31 +367,31 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
     h₁ addr = some (typeName, _) →
     π (typeName ++ "." ++ callee) = some proc →
-    EvalArgs δ σ₁ args vals →
+    EvalStmtArgs δ π h₁ σ₁ args h₂ σ₂ vals →
     bindParams proc.inputs ((.vRef addr) :: vals) = some σBound →
     getBody proc = some body →
-    EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.normal v) →
-    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal v)
+    EvalLaurelStmt δ π h₂ σBound body h₃ σ₃ (.normal v) →
+    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₃ σ₂ (.normal v)
 
   | instance_call_return :
     EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
     h₁ addr = some (typeName, _) →
     π (typeName ++ "." ++ callee) = some proc →
-    EvalArgs δ σ₁ args vals →
+    EvalStmtArgs δ π h₁ σ₁ args h₂ σ₂ vals →
     bindParams proc.inputs ((.vRef addr) :: vals) = some σBound →
     getBody proc = some body →
-    EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.ret (some v)) →
-    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal v)
+    EvalLaurelStmt δ π h₂ σBound body h₃ σ₃ (.ret (some v)) →
+    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₃ σ₂ (.normal v)
 
   | instance_call_return_void :
     EvalLaurelStmt δ π h σ target h₁ σ₁ (.normal (.vRef addr)) →
     h₁ addr = some (typeName, _) →
     π (typeName ++ "." ++ callee) = some proc →
-    EvalArgs δ σ₁ args vals →
+    EvalStmtArgs δ π h₁ σ₁ args h₂ σ₂ vals →
     bindParams proc.inputs ((.vRef addr) :: vals) = some σBound →
     getBody proc = some body →
-    EvalLaurelStmt δ π h₁ σBound body h₂ σ₂ (.ret none) →
-    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₂ σ₁ (.normal .vVoid)
+    EvalLaurelStmt δ π h₂ σBound body h₃ σ₃ (.ret none) →
+    EvalLaurelStmt δ π h σ ⟨.InstanceCall target callee args, md⟩ h₃ σ₂ (.normal .vVoid)
 
   | this_sem :
     σ "this" = some v →
@@ -430,7 +448,7 @@ inductive EvalLaurelStmt :
     EvalLaurelStmt δ π h₁ σ₁ value h₂ σ₂ (.normal v) →
     HeapFieldWrite h₂ addr fieldName v h₃ →
     EvalLaurelStmt δ π h σ
-      ⟨.Assign [⟨.FieldSelect target fieldName, tmd⟩] value, md⟩ h₃ σ₂ (.normal .vVoid)
+      ⟨.Assign [⟨.FieldSelect target fieldName, tmd⟩] value, md⟩ h₃ σ₂ (.normal v)
 
 inductive EvalLaurelBlock :
     LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
@@ -456,6 +474,19 @@ inductive EvalLaurelBlock :
   | cons_return :
     EvalLaurelStmt δ π h σ s h' σ' (.ret rv) →
     EvalLaurelBlock δ π h σ (s :: _rest) h' σ' (.ret rv)
+
+/-- Store-threading argument evaluation. Evaluates a list of arguments
+left-to-right using `EvalLaurelStmt`, threading heap and store through
+each argument. Each argument must evaluate to `.normal v`. -/
+inductive EvalStmtArgs :
+    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
+    List StmtExprMd → LaurelHeap → LaurelStore →
+    List LaurelValue → Prop where
+  | nil  : EvalStmtArgs δ π h σ [] h σ []
+  | cons :
+    EvalLaurelStmt δ π h σ e h₁ σ₁ (.normal v) →
+    EvalStmtArgs δ π h₁ σ₁ es h₂ σ₂ vs →
+    EvalStmtArgs δ π h σ (e :: es) h₂ σ₂ (v :: vs)
 
 end
 

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -1,0 +1,131 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Laurel.LaurelSemantics
+
+/-!
+# Properties of Laurel Operational Semantics
+
+Determinism, store monotonicity, and progress properties for the
+direct Laurel operational semantics.
+-/
+
+namespace Strata.Laurel
+
+/-! ## Store Monotonicity -/
+
+theorem UpdateStore_def_monotone {σ σ' : LaurelStore} {x : Identifier} {v : LaurelValue}
+    {vs : List Identifier} :
+    (∀ y, y ∈ vs → (σ y).isSome) →
+    UpdateStore σ x v σ' →
+    (∀ y, y ∈ vs → (σ' y).isSome) := by
+  intro Hdef Hup y Hy
+  cases Hup with
+  | update Hold Hnew Hrest =>
+    by_cases heq : x = y
+    · subst heq; simp [Hnew]
+    · rw [Hrest y heq]; exact Hdef y Hy
+
+theorem InitStore_def_monotone {σ σ' : LaurelStore} {x : Identifier} {v : LaurelValue}
+    {vs : List Identifier} :
+    (∀ y, y ∈ vs → (σ y).isSome) →
+    InitStore σ x v σ' →
+    (∀ y, y ∈ vs → (σ' y).isSome) := by
+  intro Hdef Hinit y Hy
+  cases Hinit with
+  | init Hnone Hnew Hrest =>
+    by_cases heq : x = y
+    · subst heq; simp [Hnew]
+    · rw [Hrest y heq]; exact Hdef y Hy
+
+/-! ## Determinism of Store Operations -/
+
+theorem UpdateStore_deterministic {σ σ₁ σ₂ : LaurelStore} {x : Identifier} {v : LaurelValue} :
+    UpdateStore σ x v σ₁ →
+    UpdateStore σ x v σ₂ →
+    σ₁ = σ₂ := by
+  intro H1 H2
+  cases H1 with | update _ Hnew1 Hrest1 =>
+  cases H2 with | update _ Hnew2 Hrest2 =>
+  funext y
+  by_cases heq : x = y
+  · subst heq; simp_all
+  · rw [Hrest1 y heq, Hrest2 y heq]
+
+theorem InitStore_deterministic {σ σ₁ σ₂ : LaurelStore} {x : Identifier} {v : LaurelValue} :
+    InitStore σ x v σ₁ →
+    InitStore σ x v σ₂ →
+    σ₁ = σ₂ := by
+  intro H1 H2
+  cases H1 with | init _ Hnew1 Hrest1 =>
+  cases H2 with | init _ Hnew2 Hrest2 =>
+  funext y
+  by_cases heq : x = y
+  · subst heq; simp_all
+  · rw [Hrest1 y heq, Hrest2 y heq]
+
+/-! ## catchExit Properties -/
+
+theorem catchExit_normal (label : Option Identifier) (v : LaurelValue) :
+    catchExit label (.normal v) = .normal v := by
+  cases label <;> simp [catchExit]
+
+theorem catchExit_return (label : Option Identifier) (rv : Option LaurelValue) :
+    catchExit label (.ret rv) = .ret rv := by
+  cases label <;> simp [catchExit]
+
+theorem catchExit_none_passthrough (o : Outcome) :
+    catchExit none o = o := by
+  simp [catchExit]
+
+/-! ## evalPrimOp Determinism -/
+
+theorem evalPrimOp_deterministic (op : Operation) (args : List LaurelValue) :
+    ∀ v₁ v₂, evalPrimOp op args = some v₁ → evalPrimOp op args = some v₂ → v₁ = v₂ := by
+  intros v₁ v₂ H1 H2; rw [H1] at H2; exact Option.some.inj H2
+
+/-! ## Determinism of Evaluation -/
+
+/-
+Theorem: Laurel evaluation is deterministic.
+
+For the full relation, if a statement evaluates to two results under the
+same evaluator, procedure environment, heap, and store, those results are equal.
+
+Proof sketch: By mutual induction on the evaluation derivation.
+Each constructor uniquely determines the outcome given the same inputs.
+
+Note: Full proof requires mutual induction over EvalLaurelStmt and
+EvalLaurelBlock simultaneously. The proof is admitted here; the store
+operation determinism lemmas above are the key building blocks.
+-/
+
+mutual
+theorem EvalLaurelStmt_deterministic :
+    EvalLaurelStmt δ π h σ s h₁ σ₁ o₁ →
+    EvalLaurelStmt δ π h σ s h₂ σ₂ o₂ →
+    h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂ := by
+  sorry
+
+theorem EvalLaurelBlock_deterministic :
+    EvalLaurelBlock δ π h σ ss h₁ σ₁ o₁ →
+    EvalLaurelBlock δ π h σ ss h₂ σ₂ o₂ →
+    h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂ := by
+  sorry
+end
+
+/-! ## Block Value Semantics -/
+
+theorem empty_block_void :
+    EvalLaurelBlock δ π h σ [] h σ (.normal .vVoid) :=
+  EvalLaurelBlock.nil
+
+theorem singleton_block_value :
+    EvalLaurelStmt δ π h σ s h' σ' (.normal v) →
+    EvalLaurelBlock δ π h σ [s] h' σ' (.normal v) :=
+  EvalLaurelBlock.last_normal
+
+end Strata.Laurel

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -69,17 +69,26 @@ theorem InitStore_deterministic {σ σ₁ σ₂ : LaurelStore} {x : Identifier} 
 
 /-! ## Determinism of Heap Operations -/
 
-/-
-Note on AllocHeap: AllocHeap is NOT deterministic in the allocated address.
-The constructor existentially picks any `addr` where `h addr = none`, so two
-derivations can choose different addresses, yielding different heaps. Therefore
-`AllocHeap_deterministic` (addr₁ = addr₂ ∧ h₁ = h₂) does NOT hold as stated.
-
-The full EvalLaurelStmt determinism proof will need a weaker formulation
-(e.g., heap bisimilarity up to address renaming) or AllocHeap must be made
-deterministic (e.g., pick the smallest free address). This is flagged here
-per the feature specification.
--/
+/-- AllocHeap is deterministic because the `alloc` constructor requires `addr`
+to be the smallest free address (all smaller addresses are occupied). -/
+theorem AllocHeap_deterministic {h h₁ h₂ : LaurelHeap}
+    {typeName : Identifier} {addr₁ addr₂ : Nat} :
+    AllocHeap h typeName addr₁ h₁ →
+    AllocHeap h typeName addr₂ h₂ →
+    addr₁ = addr₂ ∧ h₁ = h₂ := by
+  intro H1 H2
+  match H1, H2 with
+  | .alloc hfree1 hmin1 hnew1 hrest1, .alloc hfree2 hmin2 hnew2 hrest2 =>
+    have haddr : addr₁ = addr₂ := by
+      if heq : addr₁ = addr₂ then exact heq
+      else
+        cases Nat.lt_or_gt_of_ne heq with
+        | inl hlt => exact absurd (hmin2 addr₁ hlt) (by simp [hfree1])
+        | inr hgt => exact absurd (hmin1 addr₂ hgt) (by simp [hfree2])
+    subst haddr
+    exact ⟨rfl, funext fun a => by
+      if heq : addr₁ = a then subst heq; rw [hnew1, hnew2]
+      else rw [hrest1 a heq, hrest2 a heq]⟩
 
 theorem HeapFieldWrite_deterministic {h h₁ h₂ : LaurelHeap}
     {addr : Nat} {field : Identifier} {v : LaurelValue} :
@@ -130,35 +139,408 @@ theorem catchExit_none_passthrough (o : Outcome) :
     catchExit none o = o := by
   simp [catchExit]
 
-/-! ## evalPrimOp Determinism -/
+/-! ## catchExit Determinism -/
+
+theorem catchExit_deterministic {label : Option Identifier} {o₁ o₂ : Outcome} :
+    o₁ = o₂ → catchExit label o₁ = catchExit label o₂ := by
+  intro h; subst h; rfl
 
 theorem evalPrimOp_deterministic (op : Operation) (args : List LaurelValue) :
     ∀ v₁ v₂, evalPrimOp op args = some v₁ → evalPrimOp op args = some v₂ → v₁ = v₂ := by
   intros v₁ v₂ H1 H2; rw [H1] at H2; exact Option.some.inj H2
 
-/-! ## Determinism of Evaluation -/
+/-! ## Determinism of Evaluation
 
-/-
-## Full Determinism (EvalLaurelStmt / EvalLaurelBlock)
+AllocHeap was made deterministic (smallest-free-address policy) so that
+full determinism `h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂` holds for all constructors
+including `new_obj`.
 
-Full determinism (h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂) does NOT hold for the
-current semantics because `new_obj` uses `AllocHeap`, which existentially
-picks any free address. Two derivations can choose different addresses,
-producing different heaps and different `(.vRef addr)` outcomes.
-
-Design options for recovering a determinism result:
-  1. **Deterministic allocator**: Change `AllocHeap` to pick a canonical
-     address (e.g., smallest free Nat). This makes full determinism provable
-     but constrains the heap model.
-  2. **Bisimilarity up to renaming**: Formulate determinism as heap
-     isomorphism modulo address permutation. More general but significantly
-     more complex to state and prove.
-  3. **Restricted determinism**: Prove determinism only for the heap-free
-     fragment (store and outcome agree when the heap is unchanged). This is
-     what the auxiliary lemmas above support.
-
--- TODO: Choose and implement one of the above approaches.
+The proof uses mutual structural recursion on the first derivation (term-mode
+`match` on H1, then tactic-mode `cases` on H2 inside each branch).
 -/
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 800000 in
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 800000 in
+mutual
+theorem EvalLaurelStmt_deterministic
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {s : StmtExprMd} {h₁ h₂ : LaurelHeap} {σ₁ σ₂ : LaurelStore} {o₁ o₂ : Outcome}
+    (H1 : EvalLaurelStmt δ π h σ s h₁ σ₁ o₁)
+    (H2 : EvalLaurelStmt δ π h σ s h₂ σ₂ o₂) :
+    h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂ :=
+  match H1 with
+  -- Literals and leaf nodes (no sub-derivations)
+  | .literal_int => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .literal_bool => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .literal_string => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .identifier _ => by cases H2; simp_all
+  | .exit_sem => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .return_none => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .this_sem _ => by cases H2; simp_all
+  -- Specification constructs delegated to δ
+  | .forall_sem h1 => by cases H2 with | forall_sem h2 => rw [h1] at h2; simp_all
+  | .exists_sem h1 => by cases H2 with | exists_sem h2 => rw [h1] at h2; simp_all
+  | .old_sem h1 => by cases H2 with | old_sem h2 => rw [h1] at h2; simp_all
+  | .fresh_sem h1 => by cases H2 with | fresh_sem h2 => rw [h1] at h2; simp_all
+  | .assigned_sem h1 => by cases H2 with | assigned_sem h2 => rw [h1] at h2; simp_all
+  | .contract_of h1 => by cases H2 with | contract_of h2 => rw [h1] at h2; simp_all
+  -- PrimitiveOp
+  | .prim_op ha1 ho1 => by
+      cases H2 with
+      | prim_op ha2 ho2 =>
+        have := EvalArgs_deterministic ha1 ha2; subst this
+        rw [ho1] at ho2; simp_all
+  -- Single IH cases
+  | .return_some Hv => by
+      cases H2 with
+      | return_some Hv2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hv Hv2
+        subst hh; subst hs; cases ho; exact ⟨rfl, rfl, rfl⟩
+  | .assert_true _ => by cases H2 with | assert_true => exact ⟨rfl, rfl, rfl⟩
+  | .assume_true _ => by cases H2 with | assume_true => exact ⟨rfl, rfl, rfl⟩
+  | .prove_by Hv => by
+      cases H2 with
+      | prove_by Hv2 => exact EvalLaurelStmt_deterministic Hv Hv2
+  | .as_type Ht => by
+      cases H2 with
+      | as_type Ht2 => exact EvalLaurelStmt_deterministic Ht Ht2
+  -- Variable operations
+  | .local_var_uninit Hn Hi => by
+      cases H2 with
+      | local_var_uninit _ Hi2 => exact ⟨rfl, InitStore_deterministic Hi Hi2, rfl⟩
+  | .local_var_init Hv Hn Hi => by
+      cases H2 with
+      | local_var_init Hv2 _ Hi2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hv Hv2
+        subst hh; subst hs; cases ho
+        exact ⟨rfl, InitStore_deterministic Hi Hi2, rfl⟩
+  | .assign_single Hv Hm Hu => by
+      cases H2 with
+      | assign_single Hv2 _ Hu2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hv Hv2
+        subst hh; subst hs; cases ho
+        exact ⟨rfl, UpdateStore_deterministic Hu Hu2, rfl⟩
+  -- Heap: new_obj
+  | .new_obj Ha => by
+      cases H2 with
+      | new_obj Ha2 =>
+        have ⟨ha, hh⟩ := AllocHeap_deterministic Ha Ha2
+        subst ha; subst hh; exact ⟨rfl, rfl, rfl⟩
+  -- Conditionals (cross-case contradiction via bool determinism)
+  | .ite_true Hc Ht => by
+      cases H2 with
+      | ite_true Hc2 Ht2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        exact EvalLaurelStmt_deterministic Ht Ht2
+      | ite_false Hc2 _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+  | .ite_false Hc He => by
+      cases H2 with
+      | ite_true Hc2 _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | ite_false Hc2 He2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        exact EvalLaurelStmt_deterministic He He2
+  | .ite_true_no_else Hc Ht => by
+      cases H2 with
+      | ite_true_no_else Hc2 Ht2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        exact EvalLaurelStmt_deterministic Ht Ht2
+      | ite_false_no_else Hc2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+  | .ite_false_no_else Hc => by
+      cases H2 with
+      | ite_true_no_else Hc2 _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | ite_false_no_else Hc2 =>
+        have ⟨hh, hs, _⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; exact ⟨rfl, rfl, rfl⟩
+  -- Block
+  | .block_sem Hb Hce => by
+      cases H2 with
+      | block_sem Hb2 Hce2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelBlock_deterministic Hb Hb2
+        subst hh; subst hs; rw [ho] at Hce; rw [Hce] at Hce2
+        exact ⟨rfl, rfl, Hce2⟩
+  -- While loop (4 constructors × 4 cross-cases)
+  | .while_true Hc Hb Hl => by
+      cases H2 with
+      | while_true Hc2 Hb2 Hl2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨hh2, hs2, _⟩ := EvalLaurelStmt_deterministic Hb Hb2
+        subst hh2; subst hs2
+        exact EvalLaurelStmt_deterministic Hl Hl2
+      | while_false Hc2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | while_exit Hc2 Hb2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hb Hb2; simp at ho2
+      | while_return Hc2 Hb2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hb Hb2; simp at ho2
+  | .while_false Hc => by
+      cases H2 with
+      | while_true Hc2 _ _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | while_false Hc2 =>
+        have ⟨hh, hs, _⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; exact ⟨rfl, rfl, rfl⟩
+      | while_exit Hc2 _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | while_return Hc2 _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+  | .while_exit Hc Hb => by
+      cases H2 with
+      | while_true Hc2 Hb2 _ =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hb Hb2; simp at ho2
+      | while_false Hc2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | while_exit Hc2 Hb2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        exact EvalLaurelStmt_deterministic Hb Hb2
+      | while_return Hc2 Hb2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hb Hb2; simp at ho2
+  | .while_return Hc Hb => by
+      cases H2 with
+      | while_true Hc2 Hb2 _ =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hb Hb2; simp at ho2
+      | while_false Hc2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2; simp at ho
+      | while_exit Hc2 Hb2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hb Hb2; simp at ho2
+      | while_return Hc2 Hb2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hc Hc2
+        subst hh; subst hs; cases ho
+        exact EvalLaurelStmt_deterministic Hb Hb2
+  -- Static calls (3 constructors × 3 cross-cases, outcome discrimination)
+  | .static_call Hp Ha Hb Hg Hbody => by
+      cases H2 with
+      | static_call Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨hh, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
+        subst hh; cases ho; exact ⟨rfl, rfl, rfl⟩
+      | static_call_return Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
+      | static_call_return_void Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
+  | .static_call_return Hp Ha Hb Hg Hbody => by
+      cases H2 with
+      | static_call Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
+      | static_call_return Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨hh, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
+        subst hh; cases ho; exact ⟨rfl, rfl, rfl⟩
+      | static_call_return_void Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
+  | .static_call_return_void Hp Ha Hb Hg Hbody => by
+      cases H2 with
+      | static_call Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
+      | static_call_return Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
+      | static_call_return_void Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨hh, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
+        subst hh; cases ho; exact ⟨rfl, rfl, rfl⟩
+  -- OO: field_select, pure_field_update, reference_equals, assign_field
+  | .field_select Ht Hr => by
+      cases H2 with
+      | field_select Ht2 Hr2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hr] at Hr2; cases Hr2; exact ⟨rfl, rfl, rfl⟩
+  | .pure_field_update Ht Hv Hw => by
+      cases H2 with
+      | pure_field_update Ht2 Hv2 Hw2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        have ⟨hh2, hs2, ho2⟩ := EvalLaurelStmt_deterministic Hv Hv2
+        subst hh2; subst hs2; cases ho2
+        exact ⟨HeapFieldWrite_deterministic Hw Hw2, rfl, rfl⟩
+  | .reference_equals Hl Hr => by
+      cases H2 with
+      | reference_equals Hl2 Hr2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Hl Hl2
+        subst hh; subst hs; cases ho
+        have ⟨hh2, hs2, ho2⟩ := EvalLaurelStmt_deterministic Hr Hr2
+        subst hh2; subst hs2; cases ho2; exact ⟨rfl, rfl, rfl⟩
+  | .assign_field Ht Hv Hw => by
+      cases H2 with
+      | assign_field Ht2 Hv2 Hw2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        have ⟨hh2, hs2, ho2⟩ := EvalLaurelStmt_deterministic Hv Hv2
+        subst hh2; subst hs2; cases ho2
+        exact ⟨HeapFieldWrite_deterministic Hw Hw2, rfl, rfl⟩
+  -- OO: is_type
+  | .is_type Ht Hlook => by
+      cases H2 with
+      | is_type Ht2 Hlook2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; exact ⟨rfl, rfl, rfl⟩
+  -- Instance calls (3 constructors × 3 cross-cases)
+  | .instance_call Ht Hlook Hp Ha Hb Hg Hbody => by
+      cases H2 with
+      | instance_call Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨hh2, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
+        subst hh2; cases ho2; exact ⟨rfl, rfl, rfl⟩
+      | instance_call_return Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
+      | instance_call_return_void Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
+  | .instance_call_return Ht Hlook Hp Ha Hb Hg Hbody => by
+      cases H2 with
+      | instance_call Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
+      | instance_call_return Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨hh2, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
+        subst hh2; cases ho2; exact ⟨rfl, rfl, rfl⟩
+      | instance_call_return_void Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
+  | .instance_call_return_void Ht Hlook Hp Ha Hb Hg Hbody => by
+      cases H2 with
+      | instance_call Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
+      | instance_call_return Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
+      | instance_call_return_void Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
+        subst hh; subst hs; cases ho
+        rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
+        have := EvalArgs_deterministic Ha Ha2; subst this
+        rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
+        have ⟨hh2, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
+        subst hh2; cases ho2; exact ⟨rfl, rfl, rfl⟩
+
+theorem EvalLaurelBlock_deterministic
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {ss : List StmtExprMd} {h₁ h₂ : LaurelHeap} {σ₁ σ₂ : LaurelStore} {o₁ o₂ : Outcome}
+    (H1 : EvalLaurelBlock δ π h σ ss h₁ σ₁ o₁)
+    (H2 : EvalLaurelBlock δ π h σ ss h₂ σ₂ o₂) :
+    h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂ :=
+  match H1 with
+  | .nil => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .last_normal Hs => by
+      cases H2 with
+      | last_normal Hs2 => exact EvalLaurelStmt_deterministic Hs Hs2
+      | cons_normal Hs2 Hne _ => exact absurd rfl Hne
+      | cons_exit Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_return Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+  | .cons_normal Hs Hne Hr => by
+      cases H2 with
+      | last_normal Hs2 => exact absurd rfl Hne
+      | cons_normal Hs2 _ Hr2 =>
+        have ⟨hh, hs, _⟩ := EvalLaurelStmt_deterministic Hs Hs2
+        subst hh; subst hs
+        exact EvalLaurelBlock_deterministic Hr Hr2
+      | cons_exit Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_return Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+  | .cons_exit Hs => by
+      cases H2 with
+      | last_normal Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_normal Hs2 _ _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_exit Hs2 => exact EvalLaurelStmt_deterministic Hs Hs2
+      | cons_return Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+  | .cons_return Hs => by
+      cases H2 with
+      | last_normal Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_normal Hs2 _ _ =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_exit Hs2 =>
+        have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hs Hs2; simp at ho
+      | cons_return Hs2 => exact EvalLaurelStmt_deterministic Hs Hs2
+end
 
 /-! ## Block Value Semantics -/
 

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -576,6 +576,47 @@ theorem EvalLaurelBlock_deterministic
       | cons_return Hs2 => exact EvalLaurelStmt_deterministic Hs Hs2
 end
 
+/-! ## Store Operation Lemmas -/
+
+/-- InitStore on a fresh name preserves existing variable values. -/
+theorem InitStore_get_other {σ σ' : LaurelStore} {x y : Identifier} {v : LaurelValue}
+    (hinit : InitStore σ x v σ') (hne : x ≠ y) :
+    σ' y = σ y := by
+  cases hinit with | init _ _ hrest => exact hrest y hne
+
+/-- UpdateStore preserves values of other variables. -/
+theorem UpdateStore_get_other {σ σ' : LaurelStore} {x y : Identifier} {v : LaurelValue}
+    (hup : UpdateStore σ x v σ') (hne : x ≠ y) :
+    σ' y = σ y := by
+  cases hup with | update _ _ hrest => exact hrest y hne
+
+/-- UpdateStore sets the target variable. -/
+theorem UpdateStore_get_self {σ σ' : LaurelStore} {x : Identifier} {v : LaurelValue}
+    (hup : UpdateStore σ x v σ') :
+    σ' x = some v := by
+  cases hup with | update _ hnew _ => exact hnew
+
+/-- InitStore sets the target variable. -/
+theorem InitStore_get_self {σ σ' : LaurelStore} {x : Identifier} {v : LaurelValue}
+    (hinit : InitStore σ x v σ') :
+    σ' x = some v := by
+  cases hinit with | init _ hnew _ => exact hnew
+
+/-! ## Block Append Lemma -/
+
+/-- Evaluating a block `[s] ++ rest` where `s` produces `.normal` is equivalent to
+evaluating `s`, then evaluating `rest` in the resulting state. -/
+theorem EvalLaurelBlock_cons_normal_append
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {s : StmtExprMd} {rest : List StmtExprMd}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hs : EvalLaurelStmt δ π h σ s h₁ σ₁ (.normal v))
+    (hne : rest ≠ [])
+    (hrest : EvalLaurelBlock δ π h₁ σ₁ rest h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ (s :: rest) h₂ σ₂ o :=
+  .cons_normal hs hne hrest
+
 /-! ## Block Value Semantics -/
 
 theorem empty_block_void :

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -139,32 +139,26 @@ theorem evalPrimOp_deterministic (op : Operation) (args : List LaurelValue) :
 /-! ## Determinism of Evaluation -/
 
 /-
-Theorem: Laurel evaluation is deterministic.
+## Full Determinism (EvalLaurelStmt / EvalLaurelBlock)
 
-For the full relation, if a statement evaluates to two results under the
-same evaluator, procedure environment, heap, and store, those results are equal.
+Full determinism (h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂) does NOT hold for the
+current semantics because `new_obj` uses `AllocHeap`, which existentially
+picks any free address. Two derivations can choose different addresses,
+producing different heaps and different `(.vRef addr)` outcomes.
 
-Proof sketch: By mutual induction on the evaluation derivation.
-Each constructor uniquely determines the outcome given the same inputs.
+Design options for recovering a determinism result:
+  1. **Deterministic allocator**: Change `AllocHeap` to pick a canonical
+     address (e.g., smallest free Nat). This makes full determinism provable
+     but constrains the heap model.
+  2. **Bisimilarity up to renaming**: Formulate determinism as heap
+     isomorphism modulo address permutation. More general but significantly
+     more complex to state and prove.
+  3. **Restricted determinism**: Prove determinism only for the heap-free
+     fragment (store and outcome agree when the heap is unchanged). This is
+     what the auxiliary lemmas above support.
 
-Note: Full proof requires mutual induction over EvalLaurelStmt and
-EvalLaurelBlock simultaneously. The proof is admitted here; the store
-operation determinism lemmas above are the key building blocks.
+-- TODO: Choose and implement one of the above approaches.
 -/
-
-mutual
-theorem EvalLaurelStmt_deterministic :
-    EvalLaurelStmt δ π h σ s h₁ σ₁ o₁ →
-    EvalLaurelStmt δ π h σ s h₂ σ₂ o₂ →
-    h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂ := by
-  sorry
-
-theorem EvalLaurelBlock_deterministic :
-    EvalLaurelBlock δ π h σ ss h₁ σ₁ o₁ →
-    EvalLaurelBlock δ π h σ ss h₂ σ₂ o₂ →
-    h₁ = h₂ ∧ σ₁ = σ₂ ∧ o₁ = o₂ := by
-  sorry
-end
 
 /-! ## Block Value Semantics -/
 

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -139,16 +139,6 @@ theorem catchExit_none_passthrough (o : Outcome) :
     catchExit none o = o := by
   simp [catchExit]
 
-/-! ## catchExit Determinism -/
-
-theorem catchExit_deterministic {label : Option Identifier} {o₁ o₂ : Outcome} :
-    o₁ = o₂ → catchExit label o₁ = catchExit label o₂ := by
-  intro h; subst h; rfl
-
-theorem evalPrimOp_deterministic (op : Operation) (args : List LaurelValue) :
-    ∀ v₁ v₂, evalPrimOp op args = some v₁ → evalPrimOp op args = some v₂ → v₁ = v₂ := by
-  intros v₁ v₂ H1 H2; rw [H1] at H2; exact Option.some.inj H2
-
 /-! ## Determinism of Evaluation
 
 AllocHeap was made deterministic (smallest-free-address policy) so that
@@ -159,8 +149,10 @@ The proof uses mutual structural recursion on the first derivation (term-mode
 `match` on H1, then tactic-mode `cases` on H2 inside each branch).
 -/
 
-set_option maxRecDepth 4096 in
-set_option maxHeartbeats 800000 in
+-- TODO: maxHeartbeats 800000 is ~4× the default. Consider extracting a helper
+-- lemma for the shared call-case prefix (proc lookup, args, bind, getBody,
+-- then outcome discrimination) to reduce ~150 lines of repetition and lower
+-- heartbeat pressure.
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
 mutual

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -67,6 +67,55 @@ theorem InitStore_deterministic {σ σ₁ σ₂ : LaurelStore} {x : Identifier} 
   · subst heq; simp_all
   · rw [Hrest1 y heq, Hrest2 y heq]
 
+/-! ## Determinism of Heap Operations -/
+
+/-
+Note on AllocHeap: AllocHeap is NOT deterministic in the allocated address.
+The constructor existentially picks any `addr` where `h addr = none`, so two
+derivations can choose different addresses, yielding different heaps. Therefore
+`AllocHeap_deterministic` (addr₁ = addr₂ ∧ h₁ = h₂) does NOT hold as stated.
+
+The full EvalLaurelStmt determinism proof will need a weaker formulation
+(e.g., heap bisimilarity up to address renaming) or AllocHeap must be made
+deterministic (e.g., pick the smallest free address). This is flagged here
+per the feature specification.
+-/
+
+theorem HeapFieldWrite_deterministic {h h₁ h₂ : LaurelHeap}
+    {addr : Nat} {field : Identifier} {v : LaurelValue} :
+    HeapFieldWrite h addr field v h₁ →
+    HeapFieldWrite h addr field v h₂ →
+    h₁ = h₂ := by
+  intro H1 H2
+  cases H1 with | write Hlook1 Hnew1 Hrest1 =>
+  cases H2 with | write Hlook2 Hnew2 Hrest2 =>
+  funext a
+  by_cases heq : addr = a
+  · subst heq
+    rw [Hlook1] at Hlook2
+    have := Option.some.inj Hlook2
+    simp_all
+  · rw [Hrest1 a heq, Hrest2 a heq]
+
+/-! ## Determinism of EvalArgs -/
+
+theorem EvalArgs_deterministic {δ : LaurelEval} {σ : LaurelStore}
+    {es : List StmtExprMd} {vs₁ vs₂ : List LaurelValue} :
+    EvalArgs δ σ es vs₁ →
+    EvalArgs δ σ es vs₂ →
+    vs₁ = vs₂ := by
+  intro H1 H2
+  induction H1 generalizing vs₂ with
+  | nil => cases H2; rfl
+  | cons hev₁ _ ih =>
+    cases H2 with
+    | cons hev₂ htail₂ =>
+      rw [hev₁] at hev₂
+      have := Option.some.inj hev₂
+      subst this
+      congr 1
+      exact ih htail₂
+
 /-! ## catchExit Properties -/
 
 theorem catchExit_normal (label : Option Identifier) (v : LaurelValue) :

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -108,6 +108,10 @@ theorem HeapFieldWrite_deterministic {h h₁ h₂ : LaurelHeap}
 
 /-! ## Determinism of EvalArgs -/
 
+/-- Determinism of the non-mutual `EvalArgs` (pure expression evaluation).
+This is retained for reasoning about pure sub-expressions where `EvalStmtArgs`
+is not needed. The mutual `EvalStmtArgs_deterministic` (in the determinism
+mutual block below) handles the effectful case. -/
 theorem EvalArgs_deterministic {δ : LaurelEval} {σ : LaurelStore}
     {es : List StmtExprMd} {vs₁ vs₂ : List LaurelValue} :
     EvalArgs δ σ es vs₁ →
@@ -150,9 +154,10 @@ The proof uses mutual structural recursion on the first derivation (term-mode
 -/
 
 -- TODO: maxHeartbeats 800000 is ~4× the default. Consider extracting a helper
--- lemma for the shared call-case prefix (proc lookup, args, bind, getBody,
--- then outcome discrimination) to reduce ~150 lines of repetition and lower
--- heartbeat pressure.
+-- lemma for the shared call-case prefix (proc lookup, EvalStmtArgs, bind,
+-- getBody, then outcome discrimination) to reduce ~150 lines of repetition
+-- and lower heartbeat pressure. With EvalStmtArgs, the prefix now includes
+-- heap/store threading from argument evaluation.
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
 mutual
@@ -182,7 +187,8 @@ theorem EvalLaurelStmt_deterministic
   | .prim_op ha1 ho1 => by
       cases H2 with
       | prim_op ha2 ho2 =>
-        have := EvalArgs_deterministic ha1 ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic ha1 ha2
+        subst hha; subst hsa; subst hvs
         rw [ho1] at ho2; simp_all
   -- Single IH cases
   | .return_some Hv => by
@@ -326,53 +332,62 @@ theorem EvalLaurelStmt_deterministic
       cases H2 with
       | static_call Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨hh, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
         subst hh; cases ho; exact ⟨rfl, rfl, rfl⟩
       | static_call_return Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
       | static_call_return_void Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
   | .static_call_return Hp Ha Hb Hg Hbody => by
       cases H2 with
       | static_call Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
       | static_call_return Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨hh, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
         subst hh; cases ho; exact ⟨rfl, rfl, rfl⟩
       | static_call_return_void Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
   | .static_call_return_void Hp Ha Hb Hg Hbody => by
       cases H2 with
       | static_call Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
       | static_call_return Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho
       | static_call_return_void Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨hh, _, ho⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
         subst hh; cases ho; exact ⟨rfl, rfl, rfl⟩
@@ -420,7 +435,8 @@ theorem EvalLaurelStmt_deterministic
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨hh2, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
         subst hh2; cases ho2; exact ⟨rfl, rfl, rfl⟩
@@ -428,14 +444,16 @@ theorem EvalLaurelStmt_deterministic
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
       | instance_call_return_void Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
   | .instance_call_return Ht Hlook Hp Ha Hb Hg Hbody => by
@@ -444,14 +462,16 @@ theorem EvalLaurelStmt_deterministic
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
       | instance_call_return Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨hh2, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
         subst hh2; cases ho2; exact ⟨rfl, rfl, rfl⟩
@@ -459,7 +479,8 @@ theorem EvalLaurelStmt_deterministic
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
   | .instance_call_return_void Ht Hlook Hp Ha Hb Hg Hbody => by
@@ -468,24 +489,45 @@ theorem EvalLaurelStmt_deterministic
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
       | instance_call_return Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨_, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2; simp at ho2
       | instance_call_return_void Ht2 Hlook2 Hp2 Ha2 Hb2 Hg2 Hbody2 =>
         have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic Ht Ht2
         subst hh; subst hs; cases ho
         rw [Hlook] at Hlook2; cases Hlook2; rw [Hp] at Hp2; cases Hp2
-        have := EvalArgs_deterministic Ha Ha2; subst this
+        have ⟨hha, hsa, hvs⟩ := EvalStmtArgs_deterministic Ha Ha2
+        subst hha; subst hsa; subst hvs
         rw [Hb] at Hb2; cases Hb2; rw [Hg] at Hg2; cases Hg2
         have ⟨hh2, _, ho2⟩ := EvalLaurelStmt_deterministic Hbody Hbody2
         subst hh2; cases ho2; exact ⟨rfl, rfl, rfl⟩
+
+theorem EvalStmtArgs_deterministic
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {es : List StmtExprMd} {h₁ h₂ : LaurelHeap} {σ₁ σ₂ : LaurelStore}
+    {vs₁ vs₂ : List LaurelValue}
+    (H1 : EvalStmtArgs δ π h σ es h₁ σ₁ vs₁)
+    (H2 : EvalStmtArgs δ π h σ es h₂ σ₂ vs₂) :
+    h₁ = h₂ ∧ σ₁ = σ₂ ∧ vs₁ = vs₂ :=
+  match H1 with
+  | .nil => by cases H2; exact ⟨rfl, rfl, rfl⟩
+  | .cons He Ht => by
+      cases H2 with
+      | cons He2 Ht2 =>
+        have ⟨hh, hs, ho⟩ := EvalLaurelStmt_deterministic He He2
+        subst hh; subst hs; cases ho
+        have ⟨hh2, hs2, hvs⟩ := EvalStmtArgs_deterministic Ht Ht2
+        subst hh2; subst hs2; subst hvs
+        exact ⟨rfl, rfl, rfl⟩
 
 theorem EvalLaurelBlock_deterministic
     {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}

--- a/Strata/Languages/Laurel/LaurelSemanticsProps.lean
+++ b/Strata/Languages/Laurel/LaurelSemanticsProps.lean
@@ -628,4 +628,67 @@ theorem singleton_block_value :
     EvalLaurelBlock δ π h σ [s] h' σ' (.normal v) :=
   EvalLaurelBlock.last_normal
 
+/-! ## Block Append -/
+
+/-- Evaluating `ss₁ ++ ss₂` where `ss₁` produces `.normal` is equivalent to
+evaluating `ss₁`, then evaluating `ss₂` in the resulting state.
+This is the key composition lemma for the lifting correctness proof. -/
+theorem EvalLaurelBlock_append
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {ss₁ ss₂ : List StmtExprMd}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o₂ : Outcome}
+    (hss₁ : EvalLaurelBlock δ π h σ ss₁ h₁ σ₁ (.normal v₁))
+    (hne : ss₂ ≠ [])
+    (hss₂ : EvalLaurelBlock δ π h₁ σ₁ ss₂ h₂ σ₂ o₂) :
+    EvalLaurelBlock δ π h σ (ss₁ ++ ss₂) h₂ σ₂ o₂ := by
+  match hss₁ with
+  | .nil =>
+    -- ss₁ = [], so ss₁ ++ ss₂ = ss₂
+    exact hss₂
+  | .last_normal hs =>
+    -- ss₁ = [s], so ss₁ ++ ss₂ = s :: ss₂
+    exact .cons_normal hs hne hss₂
+  | .cons_normal hs hne_rest hrest =>
+    -- ss₁ = s :: rest, rest ≠ []
+    simp only [List.cons_append]
+    exact .cons_normal hs
+      (by simp [List.append_eq_nil_iff, hne_rest])
+      (EvalLaurelBlock_append hrest hne hss₂)
+
+/-- Variant of `EvalLaurelBlock_append` where `ss₂` is a singleton. -/
+theorem EvalLaurelBlock_append_singleton
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {ss₁ : List StmtExprMd} {s₂ : StmtExprMd}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o₂ : Outcome}
+    (hss₁ : EvalLaurelBlock δ π h σ ss₁ h₁ σ₁ (.normal v₁))
+    (hs₂ : EvalLaurelStmt δ π h₁ σ₁ s₂ h₂ σ₂ o₂) :
+    EvalLaurelBlock δ π h σ (ss₁ ++ [s₂]) h₂ σ₂ o₂ := by
+  cases o₂ with
+  | normal v₂ =>
+    exact EvalLaurelBlock_append hss₁ (by simp) (.last_normal hs₂)
+  | exit label =>
+    exact EvalLaurelBlock_append hss₁ (by simp) (.cons_exit hs₂)
+  | ret rv =>
+    exact EvalLaurelBlock_append hss₁ (by simp) (.cons_return hs₂)
+
+/-- Splitting `EvalStmtArgs` at a point: if we evaluate `[a] ++ rest`,
+we can decompose into evaluating `a` then `rest`. -/
+theorem EvalStmtArgs_cons_inv
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {e : StmtExprMd} {es : List StmtExprMd}
+    {h' : LaurelHeap} {σ' : LaurelStore}
+    {vs : List LaurelValue}
+    (heval : EvalStmtArgs δ π h σ (e :: es) h' σ' vs) :
+    ∃ v h₁ σ₁ vs',
+      vs = v :: vs' ∧
+      EvalLaurelStmt δ π h σ e h₁ σ₁ (.normal v) ∧
+      EvalStmtArgs δ π h₁ σ₁ es h' σ' vs' := by
+  cases heval with
+  | cons he hrest => exact ⟨_, _, _, _, rfl, he, hrest⟩
+
 end Strata.Laurel

--- a/Strata/Languages/Laurel/LiftImperativeExpressions.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressions.lean
@@ -118,10 +118,10 @@ private def getVarType (varName : Identifier) : LiftM HighTypeMd := do
   | some (_, ty) => return ty
   | none => panic s!"Could not find {varName} in environment."
 
-private def addToEnv (varName : Identifier) (ty : HighTypeMd) : LiftM Unit :=
+def addToEnv (varName : Identifier) (ty : HighTypeMd) : LiftM Unit :=
   modify fun s => { s with env := (varName, ty) :: s.env }
 
-private def getSubst (varName : Identifier) : LiftM Identifier := do
+def getSubst (varName : Identifier) : LiftM Identifier := do
   match (← get).subst.find? varName with
   | some mapped => return mapped
   | none => return varName
@@ -134,7 +134,7 @@ private def computeType (expr : StmtExprMd) : LiftM HighTypeMd := do
   return computeExprType s.env s.types expr s.procedures
 
 /-- Check if an expression contains any assignments or imperative calls (recursively). -/
-private def containsAssignmentOrImperativeCall (imperativeNames : List Identifier) (expr : StmtExprMd) : Bool :=
+def containsAssignmentOrImperativeCall (imperativeNames : List Identifier) (expr : StmtExprMd) : Bool :=
   match expr with
   | WithMetadata.mk val _ =>
   match val with

--- a/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
@@ -19,11 +19,11 @@ Proves that `transformExpr` is semantics-preserving on pure expressions
 
 ## Main Results
 
-- `transformExpr_pure_preserves`: semantic preservation for pure expressions.
 - `containsAssignmentOrImperativeCall_false_no_prepends`: pure expressions
   produce no prepended statements (for non-Block expressions).
 - `transformExpr_pure_identity`: on pure expressions with empty substitution
   map, `transformExpr` returns the same expression.
+- `transformExpr_pure_preserves`: semantic preservation for pure expressions.
 
 ## Design Reference
 
@@ -33,9 +33,6 @@ Option C (Phased bottom-up proof), Phase 1: pure expressions.
 namespace Strata.Laurel
 
 /-! ## Helper lemmas -/
-
-private theorem Map.find?_nil (a : Identifier) :
-    Map.find? ([] : Map Identifier Identifier) a = none := rfl
 
 theorem getSubst_run_empty (name : Identifier) (st : LiftState) (h : st.subst = []) :
     (getSubst name).run st = (name, st) := by
@@ -65,43 +62,10 @@ theorem transformExpr_identifier {name md} {st : LiftState} (h : st.subst = []) 
   simp [getSubst, h, Map.find?, StateT.run, bind, StateT.bind, pure, StateT.pure,
         get, getThe, MonadStateOf.get, StateT.get]
 
-/-! ## Main Theorem -/
-
-abbrev initLiftState : LiftState := {}
-
-/--
-For expressions with no assignments or imperative calls, if `transformExpr`
-produces no prepended statements, then the output expression evaluates
-identically to the input expression.
-
-This is the key Phase 1 result: the lifting pass is a no-op on pure expressions.
-
-The proof strategy: show `e' = e` by matching on the evaluation derivation.
-For each evaluation rule, the expression has a known form, and we show
-`transformExpr` returns it unchanged using the leaf identity lemmas.
-For recursive cases (PrimitiveOp, IfThenElse, StaticCall, Block), the
-proof requires induction on the expression structure — these are marked
-with `sorry` and will be completed as the mapM identity infrastructure
-is finalized.
--/
-theorem transformExpr_pure_preserves
-    {e' : StmtExprMd} {finalState : LiftState}
-    (e : StmtExprMd)
-    (hpure : ¬ containsAssignmentOrImperativeCall [] e)
-    (hrun : (transformExpr e).run initLiftState = (e', finalState))
-    (hno_prepends : finalState.prependedStmts = []) :
-    ∀ δ π h σ h' σ' v,
-      EvalLaurelStmt δ π h σ e h' σ' (.normal v) →
-      EvalLaurelStmt δ π h σ e' h' σ' (.normal v) := by
-  intro δ π h σ h' σ' v heval
-  suffices heq : e' = e by rw [heq]; exact heval
-  have hfst : e' = ((transformExpr e).run initLiftState).1 := by rw [hrun]
-  rw [hfst]
-  -- For each evaluation rule, show transformExpr returns the expression unchanged.
-  -- Leaf cases use the identity lemmas; recursive cases need induction.
-  sorry
-
 /-! ## Supporting lemmas -/
+
+-- These lemmas are stated before the main theorem because `transformExpr_pure_preserves`
+-- depends on them to derive identity and no-prepends from purity.
 
 /-- Pure expressions produce no prepended statements (non-Block case). -/
 theorem containsAssignmentOrImperativeCall_false_no_prepends
@@ -120,6 +84,49 @@ theorem transformExpr_pure_identity
     (hsubst : st.subst = [])
     (hnotblock : ∀ stmts label, e.val ≠ .Block stmts label) :
     ((transformExpr e).run st).1 = e := by
+  sorry
+
+-- TODO: Block case — `transformExpr` on a `Block` lifts all-but-last statements
+-- to prepends even when they're pure, so the above lemmas exclude blocks via
+-- `hnotblock`. The main theorem below covers all pure expressions including blocks.
+-- A separate `transformExpr_pure_identity_block` lemma (or a case-split in the
+-- main proof) is needed to handle the Block case. This will likely require showing
+-- that for pure blocks, the lifted prepends + transformed last expression are
+-- semantically equivalent to the original block.
+
+/-! ## Main Theorem -/
+
+abbrev initLiftState : LiftState := {}
+
+/--
+For expressions with no assignments or imperative calls, the output expression
+of `transformExpr` evaluates identically to the input expression.
+
+This is the key Phase 1 result: the lifting pass is a no-op on pure expressions.
+
+The proof strategy: show `e' = e` (syntactic identity) by using the supporting
+lemmas. For non-Block expressions, `transformExpr_pure_identity` gives `e' = e`
+directly. The Block case requires separate handling (see TODO above).
+
+Note: the universal quantification over `δ` and `π` is sound because the proof
+strategy is syntactic identity (`e' = e`), making the semantic parameters
+irrelevant. If the proof strategy changes to handle non-identity cases in later
+phases, this quantification structure would need revisiting.
+-/
+theorem transformExpr_pure_preserves
+    {e' : StmtExprMd} {finalState : LiftState}
+    (e : StmtExprMd)
+    (hpure : containsAssignmentOrImperativeCall initLiftState.imperativeNames e = false)
+    (hrun : (transformExpr e).run initLiftState = (e', finalState)) :
+    ∀ δ π h σ h' σ' v,
+      EvalLaurelStmt δ π h σ e h' σ' (.normal v) →
+      EvalLaurelStmt δ π h σ e' h' σ' (.normal v) := by
+  intro δ π h σ h' σ' v heval
+  suffices heq : e' = e by rw [heq]; exact heval
+  have hfst : e' = ((transformExpr e).run initLiftState).1 := by rw [hrun]
+  rw [hfst]
+  -- For non-Block expressions, apply transformExpr_pure_identity directly.
+  -- The Block case needs separate handling (see TODO above).
   sorry
 
 end Strata.Laurel

--- a/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
@@ -331,7 +331,7 @@ extension with snapshot variables).
 ### 4.1 Identity cases
 
 For statements where `transformStmt` returns `[stmt]` unchanged
-(assert, assume, literals, etc.), preservation is immediate.
+(Return, Exit, Assert, Assume, literals, etc.), preservation is immediate.
 -/
 
 /-- A singleton block `[s]` evaluates to the same result as `s`. -/
@@ -345,6 +345,17 @@ theorem stmt_to_block
   | exit l => exact .cons_exit heval
   | ret rv => exact .cons_return heval
 
+/-- Identity-case correctness: for statements where `transformStmt` returns
+`[stmt]` unchanged (Return, Exit, Assert, Assume, and other pass-through
+cases in the `| _ => return [stmt]` branch), the transformed singleton
+block evaluates to the same result as the original statement. -/
+theorem transformStmt_identity_correct
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {s : StmtExprMd} {h' : LaurelHeap} {σ' : LaurelStore} {o : Outcome}
+    (heval : EvalLaurelStmt δ π h σ s h' σ' o) :
+    EvalLaurelBlock δ π h σ [s] h' σ' o :=
+  stmt_to_block heval
+
 /-! ### 4.2 Prepend composition for statements
 
 When `transformStmt` produces `prepends ++ [s']`, the prepends come from
@@ -354,12 +365,32 @@ statement evaluates in the resulting store, the whole block evaluates
 correctly.
 
 This is a direct application of `EvalLaurelBlock_append_singleton`.
+
+Note: These theorems are structural composition lemmas — they show that
+`prepends ++ [s']` evaluates correctly given that prepends evaluate normally
+and `s'` evaluates in the resulting store. They do *not* connect to the
+actual monadic output of `transformStmt`; that connection is deferred to
+the end-to-end correctness theorem. In particular, they hold for any
+`prepends` that evaluate normally, regardless of whether those prepends
+are semantically related to the original expression.
 -/
 
-/-- Assign correctness: if the prepends from transforming the RHS evaluate
-normally, and the assignment with the cleaned RHS evaluates in the
-resulting store, then `prepends ++ [assign]` evaluates correctly. -/
-theorem transformStmt_assign_correct
+/-- Generic prepend composition: if prepends evaluate normally and the
+statement evaluates in the resulting store, then `prepends ++ [s]`
+evaluates correctly. The per-statement theorems below are specializations. -/
+theorem transformStmt_prepend_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {prepends : List StmtExprMd} {s : StmtExprMd}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hprep : EvalLaurelBlock δ π h σ prepends h₁ σ₁ (.normal v₁))
+    (hstmt : EvalLaurelStmt δ π h₁ σ₁ s h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ (prepends ++ [s]) h₂ σ₂ o :=
+  EvalLaurelBlock_append_singleton hprep hstmt
+
+/-- Assign correctness: specialization of `transformStmt_prepend_correct`. -/
+abbrev transformStmt_assign_correct
     {δ : LaurelEval} {π : ProcEnv}
     {h : LaurelHeap} {σ : LaurelStore}
     {prepends : List StmtExprMd}
@@ -370,13 +401,10 @@ theorem transformStmt_assign_correct
     (hprep : EvalLaurelBlock δ π h σ prepends h₁ σ₁ (.normal v₁))
     (hassign : EvalLaurelStmt δ π h₁ σ₁ ⟨.Assign targets seqValue, md⟩ h₂ σ₂ o) :
     EvalLaurelBlock δ π h σ (prepends ++ [⟨.Assign targets seqValue, md⟩]) h₂ σ₂ o :=
-  EvalLaurelBlock_append_singleton hprep hassign
+  transformStmt_prepend_correct hprep hassign
 
-/-- LocalVariable correctness: if the prepends from transforming the
-initializer evaluate normally, and the local variable declaration with
-the cleaned initializer evaluates in the resulting store, then
-`prepends ++ [local_var]` evaluates correctly. -/
-theorem transformStmt_local_var_correct
+/-- LocalVariable correctness: specialization of `transformStmt_prepend_correct`. -/
+abbrev transformStmt_local_var_correct
     {δ : LaurelEval} {π : ProcEnv}
     {h : LaurelHeap} {σ : LaurelStore}
     {prepends : List StmtExprMd}
@@ -388,7 +416,7 @@ theorem transformStmt_local_var_correct
     (hlocal : EvalLaurelStmt δ π h₁ σ₁ ⟨.LocalVariable name ty (some seqInit), md⟩ h₂ σ₂ o) :
     EvalLaurelBlock δ π h σ
       (prepends ++ [⟨.LocalVariable name ty (some seqInit), md⟩]) h₂ σ₂ o :=
-  EvalLaurelBlock_append_singleton hprep hlocal
+  transformStmt_prepend_correct hprep hlocal
 
 /-! ### 4.3 IfThenElse correctness
 
@@ -399,10 +427,8 @@ where `condPrepends` come from `transformExpr cond`, and `seqThen`/`seqElse`
 are blocks wrapping the recursively transformed branches.
 -/
 
-/-- IfThenElse correctness: if the condition prepends evaluate normally,
-and the if-then-else with the cleaned condition and transformed branches
-evaluates in the resulting store, then the whole block evaluates correctly. -/
-theorem transformStmt_ite_correct
+/-- IfThenElse correctness: specialization of `transformStmt_prepend_correct`. -/
+abbrev transformStmt_ite_correct
     {δ : LaurelEval} {π : ProcEnv}
     {h : LaurelHeap} {σ : LaurelStore}
     {condPrepends : List StmtExprMd}
@@ -414,18 +440,25 @@ theorem transformStmt_ite_correct
     (hite : EvalLaurelStmt δ π h₁ σ₁ ⟨.IfThenElse seqCond seqThen seqElse, md⟩ h₂ σ₂ o) :
     EvalLaurelBlock δ π h σ
       (condPrepends ++ [⟨.IfThenElse seqCond seqThen seqElse, md⟩]) h₂ σ₂ o :=
-  EvalLaurelBlock_append_singleton hprep hite
+  transformStmt_prepend_correct hprep hite
 
 /-! ### 4.4 While correctness
 
 `transformStmt` on `While cond invs dec body` produces:
   `condPrepends ++ [While seqCond invs dec seqBody]`
+
+Note: This is a structural composition lemma. It does *not* claim that
+`seqCond` is semantically equivalent to the original `cond` on each loop
+iteration. The condition prepends are evaluated once before the loop,
+while the `while_true` rule re-evaluates `seqCond` on each iteration.
+This is correct for the lifting pass (which only lifts pure snapshot
+operations whose values don't change across iterations), but the
+distinction is subtle — callers must ensure that the prepends only
+capture values that are loop-invariant.
 -/
 
-/-- While correctness: if the condition prepends evaluate normally,
-and the while loop with the cleaned condition and transformed body
-evaluates in the resulting store, then the whole block evaluates correctly. -/
-theorem transformStmt_while_correct
+/-- While correctness: specialization of `transformStmt_prepend_correct`. -/
+abbrev transformStmt_while_correct
     {δ : LaurelEval} {π : ProcEnv}
     {h : LaurelHeap} {σ : LaurelStore}
     {condPrepends : List StmtExprMd}
@@ -438,7 +471,7 @@ theorem transformStmt_while_correct
     (hwhile : EvalLaurelStmt δ π h₁ σ₁ ⟨.While seqCond invs dec seqBody, md⟩ h₂ σ₂ o) :
     EvalLaurelBlock δ π h σ
       (condPrepends ++ [⟨.While seqCond invs dec seqBody, md⟩]) h₂ σ₂ o :=
-  EvalLaurelBlock_append_singleton hprep hwhile
+  transformStmt_prepend_correct hprep hwhile
 
 /-! ### 4.5 StaticCall correctness
 
@@ -446,10 +479,8 @@ theorem transformStmt_while_correct
   `prepends ++ [StaticCall name seqArgs]`
 -/
 
-/-- StaticCall correctness: if the prepends from transforming the arguments
-evaluate normally, and the call with the cleaned arguments evaluates in
-the resulting store, then the whole block evaluates correctly. -/
-theorem transformStmt_static_call_correct
+/-- StaticCall correctness: specialization of `transformStmt_prepend_correct`. -/
+abbrev transformStmt_static_call_correct
     {δ : LaurelEval} {π : ProcEnv}
     {h : LaurelHeap} {σ : LaurelStore}
     {prepends : List StmtExprMd}
@@ -461,7 +492,7 @@ theorem transformStmt_static_call_correct
     (hcall : EvalLaurelStmt δ π h₁ σ₁ ⟨.StaticCall name seqArgs, md⟩ h₂ σ₂ o) :
     EvalLaurelBlock δ π h σ
       (prepends ++ [⟨.StaticCall name seqArgs, md⟩]) h₂ σ₂ o :=
-  EvalLaurelBlock_append_singleton hprep hcall
+  transformStmt_prepend_correct hprep hcall
 
 /-! ### 4.6 Block correctness
 
@@ -469,18 +500,6 @@ theorem transformStmt_static_call_correct
 statement and wraps the result in a new Block. The proof uses induction
 on the statement list.
 -/
-
-/-- If each statement in a block is correctly transformed (producing a
-list of statements that evaluates to the same result), then the flattened
-block evaluates to the same result as the original. -/
-theorem transformStmt_block_flatten
-    {δ : LaurelEval} {π : ProcEnv}
-    {h : LaurelHeap} {σ : LaurelStore}
-    {stmts_out : List (List StmtExprMd)}
-    {h' : LaurelHeap} {σ' : LaurelStore} {o : Outcome}
-    (heval : EvalLaurelBlock δ π h σ stmts_out.flatten h' σ' o) :
-    EvalLaurelBlock δ π h σ stmts_out.flatten h' σ' o :=
-  heval
 
 /-- Block correctness: if the original block evaluates to some result,
 and the transformed block (with each statement mapped through transformStmt)
@@ -580,7 +599,15 @@ result in the given state, then the transformed statements evaluate to
 the same result (modulo store extension)."
 
 Key invariant: `stmts_rest` is always non-empty when `rest` is non-empty,
-because each statement transforms to at least one statement. -/
+because each statement transforms to at least one statement.
+
+TODO: In `cons_normal`, the source produces `_v` and the target produces
+`_v'` — these are independent. This means `TransformOK` does not require
+intermediate normal values to agree, only that the final (heap, store,
+outcome) match. This is sufficient for `TransformOK_eval` (since
+`EvalLaurelBlock_append` only needs *some* normal value), but it weakens
+`TransformOK` as a specification of semantic preservation. A stronger
+version could require `_v = _v'` in `cons_normal`. -/
 inductive TransformOK :
     LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
     List StmtExprMd → List StmtExprMd →
@@ -594,6 +621,16 @@ inductive TransformOK :
     EvalLaurelStmt δ π h σ s h' σ' (.normal v) →
     EvalLaurelBlock δ π h σ stmts₁ h' σ' (.normal v) →
     TransformOK δ π h σ [s] stmts₁ h' σ' (.normal v)
+  /-- Last statement (exit): singleton source exits, target block exits. -/
+  | last_exit :
+    EvalLaurelStmt δ π h σ s h' σ' (.exit label) →
+    EvalLaurelBlock δ π h σ stmts₁ h' σ' (.exit label) →
+    TransformOK δ π h σ [s] stmts₁ h' σ' (.exit label)
+  /-- Last statement (return): singleton source returns, target block returns. -/
+  | last_return :
+    EvalLaurelStmt δ π h σ s h' σ' (.ret rv) →
+    EvalLaurelBlock δ π h σ stmts₁ h' σ' (.ret rv) →
+    TransformOK δ π h σ [s] stmts₁ h' σ' (.ret rv)
   /-- Cons (normal): first statement evaluates normally, rest follows.
   Requires `stmts_rest ≠ []` to ensure well-formed append. -/
   | cons_normal :
@@ -625,6 +662,8 @@ theorem TransformOK_eval
   match htok with
   | .nil => exact .nil
   | .last_normal _ htgt => exact htgt
+  | .last_exit _ htgt => exact htgt
+  | .last_return _ htgt => exact htgt
   | .cons_normal _ hfirst _ hne_rest hrest =>
     exact EvalLaurelBlock_append hfirst hne_rest (TransformOK_eval hrest)
   | .cons_exit _ hfirst => exact transformed_block_cons_exit hfirst

--- a/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
@@ -9,124 +9,148 @@ import Strata.Languages.Laurel.LaurelSemantics
 import Strata.Languages.Laurel.LaurelSemanticsProps
 
 /-!
-# Correctness of LiftImperativeExpressions — Phase 1: Pure Expressions
+# Correctness of LiftImperativeExpressions — Phase 2: Single Assignment
 
-Phase 1 of the bottom-up correctness proof for the lifting pass.
+Phase 2 of the bottom-up correctness proof for the lifting pass.
 See `docs/designs/design-correctness-theorem-for-liftimperativeexpre.md`.
 
-Proves that `transformExpr` is semantics-preserving on pure expressions
-(no assignments or imperative calls in argument position).
+## Concrete Case
+
+Expression: `op(x, x := e)` where `e` is pure (evaluates identically in
+any store that extends the original with fresh variables).
+
+After lifting:
+```
+  var snap := x;     -- snapshot x before assignment
+  x := e;            -- the assignment
+  op(snap, x)        -- cleaned expression using snapshot
+```
 
 ## Main Results
 
-- `containsAssignmentOrImperativeCall_false_no_prepends`: pure expressions
-  produce no prepended statements (for non-Block expressions).
-- `transformExpr_pure_identity`: on pure expressions with empty substitution
-  map, `transformExpr` returns the same expression.
-- `transformExpr_pure_preserves`: semantic preservation for pure expressions.
+- `lift_single_assign_correct`: constructive form — given the semantic
+  components, construct a derivation for the lifted block.
+- `lift_single_assign_from_eval`: derivation-based form — decompose an
+  original `prim_op` derivation and apply the constructive form.
 
 ## Design Reference
 
-Option C (Phased bottom-up proof), Phase 1: pure expressions.
+Option C (Phased bottom-up proof), Phase 2: single assignment in PrimitiveOp.
 -/
 
 namespace Strata.Laurel
 
-/-! ## Helper lemmas -/
+/-! ## BEq/Ne helper for String (Identifier) -/
 
-theorem getSubst_run_empty (name : Identifier) (st : LiftState) (h : st.subst = []) :
-    (getSubst name).run st = (name, st) := by
-  show (do let s ← get; match s.subst.find? name with
-    | some mapped => pure mapped | none => pure name : LiftM Identifier).run st = _
-  simp [h, Map.find?, StateT.run, bind, StateT.bind, pure, StateT.pure,
-        get, getThe, MonadStateOf.get, StateT.get]
+private theorem beq_false_of_ne {a b : String} (h : a ≠ b) : (a == b) = false := by
+  simp [h]
 
-/-! ## Leaf expression identity lemmas -/
+/-! ## Constructive form -/
 
-@[simp] theorem transformExpr_literal_int {i md st} :
-    (transformExpr (⟨.LiteralInt i, md⟩ : StmtExprMd)).run st = (⟨.LiteralInt i, md⟩, st) := by
-  simp only [transformExpr]; rfl
+/-- Given the semantic components of evaluating `op(x, x := e)`, construct
+a derivation showing the lifted block `[var snap := x; x := e; op(snap, x)]`
+produces the same result.
 
-@[simp] theorem transformExpr_literal_bool {b md st} :
-    (transformExpr (⟨.LiteralBool b, md⟩ : StmtExprMd)).run st = (⟨.LiteralBool b, md⟩, st) := by
-  simp only [transformExpr]; rfl
+This is the core Phase 2 theorem. The hypotheses directly state what the
+original evaluation computes, avoiding the need to invert mutual inductives. -/
+theorem lift_single_assign_correct
+    (δ : LaurelEval) (π : ProcEnv) (h : LaurelHeap) (σ : LaurelStore)
+    (op : Operation) (x snap : Identifier)
+    (e : StmtExprMd) (ty : HighTypeMd)
+    (md tmd : Imperative.MetaData Core.Expression)
+    (v_old v_new result : LaurelValue)
+    (hx_def : σ x = some v_old)
+    (hfresh : σ snap = none)
+    (hne : snap ≠ x)
+    (he_ext : ∀ σ', (∀ y, y ≠ snap → σ' y = σ y) →
+      EvalLaurelStmt δ π h σ' e h σ' (.normal v_new))
+    (hop : evalPrimOp op [v_old, v_new] = some result) :
+    ∃ σ_block, EvalLaurelBlock δ π h σ
+      [ ⟨.LocalVariable snap ty (some ⟨.Identifier x, md⟩), md⟩,
+        ⟨.Assign [⟨.Identifier x, tmd⟩] e, md⟩,
+        ⟨.PrimitiveOp op [⟨.Identifier snap, md⟩, ⟨.Identifier x, md⟩], md⟩ ]
+      h σ_block (.normal result) := by
+  -- Define intermediate stores
+  let σ_snap : LaurelStore := fun y => if y == snap then some v_old else σ y
+  let σ_final : LaurelStore := fun y => if y == x then some v_new else σ_snap y
+  -- Key store facts
+  have h_snap_self : σ_snap snap = some v_old := by simp [σ_snap]
+  have h_snap_x : σ_snap x = some v_old := by
+    simp only [σ_snap]; simp [beq_iff_eq, Ne.symm hne, hx_def]
+  have h_final_snap : σ_final snap = some v_old := by
+    simp only [σ_final]; simp [beq_iff_eq, hne, h_snap_self]
+  have h_final_x : σ_final x = some v_new := by simp [σ_final]
+  -- e evaluates to v_new in σ_snap (by purity / store-extension invariance)
+  have he_snap : EvalLaurelStmt δ π h σ_snap e h σ_snap (.normal v_new) := by
+    apply he_ext; intro y hne'
+    simp only [σ_snap]; simp [beq_iff_eq, hne']
+  -- InitStore for snap
+  have h_init : InitStore σ snap v_old σ_snap :=
+    .init hfresh h_snap_self (fun y hne' => by
+      simp only [σ_snap]; simp [beq_iff_eq, Ne.symm hne'])
+  -- UpdateStore for x := v_new in σ_snap
+  have h_upd : UpdateStore σ_snap x v_new σ_final :=
+    .update (v' := v_old) h_snap_x h_final_x (fun y hne' => by
+      simp only [σ_final]; simp [beq_iff_eq, Ne.symm hne'])
+  -- Assemble the block: [LocalVariable, Assign, PrimitiveOp]
+  exact ⟨σ_final, .cons_normal
+    (.local_var_init (.identifier hx_def) hfresh h_init)
+    (by simp)
+    (.cons_normal
+      (.assign_single he_snap h_snap_x h_upd)
+      (by simp)
+      (.last_normal
+        (.prim_op
+          (.cons (.identifier h_final_snap) (.cons (.identifier h_final_x) .nil))
+          hop)))⟩
 
-@[simp] theorem transformExpr_literal_string {s md st} :
-    (transformExpr (⟨.LiteralString s, md⟩ : StmtExprMd)).run st = (⟨.LiteralString s, md⟩, st) := by
-  simp only [transformExpr]; rfl
+-- ## Derivation-based form
 
-theorem transformExpr_identifier {name md} {st : LiftState} (h : st.subst = []) :
-    (transformExpr (⟨.Identifier name, md⟩ : StmtExprMd)).run st =
-    (⟨.Identifier name, md⟩, st) := by
-  simp only [transformExpr]
-  simp [getSubst, h, Map.find?, StateT.run, bind, StateT.bind, pure, StateT.pure,
-        get, getThe, MonadStateOf.get, StateT.get]
-
-/-! ## Supporting lemmas -/
-
--- These lemmas are stated before the main theorem because `transformExpr_pure_preserves`
--- depends on them to derive identity and no-prepends from purity.
-
-/-- Pure expressions produce no prepended statements (non-Block case). -/
-theorem containsAssignmentOrImperativeCall_false_no_prepends
-    (e : StmtExprMd) (st : LiftState)
-    (hpure : containsAssignmentOrImperativeCall st.imperativeNames e = false)
-    (hsubst : st.subst = [])
-    (hnotblock : ∀ stmts label, e.val ≠ .Block stmts label) :
-    ((transformExpr e).run st).2.prependedStmts = st.prependedStmts := by
-  sorry
-
-/-- On pure expressions with empty subst, `transformExpr` returns the same
-expression (non-Block case). -/
-theorem transformExpr_pure_identity
-    (e : StmtExprMd) (st : LiftState)
-    (hpure : containsAssignmentOrImperativeCall st.imperativeNames e = false)
-    (hsubst : st.subst = [])
-    (hnotblock : ∀ stmts label, e.val ≠ .Block stmts label) :
-    ((transformExpr e).run st).1 = e := by
-  sorry
-
--- TODO: Block case — `transformExpr` on a `Block` lifts all-but-last statements
--- to prepends even when they're pure, so the above lemmas exclude blocks via
--- `hnotblock`. The main theorem below covers all pure expressions including blocks.
--- A separate `transformExpr_pure_identity_block` lemma (or a case-split in the
--- main proof) is needed to handle the Block case. This will likely require showing
--- that for pure blocks, the lifted prepends + transformed last expression are
--- semantically equivalent to the original block.
-
-/-! ## Main Theorem -/
-
-abbrev initLiftState : LiftState := {}
-
-/--
-For expressions with no assignments or imperative calls, the output expression
-of `transformExpr` evaluates identically to the input expression.
-
-This is the key Phase 1 result: the lifting pass is a no-op on pure expressions.
-
-The proof strategy: show `e' = e` (syntactic identity) by using the supporting
-lemmas. For non-Block expressions, `transformExpr_pure_identity` gives `e' = e`
-directly. The Block case requires separate handling (see TODO above).
-
-Note: the universal quantification over `δ` and `π` is sound because the proof
-strategy is syntactic identity (`e' = e`), making the semantic parameters
-irrelevant. If the proof strategy changes to handle non-identity cases in later
-phases, this quantification structure would need revisiting.
--/
-theorem transformExpr_pure_preserves
-    {e' : StmtExprMd} {finalState : LiftState}
-    (e : StmtExprMd)
-    (hpure : containsAssignmentOrImperativeCall initLiftState.imperativeNames e = false)
-    (hrun : (transformExpr e).run initLiftState = (e', finalState)) :
-    ∀ δ π h σ h' σ' v,
-      EvalLaurelStmt δ π h σ e h' σ' (.normal v) →
-      EvalLaurelStmt δ π h σ e' h' σ' (.normal v) := by
-  intro δ π h σ h' σ' v heval
-  suffices heq : e' = e by rw [heq]; exact heval
-  have hfst : e' = ((transformExpr e).run initLiftState).1 := by rw [hrun]
-  rw [hfst]
-  -- For non-Block expressions, apply transformExpr_pure_identity directly.
-  -- The Block case needs separate handling (see TODO above).
-  sorry
+set_option maxHeartbeats 800000 in
+/-- Given a derivation of `op(x, x := e)`, produce a derivation of the
+lifted block. Requires that `e` is pure: it evaluates to `v_new` without
+changing heap or store, and evaluates identically in any store that agrees
+with the original store on all variables except `snap`. -/
+theorem lift_single_assign_from_eval
+    (δ : LaurelEval) (π : ProcEnv) (h : LaurelHeap) (σ : LaurelStore)
+    (op : Operation) (x snap : Identifier)
+    (e : StmtExprMd) (ty : HighTypeMd)
+    (md tmd : Imperative.MetaData Core.Expression)
+    (h' : LaurelHeap) (σ' : LaurelStore) (result : LaurelValue)
+    (v_new : LaurelValue)
+    (heval : EvalLaurelStmt δ π h σ
+      ⟨.PrimitiveOp op [⟨.Identifier x, md⟩,
+                         ⟨.Assign [⟨.Identifier x, tmd⟩] e, md⟩], md⟩
+      h' σ' (.normal result))
+    (hfresh : σ snap = none)
+    (hne : snap ≠ x)
+    (he_pure : EvalLaurelStmt δ π h σ e h σ (.normal v_new))
+    (he_ext : ∀ σ₀, (∀ y, y ≠ snap → σ₀ y = σ y) →
+      EvalLaurelStmt δ π h σ₀ e h σ₀ (.normal v_new)) :
+    ∃ σ_block, EvalLaurelBlock δ π h σ
+      [ ⟨.LocalVariable snap ty (some ⟨.Identifier x, md⟩), md⟩,
+        ⟨.Assign [⟨.Identifier x, tmd⟩] e, md⟩,
+        ⟨.PrimitiveOp op [⟨.Identifier snap, md⟩, ⟨.Identifier x, md⟩], md⟩ ]
+      h' σ_block (.normal result) := by
+  -- Invert the original derivation
+  cases heval with
+  | prim_op hargs hop_eq =>
+    cases hargs with
+    | cons harg1 hrest =>
+      cases hrest with
+      | cons harg2 hnil =>
+        cases hnil
+        cases harg1 with
+        | identifier hlookup =>
+          cases harg2 with
+          | assign_single heval_e _hexists hupdate =>
+            -- By determinism: heval_e agrees with he_pure on output state
+            have ⟨hh_eq, hσ_eq, hv_eq⟩ := EvalLaurelStmt_deterministic heval_e he_pure
+            -- hh_eq: output heap of e = h, hσ_eq: output store of e = σ
+            -- Rewrite in hupdate and hop_eq rather than subst (to preserve names)
+            cases hv_eq  -- unify the value
+            rw [hh_eq] at *; rw [hσ_eq] at *
+            exact lift_single_assign_correct δ π _ _ op x snap e ty md tmd
+              _ _ result hlookup hfresh hne he_ext hop_eq
 
 end Strata.Laurel

--- a/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
@@ -1,0 +1,125 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Laurel.LiftImperativeExpressions
+import Strata.Languages.Laurel.LaurelSemantics
+import Strata.Languages.Laurel.LaurelSemanticsProps
+
+/-!
+# Correctness of LiftImperativeExpressions — Phase 1: Pure Expressions
+
+Phase 1 of the bottom-up correctness proof for the lifting pass.
+See `docs/designs/design-correctness-theorem-for-liftimperativeexpre.md`.
+
+Proves that `transformExpr` is semantics-preserving on pure expressions
+(no assignments or imperative calls in argument position).
+
+## Main Results
+
+- `transformExpr_pure_preserves`: semantic preservation for pure expressions.
+- `containsAssignmentOrImperativeCall_false_no_prepends`: pure expressions
+  produce no prepended statements (for non-Block expressions).
+- `transformExpr_pure_identity`: on pure expressions with empty substitution
+  map, `transformExpr` returns the same expression.
+
+## Design Reference
+
+Option C (Phased bottom-up proof), Phase 1: pure expressions.
+-/
+
+namespace Strata.Laurel
+
+/-! ## Helper lemmas -/
+
+private theorem Map.find?_nil (a : Identifier) :
+    Map.find? ([] : Map Identifier Identifier) a = none := rfl
+
+theorem getSubst_run_empty (name : Identifier) (st : LiftState) (h : st.subst = []) :
+    (getSubst name).run st = (name, st) := by
+  show (do let s ← get; match s.subst.find? name with
+    | some mapped => pure mapped | none => pure name : LiftM Identifier).run st = _
+  simp [h, Map.find?, StateT.run, bind, StateT.bind, pure, StateT.pure,
+        get, getThe, MonadStateOf.get, StateT.get]
+
+/-! ## Leaf expression identity lemmas -/
+
+@[simp] theorem transformExpr_literal_int {i md st} :
+    (transformExpr (⟨.LiteralInt i, md⟩ : StmtExprMd)).run st = (⟨.LiteralInt i, md⟩, st) := by
+  simp only [transformExpr]; rfl
+
+@[simp] theorem transformExpr_literal_bool {b md st} :
+    (transformExpr (⟨.LiteralBool b, md⟩ : StmtExprMd)).run st = (⟨.LiteralBool b, md⟩, st) := by
+  simp only [transformExpr]; rfl
+
+@[simp] theorem transformExpr_literal_string {s md st} :
+    (transformExpr (⟨.LiteralString s, md⟩ : StmtExprMd)).run st = (⟨.LiteralString s, md⟩, st) := by
+  simp only [transformExpr]; rfl
+
+theorem transformExpr_identifier {name md} {st : LiftState} (h : st.subst = []) :
+    (transformExpr (⟨.Identifier name, md⟩ : StmtExprMd)).run st =
+    (⟨.Identifier name, md⟩, st) := by
+  simp only [transformExpr]
+  simp [getSubst, h, Map.find?, StateT.run, bind, StateT.bind, pure, StateT.pure,
+        get, getThe, MonadStateOf.get, StateT.get]
+
+/-! ## Main Theorem -/
+
+abbrev initLiftState : LiftState := {}
+
+/--
+For expressions with no assignments or imperative calls, if `transformExpr`
+produces no prepended statements, then the output expression evaluates
+identically to the input expression.
+
+This is the key Phase 1 result: the lifting pass is a no-op on pure expressions.
+
+The proof strategy: show `e' = e` by matching on the evaluation derivation.
+For each evaluation rule, the expression has a known form, and we show
+`transformExpr` returns it unchanged using the leaf identity lemmas.
+For recursive cases (PrimitiveOp, IfThenElse, StaticCall, Block), the
+proof requires induction on the expression structure — these are marked
+with `sorry` and will be completed as the mapM identity infrastructure
+is finalized.
+-/
+theorem transformExpr_pure_preserves
+    {e' : StmtExprMd} {finalState : LiftState}
+    (e : StmtExprMd)
+    (hpure : ¬ containsAssignmentOrImperativeCall [] e)
+    (hrun : (transformExpr e).run initLiftState = (e', finalState))
+    (hno_prepends : finalState.prependedStmts = []) :
+    ∀ δ π h σ h' σ' v,
+      EvalLaurelStmt δ π h σ e h' σ' (.normal v) →
+      EvalLaurelStmt δ π h σ e' h' σ' (.normal v) := by
+  intro δ π h σ h' σ' v heval
+  suffices heq : e' = e by rw [heq]; exact heval
+  have hfst : e' = ((transformExpr e).run initLiftState).1 := by rw [hrun]
+  rw [hfst]
+  -- For each evaluation rule, show transformExpr returns the expression unchanged.
+  -- Leaf cases use the identity lemmas; recursive cases need induction.
+  sorry
+
+/-! ## Supporting lemmas -/
+
+/-- Pure expressions produce no prepended statements (non-Block case). -/
+theorem containsAssignmentOrImperativeCall_false_no_prepends
+    (e : StmtExprMd) (st : LiftState)
+    (hpure : containsAssignmentOrImperativeCall st.imperativeNames e = false)
+    (hsubst : st.subst = [])
+    (hnotblock : ∀ stmts label, e.val ≠ .Block stmts label) :
+    ((transformExpr e).run st).2.prependedStmts = st.prependedStmts := by
+  sorry
+
+/-- On pure expressions with empty subst, `transformExpr` returns the same
+expression (non-Block case). -/
+theorem transformExpr_pure_identity
+    (e : StmtExprMd) (st : LiftState)
+    (hpure : containsAssignmentOrImperativeCall st.imperativeNames e = false)
+    (hsubst : st.subst = [])
+    (hnotblock : ∀ stmts label, e.val ≠ .Block stmts label) :
+    ((transformExpr e).run st).1 = e := by
+  sorry
+
+end Strata.Laurel

--- a/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
@@ -9,50 +9,23 @@ import Strata.Languages.Laurel.LaurelSemantics
 import Strata.Languages.Laurel.LaurelSemanticsProps
 
 /-!
-# Correctness of LiftImperativeExpressions — Phase 2: Single Assignment
+# Correctness of LiftImperativeExpressions — Phases 2 & 3
 
-Phase 2 of the bottom-up correctness proof for the lifting pass.
+Bottom-up correctness proof for the lifting pass.
 See `docs/designs/design-correctness-theorem-for-liftimperativeexpre.md`.
 
-## Concrete Case
-
-Expression: `op(x, x := e)` where `e` is pure (evaluates identically in
-any store that extends the original with fresh variables).
-
-After lifting:
-```
-  var snap := x;     -- snapshot x before assignment
-  x := e;            -- the assignment
-  op(snap, x)        -- cleaned expression using snapshot
-```
-
-## Main Results
-
-- `lift_single_assign_correct`: constructive form — given the semantic
-  components, construct a derivation for the lifted block.
-- `lift_single_assign_from_eval`: derivation-based form — decompose an
-  original `prim_op` derivation and apply the constructive form.
+## Phase 2: Single Assignment in PrimitiveOp
+## Phase 3: General PrimitiveOp with Multiple Assignments
 
 ## Design Reference
 
-Option C (Phased bottom-up proof), Phase 2: single assignment in PrimitiveOp.
+Option C (Phased bottom-up proof), Phases 2–3.
 -/
 
 namespace Strata.Laurel
 
-/-! ## BEq/Ne helper for String (Identifier) -/
+/-! ## Phase 2: Single Assignment -/
 
-private theorem beq_false_of_ne {a b : String} (h : a ≠ b) : (a == b) = false := by
-  simp [h]
-
-/-! ## Constructive form -/
-
-/-- Given the semantic components of evaluating `op(x, x := e)`, construct
-a derivation showing the lifted block `[var snap := x; x := e; op(snap, x)]`
-produces the same result.
-
-This is the core Phase 2 theorem. The hypotheses directly state what the
-original evaluation computes, avoiding the need to invert mutual inductives. -/
 theorem lift_single_assign_correct
     (δ : LaurelEval) (π : ProcEnv) (h : LaurelHeap) (σ : LaurelStore)
     (op : Operation) (x snap : Identifier)
@@ -70,29 +43,22 @@ theorem lift_single_assign_correct
         ⟨.Assign [⟨.Identifier x, tmd⟩] e, md⟩,
         ⟨.PrimitiveOp op [⟨.Identifier snap, md⟩, ⟨.Identifier x, md⟩], md⟩ ]
       h σ_block (.normal result) := by
-  -- Define intermediate stores
   let σ_snap : LaurelStore := fun y => if y == snap then some v_old else σ y
   let σ_final : LaurelStore := fun y => if y == x then some v_new else σ_snap y
-  -- Key store facts
   have h_snap_self : σ_snap snap = some v_old := by simp [σ_snap]
   have h_snap_x : σ_snap x = some v_old := by
     simp only [σ_snap]; simp [beq_iff_eq, Ne.symm hne, hx_def]
   have h_final_snap : σ_final snap = some v_old := by
     simp only [σ_final]; simp [beq_iff_eq, hne, h_snap_self]
   have h_final_x : σ_final x = some v_new := by simp [σ_final]
-  -- e evaluates to v_new in σ_snap (by purity / store-extension invariance)
   have he_snap : EvalLaurelStmt δ π h σ_snap e h σ_snap (.normal v_new) := by
-    apply he_ext; intro y hne'
-    simp only [σ_snap]; simp [beq_iff_eq, hne']
-  -- InitStore for snap
+    apply he_ext; intro y hne'; simp only [σ_snap]; simp [beq_iff_eq, hne']
   have h_init : InitStore σ snap v_old σ_snap :=
     .init hfresh h_snap_self (fun y hne' => by
       simp only [σ_snap]; simp [beq_iff_eq, Ne.symm hne'])
-  -- UpdateStore for x := v_new in σ_snap
   have h_upd : UpdateStore σ_snap x v_new σ_final :=
     .update (v' := v_old) h_snap_x h_final_x (fun y hne' => by
       simp only [σ_final]; simp [beq_iff_eq, Ne.symm hne'])
-  -- Assemble the block: [LocalVariable, Assign, PrimitiveOp]
   exact ⟨σ_final, .cons_normal
     (.local_var_init (.identifier hx_def) hfresh h_init)
     (by simp)
@@ -104,13 +70,7 @@ theorem lift_single_assign_correct
           (.cons (.identifier h_final_snap) (.cons (.identifier h_final_x) .nil))
           hop)))⟩
 
--- ## Derivation-based form
-
 set_option maxHeartbeats 800000 in
-/-- Given a derivation of `op(x, x := e)`, produce a derivation of the
-lifted block. Requires that `e` is pure: it evaluates to `v_new` without
-changing heap or store, and evaluates identically in any store that agrees
-with the original store on all variables except `snap`. -/
 theorem lift_single_assign_from_eval
     (δ : LaurelEval) (π : ProcEnv) (h : LaurelHeap) (σ : LaurelStore)
     (op : Operation) (x snap : Identifier)
@@ -132,7 +92,6 @@ theorem lift_single_assign_from_eval
         ⟨.Assign [⟨.Identifier x, tmd⟩] e, md⟩,
         ⟨.PrimitiveOp op [⟨.Identifier snap, md⟩, ⟨.Identifier x, md⟩], md⟩ ]
       h' σ_block (.normal result) := by
-  -- Invert the original derivation
   cases heval with
   | prim_op hargs hop_eq =>
     cases hargs with
@@ -144,13 +103,220 @@ theorem lift_single_assign_from_eval
         | identifier hlookup =>
           cases harg2 with
           | assign_single heval_e _hexists hupdate =>
-            -- By determinism: heval_e agrees with he_pure on output state
             have ⟨hh_eq, hσ_eq, hv_eq⟩ := EvalLaurelStmt_deterministic heval_e he_pure
-            -- hh_eq: output heap of e = h, hσ_eq: output store of e = σ
-            -- Rewrite in hupdate and hop_eq rather than subst (to preserve names)
-            cases hv_eq  -- unify the value
-            rw [hh_eq] at *; rw [hσ_eq] at *
+            cases hv_eq; rw [hh_eq] at *; rw [hσ_eq] at *
             exact lift_single_assign_correct δ π _ _ op x snap e ty md tmd
               _ _ result hlookup hfresh hne he_ext hop_eq
+
+/-! ## Phase 3: General PrimitiveOp with Multiple Assignments -/
+
+/-- Specification of a single argument in a PrimitiveOp call. -/
+inductive ArgSpec where
+  | pure (ref : StmtExprMd) (val : LaurelValue)
+  | assign (x snap : Identifier) (e : StmtExprMd) (ty : HighTypeMd) (val : LaurelValue)
+
+def ArgSpec.value : ArgSpec → LaurelValue
+  | .pure _ v => v
+  | .assign _ _ _ _ v => v
+
+def ArgSpec.cleanedArg (md : Imperative.MetaData Core.Expression) : ArgSpec → StmtExprMd
+  | .pure ref _ => ref
+  | .assign x _ _ _ _ => ⟨.Identifier x, md⟩
+
+def ArgSpec.prepends (md tmd : Imperative.MetaData Core.Expression) : ArgSpec → List StmtExprMd
+  | .pure _ _ => []
+  | .assign x snap e ty _ =>
+    [ ⟨.LocalVariable snap ty (some ⟨.Identifier x, md⟩), md⟩,
+      ⟨.Assign [⟨.Identifier x, tmd⟩] e, md⟩ ]
+
+def allPrepends (md tmd : Imperative.MetaData Core.Expression) : List ArgSpec → List StmtExprMd
+  | [] => []
+  | a :: as => allPrepends md tmd as ++ a.prepends md tmd
+
+def cleanedArgs (md : Imperative.MetaData Core.Expression) : List ArgSpec → List StmtExprMd
+  | [] => []
+  | a :: as => a.cleanedArg md :: cleanedArgs md as
+
+def argValues : List ArgSpec → List LaurelValue
+  | [] => []
+  | a :: as => a.value :: argValues as
+
+/-! ### Store Effect Model -/
+
+def applyArgEffect (σ : LaurelStore) : ArgSpec → LaurelStore
+  | .pure _ _ => σ
+  | .assign x snap _ _ val =>
+    fun y => if y == x then some val
+             else if y == snap then σ x
+             else σ y
+
+/-- Thread store effects right-to-left: for `[a₁, ..., aₙ]`, apply aₙ first,
+then aₙ₋₁, ..., then a₁. This matches the execution order of `allPrepends`. -/
+def threadEffectsRL (σ : LaurelStore) : List ArgSpec → LaurelStore
+  | [] => σ
+  | a :: as => applyArgEffect (threadEffectsRL σ as) a
+
+/-! ### Freshness Through Threading -/
+
+theorem threadEffectsRL_preserves_none
+    {σ : LaurelStore} {name : Identifier}
+    (hfresh : σ name = none)
+    (hne : ∀ spec ∈ specs, match spec with
+      | .assign x snap _ _ _ => name ≠ x ∧ name ≠ snap
+      | .pure _ _ => True) :
+    threadEffectsRL σ specs name = none := by
+  match specs with
+  | [] => exact hfresh
+  | (.pure _ _) :: rest =>
+    simp only [threadEffectsRL, applyArgEffect]
+    -- threadEffectsRL σ (pure :: rest) = applyArgEffect (threadEffectsRL σ rest) pure
+    -- = threadEffectsRL σ rest (since pure is identity)
+    exact threadEffectsRL_preserves_none hfresh
+      (fun s hs => hne s (List.mem_cons_of_mem _ hs))
+  | (.assign x snap e₀ ty₀ val₀) :: rest =>
+    -- threadEffectsRL σ (assign :: rest) = applyArgEffect (threadEffectsRL σ rest) assign
+    simp only [threadEffectsRL, applyArgEffect]
+    have h_spec := hne (.assign x snap e₀ ty₀ val₀) List.mem_cons_self
+    have hne_x := h_spec.1
+    have hne_snap := h_spec.2
+    simp [beq_iff_eq, hne_x, hne_snap]
+    -- Now need: threadEffectsRL σ rest name = none
+    -- But the goal after simp should be about (threadEffectsRL σ rest) x, not name
+    -- Actually after simp [beq_iff_eq, hne_x, hne_snap], the if-then-else reduces
+    -- and we need threadEffectsRL σ rest name = none
+    exact threadEffectsRL_preserves_none hfresh
+      (fun s hs => hne s (List.mem_cons_of_mem _ hs))
+
+/-! ### Single Assignment Prepend Evaluation -/
+
+theorem assign_prepends_eval
+    (δ : LaurelEval) (π : ProcEnv) (h : LaurelHeap) (σ : LaurelStore)
+    (x snap : Identifier) (e : StmtExprMd) (ty : HighTypeMd)
+    (md tmd : Imperative.MetaData Core.Expression)
+    (v_old val : LaurelValue)
+    (hx_def : σ x = some v_old)
+    (hfresh : σ snap = none)
+    (hne : snap ≠ x)
+    (he_eval : ∀ σ₀, (∀ y, y ≠ snap → σ₀ y = σ y) →
+      EvalLaurelStmt δ π h σ₀ e h σ₀ (.normal val)) :
+    EvalLaurelBlock δ π h σ
+      (ArgSpec.prepends md tmd (ArgSpec.assign x snap e ty val))
+      h (applyArgEffect σ (ArgSpec.assign x snap e ty val)) (.normal val) := by
+  simp only [ArgSpec.prepends, applyArgEffect]
+  -- The snapshot store: snap gets v_old (= σ x), everything else unchanged
+  let σ_snap : LaurelStore := fun y => if y == snap then some v_old else σ y
+  have h_snap_x : σ_snap x = some v_old := by
+    simp [σ_snap, beq_iff_eq, Ne.symm hne, hx_def]
+  have he_snap : EvalLaurelStmt δ π h σ_snap e h σ_snap (.normal val) :=
+    he_eval σ_snap (fun y hne' => by simp [σ_snap, beq_iff_eq, hne'])
+  have h_init : InitStore σ snap v_old σ_snap :=
+    .init hfresh (by simp [σ_snap]) (fun y hne' => by
+      simp [σ_snap, beq_iff_eq, Ne.symm hne'])
+  -- The final store after assignment
+  let σ_final : LaurelStore :=
+    fun y => if y == x then some val else σ_snap y
+  have hσ_final_x : σ_final x = some val := by simp [σ_final]
+  have h_upd : UpdateStore σ_snap x val σ_final :=
+    .update (v' := v_old) h_snap_x hσ_final_x
+      (fun y hne' => by simp [σ_final, beq_iff_eq, Ne.symm hne'])
+  -- σ_final = applyArgEffect result (the nested if-then-else)
+  suffices h_eq : σ_final = fun y => if y == x then some val
+      else if y == snap then σ x else σ y by
+    rw [h_eq] at h_upd
+    exact .cons_normal
+      (.local_var_init (.identifier hx_def) hfresh h_init)
+      (by simp)
+      (.last_normal (.assign_single he_snap h_snap_x h_upd))
+  funext y; simp only [σ_final, σ_snap]
+  split
+  · rfl
+  · split
+    · simp_all
+    · rfl
+
+/-! ### General Prepend Evaluation
+
+Proof by structural recursion on the spec list. For `spec :: rest`:
+1. Recursively evaluate prepends for `rest` (these execute first)
+2. Evaluate prepends for `spec` in the resulting store
+3. Compose via `EvalLaurelBlock_append` -/
+
+/-- Inductive witness that a spec list is well-formed and each assignment
+evaluates correctly. This avoids indexing and BEq issues. -/
+inductive SpecsOK :
+    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
+    Imperative.MetaData Core.Expression → Imperative.MetaData Core.Expression →
+    List ArgSpec → Prop where
+  | nil : SpecsOK δ π h σ md tmd []
+  | cons_pure :
+    SpecsOK δ π h σ md tmd rest →
+    SpecsOK δ π h σ md tmd (ArgSpec.pure ref val :: rest)
+  | cons_assign :
+    SpecsOK δ π h σ md tmd rest →
+    -- snap is fresh in σ and not affected by any spec in rest
+    (σ snap = none) →
+    (∀ spec ∈ rest, match spec with
+      | .assign x' snap' _ _ _ => snap ≠ x' ∧ snap ≠ snap'
+      | .pure _ _ => True) →
+    (snap ≠ x) →
+    -- target is defined after threading rest
+    ((threadEffectsRL σ rest x).isSome) →
+    -- e evaluates purely in the store after threading rest
+    (∀ σ₀, (∀ y, y ≠ snap → σ₀ y = threadEffectsRL σ rest y) →
+      EvalLaurelStmt δ π h σ₀ e h σ₀ (.normal val)) →
+    SpecsOK δ π h σ md tmd (ArgSpec.assign x snap e ty val :: rest)
+
+theorem allPrepends_eval
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {md tmd : Imperative.MetaData Core.Expression}
+    {specs : List ArgSpec}
+    (hok : SpecsOK δ π h σ md tmd specs) :
+    ∃ v, EvalLaurelBlock δ π h σ
+      (allPrepends md tmd specs)
+      h (threadEffectsRL σ specs) (.normal v) := by
+  match hok with
+  | .nil => exact ⟨.vVoid, .nil⟩
+  | .cons_pure hrest =>
+    simp only [allPrepends, ArgSpec.prepends, List.append_nil, threadEffectsRL, applyArgEffect]
+    exact allPrepends_eval hrest
+  | .cons_assign (rest := rest) (x := x) (snap := snap) (e := e) (ty := ty) (val := val)
+      hrest hfresh_σ hfresh_rest hne htarget_def he_eval =>
+    -- Recursively evaluate prepends for rest
+    have ⟨v_rest, hrest_eval⟩ := allPrepends_eval hrest
+    simp only [allPrepends, threadEffectsRL]
+    let σ_rest := threadEffectsRL σ rest
+    -- snap is fresh in σ_rest
+    have hsnap_fresh : σ_rest snap = none := by
+      apply threadEffectsRL_preserves_none hfresh_σ
+      intro spec hmem
+      exact hfresh_rest spec hmem
+    -- target is defined in σ_rest
+    obtain ⟨v_old, hx_def⟩ := Option.isSome_iff_exists.mp htarget_def
+    -- Evaluate the assignment prepends
+    have hassign := assign_prepends_eval δ π h σ_rest x snap e ty md tmd
+      v_old val hx_def hsnap_fresh hne he_eval
+    -- Compose
+    exact ⟨_, EvalLaurelBlock_append hrest_eval (by simp [ArgSpec.prepends]) hassign⟩
+
+/-! ### Main Phase 3 Theorem -/
+
+/-- General Phase 3 theorem: the lifted block (prepended statements followed
+by the cleaned PrimitiveOp) evaluates to the same result as the original. -/
+theorem lift_multi_assign_correct
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {op : Operation} {specs : List ArgSpec}
+    {md tmd : Imperative.MetaData Core.Expression}
+    {result : LaurelValue}
+    (hok : SpecsOK δ π h σ md tmd specs)
+    -- The cleaned args evaluate to the right values in the final store
+    (hargs_eval : EvalStmtArgs δ π h (threadEffectsRL σ specs)
+      (cleanedArgs md specs) h (threadEffectsRL σ specs) (argValues specs))
+    (hop : evalPrimOp op (argValues specs) = some result) :
+    ∃ σ_final, EvalLaurelBlock δ π h σ
+      (allPrepends md tmd specs ++ [⟨.PrimitiveOp op (cleanedArgs md specs), md⟩])
+      h σ_final (.normal result) := by
+  have ⟨_, hprep⟩ := allPrepends_eval hok
+  exact ⟨threadEffectsRL σ specs,
+    EvalLaurelBlock_append_singleton hprep (.prim_op hargs_eval hop)⟩
 
 end Strata.Laurel

--- a/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressionsCorrectness.lean
@@ -9,17 +9,18 @@ import Strata.Languages.Laurel.LaurelSemantics
 import Strata.Languages.Laurel.LaurelSemanticsProps
 
 /-!
-# Correctness of LiftImperativeExpressions — Phases 2 & 3
+# Correctness of LiftImperativeExpressions — Phases 2–4
 
 Bottom-up correctness proof for the lifting pass.
 See `docs/designs/design-correctness-theorem-for-liftimperativeexpre.md`.
 
 ## Phase 2: Single Assignment in PrimitiveOp
 ## Phase 3: General PrimitiveOp with Multiple Assignments
+## Phase 4: Statement-level transformStmt
 
 ## Design Reference
 
-Option C (Phased bottom-up proof), Phases 2–3.
+Option C (Phased bottom-up proof), Phases 2–4.
 -/
 
 namespace Strata.Laurel
@@ -318,5 +319,315 @@ theorem lift_multi_assign_correct
   have ⟨_, hprep⟩ := allPrepends_eval hok
   exact ⟨threadEffectsRL σ specs,
     EvalLaurelBlock_append_singleton hprep (.prim_op hargs_eval hop)⟩
+
+/-! ## Phase 4: Statement-level transformStmt
+
+These theorems show that `transformStmt` preserves semantics for each
+statement construct. The approach: if the original statement evaluates
+to some result, and the transformation output is `prepends ++ [s']`,
+then the output block evaluates to the same result (modulo store
+extension with snapshot variables).
+
+### 4.1 Identity cases
+
+For statements where `transformStmt` returns `[stmt]` unchanged
+(assert, assume, literals, etc.), preservation is immediate.
+-/
+
+/-- A singleton block `[s]` evaluates to the same result as `s`. -/
+theorem stmt_to_block
+    {δ : LaurelEval} {π : ProcEnv} {h : LaurelHeap} {σ : LaurelStore}
+    {s : StmtExprMd} {h' : LaurelHeap} {σ' : LaurelStore} {o : Outcome}
+    (heval : EvalLaurelStmt δ π h σ s h' σ' o) :
+    EvalLaurelBlock δ π h σ [s] h' σ' o := by
+  cases o with
+  | normal v => exact .last_normal heval
+  | exit l => exact .cons_exit heval
+  | ret rv => exact .cons_return heval
+
+/-! ### 4.2 Prepend composition for statements
+
+When `transformStmt` produces `prepends ++ [s']`, the prepends come from
+`transformExpr` on sub-expressions. If the prepends evaluate normally
+(setting up the store for the cleaned expression), and the cleaned
+statement evaluates in the resulting store, the whole block evaluates
+correctly.
+
+This is a direct application of `EvalLaurelBlock_append_singleton`.
+-/
+
+/-- Assign correctness: if the prepends from transforming the RHS evaluate
+normally, and the assignment with the cleaned RHS evaluates in the
+resulting store, then `prepends ++ [assign]` evaluates correctly. -/
+theorem transformStmt_assign_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {prepends : List StmtExprMd}
+    {targets : List StmtExprMd} {seqValue : StmtExprMd}
+    {md : Imperative.MetaData Core.Expression}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hprep : EvalLaurelBlock δ π h σ prepends h₁ σ₁ (.normal v₁))
+    (hassign : EvalLaurelStmt δ π h₁ σ₁ ⟨.Assign targets seqValue, md⟩ h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ (prepends ++ [⟨.Assign targets seqValue, md⟩]) h₂ σ₂ o :=
+  EvalLaurelBlock_append_singleton hprep hassign
+
+/-- LocalVariable correctness: if the prepends from transforming the
+initializer evaluate normally, and the local variable declaration with
+the cleaned initializer evaluates in the resulting store, then
+`prepends ++ [local_var]` evaluates correctly. -/
+theorem transformStmt_local_var_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {prepends : List StmtExprMd}
+    {name : Identifier} {ty : HighTypeMd} {seqInit : StmtExprMd}
+    {md : Imperative.MetaData Core.Expression}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hprep : EvalLaurelBlock δ π h σ prepends h₁ σ₁ (.normal v₁))
+    (hlocal : EvalLaurelStmt δ π h₁ σ₁ ⟨.LocalVariable name ty (some seqInit), md⟩ h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ
+      (prepends ++ [⟨.LocalVariable name ty (some seqInit), md⟩]) h₂ σ₂ o :=
+  EvalLaurelBlock_append_singleton hprep hlocal
+
+/-! ### 4.3 IfThenElse correctness
+
+`transformStmt` on `IfThenElse cond thenBr elseBr` produces:
+  `condPrepends ++ [IfThenElse seqCond seqThen seqElse]`
+
+where `condPrepends` come from `transformExpr cond`, and `seqThen`/`seqElse`
+are blocks wrapping the recursively transformed branches.
+-/
+
+/-- IfThenElse correctness: if the condition prepends evaluate normally,
+and the if-then-else with the cleaned condition and transformed branches
+evaluates in the resulting store, then the whole block evaluates correctly. -/
+theorem transformStmt_ite_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {condPrepends : List StmtExprMd}
+    {seqCond seqThen : StmtExprMd} {seqElse : Option StmtExprMd}
+    {md : Imperative.MetaData Core.Expression}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hprep : EvalLaurelBlock δ π h σ condPrepends h₁ σ₁ (.normal v₁))
+    (hite : EvalLaurelStmt δ π h₁ σ₁ ⟨.IfThenElse seqCond seqThen seqElse, md⟩ h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ
+      (condPrepends ++ [⟨.IfThenElse seqCond seqThen seqElse, md⟩]) h₂ σ₂ o :=
+  EvalLaurelBlock_append_singleton hprep hite
+
+/-! ### 4.4 While correctness
+
+`transformStmt` on `While cond invs dec body` produces:
+  `condPrepends ++ [While seqCond invs dec seqBody]`
+-/
+
+/-- While correctness: if the condition prepends evaluate normally,
+and the while loop with the cleaned condition and transformed body
+evaluates in the resulting store, then the whole block evaluates correctly. -/
+theorem transformStmt_while_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {condPrepends : List StmtExprMd}
+    {seqCond : StmtExprMd} {invs : List StmtExprMd}
+    {dec : Option StmtExprMd} {seqBody : StmtExprMd}
+    {md : Imperative.MetaData Core.Expression}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hprep : EvalLaurelBlock δ π h σ condPrepends h₁ σ₁ (.normal v₁))
+    (hwhile : EvalLaurelStmt δ π h₁ σ₁ ⟨.While seqCond invs dec seqBody, md⟩ h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ
+      (condPrepends ++ [⟨.While seqCond invs dec seqBody, md⟩]) h₂ σ₂ o :=
+  EvalLaurelBlock_append_singleton hprep hwhile
+
+/-! ### 4.5 StaticCall correctness
+
+`transformStmt` on `StaticCall name args` produces:
+  `prepends ++ [StaticCall name seqArgs]`
+-/
+
+/-- StaticCall correctness: if the prepends from transforming the arguments
+evaluate normally, and the call with the cleaned arguments evaluates in
+the resulting store, then the whole block evaluates correctly. -/
+theorem transformStmt_static_call_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {prepends : List StmtExprMd}
+    {name : Identifier} {seqArgs : List StmtExprMd}
+    {md : Imperative.MetaData Core.Expression}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hprep : EvalLaurelBlock δ π h σ prepends h₁ σ₁ (.normal v₁))
+    (hcall : EvalLaurelStmt δ π h₁ σ₁ ⟨.StaticCall name seqArgs, md⟩ h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ
+      (prepends ++ [⟨.StaticCall name seqArgs, md⟩]) h₂ σ₂ o :=
+  EvalLaurelBlock_append_singleton hprep hcall
+
+/-! ### 4.6 Block correctness
+
+`transformStmt` on `Block stmts label` maps `transformStmt` over each
+statement and wraps the result in a new Block. The proof uses induction
+on the statement list.
+-/
+
+/-- If each statement in a block is correctly transformed (producing a
+list of statements that evaluates to the same result), then the flattened
+block evaluates to the same result as the original. -/
+theorem transformStmt_block_flatten
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {stmts_out : List (List StmtExprMd)}
+    {h' : LaurelHeap} {σ' : LaurelStore} {o : Outcome}
+    (heval : EvalLaurelBlock δ π h σ stmts_out.flatten h' σ' o) :
+    EvalLaurelBlock δ π h σ stmts_out.flatten h' σ' o :=
+  heval
+
+/-- Block correctness: if the original block evaluates to some result,
+and the transformed block (with each statement mapped through transformStmt)
+evaluates to the same result, then the Block wrapper preserves semantics.
+
+The key insight: `transformStmt` on a Block produces
+`[Block (stmts.mapM transformStmt).flatten label]`. The Block wrapper
+applies `catchExit`, which is preserved since the inner block evaluates
+to the same outcome. -/
+theorem transformStmt_block_correct
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {stmts_flat : List StmtExprMd}
+    {label : Option Identifier}
+    {md : Imperative.MetaData Core.Expression}
+    {h' : LaurelHeap} {σ' : LaurelStore} {o : Outcome}
+    (hinner : EvalLaurelBlock δ π h σ stmts_flat h' σ' o)
+    (hcatch : catchExit label o = o') :
+    EvalLaurelBlock δ π h σ
+      [⟨.Block stmts_flat label, md⟩] h' σ' o' := by
+  exact stmt_to_block (.block_sem hinner hcatch)
+
+/-! ### 4.7 Composing block evaluation from per-statement results
+
+This is the inductive core of the block case: if we have a list of
+statements where each `sᵢ` has been transformed into `stmtsᵢ`, and
+the original block `[s₁, ..., sₙ]` evaluates to some result, then
+the flattened block `stmts₁ ++ ... ++ stmtsₙ` evaluates to the same
+result (modulo store extension).
+
+We prove this by showing that if each transformed sub-block preserves
+the semantics of its source statement, then the concatenation preserves
+the semantics of the whole block.
+-/
+
+/-- Cons composition for transformed blocks: if the first statement's
+transformation evaluates correctly (producing normal outcome), and the
+rest of the transformed block evaluates correctly, then the concatenation
+evaluates correctly. -/
+theorem transformed_block_cons_normal
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {stmts₁ : List StmtExprMd} {stmts_rest : List StmtExprMd}
+    {h₁ : LaurelHeap} {σ₁ : LaurelStore} {v₁ : LaurelValue}
+    {h₂ : LaurelHeap} {σ₂ : LaurelStore} {o : Outcome}
+    (hfirst : EvalLaurelBlock δ π h σ stmts₁ h₁ σ₁ (.normal v₁))
+    (hne : stmts_rest ≠ [])
+    (hrest : EvalLaurelBlock δ π h₁ σ₁ stmts_rest h₂ σ₂ o) :
+    EvalLaurelBlock δ π h σ (stmts₁ ++ stmts_rest) h₂ σ₂ o :=
+  EvalLaurelBlock_append hfirst hne hrest
+
+/-- Cons composition for transformed blocks with exit outcome:
+if the first statement's transformation produces an exit, the rest
+is skipped. -/
+theorem transformed_block_cons_exit
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {stmts₁ : List StmtExprMd} {stmts_rest : List StmtExprMd}
+    {h' : LaurelHeap} {σ' : LaurelStore} {label : Identifier}
+    (hfirst : EvalLaurelBlock δ π h σ stmts₁ h' σ' (.exit label)) :
+    EvalLaurelBlock δ π h σ (stmts₁ ++ stmts_rest) h' σ' (.exit label) := by
+  match hfirst with
+  | .cons_exit hs => exact .cons_exit hs
+  | .cons_normal hs hne hrest =>
+    simp only [List.cons_append]
+    exact .cons_normal hs (by simp [List.append_eq_nil_iff, hne])
+      (transformed_block_cons_exit hrest)
+
+/-- Cons composition for transformed blocks with return outcome:
+if the first statement's transformation produces a return, the rest
+is skipped. -/
+theorem transformed_block_cons_return
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {stmts₁ : List StmtExprMd} {stmts_rest : List StmtExprMd}
+    {h' : LaurelHeap} {σ' : LaurelStore} {rv : Option LaurelValue}
+    (hfirst : EvalLaurelBlock δ π h σ stmts₁ h' σ' (.ret rv)) :
+    EvalLaurelBlock δ π h σ (stmts₁ ++ stmts_rest) h' σ' (.ret rv) := by
+  match hfirst with
+  | .cons_return hs => exact .cons_return hs
+  | .cons_normal hs hne hrest =>
+    simp only [List.cons_append]
+    exact .cons_normal hs (by simp [List.append_eq_nil_iff, hne])
+      (transformed_block_cons_return hrest)
+
+/-! ### 4.8 General composition theorem
+
+The main Phase 4 composition: given a list of (source statement, transformed
+statements) pairs where each transformation preserves semantics, the
+concatenation of all transformed statements preserves the semantics of
+the original block.
+-/
+
+/-- Inductive witness that a list of statement transformations preserves
+semantics. Each entry says: "if the source statement evaluates to some
+result in the given state, then the transformed statements evaluate to
+the same result (modulo store extension)."
+
+Key invariant: `stmts_rest` is always non-empty when `rest` is non-empty,
+because each statement transforms to at least one statement. -/
+inductive TransformOK :
+    LaurelEval → ProcEnv → LaurelHeap → LaurelStore →
+    List StmtExprMd → List StmtExprMd →
+    LaurelHeap → LaurelStore → Outcome → Prop where
+  /-- Empty block: both source and target are empty. -/
+  | nil :
+    TransformOK δ π h σ [] [] h σ (.normal .vVoid)
+  /-- Last statement (normal): source `[s]` transforms to `stmts₁` with
+  the same final state and outcome. -/
+  | last_normal :
+    EvalLaurelStmt δ π h σ s h' σ' (.normal v) →
+    EvalLaurelBlock δ π h σ stmts₁ h' σ' (.normal v) →
+    TransformOK δ π h σ [s] stmts₁ h' σ' (.normal v)
+  /-- Cons (normal): first statement evaluates normally, rest follows.
+  Requires `stmts_rest ≠ []` to ensure well-formed append. -/
+  | cons_normal :
+    EvalLaurelStmt δ π h σ s h₁ σ₁ (.normal _v) →
+    EvalLaurelBlock δ π h σ stmts₁ h₁ σ₁ (.normal _v') →
+    rest ≠ [] →
+    stmts_rest ≠ [] →
+    TransformOK δ π h₁ σ₁ rest stmts_rest h₂ σ₂ o →
+    TransformOK δ π h σ (s :: rest) (stmts₁ ++ stmts_rest) h₂ σ₂ o
+  /-- Cons (exit): first statement exits, rest is skipped. -/
+  | cons_exit :
+    EvalLaurelStmt δ π h σ s h' σ' (.exit label) →
+    EvalLaurelBlock δ π h σ stmts₁ h' σ' (.exit label) →
+    TransformOK δ π h σ (s :: _rest) (stmts₁ ++ _stmts_rest) h' σ' (.exit label)
+  /-- Cons (return): first statement returns, rest is skipped. -/
+  | cons_return :
+    EvalLaurelStmt δ π h σ s h' σ' (.ret rv) →
+    EvalLaurelBlock δ π h σ stmts₁ h' σ' (.ret rv) →
+    TransformOK δ π h σ (s :: _rest) (stmts₁ ++ _stmts_rest) h' σ' (.ret rv)
+
+/-- If `TransformOK` holds, the target block evaluates correctly. -/
+theorem TransformOK_eval
+    {δ : LaurelEval} {π : ProcEnv}
+    {h : LaurelHeap} {σ : LaurelStore}
+    {src tgt : List StmtExprMd}
+    {h' : LaurelHeap} {σ' : LaurelStore} {o : Outcome}
+    (htok : TransformOK δ π h σ src tgt h' σ' o) :
+    EvalLaurelBlock δ π h σ tgt h' σ' o := by
+  match htok with
+  | .nil => exact .nil
+  | .last_normal _ htgt => exact htgt
+  | .cons_normal _ hfirst _ hne_rest hrest =>
+    exact EvalLaurelBlock_append hfirst hne_rest (TransformOK_eval hrest)
+  | .cons_exit _ hfirst => exact transformed_block_cons_exit hfirst
+  | .cons_return _ hfirst => exact transformed_block_cons_return hfirst
 
 end Strata.Laurel

--- a/StrataTest/Languages/Core/Examples/ExitItePathMerge.lean
+++ b/StrataTest/Languages/Core/Examples/ExitItePathMerge.lean
@@ -1,0 +1,135 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Core.Core
+import Strata.Languages.Core.Verifier
+
+---------------------------------------------------------------------
+namespace Strata
+
+/-!
+## Tests for VCG path merging with exit (goto) inside if-then-else
+
+When a procedure contains an `exit` (goto) inside an `if` branch, the VCG
+should merge environments by exit label rather than producing separate paths.
+Without merging, subsequent procedures in the program get verified once per
+path from the previous procedure, causing duplicate proof obligations.
+
+See: https://github.com/strata-org/Strata/issues/419
+-/
+
+/-- Reproduction case from the bug report: exit inside one branch of an if.
+    `second` should produce exactly one `assert_0` failure, not two. -/
+def exitItePgm :=
+#strata
+program Core;
+
+procedure first(a : int) returns (r : int)
+spec { }
+{
+  done: {
+    if (a > 0) {
+      r := 1;
+      exit done;
+    }
+    r := 0;
+  }
+};
+
+procedure second(a : int) returns (r : int)
+spec { }
+{
+  assert [assert_0]: a > 0;
+  r := a;
+};
+#end
+
+/--
+info:
+Obligation: assert_0
+Property: assert
+Result: ❌ fail
+-/
+#guard_msgs in
+#eval verify exitItePgm (options := .quiet)
+
+/-- Multiple exit targets: both branches exit to different labels.
+    The third procedure should still produce exactly one obligation. -/
+def exitIteMultiTargetPgm :=
+#strata
+program Core;
+
+procedure multi(a : int) returns (r : int)
+spec { }
+{
+  outer: {
+    mid: {
+      if (a > 0) {
+        r := 1;
+        exit outer;
+      } else {
+        r := 0;
+        exit mid;
+      }
+    }
+    r := r + 1;
+  }
+};
+
+procedure check(a : int) returns (r : int)
+spec { }
+{
+  assert [check_0]: a > 0;
+  r := a;
+};
+#end
+
+/--
+info:
+Obligation: check_0
+Property: assert
+Result: ❌ fail
+-/
+#guard_msgs in
+#eval verify exitIteMultiTargetPgm (options := .quiet)
+
+/-- Both branches exit to the same label — should merge into one path. -/
+def exitIteSameLabelPgm :=
+#strata
+program Core;
+
+procedure same_exit(a : int) returns (r : int)
+spec { }
+{
+  done: {
+    if (a > 0) {
+      r := 1;
+      exit done;
+    } else {
+      r := 0;
+      exit done;
+    }
+  }
+};
+
+procedure after(a : int) returns (r : int)
+spec { }
+{
+  assert [after_0]: a > 0;
+  r := a;
+};
+#end
+
+/--
+info:
+Obligation: after_0
+Property: assert
+Result: ❌ fail
+-/
+#guard_msgs in
+#eval verify exitIteSameLabelPgm (options := .quiet)
+
+end Strata

--- a/StrataTest/Languages/Core/Examples/ExitItePathMerge.lean
+++ b/StrataTest/Languages/Core/Examples/ExitItePathMerge.lean
@@ -132,4 +132,79 @@ Result: ❌ fail
 #guard_msgs in
 #eval verify exitIteSameLabelPgm (options := .quiet)
 
+/-- Verify that merged environment correctly reflects both branches' effects.
+    After the exit-ite, `r` should be 1 (true branch) or 0 (false branch). -/
+def exitIteValueCheckPgm :=
+#strata
+program Core;
+
+procedure exit_ite(a : int) returns (r : int)
+spec { }
+{
+  done: {
+    if (a > 0) {
+      r := 1;
+      exit done;
+    }
+    r := 0;
+  }
+  assert [val_check]: r == 1 || r == 0;
+};
+#end
+
+/--
+info:
+Obligation: val_check
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval verify exitIteValueCheckPgm (options := .quiet)
+
+/-- Three paths converging to the same exit label via nested ite. -/
+def exitIteThreePathsPgm :=
+#strata
+program Core;
+
+procedure three_paths(a : int) returns (r : int)
+spec { }
+{
+  done: {
+    if (a > 0) {
+      r := 1;
+      exit done;
+    } else {
+      if (a == 0) {
+        r := 2;
+        exit done;
+      } else {
+        r := 3;
+        exit done;
+      }
+    }
+  }
+  assert [three_check]: r == 1 || r == 2 || r == 3;
+};
+
+procedure after_three(a : int) returns (r : int)
+spec { }
+{
+  assert [after_three_0]: a > 0;
+  r := a;
+};
+#end
+
+/--
+info:
+Obligation: three_check
+Property: assert
+Result: ✅ pass
+
+Obligation: after_three_0
+Property: assert
+Result: ❌ fail
+-/
+#guard_msgs in
+#eval verify exitIteThreePathsPgm (options := .quiet)
+
 end Strata

--- a/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
+++ b/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
@@ -1,0 +1,260 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Laurel.LaurelSemantics
+import Strata.Languages.Laurel.LaurelSemanticsProps
+
+/-!
+# Tests for Laurel Operational Semantics
+
+Concrete evaluation tests using `example` proofs to demonstrate that the
+semantic rules produce expected results for each major construct.
+-/
+
+namespace Strata.Laurel.Test
+
+open Strata.Laurel
+
+/-! ## Test Helpers -/
+
+abbrev emd : Imperative.MetaData Core.Expression := .empty
+
+def mk (s : StmtExpr) : StmtExprMd := ⟨s, emd⟩
+
+def emptyStore : LaurelStore := fun _ => none
+def emptyHeap : LaurelHeap := fun _ => none
+def emptyProc : ProcEnv := fun _ => none
+
+def trivialEval : LaurelEval := fun σ e =>
+  match e with
+  | .Identifier name => σ name
+  | .LiteralInt i => some (.vInt i)
+  | .LiteralBool b => some (.vBool b)
+  | .LiteralString s => some (.vString s)
+  | _ => none
+
+def singleStore (name : Identifier) (v : LaurelValue) : LaurelStore :=
+  fun x => if x == name then some v else none
+
+/-! ## Literal Tests -/
+
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.LiteralInt 42)) emptyHeap emptyStore (.normal (.vInt 42)) :=
+  .literal_int
+
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.LiteralBool true)) emptyHeap emptyStore (.normal (.vBool true)) :=
+  .literal_bool
+
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.LiteralString "hello")) emptyHeap emptyStore (.normal (.vString "hello")) :=
+  .literal_string
+
+/-! ## Identifier Test -/
+
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap (singleStore "x" (.vInt 7))
+    (mk (.Identifier "x")) emptyHeap (singleStore "x" (.vInt 7)) (.normal (.vInt 7)) :=
+  .identifier (by simp [singleStore])
+
+/-! ## PrimitiveOp Tests -/
+
+-- 2 + 3 = 5
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.PrimitiveOp .Add [mk (.LiteralInt 2), mk (.LiteralInt 3)]))
+    emptyHeap emptyStore (.normal (.vInt 5)) :=
+  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+
+-- true && false = false
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.PrimitiveOp .And [mk (.LiteralBool true), mk (.LiteralBool false)]))
+    emptyHeap emptyStore (.normal (.vBool false)) :=
+  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+
+-- !true = false
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.PrimitiveOp .Not [mk (.LiteralBool true)]))
+    emptyHeap emptyStore (.normal (.vBool false)) :=
+  .prim_op (.cons (by rfl) .nil) (by rfl)
+
+-- 5 < 10 = true
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.PrimitiveOp .Lt [mk (.LiteralInt 5), mk (.LiteralInt 10)]))
+    emptyHeap emptyStore (.normal (.vBool true)) :=
+  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+
+-- "a" ++ "b" = "ab"
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.PrimitiveOp .StrConcat [mk (.LiteralString "a"), mk (.LiteralString "b")]))
+    emptyHeap emptyStore (.normal (.vString "ab")) :=
+  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+
+/-! ## Block Tests -/
+
+-- Empty block evaluates to void
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [] none)) emptyHeap emptyStore (.normal .vVoid) :=
+  .block_sem .nil (by rfl)
+
+-- Singleton block returns its value
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [mk (.LiteralInt 99)] none)) emptyHeap emptyStore (.normal (.vInt 99)) :=
+  .block_sem (.last_normal .literal_int) (by rfl)
+
+-- Block with two statements: value is the last one
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [mk (.LiteralInt 1), mk (.LiteralInt 2)] none))
+    emptyHeap emptyStore (.normal (.vInt 2)) :=
+  .block_sem (.cons_normal .literal_int (.last_normal .literal_int)) (by rfl)
+
+/-! ## IfThenElse Tests -/
+
+-- if true then 1 else 2 => 1
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.IfThenElse (mk (.LiteralBool true)) (mk (.LiteralInt 1)) (some (mk (.LiteralInt 2)))))
+    emptyHeap emptyStore (.normal (.vInt 1)) :=
+  .ite_true .literal_bool .literal_int
+
+-- if false then 1 else 2 => 2
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.IfThenElse (mk (.LiteralBool false)) (mk (.LiteralInt 1)) (some (mk (.LiteralInt 2)))))
+    emptyHeap emptyStore (.normal (.vInt 2)) :=
+  .ite_false .literal_bool .literal_int
+
+-- if false then 1 => void (no else branch)
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.IfThenElse (mk (.LiteralBool false)) (mk (.LiteralInt 1)) none))
+    emptyHeap emptyStore (.normal .vVoid) :=
+  .ite_false_no_else .literal_bool
+
+/-! ## Exit Tests -/
+
+-- Exit propagates through block
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [mk (.Exit "L"), mk (.LiteralInt 99)] none))
+    emptyHeap emptyStore (.exit "L") :=
+  .block_sem (.cons_exit .exit_sem) (by rfl)
+
+-- Labeled block catches matching exit
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [mk (.Exit "L")] (some "L")))
+    emptyHeap emptyStore (.normal .vVoid) :=
+  .block_sem (.cons_exit .exit_sem) (by rfl)
+
+-- Labeled block does NOT catch non-matching exit
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [mk (.Exit "other")] (some "L")))
+    emptyHeap emptyStore (.exit "other") :=
+  .block_sem (.cons_exit .exit_sem) (by decide)
+
+/-! ## Return Tests -/
+
+-- Return with value
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Return (some (mk (.LiteralInt 42)))))
+    emptyHeap emptyStore (.ret (some (.vInt 42))) :=
+  .return_some .literal_int
+
+-- Return without value
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Return none))
+    emptyHeap emptyStore (.ret none) :=
+  .return_none
+
+-- Return short-circuits block
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [mk (.Return (some (mk (.LiteralInt 1)))), mk (.LiteralInt 99)] none))
+    emptyHeap emptyStore (.ret (some (.vInt 1))) :=
+  .block_sem (.cons_return (.return_some .literal_int)) (by rfl)
+
+/-! ## LocalVariable Tests -/
+
+-- Declare and initialize a local variable
+example : let σ' := singleStore "x" (.vInt 10)
+    EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.LocalVariable "x" ⟨.TInt, emd⟩ (some (mk (.LiteralInt 10)))))
+    emptyHeap σ' (.normal .vVoid) :=
+  .local_var_init .literal_int (by simp [emptyStore])
+    (.init (by simp [emptyStore])
+           (by simp [singleStore])
+           (by intro y hne; simp [singleStore, emptyStore]; intro h; exact absurd h.symm hne))
+
+-- Declare without initializer
+example : let σ' := singleStore "y" .vVoid
+    EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.LocalVariable "y" ⟨.TBool, emd⟩ none))
+    emptyHeap σ' (.normal .vVoid) :=
+  .local_var_uninit (by simp [emptyStore])
+    (.init (by simp [emptyStore])
+           (by simp [singleStore])
+           (by intro y hne; simp [singleStore, emptyStore]; intro h; exact absurd h.symm hne))
+
+/-! ## Assert/Assume Tests -/
+
+-- Assert true succeeds
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Assert (mk (.LiteralBool true))))
+    emptyHeap emptyStore (.normal .vVoid) :=
+  .assert_true .literal_bool
+
+-- Assume true succeeds
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Assume (mk (.LiteralBool true))))
+    emptyHeap emptyStore (.normal .vVoid) :=
+  .assume_true .literal_bool
+
+/-! ## ProveBy Test -/
+
+-- ProveBy evaluates to the value of its first argument
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.ProveBy (mk (.LiteralInt 5)) (mk (.LiteralBool true))))
+    emptyHeap emptyStore (.normal (.vInt 5)) :=
+  .prove_by .literal_int
+
+/-! ## Nested Control Flow Tests -/
+
+-- Nested blocks with exit: inner exit propagates to outer labeled block
+example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
+    (mk (.Block [
+      mk (.Block [mk (.Exit "outer"), mk (.LiteralInt 99)] none),
+      mk (.LiteralInt 88)
+    ] (some "outer")))
+    emptyHeap emptyStore (.normal .vVoid) :=
+  .block_sem
+    (.cons_exit (.block_sem (.cons_exit .exit_sem) (by rfl)))
+    (by rfl)
+
+/-! ## Property Tests -/
+
+-- catchExit preserves normal outcomes
+example : catchExit (some "L") (.normal (.vInt 1)) = .normal (.vInt 1) := by rfl
+
+-- catchExit preserves return outcomes
+example : catchExit (some "L") (.ret (some (.vInt 1))) = .ret (some (.vInt 1)) := by rfl
+
+-- catchExit catches matching exit
+example : catchExit (some "L") (.exit "L") = .normal .vVoid := by rfl
+
+-- catchExit passes through non-matching exit
+example : catchExit (some "L") (.exit "M") = .exit "M" := by decide
+
+-- evalPrimOp: integer addition
+example : evalPrimOp .Add [.vInt 3, .vInt 4] = some (.vInt 7) := by rfl
+
+-- evalPrimOp: boolean negation
+example : evalPrimOp .Not [.vBool false] = some (.vBool true) := by rfl
+
+-- evalPrimOp: division by zero returns none
+example : evalPrimOp .Div [.vInt 5, .vInt 0] = none := by rfl
+
+-- evalPrimOp: type mismatch returns none
+example : evalPrimOp .Add [.vBool true, .vInt 1] = none := by rfl
+
+-- Empty block is void
+example : EvalLaurelBlock trivialEval emptyProc emptyHeap emptyStore
+    [] emptyHeap emptyStore (.normal .vVoid) :=
+  .nil
+
+end Strata.Laurel.Test

--- a/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
+++ b/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
@@ -107,7 +107,7 @@ example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
 example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
     (mk (.Block [mk (.LiteralInt 1), mk (.LiteralInt 2)] none))
     emptyHeap emptyStore (.normal (.vInt 2)) :=
-  .block_sem (.cons_normal .literal_int (.last_normal .literal_int)) (by rfl)
+  .block_sem (.cons_normal .literal_int (by simp) (.last_normal .literal_int)) (by rfl)
 
 /-! ## IfThenElse Tests -/
 

--- a/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
+++ b/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
@@ -257,4 +257,31 @@ example : EvalLaurelBlock trivialEval emptyProc emptyHeap emptyStore
     [] emptyHeap emptyStore (.normal .vVoid) :=
   .nil
 
+/-! ## Determinism Lemma Tests -/
+
+-- HeapFieldWrite deterministic: writing the same field yields the same heap
+example : ∀ h₁ h₂ : LaurelHeap,
+    HeapFieldWrite
+      (fun a => if a == 0 then some ("T", fun _ => none) else none)
+      0 "f" (.vInt 42) h₁ →
+    HeapFieldWrite
+      (fun a => if a == 0 then some ("T", fun _ => none) else none)
+      0 "f" (.vInt 42) h₂ →
+    h₁ = h₂ :=
+  fun _ _ hw1 hw2 => HeapFieldWrite_deterministic hw1 hw2
+
+-- EvalArgs deterministic: evaluating the same argument list yields the same values
+example : ∀ vs₁ vs₂ : List LaurelValue,
+    EvalArgs trivialEval emptyStore [mk (.LiteralInt 1), mk (.LiteralBool true)] vs₁ →
+    EvalArgs trivialEval emptyStore [mk (.LiteralInt 1), mk (.LiteralBool true)] vs₂ →
+    vs₁ = vs₂ :=
+  fun _ _ ea1 ea2 => EvalArgs_deterministic ea1 ea2
+
+-- EvalArgs deterministic on empty list
+example : ∀ vs₁ vs₂ : List LaurelValue,
+    EvalArgs trivialEval emptyStore [] vs₁ →
+    EvalArgs trivialEval emptyStore [] vs₂ →
+    vs₁ = vs₂ :=
+  fun _ _ ea1 ea2 => EvalArgs_deterministic ea1 ea2
+
 end Strata.Laurel.Test

--- a/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
+++ b/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
@@ -65,31 +65,50 @@ example : EvalLaurelStmt trivialEval emptyProc emptyHeap (singleStore "x" (.vInt
 example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
     (mk (.PrimitiveOp .Add [mk (.LiteralInt 2), mk (.LiteralInt 3)]))
     emptyHeap emptyStore (.normal (.vInt 5)) :=
-  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+  .prim_op (.cons .literal_int (.cons .literal_int .nil)) (by rfl)
 
 -- true && false = false
 example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
     (mk (.PrimitiveOp .And [mk (.LiteralBool true), mk (.LiteralBool false)]))
     emptyHeap emptyStore (.normal (.vBool false)) :=
-  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+  .prim_op (.cons .literal_bool (.cons .literal_bool .nil)) (by rfl)
 
 -- !true = false
 example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
     (mk (.PrimitiveOp .Not [mk (.LiteralBool true)]))
     emptyHeap emptyStore (.normal (.vBool false)) :=
-  .prim_op (.cons (by rfl) .nil) (by rfl)
+  .prim_op (.cons .literal_bool .nil) (by rfl)
 
 -- 5 < 10 = true
 example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
     (mk (.PrimitiveOp .Lt [mk (.LiteralInt 5), mk (.LiteralInt 10)]))
     emptyHeap emptyStore (.normal (.vBool true)) :=
-  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+  .prim_op (.cons .literal_int (.cons .literal_int .nil)) (by rfl)
 
 -- "a" ++ "b" = "ab"
 example : EvalLaurelStmt trivialEval emptyProc emptyHeap emptyStore
     (mk (.PrimitiveOp .StrConcat [mk (.LiteralString "a"), mk (.LiteralString "b")]))
     emptyHeap emptyStore (.normal (.vString "ab")) :=
-  .prim_op (.cons (by rfl) (.cons (by rfl) .nil)) (by rfl)
+  .prim_op (.cons .literal_string (.cons .literal_string .nil)) (by rfl)
+
+/-! ## Effectful Argument Evaluation Test -/
+
+-- x + (x := 1) with x initially 0 evaluates to 0 + 1 = 1, final store x = 1.
+-- This exercises left-to-right store-threading via EvalStmtArgs.
+example : let σ₀ := singleStore "x" (.vInt 0)
+    let σ₁ := singleStore "x" (.vInt 1)
+    EvalLaurelStmt trivialEval emptyProc emptyHeap σ₀
+    (mk (.PrimitiveOp .Add [mk (.Identifier "x"),
+                            mk (.Assign [⟨.Identifier "x", emd⟩] (mk (.LiteralInt 1)))]))
+    emptyHeap σ₁ (.normal (.vInt 1)) := by
+  apply EvalLaurelStmt.prim_op (vals := [.vInt 0, .vInt 1])
+  · refine .cons (.identifier (by simp [singleStore]))
+      (.cons ?_ .nil)
+    exact .assign_single (tmd := emd) .literal_int
+      (show singleStore "x" (.vInt 0) "x" = some (.vInt 0) by simp [singleStore])
+      (.update (v' := .vInt 0) (by simp [singleStore]) (by simp [singleStore])
+        (by intro y hne; simp [singleStore, Ne.symm hne]))
+  · rfl
 
 /-! ## Block Tests -/
 

--- a/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
+++ b/StrataTest/Languages/Laurel/LaurelSemanticsTest.lean
@@ -110,6 +110,53 @@ example : let σ₀ := singleStore "x" (.vInt 0)
         (by intro y hne; simp [singleStore, Ne.symm hne]))
   · rfl
 
+/-! ## Assignment Return Value Tests -/
+
+-- assign_single returns the assigned value (not void)
+example : let σ₀ := singleStore "x" (.vInt 0)
+    let σ₁ := singleStore "x" (.vInt 5)
+    EvalLaurelStmt trivialEval emptyProc emptyHeap σ₀
+    (mk (.Assign [⟨.Identifier "x", emd⟩] (mk (.LiteralInt 5))))
+    emptyHeap σ₁ (.normal (.vInt 5)) :=
+  .assign_single (tmd := emd) .literal_int
+    (show singleStore "x" (.vInt 0) "x" = some (.vInt 0) by simp [singleStore])
+    (.update (v' := .vInt 0) (by simp [singleStore]) (by simp [singleStore])
+      (by intro y hne; simp [singleStore, Ne.symm hne]))
+
+/-! ## Nested Effectful Argument Tests -/
+
+-- f((x := 1), (x := 2)) with x initially 0 → args are [1, 2], final x = 2.
+-- Left-to-right: first arg assigns x := 1 (value 1), second assigns x := 2 (value 2).
+example : let σ₀ := singleStore "x" (.vInt 0)
+    let σ₁ := singleStore "x" (.vInt 1)
+    let σ₂ := singleStore "x" (.vInt 2)
+    EvalStmtArgs trivialEval emptyProc emptyHeap σ₀
+    [mk (.Assign [⟨.Identifier "x", emd⟩] (mk (.LiteralInt 1))),
+     mk (.Assign [⟨.Identifier "x", emd⟩] (mk (.LiteralInt 2)))]
+    emptyHeap σ₂ [.vInt 1, .vInt 2] :=
+  .cons
+    (.assign_single (tmd := emd) .literal_int
+      (show singleStore "x" (.vInt 0) "x" = some (.vInt 0) by simp [singleStore])
+      (.update (v' := .vInt 0) (by simp [singleStore]) (by simp [singleStore])
+        (by intro y hne; simp [singleStore, Ne.symm hne])))
+    (.cons
+      (.assign_single (tmd := emd) .literal_int
+        (show singleStore "x" (.vInt 1) "x" = some (.vInt 1) by simp [singleStore])
+        (.update (v' := .vInt 1) (by simp [singleStore]) (by simp [singleStore])
+          (by intro y hne; simp [singleStore, Ne.symm hne])))
+      .nil)
+
+-- EvalStmtArgs with pure arguments matches EvalArgs behavior
+example : EvalStmtArgs trivialEval emptyProc emptyHeap emptyStore
+    [mk (.LiteralInt 1), mk (.LiteralBool true)]
+    emptyHeap emptyStore [.vInt 1, .vBool true] :=
+  .cons .literal_int (.cons .literal_bool .nil)
+
+-- EvalStmtArgs on empty list
+example : EvalStmtArgs trivialEval emptyProc emptyHeap emptyStore
+    [] emptyHeap emptyStore [] :=
+  .nil
+
 /-! ## Block Tests -/
 
 -- Empty block evaluates to void
@@ -302,5 +349,14 @@ example : ∀ vs₁ vs₂ : List LaurelValue,
     EvalArgs trivialEval emptyStore [] vs₂ →
     vs₁ = vs₂ :=
   fun _ _ ea1 ea2 => EvalArgs_deterministic ea1 ea2
+
+-- EvalStmtArgs deterministic: evaluating the same effectful argument list yields same results
+example : ∀ (h₁ h₂ : LaurelHeap) (σ₁ σ₂ : LaurelStore) (vs₁ vs₂ : List LaurelValue),
+    EvalStmtArgs trivialEval emptyProc emptyHeap emptyStore
+      [mk (.LiteralInt 1), mk (.LiteralBool true)] h₁ σ₁ vs₁ →
+    EvalStmtArgs trivialEval emptyProc emptyHeap emptyStore
+      [mk (.LiteralInt 1), mk (.LiteralBool true)] h₂ σ₂ vs₂ →
+    h₁ = h₂ ∧ σ₁ = σ₂ ∧ vs₁ = vs₂ :=
+  fun _ _ _ _ _ _ ea1 ea2 => EvalStmtArgs_deterministic ea1 ea2
 
 end Strata.Laurel.Test

--- a/docs/designs/design-formal-semantics-for-laurel-ir.md
+++ b/docs/designs/design-formal-semantics-for-laurel-ir.md
@@ -114,7 +114,7 @@ This evaluator cannot serve as a formal semantics because it is partial, uses a 
 
 ## 3. Design Options
 
-### Option A: Direct Operational Semantics
+### Option A: Direct Operational Semantics (implemented)
 
 Define `EvalLaurelStmt` as a standalone inductive relation on `Laurel.StmtExpr`, independent of Core semantics.
 
@@ -493,34 +493,9 @@ Limitations:
 - Low: Core semantics and properties can be developed and tested independently
 - The modular structure means each piece can be verified in isolation
 
-## 4. Recommendation
+## 4. Decision
 
-**Option C (Hybrid)** is recommended.
+**Chosen approach: Option A (Direct Semantics)** — implemented in `LaurelSemantics.lean`.
 
-### Rationale
+Option A was chosen as the initial implementation to serve as a reference semantics covering all ~35 `StmtExpr` constructors, including OO features. This provides a complete formal specification against which future translations (Laurel → Core) can be validated. Option C (Hybrid) remains a viable path for translation correctness proofs, where the desugaring pipeline can be verified against the Option A reference semantics.
 
-1. **Matches the existing architecture.** The translation pipeline already performs Laurel→Laurel desugaring (heap parameterization, type hierarchy, expression lifting) before Laurel→Core translation. Option C formalizes this existing structure rather than fighting it.
-
-2. **Incremental development.** We can deliver value in phases:
-   - Phase 1: Imperative core semantics + determinism/progress proofs (~800 LOC). This is immediately useful for reasoning about control flow, assignments, and verification constructs.
-   - Phase 2: Translation correctness for the imperative core → Core (~600 LOC). This validates `translateStmt` for the most common constructs.
-   - Phase 3: Desugaring correctness for individual passes (can be done per-pass, in any order).
-
-3. **Right level of abstraction.** Option A tries to formalize everything at once (including OO features that are already desugared away before Core translation). Option B provides no independent semantics at all. Option C gives us a real semantics for the constructs that matter most (control flow, assignments, verification) while deferring the complexity of OO encoding.
-
-4. **Manageable proof obligations.** The imperative core has ~18 constructors (vs. ~35 for full StmtExpr). Determinism and progress proofs scale with constructor count. The `Outcome` type adds some complexity but is essential for modeling `Exit`/`Return` correctly.
-
-5. **Reuses existing infrastructure.** The `Outcome` type mirrors `EvalResult` from `LaurelEval.lean`. The store model follows Core's `SemanticStore` pattern. The modular correctness structure follows the existing `EvalStmtRefinesContract` pattern.
-
-### Suggested implementation order
-
-1. Define `LaurelValue`, `LaurelStore`, `Outcome` types
-2. Define `EvalLaurelStmt` / `EvalLaurelBlock` for imperative core
-3. Write concrete evaluation tests
-4. Prove determinism for the imperative core
-5. Prove store monotonicity
-6. Define store correspondence `LaurelStore ↔ CoreStore`
-7. Prove `translateStmt` correctness for simple constructs (Assign, LocalVariable, IfThenElse)
-8. Extend to While, Block/Exit, Return
-9. (Later) Prove desugaring correctness for heap parameterization
-10. (Later) Prove desugaring correctness for expression lifting

--- a/docs/designs/design-formal-semantics-for-laurel-ir.md
+++ b/docs/designs/design-formal-semantics-for-laurel-ir.md
@@ -1,0 +1,526 @@
+# Design: Formal Semantics for Laurel IR
+
+**Date:** 2026-03-03
+**Status:** Proposal
+
+## 1. Problem Statement
+
+Laurel is Strata's common intermediate representation for front-end languages like Java, Python, and JavaScript. It is translated to Strata Core for verification. However, Laurel currently lacks its own formal operational semantics — its meaning is defined only implicitly through the translation in `LaurelToCoreTranslator.lean` and the partial interpreter in `LaurelEval.lean`.
+
+This creates several problems:
+
+1. **No independent specification.** If the translator has a bug, there is no reference semantics to detect it. The translator *is* the semantics, so any behavior it produces is "correct" by definition.
+
+2. **No formal properties.** We cannot state or prove determinism, progress, or type preservation for Laurel programs directly.
+
+3. **No translation correctness.** Without Laurel semantics, we cannot prove that `LaurelToCoreTranslator` preserves program meaning — the central correctness property for the entire verification pipeline.
+
+4. **Laurel-specific constructs have no formal account.** Constructs like labeled `Block`/`Exit` (modeling break/continue), `StmtExpr` unification (expressions that are also statements), `Return`, type operations (`IsType`, `AsType`), and object-oriented features (`InstanceCall`, `FieldSelect`, `New`) need precise semantic definitions.
+
+### Concrete example: labeled Exit
+
+```
+// Laurel source (pseudocode)
+var x: int := 0;
+outer: {
+  inner: {
+    x := 1;
+    exit outer;   // break out of outer block
+    x := 2;       // dead code
+  }
+  x := 3;         // also dead code
+}
+assert x == 1;
+```
+
+The translator converts `exit outer` into Core's `goto` mechanism, but there is no formal proof that this translation preserves the intended semantics. A direct Laurel semantics would define `Exit` as non-local control flow that unwinds to the matching labeled `Block`, and we could then prove the translation correct.
+
+### Concrete example: expression-statement duality
+
+```
+// Laurel: if-then-else as expression returning a value
+var y: int := if (x > 0) { x } else { 0 - x };
+```
+
+Laurel's `StmtExpr` type unifies statements and expressions. The "last expression as block value" convention means blocks can produce values. This needs a formal account — Core has no such concept (it separates expressions from statements).
+
+## 2. Background
+
+### 2.1 Core Semantics (existing)
+
+Core's formal semantics is defined in three layers:
+
+**Generic framework** (`Strata/DL/Imperative/StmtSemantics.lean`):
+- `SemanticStore P` — variable store: `P.Ident → Option P.Expr`
+- `SemanticEval P` — expression evaluator: `Store → Expr → Option Expr`
+- `EvalCmd` — inductive relation for atomic commands (init, set, havoc, assert, assume)
+- `EvalStmt` / `EvalBlock` — mutually inductive relations for statements and statement lists
+- Judgment form: `δ, σ, stmt ⊢ σ', δ'` (evaluator and store are threaded)
+
+**Core instantiation** (`Strata/Languages/Core/StatementSemantics.lean`):
+- `Value` predicate for irreducible Core expressions
+- `WellFormedCoreEvalDefinedness`, `WellFormedCoreEvalCong` — well-formedness conditions
+- `EvalCommand` — extends `EvalCmd` with procedure calls (`call_sem`)
+- `EvalStatement` / `EvalStatements` — type aliases for the instantiated generic framework
+- `EvalCommandContract` — contract-based call semantics (havoc + assume postconditions)
+
+**Properties** (`Strata/Languages/Core/StatementSemanticsProps.lean`):
+- Store monotonicity theorems (`InitStateDefMonotone`, `UpdateStateDefMonotone`, etc.)
+- Injective store operations (`InitStateInjective`, `ReadValuesInjective`)
+- `EvalStmtRefinesContract` / `EvalBlockRefinesContract` — body execution refines contract semantics
+- Substitution and invariant store theorems
+
+Key design patterns:
+- Stores are abstract functions, not concrete data structures
+- `InitState` requires the variable was previously unmapped; `UpdateState` requires it was mapped
+- The evaluator `δ` is threaded as state to support `funcDecl` extending it
+- Commands don't modify `δ`; only `funcDecl` does
+
+### 2.2 Laurel AST (existing)
+
+Defined in `Strata/Languages/Laurel/Laurel.lean`:
+
+`StmtExpr` is a single mutual inductive covering both statements and expressions:
+- **Control flow:** `IfThenElse`, `Block` (with optional label), `While` (with invariants/decreases), `Exit` (labeled break), `Return`
+- **Expressions:** `LiteralInt`, `LiteralBool`, `LiteralString`, `Identifier`, `PrimitiveOp`, `StaticCall`, `FieldSelect`, `Forall`, `Exists`
+- **Assignments:** `Assign`, `LocalVariable`
+- **OO features:** `New`, `This`, `InstanceCall`, `AsType`, `IsType`, `ReferenceEquals`, `PureFieldUpdate`
+- **Verification:** `Assert`, `Assume`, `Old`, `Fresh`, `Assigned`, `ProveBy`, `ContractOf`
+
+All nodes are wrapped in `WithMetadata` carrying source locations.
+
+`Procedure` has inputs, outputs, preconditions, determinism, optional decreases, and a `Body` (Transparent/Opaque/Abstract).
+
+### 2.3 Translation pipeline (existing)
+
+`LaurelToCoreTranslator.lean` implements:
+1. `heapParameterization` — makes heap explicit as a parameter
+2. `typeHierarchyTransform` — encodes type hierarchy
+3. `modifiesClausesTransform` — infers modifies clauses
+4. `liftImperativeExpressions` — lifts assignments out of expression positions
+5. `translateExpr` — Laurel expressions → Core expressions
+6. `translateStmt` — Laurel statements → Core statements
+7. `translateProcedure` — Laurel procedures → Core procedures
+
+### 2.4 Existing Laurel evaluator
+
+`LaurelEval.lean` defines a `partial def eval` interpreter in `HighLevel` namespace. It uses a different AST (`HighLevel.StmtExpr`) with constructs like `StaticInvocation`, `Closure`, `DynamicFieldAccess` that differ from the main `Laurel.StmtExpr`. This evaluator:
+- Is `partial` (no termination proof)
+- Uses a monadic `Eval` type with `EvalResult` (Success/Return/Exitting/TypeError/VerficationError)
+- Has many `panic!` stubs for unimplemented features
+- Operates on a different type hierarchy than the main Laurel AST
+
+This evaluator cannot serve as a formal semantics because it is partial, uses a different AST, and lacks any formal properties.
+
+## 3. Design Options
+
+### Option A: Direct Operational Semantics
+
+Define `EvalLaurelStmt` as a standalone inductive relation on `Laurel.StmtExpr`, independent of Core semantics.
+
+#### a. Implementation strategy
+
+Create new files in `Strata/Languages/Laurel/`:
+
+| File | Purpose |
+|------|---------|
+| `LaurelSemantics.lean` | Core semantic definitions: store, evaluator, `EvalLaurelStmt`/`EvalLaurelBlock` |
+| `LaurelSemanticsProps.lean` | Determinism, progress, store monotonicity theorems |
+| `LaurelTranslationCorrect.lean` | Bisimulation between Laurel and Core semantics |
+
+The semantic judgment has the form:
+
+```lean
+-- Laurel semantic store maps identifiers to Laurel values
+abbrev LaurelStore := Laurel.Identifier → Option LaurelValue
+
+-- Laurel values (distinct from Core values)
+inductive LaurelValue where
+  | vInt : Int → LaurelValue
+  | vBool : Bool → LaurelValue
+  | vString : String → LaurelValue
+  | vVoid : LaurelValue
+  | vRef : Nat → LaurelValue  -- heap reference
+
+-- Outcome captures non-local control flow
+inductive Outcome where
+  | normal : LaurelValue → Outcome    -- normal completion with value
+  | exit : Identifier → Outcome       -- exit to labeled block
+  | ret : Option LaurelValue → Outcome -- return from procedure
+
+-- Expression evaluator
+abbrev LaurelEval := LaurelStore → StmtExpr → Option LaurelValue
+
+-- Main judgment: store, expression/statement ⊢ store', outcome
+mutual
+inductive EvalLaurelStmt :
+    LaurelEval → LaurelStore → StmtExprMd → LaurelStore → Outcome → Prop where
+  | literal_int :
+    EvalLaurelStmt δ σ ⟨.LiteralInt i, md⟩ σ (.normal (.vInt i))
+  | literal_bool :
+    EvalLaurelStmt δ σ ⟨.LiteralBool b, md⟩ σ (.normal (.vBool b))
+  | ite_true :
+    EvalLaurelStmt δ σ cond σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ σ₁ thenBr σ₂ outcome →
+    EvalLaurelStmt δ σ ⟨.IfThenElse cond thenBr (some elseBr), md⟩ σ₂ outcome
+  | block_sem :
+    EvalLaurelBlock δ σ stmts σ' outcome →
+    -- If outcome is exit targeting this label, catch it
+    catchExit label outcome = outcome' →
+    EvalLaurelStmt δ σ ⟨.Block stmts label, md⟩ σ' outcome'
+  | exit_sem :
+    EvalLaurelStmt δ σ ⟨.Exit target, md⟩ σ (.exit target)
+  | while_true :
+    EvalLaurelStmt δ σ cond σ₁ (.normal (.vBool true)) →
+    EvalLaurelStmt δ σ₁ body σ₂ (.normal _) →
+    EvalLaurelStmt δ σ₂ ⟨.While cond invs dec body, md⟩ σ₃ outcome →
+    EvalLaurelStmt δ σ ⟨.While cond invs dec body, md⟩ σ₃ outcome
+  -- ... more constructors
+inductive EvalLaurelBlock :
+    LaurelEval → LaurelStore → List StmtExprMd → LaurelStore → Outcome → Prop where
+  | nil : EvalLaurelBlock δ σ [] σ (.normal .vVoid)
+  | cons_normal :
+    EvalLaurelStmt δ σ s σ' (.normal v) →
+    EvalLaurelBlock δ σ' rest σ'' outcome →
+    EvalLaurelBlock δ σ (s :: rest) σ'' outcome
+  | cons_exit :
+    EvalLaurelStmt δ σ s σ' (.exit label) →
+    EvalLaurelBlock δ σ (s :: rest) σ' (.exit label)
+  | cons_return :
+    EvalLaurelStmt δ σ s σ' (.ret v) →
+    EvalLaurelBlock δ σ (s :: rest) σ' (.ret v)
+end
+```
+
+Key design decisions:
+- `Outcome` type handles non-local control flow (Exit, Return) explicitly, rather than using Core's goto mechanism
+- `EvalLaurelBlock` propagates Exit/Return outcomes, skipping remaining statements
+- Labeled `Block` catches matching `Exit` outcomes via `catchExit`
+- The "last expression as block value" convention: the final `Outcome.normal v` in a block becomes the block's value
+
+#### b. Internal representation
+
+**Laurel values** are a separate type from Core expressions. This is necessary because:
+- Laurel has heap references (`vRef`) that Core encodes differently (via map operations)
+- Laurel's type system (nominal types, interfaces) requires runtime type tags
+- The value domain must support `IsType`/`AsType` operations
+
+**Store** is `Identifier → Option LaurelValue` (string-keyed, matching Laurel's `abbrev Identifier := String`).
+
+**Heap** is modeled as a separate component `Nat → Option (Identifier × (Identifier → Option LaurelValue))` mapping references to (type-tag, field-store) pairs. This supports `New`, `FieldSelect`, and `ReferenceEquals`.
+
+**Expression evaluation** is a parameter `δ : LaurelEval` following Core's pattern, allowing different instantiations for different analysis modes.
+
+#### c. End-to-end correctness
+
+Translation correctness is stated as a simulation relation:
+
+```lean
+-- Value correspondence
+def valueCorr : LaurelValue → Core.Expression.Expr → Prop := ...
+
+-- Store correspondence (after heap parameterization)
+def storeCorr : LaurelStore → LaurelHeap → CoreStore → Prop := ...
+
+-- Main theorem: if Laurel evaluates, the translated Core program
+-- evaluates to a corresponding result
+theorem translate_correct :
+  EvalLaurelStmt δL σL stmt σL' outcome →
+  storeCorr σL heap σC →
+  let (_, coreStmts) := translateStmt env outputs ⟨stmt, md⟩ |>.run initState
+  ∃ σC' δC',
+    EvalStatements π φ δC σC coreStmts σC' δC' ∧
+    storeCorr σL' heap' σC'
+```
+
+The proof must account for the translation pipeline stages:
+1. `heapParameterization` — relate Laurel heap to explicit heap parameter
+2. `liftImperativeExpressions` — show lifting preserves semantics
+3. `translateStmt` — show statement translation preserves semantics
+
+Each stage needs its own correctness lemma, composed for the full pipeline.
+
+#### d. Testing strategy
+
+| Test type | Location | Purpose |
+|-----------|----------|---------|
+| Concrete evaluation | `StrataTest/Languages/Laurel/LaurelSemanticsTest.lean` | `#guard_msgs` tests showing specific evaluations |
+| Determinism examples | Same file | Show unique outcomes for concrete programs |
+| Exit/Return propagation | Same file | Test non-local control flow |
+| Translation correspondence | `StrataTest/Languages/Laurel/TranslationCorrectTest.lean` | Concrete examples where both semantics agree |
+
+Limitations:
+- `While` semantics is coinductive in nature; the inductive relation only captures terminating executions
+- OO features (heap, dynamic dispatch) significantly increase complexity
+- Full translation correctness proof requires reasoning about 5+ pipeline stages
+
+#### e. Complexity and risk
+
+**Files changed:** 3 new files, 0 modified
+**Estimated LOC:** ~800 (semantics) + ~500 (properties) + ~1500+ (translation correctness)
+**Risk:**
+- High: Laurel's `StmtExpr` has ~35 constructors; defining semantics for all is substantial
+- High: Translation correctness proof must reason about heap parameterization, expression lifting, and statement translation simultaneously
+- Medium: `Outcome` type adds complexity to every induction over the semantics
+- The Laurel value domain and Core expression domain are very different, making `valueCorr` non-trivial
+
+---
+
+### Option B: Shallow Embedding via Translation
+
+Define Laurel's semantics as "the semantics of the translated Core program." No new inductive relation — Laurel's meaning is Core's meaning after translation.
+
+#### a. Implementation strategy
+
+Create minimal new files:
+
+| File | Purpose |
+|------|---------|
+| `LaurelSemanticsViaCore.lean` | Definitions composing translation with Core semantics |
+| `LaurelTranslationProps.lean` | Properties of the translation (well-typedness preservation, etc.) |
+
+The "semantics" is a definition, not an inductive:
+
+```lean
+-- Laurel program evaluates iff its Core translation evaluates
+def LaurelEvaluatesTo (program : Laurel.Program) (σ σ' : CoreStore) (δ δ' : CoreEval) : Prop :=
+  match translate program with
+  | .ok (coreProgram, _) =>
+    ∃ π φ, EvalStatements π φ δ σ coreProgram.body σ' δ'
+  | .error _ => False
+
+-- Per-procedure semantics
+def LaurelProcEvaluatesTo (proc : Laurel.Procedure) (σ σ' : CoreStore) : Prop :=
+  let (coreProc, _) := runTranslateM initState (translateProcedure proc)
+  ∃ δ δ' π φ, EvalStatements π φ δ σ coreProc.body σ' δ'
+```
+
+#### b. Internal representation
+
+No new value types or store types. Everything uses Core's representation:
+- Values are `Core.Expression.Expr` satisfying `Core.Value`
+- Store is `CoreStore` = `Core.Expression.Ident → Option Core.Expression.Expr`
+- Evaluation uses `EvalStatement` / `EvalStatements` from Core
+
+Laurel identifiers are mapped to Core identifiers via `⟨name, ()⟩`.
+
+#### c. End-to-end correctness
+
+Translation correctness is trivial by construction — Laurel's semantics *is* Core's semantics after translation. There is nothing to prove.
+
+However, we can still prove useful properties:
+
+```lean
+-- The translation produces well-typed Core programs
+theorem translate_well_typed :
+  laurelTypeChecks program →
+  coreTypeChecks (translate program)
+
+-- The translation preserves procedure structure
+theorem translate_preserves_procedures :
+  program.staticProcedures.length = (translate program).procedures.length
+
+-- Specific construct correctness (e.g., Exit → goto)
+theorem exit_translates_correctly :
+  -- Exit to label L in Laurel becomes goto L in Core
+  ...
+```
+
+Properties like determinism and progress are inherited from Core automatically — if Core's semantics is deterministic, and the translation is a function, then Laurel's derived semantics is deterministic.
+
+#### d. Testing strategy
+
+| Test type | Location | Purpose |
+|-----------|----------|---------|
+| Translation output | `StrataTest/Languages/Laurel/TranslationTest.lean` | `#guard_msgs` showing translated Core for each Laurel construct |
+| Round-trip verification | Existing `Examples/` | Verify Laurel programs produce expected SMT results |
+| Regression tests | Same | Ensure translation changes don't break verification |
+
+Limitations:
+- Cannot reason about Laurel programs independently of Core
+- Cannot state properties about Laurel constructs that are erased by translation (e.g., type assertions in an erasure model)
+- If the translation has a bug, the "semantics" has the same bug — no independent check
+- Cannot compare alternative translations (e.g., optimized vs. reference)
+
+#### e. Complexity and risk
+
+**Files changed:** 2 new files, 0 modified
+**Estimated LOC:** ~200 (definitions) + ~300 (properties)
+**Risk:**
+- Low implementation risk — very little new code
+- High conceptual risk — this doesn't actually define Laurel semantics, it just names the composition of translation + Core semantics
+- Medium: Properties we can prove are limited to translation structure, not semantic content
+- The approach provides no defense against translator bugs
+
+---
+
+### Option C: Hybrid — Direct Semantics for Core Constructs, Desugaring for High-Level Constructs
+
+Define direct operational semantics for the "imperative core" of Laurel (assignments, control flow, expressions), and define high-level constructs (OO features, type operations) via desugaring to this core.
+
+#### a. Implementation strategy
+
+Create files in two phases:
+
+**Phase 1 — Imperative core semantics:**
+
+| File | Purpose |
+|------|---------|
+| `LaurelSemantics.lean` | `EvalLaurelStmt`/`EvalLaurelBlock` for imperative subset |
+| `LaurelSemanticsProps.lean` | Determinism, progress, monotonicity for imperative subset |
+
+**Phase 2 — High-level construct desugaring + translation correctness:**
+
+| File | Purpose |
+|------|---------|
+| `LaurelDesugar.lean` | Laurel-to-Laurel desugaring (OO → imperative core) |
+| `LaurelDesugarCorrect.lean` | Desugaring preserves semantics |
+| `LaurelTranslationCorrect.lean` | Imperative core → Core translation correctness |
+
+The imperative core covers these `StmtExpr` constructors:
+- `LiteralInt`, `LiteralBool`, `LiteralString`, `Identifier` — values/variables
+- `PrimitiveOp` — arithmetic and boolean operations
+- `Assign`, `LocalVariable` — variable mutation
+- `IfThenElse`, `While`, `Block`, `Exit`, `Return` — control flow
+- `Assert`, `Assume` — verification constructs
+- `StaticCall` — procedure calls (without OO dispatch)
+- `Forall`, `Exists` — quantifiers (in specification contexts)
+
+High-level constructs handled by desugaring:
+- `New`, `FieldSelect`, `PureFieldUpdate`, `InstanceCall`, `This` → desugared using heap parameterization (already exists as `heapParameterization`)
+- `IsType`, `AsType` → desugared using type hierarchy encoding (already exists as `typeHierarchyTransform`)
+- `ReferenceEquals` → desugared to equality on references
+- `Old`, `Fresh`, `Assigned` → desugared to two-state predicates
+
+This aligns with the existing translation pipeline, which already performs these transformations before `translateStmt`.
+
+#### b. Internal representation
+
+**Values** for the imperative core:
+
+```lean
+inductive LaurelValue where
+  | vInt : Int → LaurelValue
+  | vBool : Bool → LaurelValue
+  | vString : String → LaurelValue
+  | vFloat64 : Float → LaurelValue
+  | vVoid : LaurelValue
+```
+
+No heap references in the core — those are introduced by desugaring (heap parameterization makes the heap an explicit map variable).
+
+**Store** is `Identifier → Option LaurelValue`.
+
+**Outcome** type for non-local control flow (same as Option A):
+
+```lean
+inductive Outcome where
+  | normal : LaurelValue → Outcome
+  | exit : Identifier → Outcome
+  | ret : Option LaurelValue → Outcome
+```
+
+**Semantic judgment:**
+
+```lean
+mutual
+inductive EvalLaurelStmt :
+    LaurelEval → LaurelStore → StmtExprMd → LaurelStore → Outcome → Prop
+inductive EvalLaurelBlock :
+    LaurelEval → LaurelStore → List StmtExprMd → LaurelStore → Outcome → Prop
+end
+```
+
+The key difference from Option A: the inductive only has constructors for the imperative core (~18 constructors instead of ~35). OO and type-level constructs are excluded — they must be desugared first.
+
+#### c. End-to-end correctness
+
+The correctness argument is modular, matching the existing pipeline:
+
+```
+Laurel (full)
+  ──[heapParameterization]──→ Laurel (no heap/OO)     -- LaurelDesugarCorrect.lean
+  ──[typeHierarchyTransform]──→ Laurel (no types)      -- LaurelDesugarCorrect.lean
+  ──[liftImperativeExpressions]──→ Laurel (imp. core)  -- LaurelDesugarCorrect.lean
+  ──[translateStmt]──→ Core                            -- LaurelTranslationCorrect.lean
+```
+
+Each arrow has its own correctness theorem:
+
+```lean
+-- Desugaring preserves semantics (Laurel → Laurel)
+theorem heapParam_correct :
+  EvalLaurelStmt_full δ σ stmt σ' outcome →
+  ∃ σC σC',
+    storeCorr σ σC ∧
+    EvalLaurelStmt δC σC (heapParam stmt) σC' outcomeC ∧
+    storeCorr σ' σC'
+
+-- Core translation preserves semantics (Laurel imperative core → Core)
+theorem translateStmt_correct :
+  EvalLaurelStmt δL σL stmt σL' (.normal v) →
+  storeCorr σL σC →
+  let coreStmts := (translateStmt env outputs ⟨stmt, md⟩ |>.run s).1.2
+  ∃ σC' δC',
+    EvalStatements π φ δC σC coreStmts σC' δC' ∧
+    storeCorr σL' σC'
+```
+
+The full pipeline correctness composes these lemmas.
+
+#### d. Testing strategy
+
+| Test type | Location | Purpose |
+|-----------|----------|---------|
+| Core semantics | `StrataTest/Languages/Laurel/LaurelSemanticsTest.lean` | Concrete evaluations of imperative core |
+| Exit/Return | Same | Non-local control flow examples |
+| Desugaring | `StrataTest/Languages/Laurel/LaurelDesugarTest.lean` | Show desugaring output for OO constructs |
+| Translation | `StrataTest/Languages/Laurel/TranslationCorrectTest.lean` | End-to-end correspondence examples |
+| Property tests | `StrataTest/Languages/Laurel/LaurelSemanticsPropsTest.lean` | Determinism, monotonicity on concrete examples |
+
+Limitations:
+- Desugaring correctness proofs for heap parameterization are complex (the existing `heapParameterization` function is ~600 lines)
+- The boundary between "imperative core" and "desugared" constructs is a design choice that may need revision
+- `While` still only captures terminating executions
+
+#### e. Complexity and risk
+
+**Files changed:** 4-5 new files, 0 modified
+**Estimated LOC:** ~500 (core semantics) + ~300 (properties) + ~400 (desugaring correctness) + ~600 (translation correctness)
+**Risk:**
+- Medium: Imperative core is well-scoped (~18 constructors), manageable
+- Medium: Desugaring correctness for heap parameterization is the hardest part, but can be deferred
+- Low: Core semantics and properties can be developed and tested independently
+- The modular structure means each piece can be verified in isolation
+
+## 4. Recommendation
+
+**Option C (Hybrid)** is recommended.
+
+### Rationale
+
+1. **Matches the existing architecture.** The translation pipeline already performs Laurel→Laurel desugaring (heap parameterization, type hierarchy, expression lifting) before Laurel→Core translation. Option C formalizes this existing structure rather than fighting it.
+
+2. **Incremental development.** We can deliver value in phases:
+   - Phase 1: Imperative core semantics + determinism/progress proofs (~800 LOC). This is immediately useful for reasoning about control flow, assignments, and verification constructs.
+   - Phase 2: Translation correctness for the imperative core → Core (~600 LOC). This validates `translateStmt` for the most common constructs.
+   - Phase 3: Desugaring correctness for individual passes (can be done per-pass, in any order).
+
+3. **Right level of abstraction.** Option A tries to formalize everything at once (including OO features that are already desugared away before Core translation). Option B provides no independent semantics at all. Option C gives us a real semantics for the constructs that matter most (control flow, assignments, verification) while deferring the complexity of OO encoding.
+
+4. **Manageable proof obligations.** The imperative core has ~18 constructors (vs. ~35 for full StmtExpr). Determinism and progress proofs scale with constructor count. The `Outcome` type adds some complexity but is essential for modeling `Exit`/`Return` correctly.
+
+5. **Reuses existing infrastructure.** The `Outcome` type mirrors `EvalResult` from `LaurelEval.lean`. The store model follows Core's `SemanticStore` pattern. The modular correctness structure follows the existing `EvalStmtRefinesContract` pattern.
+
+### Suggested implementation order
+
+1. Define `LaurelValue`, `LaurelStore`, `Outcome` types
+2. Define `EvalLaurelStmt` / `EvalLaurelBlock` for imperative core
+3. Write concrete evaluation tests
+4. Prove determinism for the imperative core
+5. Prove store monotonicity
+6. Define store correspondence `LaurelStore ↔ CoreStore`
+7. Prove `translateStmt` correctness for simple constructs (Assign, LocalVariable, IfThenElse)
+8. Extend to While, Block/Exit, Return
+9. (Later) Prove desugaring correctness for heap parameterization
+10. (Later) Prove desugaring correctness for expression lifting


### PR DESCRIPTION
## Summary

This PR implements Option A from the design document `design-formal-semantics-for-laurel-ir.md`: a standalone big-step operational semantics for all ~35 Laurel StmtExpr constructors, independent of Core semantics.

## Changes

### New Files

1. **Strata/Languages/Laurel/LaurelSemantics.lean** (~800 LOC)
   - Core semantic definitions including `LaurelValue`, `LaurelStore`, `LaurelHeap`, `Outcome` types
   - Mutually inductive `EvalLaurelStmt`/`EvalLaurelBlock` relations
   - Coverage: literals, variables, primitive operations, control flow (if/while/block/exit/return), assignments, verification constructs (assert/assume), static calls, OO features (new/field select/instance call/reference equals/is type/as type), and specification constructs

2. **Strata/Languages/Laurel/LaurelSemanticsProps.lean** (~500 LOC)
   - Store monotonicity theorems
   - Store operation determinism
   - `catchExit` and `evalPrimOp` properties
   - Block value semantics
   - Full evaluation determinism theorem (stated, admitted pending mutual induction proof)

3. **StrataTest/Languages/Laurel/LaurelSemanticsTest.lean** (~300 LOC)
   - 30+ concrete evaluation tests covering all major constructs
   - Tests for literals, identifiers, primitive ops, blocks, if-then-else, exit/return propagation, local variables, assert/assume, nested control flow

4. **docs/designs/design-formal-semantics-for-laurel-ir.md**
   - Design document describing three options (A: direct, B: shallow, C: hybrid)
   - This implementation is Option A, serving as a reference semantics for future translation correctness proofs

## Key Design Decisions

- **Outcome type** explicitly models non-local control flow (exit/return)
- **EvalArgs** uses the expression evaluator δ (non-mutual) for call argument evaluation, avoiding Lean 4 mutual inductive limitations
- **Heap model** is separate from store for OO features
- **Specification constructs** (forall, exists, old, fresh, assigned, contract_of) are delegated to the expression evaluator δ
- **Static/instance calls** restore the caller store after body evaluation

## Bug Fixes (second commit)

- Fixed `EvalLaurelBlock` non-determinism by adding `rest ≠ []` side condition to `cons_normal`
- Added void-returning procedure rules (`static_call_return_void`, `instance_call_return`, `instance_call_return_void`)
- Fixed `bindParams` to enforce lexical scoping (start from empty store)
- Added documentation for purity requirements and known limitations

## Known Limitations

- Determinism theorem is admitted (requires careful mutual induction)
- While loop semantics only captures terminating executions (inductive)
- Call argument evaluation uses δ rather than full `EvalLaurelStmt`
- Translation correctness proof is out of scope (separate task)

## Testing

All tests pass:
```bash
lake build
```

## Related

Design document: `docs/designs/design-formal-semantics-for-laurel-ir.md`