### PR TITLE
Extend pySpecs translator to handle all service specification constructs

### DIFF
--- a/Strata/DDM/Elab.lean
+++ b/Strata/DDM/Elab.lean
@@ -202,7 +202,10 @@ partial def loadDialectFromIonFragment
     (stk : Array DialectName)
     (dialect : DialectName)
     (frag : Ion.Fragment)
+
   : BaseIO (Except String Dialect) := do
+  if dialect ∈ (←fm.loaded.get).dialects then
+    return .error s!"{dialect} already loaded"
   -- Read dialect from Ion fragment
   let d ←
     match Dialect.fromIonFragment dialect frag with

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -35,29 +35,6 @@ def baseLogEvent (events : Std.HashSet EventType)
   pure ()
 
 /--
-A specification predicate. Currently only supports constant boolean values;
-placeholder for future extension with more complex predicates.
--/
-inductive Pred where
-| const (b : Bool)
-
-namespace Pred
-
-def not (p : Pred) : Pred :=
-  match p with
-  | .const b => .const (¬ b)
-
-end Pred
-
-/--
-Represents an iterable type in Python specifications.
-Currently only supports lists; other iterables (sets, generators, etc.) to be
-added.
--/
-inductive Iterable where
-| list
-
-/--
 A Python module name split into its dot-separated components.
 For example, `typing.List` has components `["typing", "List"]`.
 The size constraint ensures at least one component exists.
@@ -637,6 +614,9 @@ def pySpecArg (usedNames : Std.HashSet String)
 structure SpecAssertionContext where
   filePath : System.FilePath
   kwargsParamName : Option String := none
+  kwargsType : Option SpecType := none
+  /-- Local variable type bindings (e.g., from for-loop iteration variables). -/
+  localTypes : Std.HashMap String SpecType := {}
 
 /-- State for `SpecAssertionM`. -/
 structure SpecAssertionState where
@@ -663,17 +643,6 @@ instance : PySpecMClass SpecAssertionM where
     let new_cnt := (←get).errors.size
     return (cnt = new_cnt, r)
 
-def transPred (_e : expr SourceRange) : SpecAssertionM Pred := do
-  -- FIXME
-  pure (.const true)
-
-def transIter (_e : expr SourceRange) : SpecAssertionM Iterable := do
-  -- FIXME
-  return .list
-
-def assumePred (_p : Pred) (act : SpecAssertionM Unit) : SpecAssertionM Unit := do
-  act
-
 /-- Match a subscript expression `param["field"]` against the kwargs parameter
     name from context, returning `(paramName, fieldName)` on success. -/
 def extractKwargsField (e : expr SourceRange)
@@ -689,17 +658,126 @@ def extractKwargsField (e : expr SourceRange)
   | _ => return none
 
 /-- Extract a `SpecExpr` subject from a Python expression.
-    Recognizes kwargs subscripts (`kw["field"]` → `.getIndex (.var kn) fn`)
+    Recognizes kwargs subscripts (`kw["field"]` → `.getIndex (.var kn) fn`),
+    nested subscripts (`kw["a"]["b"]` → `.getIndex (.getIndex (.var kn) "a") "b"`),
     and plain variable names (`.Name` → `.var name`).
     Returns `none` for unsupported expression forms. -/
-def extractSubject (e : expr SourceRange)
+partial def extractSubject (e : expr SourceRange)
     : SpecAssertionM (Option SpecExpr) := do
   match ← extractKwargsField e with
   | some (kn, fn) => return some (.getIndex (.var kn) fn)
   | none => pure ()
   match e with
   | .Name _ ⟨_, name⟩ (.Load _) => return some (.var name)
+  | .Subscript _ inner (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+    match ← extractSubject inner with
+    | some subj => return some (.getIndex subj fieldName.val)
+    | none => return none
   | _ => return none
+
+/-- Translate a Python `if` condition into a `SpecExpr`.
+    Currently recognizes `"key" in container` patterns. -/
+def transCondition (e : expr SourceRange) : SpecAssertionM (Option SpecExpr) := do
+  match e with
+  | .Compare _ (.Constant _ (.ConString _ key) _) ops comparators =>
+    if h₁ : ops.val.size = 1 then
+      if h₂ : comparators.val.size = 1 then
+        match ops.val[0] with
+        | .In _ =>
+          match ← extractSubject comparators.val[0] with
+          | some subj => return some (.containsKey subj key.val)
+          | none => pure ()
+        | _ => pure ()
+    pure ()
+  | _ => pure ()
+  return none
+
+/-- Run an action that may produce assertions, then wrap each new assertion's
+    formula with `implies cond ...` (or `implies (not cond) ...` for else branches).
+    If `cond` is `none`, assertions pass through unchanged. -/
+def assumeCondition (cond : Option SpecExpr) (act : SpecAssertionM Unit)
+    : SpecAssertionM Unit := do
+  let prevAssertions := (←get).assertions
+  modify fun s => { s with assertions := #[] }
+  act
+  let newAssertions := (←get).assertions
+  match cond with
+  | some c =>
+    let wrapped := newAssertions.map fun a =>
+      { a with formula := .implies c a.formula }
+    modify fun s => { s with assertions := prevAssertions ++ wrapped }
+  | none =>
+    modify fun s => { s with assertions := prevAssertions ++ newAssertions }
+
+/-- Translate a Python expression from an f-string message into a `SpecExpr`.
+    Handles kwargs subscripts, variable names, and `len(...)` calls.
+    Falls back to `.placeholder` for unsupported patterns. -/
+def transMessageExpr (e : expr SourceRange)
+    : SpecAssertionM SpecExpr := do
+  match ← extractSubject e with
+  | some subj => return subj
+  | none => pure ()
+  match e with
+  | .Call _ (.Name _ funcName (.Load _)) args _ =>
+    if funcName.val == "len" && args.val.size == 1 then
+      match ← extractSubject args.val[0]! with
+      | some subj => return .len subj
+      | none => return .placeholder
+    else return .placeholder
+  | _ => return .placeholder
+
+/-- Look up a field in a TypedDict SpecType, returning its type if found. -/
+def lookupTypedDictField (tp : SpecType) (field : String) : Option SpecType := do
+  for atom in tp.atoms do
+    match atom with
+    | .typedDict fields fieldTypes _ =>
+      for i in [:fields.size] do
+        if fields[i]! == field then return fieldTypes[i]!
+    | _ => pure ()
+  none
+
+/-- Infer the type of a Python expression from available type context.
+    Handles kwargs subscripts, nested subscripts, and local variable bindings. -/
+partial def inferExprType (e : expr SourceRange) : SpecAssertionM (Option SpecType) := do
+  match e with
+  | .Name _ ⟨_, name⟩ (.Load _) =>
+    return (←read).localTypes[name]?
+  | .Subscript _ (.Name _ paramName (.Load _))
+      (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+    match (←read).kwargsParamName with
+    | some kn =>
+      if paramName.val == kn then
+        match (←read).kwargsType with
+        | some kwTp => return lookupTypedDictField kwTp fieldName.val
+        | none => return none
+      else return none
+    | none => return none
+  | .Subscript _ inner (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+    match ← inferExprType inner with
+    | some innerTp => return lookupTypedDictField innerTp fieldName.val
+    | none => return none
+  | _ => return none
+
+/-- Extract the element type from an iterable SpecType (e.g., typing.List(T) → T). -/
+def extractElementType (tp : SpecType) : Option SpecType := do
+  for atom in tp.atoms do
+    match atom with
+    | .ident pyId args =>
+      if (pyId == .typingList || pyId == .typingSequence) && args.size == 1 then
+        return args[0]!
+    | _ => pure ()
+  none
+
+/-- Extract key and value types from a dict SpecType
+    (e.g., typing.Dict(K, V) → (K, V)). -/
+def extractDictKeyValueTypes (tp : SpecType) : Option (SpecType × SpecType) := do
+  for atom in tp.atoms do
+    match atom with
+    | .ident pyId args =>
+      if (pyId == .typingDict || pyId == .typingMapping) && args.size == 2 then
+        return (args[0]!, args[1]!)
+    | _ => pure ()
+  none
 
 /-- Collect all `== "value"` arms from a chain of `or`-ed comparisons,
     returning the subject and string values, or `none` if the expression
@@ -737,10 +815,53 @@ partial def collectEnumValues (e : expr SourceRange)
     | _ => return none
   | _ => return none
 
-/-- Translate a Python assert expression to a `SpecExpr`. Falls back to
-    `.placeholder` with a warning for unrecognized patterns.
-    Supports kwargs subscripts (`kw["field"]`) and plain variable names
-    as subjects. -/
+/-- Extract an integer literal from a Python expression.
+    Handles `Constant(ConPos n)`, `Constant(ConNeg n)`,
+    and `UnaryOp(USub, Constant(ConPos n))` (i.e., `-n`). -/
+def extractIntBound (e : expr SourceRange) : Option Int :=
+  match e with
+  | .Constant _ (.ConPos _ n) _ => some (Int.ofNat n.val)
+  | .Constant _ (.ConNeg _ n) _ => some (Int.negOfNat n.val)
+  | .UnaryOp _ (.USub _) (.Constant _ (.ConPos _ n) _) =>
+    some (Int.negOfNat n.val)
+  | _ => none
+
+/-- Extract a float literal string from a Python expression.
+    Handles `Constant(ConFloat s)` and `UnaryOp(USub, Constant(ConFloat s))`. -/
+def extractFloatBound (e : expr SourceRange) : Option String :=
+  match e with
+  | .Constant _ (.ConFloat _ ⟨_, s⟩) _ => some s
+  | .UnaryOp _ (.USub _) (.Constant _ (.ConFloat _ ⟨_, s⟩) _) => some s!"-{s}"
+  | _ => none
+
+/-- Check if a SpecType is the `builtins.int` type. -/
+def isIntType (tp : SpecType) : Bool := tp.isAtom (.ident .builtinsInt #[])
+
+/-- Check if a SpecType is the `builtins.float` type. -/
+def isFloatType (tp : SpecType) : Bool := tp.isAtom (.ident .builtinsFloat #[])
+
+/-- Build a comparison expression dispatching to float or int variants based on type. -/
+private def makeComparison
+    (floatCtor intCtor : SpecExpr → SpecExpr → SpecExpr)
+    (isFloat isInt : Bool)
+    (subj : SpecExpr) (bound : expr SourceRange)
+    : SpecAssertionM (Option SpecExpr) := do
+  if isFloat then
+    match extractFloatBound bound with
+    | some s => return some (floatCtor subj (.floatLit s))
+    | none =>
+      match extractIntBound bound with
+      | some n => return some (floatCtor subj (.floatLit (toString n)))
+      | none => return none
+  else if isInt then
+    match extractIntBound bound with
+    | some n => return some (intCtor subj (.intLit n))
+    | none => return none
+  else
+    match extractIntBound bound with
+    | some n => return some (intCtor subj (.intLit n))
+    | none => return none
+
 def transAssertExpr (e : expr SourceRange)
     : SpecAssertionM SpecExpr := do
   -- isinstance(subject, T)
@@ -771,43 +892,29 @@ def transAssertExpr (e : expr SourceRange)
           if h₃ : comparators.val.size = 1 then
             match ← extractSubject callArgs.val[0] with
             | some subj =>
-              match ops.val[0] with
-              | .GtE _ =>
-                match comparators.val[0] with
-                | .Constant _ (.ConPos _ n) _ =>
-                  return .intGe (.len subj) (.intLit n.val)
-                | _ => pure ()
-              | .LtE _ =>
-                match comparators.val[0] with
-                | .Constant _ (.ConPos _ n) _ =>
-                  return .intLe (.len subj) (.intLit n.val)
-                | _ => pure ()
-              | _ => pure ()
+              match ops.val[0], extractIntBound comparators.val[0] with
+              | .GtE _, some n => return .intGe (.len subj) (.intLit n)
+              | .LtE _, some n => return .intLe (.len subj) (.intLit n)
+              | _, _ => pure ()
             | none => pure ()
   | _ => pure ()
-  -- subject >= N / subject <= N
+  -- subject >= N / subject <= N (type-checked: int or float)
   match e with
   | .Compare _ lhs ops comparators =>
     if h₁ : ops.val.size = 1 then
       if h₂ : comparators.val.size = 1 then
         match ← extractSubject lhs with
         | some subj =>
-          match ops.val[0] with
-          | .GtE _ =>
-            match comparators.val[0] with
-            | .Constant _ (.ConPos _ n) _ =>
-              return .intGe subj (.intLit (Int.ofNat n.val))
-            | .Constant _ (.ConNeg _ n) _ =>
-              return .intGe subj (.intLit (Int.negOfNat n.val))
-            | _ => pure ()
-          | .LtE _ =>
-            match comparators.val[0] with
-            | .Constant _ (.ConPos _ n) _ =>
-              return .intLe subj (.intLit (Int.ofNat n.val))
-            | .Constant _ (.ConNeg _ n) _ =>
-              return .intLe subj (.intLit (Int.negOfNat n.val))
-            | _ => pure ()
-          | _ => pure ()
+          let subjType ← inferExprType lhs
+          let isFloat := subjType.any isFloatType
+          let isInt := subjType.any isIntType
+          let cmp ← match ops.val[0] with
+          | .GtE _ => makeComparison .floatGe .intGe isFloat isInt subj comparators.val[0]
+          | .LtE _ => makeComparison .floatLe .intLe isFloat isInt subj comparators.val[0]
+          | _ => pure none
+          match cmp with
+          | some expr => return expr
+          | none => pure ()
         | none => pure ()
   | _ => pure ()
   -- subject == "A" or subject == "B" or ...
@@ -815,6 +922,28 @@ def transAssertExpr (e : expr SourceRange)
   | some (subj, vals) =>
     return .enumMember subj vals
   | none => pure ()
+  -- compile("pattern").search(subject) is not None
+  match e with
+  | .Compare _
+      (.Call _ (.Attribute _ (.Call _ (.Name _ compileName (.Load _)) compileArgs _)
+        searchAttr (.Load _)) searchArgs _)
+      ops comparators =>
+    if compileName.val == "compile" && searchAttr.val == "search" then
+      if h₁ : compileArgs.val.size = 1 then
+        if h₂ : searchArgs.val.size = 1 then
+          if h₃ : ops.val.size = 1 then
+            if h₄ : comparators.val.size = 1 then
+              match compileArgs.val[0] with
+              | .Constant _ (.ConString _ pattern) _ =>
+                match ← extractSubject searchArgs.val[0] with
+                | some subj =>
+                  match ops.val[0], comparators.val[0] with
+                  | .IsNot _, .Constant _ (.ConNone _) _ =>
+                    return .regexMatch subj pattern.val
+                  | _, _ => pure ()
+                | none => pure ()
+              | _ => pure ()
+  | _ => pure ()
   -- Fallback: unrecognized pattern
   specWarning e.ann s!"unrecognized assert pattern: {eformat e.toAst}"
   return .placeholder
@@ -827,16 +956,27 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
     specWarning s.ann "skipped Assign in function body"
   | .AnnAssign .. =>
     specWarning s.ann "skipped AnnAssign in function body"
+  | .Expr _ (.Constant _ (.ConEllipsis _) _) =>
+    pure () -- `...` stub body, equivalent to pass
   | .Expr .. =>
     specWarning s.ann "skipped Expr in function body"
   | .Assert _ test msg =>
     let formula ← transAssertExpr test
     let message ← match msg.val with
-      | some (.Constant _ (.ConString _ str) _) => pure str.val
-      | none => pure ""
+      | some (.Constant _ (.ConString _ str) _) => pure #[MessagePart.str str.val]
+      | some (.JoinedStr _ values) =>
+        values.val.attach.mapM fun ⟨v, _⟩ =>
+          match v with
+          | .Constant _ (.ConString _ str) _ => pure (MessagePart.str str.val)
+          | .FormattedValue _ value _ _ =>
+            MessagePart.expr <$> transMessageExpr value
+          | other => do
+            specWarning other.ann "unsupported f-string part"
+            pure (MessagePart.str "")
+      | none => pure #[]
       | some e =>
         specWarning e.ann "assert message is not a string literal"
-        pure ""
+        pure #[]
     modify fun s => { s with
       assertions := s.assertions.push { message, formula }
     }
@@ -846,23 +986,93 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
     specWarning s.ann "skipped Raise in function body"
   | .ClassDef .. =>
     specError s.ann s!"Inner classes are not supported."
-  | .For _ _target _iter _body orelse type_comment =>
-    assert! type_comment.val.isNone
-    assert! orelse.val.size == 0
-    specWarning s.ann "skipped For in function body"
+  | .For _ target iter body orelse type_comment =>
+    if type_comment.val.isSome then
+      specWarning s.ann "For: type_comment not supported"
+    if orelse.val.size > 0 then
+      specWarning s.ann "For: else clause not supported"
+    match target, iter with
+    -- for varName in iterable:
+    | .Name _ ⟨_, varName⟩ (.Store _), _ =>
+      match ← extractSubject iter with
+      | some listExpr =>
+        let elemTp ← do
+          match ← inferExprType iter with
+          | some iterTp => pure (extractElementType iterTp)
+          | none => pure none
+        let prevAssertions := (←get).assertions
+        modify fun s => { s with assertions := #[] }
+        withReader (fun ctx => match elemTp with
+          | some tp => { ctx with localTypes := ctx.localTypes.insert varName tp }
+          | none => ctx) <|
+          blockStmts body.val
+        let bodyAssertions := (←get).assertions
+        let wrapped := bodyAssertions.map fun a =>
+          { a with formula := .forallList listExpr varName a.formula }
+        modify fun s => { s with assertions := prevAssertions ++ wrapped }
+      | none =>
+        specWarning s.ann s!"For: cannot extract iterable expression"
+    -- for keyVar, valVar in dictExpr.items():
+    | .Tuple _ elts (.Store _),
+      .Call _ (.Attribute _ dictExpr ⟨_, "items"⟩ (.Load _)) args _ =>
+      if elts.val.size != 2 then
+        specWarning s.ann "For: dict unpacking requires exactly 2 variables"
+      else if args.val.size != 0 then
+        specWarning s.ann "For: .items() call should have no arguments"
+      else
+        match elts.val[0]!, elts.val[1]! with
+        | .Name _ ⟨_, keyVar⟩ (.Store _), .Name _ ⟨_, valVar⟩ (.Store _) =>
+          match ← extractSubject dictExpr with
+          | some dictSubj =>
+            -- Type-check: verify the subject is actually a dict type
+            let kvTypes ← do
+              match ← inferExprType dictExpr with
+              | some dictTp =>
+                match extractDictKeyValueTypes dictTp with
+                | some kv => pure (some kv)
+                | none =>
+                  specWarning s.ann
+                    s!"For: .items() subject is not a Dict/Mapping type"
+                  pure none
+              | none =>
+                specWarning s.ann
+                  s!"For: cannot infer type of .items() subject"
+                pure none
+            let prevAssertions := (←get).assertions
+            modify fun st => { st with assertions := #[] }
+            withReader (fun ctx => match kvTypes with
+              | some (kTp, vTp) =>
+                { ctx with localTypes := ctx.localTypes
+                    |>.insert keyVar kTp
+                    |>.insert valVar vTp }
+              | none => ctx) <|
+              blockStmts body.val
+            let bodyAssertions := (←get).assertions
+            let wrapped := bodyAssertions.map fun a =>
+              { a with formula := .forallDict dictSubj keyVar valVar a.formula }
+            modify fun st => { st with assertions := prevAssertions ++ wrapped }
+          | none =>
+            specWarning s.ann s!"For: cannot extract dict expression"
+        | _, _ =>
+          specWarning s.ann "For: dict unpacking requires Name targets"
+    | _, _ =>
+      specWarning s.ann "For: unsupported target pattern"
   | .If _ pred t f =>
-    let p ← transPred pred
-    assumePred p <| blockStmts t.val
-    assumePred (.not p) <| blockStmts f.val
+    let cond ← transCondition pred
+    if cond.isNone then
+      specWarning pred.ann s!"if: unrecognized condition pattern: {eformat pred.toAst}"
+    assumeCondition cond <| blockStmts t.val
+    if f.val.size > 0 then
+      assumeCondition (cond.map .not) <| blockStmts f.val
   | .Pass _ =>
     pure ()
   | _ => specError s.ann s!"Unsupported statement: {eformat s.toAst}"
 termination_by sizeOf s
 decreasing_by
-  · cases t;
-    decreasing_tactic
-  · cases f;
-    decreasing_tactic
+  · cases body; decreasing_tactic
+  · cases body; decreasing_tactic
+  · cases t; decreasing_tactic
+  · cases f; decreasing_tactic
 
 def blockStmts (as : Array (stmt SourceRange)) : SpecAssertionM Unit := do
   as.attach.forM fun ⟨b, _⟩ => blockStmt b
@@ -880,7 +1090,9 @@ def collectAssertions (decls : ArgDecls) (_returnType : SpecType)
   modify fun s => { s with errors := #[], warnings := #[] }
   let filePath := (←read).pythonFile
   let ctx : SpecAssertionContext :=
-    { filePath, kwargsParamName := decls.kwargs.map Prod.fst }
+    { filePath
+      kwargsParamName := decls.kwargs.map Prod.fst
+      kwargsType := decls.kwargs.map Prod.snd }
   let ((), as) := action ctx { errors, warnings }
   modify fun s => { s with errors := as.errors, warnings := as.warnings }
   pure as
@@ -983,6 +1195,30 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
     postconditions := as.postconditions
   }
 
+/-- Resolve an array of base class expressions into PythonIdents. -/
+private def resolveBaseClasses (bases : Array (expr SourceRange))
+    : PySpecM (Array PythonIdent) := do
+  let mut result : Array PythonIdent := #[]
+  for base in bases do
+    match base with
+    | .Name _ ⟨_, name⟩ _ =>
+      if name == "Exception" then
+        result := result.push .builtinsException
+      else
+        match ← getNameValue? name with
+        | some (.typeValue tp) =>
+          match tp.asSingleton with
+          | some (.ident pyIdent _) =>
+            result := result.push pyIdent
+          | some (.pyClass clsName _) =>
+            result := result.push { pythonModule := "", name := clsName }
+          | _ =>
+            specError base.ann s!"Unknown base class '{name}'"
+        | _ =>
+          specError base.ann s!"Unknown base class '{name}'"
+    | _ => specError base.ann s!"Unsupported base class expression"
+  return result
+
 partial def pySpecClassBody (loc : SourceRange) (className : String)
     (bases : Array PythonIdent)
     (body : Array (Strata.Python.stmt Strata.SourceRange)) : PySpecM ClassDef := do
@@ -1003,26 +1239,7 @@ partial def pySpecClassBody (loc : SourceRange) (className : String)
       | _ => specError stmt.ann s!"Unsupported field target"
     | .ClassDef innerLoc ⟨_, innerClassName⟩ innerBases _keywords innerStmts
                 _decorators _typeParams =>
-      let mut innerBaseIdents : Array PythonIdent := #[]
-      for base in innerBases.val do
-        match base with
-        | .Name _ ⟨_, name⟩ _ =>
-          if name == "Exception" then
-            innerBaseIdents := innerBaseIdents.push .builtinsException
-          else
-            match ← getNameValue? name with
-            | some (.typeValue tp) =>
-              match tp.asSingleton with
-              | some (.ident pyIdent _) =>
-                innerBaseIdents := innerBaseIdents.push pyIdent
-              | some (.pyClass clsName _) =>
-                innerBaseIdents := innerBaseIdents.push
-                  { pythonModule := "", name := clsName }
-              | _ =>
-                specError base.ann s!"Unknown base class '{name}'"
-            | _ =>
-              specError base.ann s!"Unknown base class '{name}'"
-        | _ => specError base.ann s!"Unsupported base class expression"
+      let innerBaseIdents ← resolveBaseClasses innerBases.val
       let innerDef ← pySpecClassBody innerLoc innerClassName
         innerBaseIdents innerStmts.val
       subclasses := subclasses.push innerDef
@@ -1037,13 +1254,42 @@ partial def pySpecClassBody (loc : SourceRange) (className : String)
     | .Pass .. => pure ()       -- Skip pass statements
     | .FunctionDef loc ⟨_, name⟩  args ⟨_, body⟩ ⟨_, decorators⟩ ⟨_, returns⟩
                    ⟨_, type_comment⟩ ⟨_, type_params⟩ =>
-      assert! type_comment.isNone
-      assert! type_params.size = 0
-      if name ∈ usedNames then
-        specError loc s!"{name} already defined."
-      let d ← pySpecFunctionArgs (className := some className) loc name args
-                                 body decorators returns
-      methods := methods.push d
+      if type_comment.isSome then
+        specWarning loc "FunctionDef: type_comment not supported"
+      if type_params.size > 0 then
+        specWarning loc "FunctionDef: type_params not supported"
+      if name == "__init__" then
+        -- Extract self.field = expr assignments as class fields
+        for initStmt in body do
+          match initStmt with
+          | .Assign _ ⟨_, targets⟩ value _ =>
+            if h : targets.size = 1 then
+              match targets[0] with
+              | .Attribute _ (.Name _ ⟨_, "self"⟩ (.Load _)) ⟨_, fieldName⟩ (.Store _) =>
+                -- Try to resolve type from self._ClassName() pattern
+                match value with
+                | .Call _ (.Attribute _ (.Name _ ⟨_, "self"⟩ (.Load _))
+                    ⟨_, innerClsName⟩ (.Load _)) _ _ =>
+                  let f : ClassField := {
+                    name := fieldName,
+                    type := SpecType.pyClass loc innerClsName #[],
+                    constValue := some s!"{innerClsName}()" }
+                  fields := fields.push f
+                | _ =>
+                  specWarning initStmt.ann
+                    s!"unsupported __init__ assignment value for self.{fieldName}"
+              | _ => specWarning initStmt.ann "unsupported __init__ assignment target"
+            else
+              specWarning initStmt.ann "unsupported __init__ multi-target assignment"
+          | .Expr _ (.Constant _ (.ConEllipsis _) _) => pure ()
+          | .Pass .. => pure ()
+          | _ => specWarning initStmt.ann s!"unsupported statement in __init__"
+      else
+        if name ∈ usedNames then
+          specError loc s!"{name} already defined."
+        let d ← pySpecFunctionArgs (className := some className) loc name args
+                                   body decorators returns
+        methods := methods.push d
     | _ =>
       specError stmt.ann s!"Unknown class statement {stmt}"
   return {
@@ -1280,26 +1526,7 @@ partial def translate (body : Array (stmt Strata.SourceRange)) : PySpecM Unit :=
       assert! keywords.val.size = 0
       assert! decorators.val.size = 0
       assert! typeParams.val.size = 0
-      -- Extract base class names as PythonIdents
-      let mut baseIdents : Array PythonIdent := #[]
-      for base in bases.val do
-        match base with
-        | .Name _ ⟨_, name⟩ _ =>
-          if name == "Exception" then
-            baseIdents := baseIdents.push .builtinsException
-          else
-            match ← getNameValue? name with
-            | some (.typeValue tp) =>
-              match tp.asSingleton with
-              | some (.ident pyIdent _) =>
-                baseIdents := baseIdents.push pyIdent
-              | some (.pyClass clsName _) =>
-                baseIdents := baseIdents.push { pythonModule := "", name := clsName }
-              | _ =>
-                specError base.ann s!"Unknown base class '{name}'"
-            | _ =>
-              specError base.ann s!"Unknown base class '{name}'"
-        | _ => specError base.ann s!"Unsupported base class expression"
+      let baseIdents ← resolveBaseClasses bases.val
       let (success, _) ← runChecked <| recordTypeDef loc className
       -- Add the class to nameMap so it can be used in forward references
       setNameValue className (.typeValue (.pyClass loc className #[]))
@@ -1321,6 +1548,7 @@ end
 
 /-- Maps file paths to their FileMap for error location reporting. -/
 public abbrev FileMaps := Std.HashMap System.FilePath Lean.FileMap
+
 
 /-- Translates Python AST statements to PySpec signatures with dependency resolution. -/
 def translateModule

--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -24,7 +24,7 @@ dialect PythonSpecs;
 
 category Int;
 op natInt (x : Num) : Int => x;
-op negSuccInt (x : Num) : Int => "-" x;
+op negInt (x : Num) : Int => "-" x;
 
 category SpecType;
 category DictFieldDecl;
@@ -46,8 +46,8 @@ op mkDictFieldDecl(name : Ident, fieldType : SpecType, isRequired : Bool) : Dict
   name " : " fieldType " [required=" isRequired "]";
 
 category ClassFieldDecl;
-op mkClassFieldDecl(name : Ident, fieldType : SpecType) : ClassFieldDecl =>
-  name " : " fieldType "\n";
+op mkClassFieldDecl(name : Ident, fieldType : SpecType, constValue : Option Str) : ClassFieldDecl =>
+  name " : " fieldType constValue "\n";
 
 category ClassVarDecl;
 op mkClassVarDecl(name : Ident, value : Ident) : ClassVarDecl =>
@@ -65,22 +65,44 @@ category SpecExprDecl;
 op placeholderExpr() : SpecExprDecl => "placeholder";
 op varExpr(name : Ident) : SpecExprDecl => name;
 op getIndexExpr(subject : SpecExprDecl, field : Ident) : SpecExprDecl =>
-  subject "[" field "]";
+  @[prec(50)] subject "[" field "]";
 op isInstanceOfExpr(subject : SpecExprDecl, typeName : Str) : SpecExprDecl =>
-  "isinstance(" subject ", " typeName ")";
+  "isinstance" "(" subject ", " typeName ")";
 op lenExpr(subject : SpecExprDecl) : SpecExprDecl =>
-  "len(" subject ")";
+  "len" "(" subject ")";
 op intExpr(value : Int) : SpecExprDecl => value;
 op intGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
-  subject " >= " bound;
+  @[prec(15)] subject " >=_int " bound;
 op intLeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
-  subject " <= " bound;
+  @[prec(15)] subject " <=_int " bound;
+op floatExpr(value : Str) : SpecExprDecl => value;
+op floatGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
+  @[prec(15)] subject " >=_float " bound;
+op floatLeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
+  @[prec(15)] subject " <=_float " bound;
 op enumMemberExpr(subject : SpecExprDecl, values : Seq Str) : SpecExprDecl =>
-  "enum(" subject ", [" values "])";
+  "enum" "(" subject ", [" values "]" ")";
+op regexMatchExpr(subject : SpecExprDecl, pattern : Str) : SpecExprDecl =>
+  "regex" "(" subject ", " pattern ")";
+op containsKeyExpr(container : SpecExprDecl, key : Ident) : SpecExprDecl =>
+  @[prec(15)] key " in " container;
+op impliesExpr(condition : SpecExprDecl, body : SpecExprDecl) : SpecExprDecl =>
+  @[prec(10), rightassoc] condition " => " body;
+op notExpr(e : SpecExprDecl) : SpecExprDecl =>
+  "not" "(" e ")";
+op forallListExpr(list : SpecExprDecl, varName : Ident, body : SpecExprDecl) : SpecExprDecl =>
+  "forall" "(" list ", " varName ", " body ")";
+op forallDictExpr(dict : SpecExprDecl, keyVar : Ident,
+    valVar : Ident, body : SpecExprDecl) : SpecExprDecl =>
+  "forallDict" "(" dict ", " keyVar ", " valVar ", " body ")";
+
+category MessagePart;
+op strMessagePart(s : Str) : MessagePart => s;
+op exprMessagePart(e : SpecExprDecl) : MessagePart => "{" e "}";
 
 category Assertion;
-op mkAssertion(formula : SpecExprDecl, message : Str) : Assertion =>
-  "ensure(" formula ", " message ")\n";
+op mkAssertion(formula : SpecExprDecl, message : Seq MessagePart) : Assertion =>
+  "ensure" "(" formula ", " message ")\n";
 
 category PostconditionEntry;
 op mkPostconditionEntry(expr : SpecExprDecl) : PostconditionEntry =>
@@ -155,18 +177,20 @@ private def PythonIdent.toDDM (d : PythonIdent) : Ann String SourceRange :=
   ⟨.none, toString d⟩
 
 /-- Converts a Lean `Int` to the DDM representation which separates natural and negative cases. -/
-private def toDDMInt {α} (ann : α) (i : Int) : DDM.Int α :=
+def toDDMInt {α} (ann : α) (i : Int) : DDM.Int α :=
   match i with
   | .ofNat n => .natInt ann ⟨ann, n⟩
-  | .negSucc n => .negSuccInt ann ⟨ann, n⟩
+  | .negSucc n => .negInt ann ⟨ann, (n+1)⟩
 
-private def DDM.Int.ofDDM : DDM.Int α → _root_.Int
+def DDM.Int.ofDDM : DDM.Int α → _root_.Int
 | .natInt _ ⟨_, n⟩ => .ofNat n
-| .negSuccInt _ ⟨_, n⟩ => .negSucc n
+| .negInt _ ⟨_, 0⟩ => 0
+| .negInt _ ⟨_, n+1⟩ => .negSucc n
 
 mutual
 
-private def SpecAtomType.toDDM (d : SpecAtomType) (loc : SourceRange := .none) : DDM.SpecType SourceRange :=
+private def SpecAtomType.toDDM (d : SpecAtomType)
+    (loc : SourceRange := .none) : DDM.SpecType SourceRange :=
   match d with
   | .ident nm args =>
     if args.isEmpty then
@@ -216,12 +240,31 @@ private def SpecExpr.toDDM (e : SpecExpr) : DDM.SpecExprDecl SourceRange :=
   | .intLit v => .intExpr .none (toDDMInt .none v)
   | .intGe subj bound => .intGeExpr .none subj.toDDM bound.toDDM
   | .intLe subj bound => .intLeExpr .none subj.toDDM bound.toDDM
+  | .floatLit v => .floatExpr .none ⟨.none, v⟩
+  | .floatGe subj bound => .floatGeExpr .none subj.toDDM bound.toDDM
+  | .floatLe subj bound => .floatLeExpr .none subj.toDDM bound.toDDM
   | .enumMember subj values =>
     .enumMemberExpr .none subj.toDDM
       ⟨.none, values.map (⟨.none, ·⟩)⟩
+  | .regexMatch subj pattern =>
+    .regexMatchExpr .none subj.toDDM ⟨.none, pattern⟩
+  | .containsKey container key =>
+    .containsKeyExpr .none container.toDDM ⟨.none, key⟩
+  | .implies cond body =>
+    .impliesExpr .none cond.toDDM body.toDDM
+  | .not e => .notExpr .none e.toDDM
+  | .forallList list varName body =>
+    .forallListExpr .none list.toDDM ⟨.none, varName⟩ body.toDDM
+  | .forallDict dict keyVar valVar body =>
+    .forallDictExpr .none dict.toDDM ⟨.none, keyVar⟩ ⟨.none, valVar⟩ body.toDDM
+
+private def MessagePart.toDDM (p : MessagePart) : DDM.MessagePart SourceRange :=
+  match p with
+  | .str s => .strMessagePart .none ⟨.none, s⟩
+  | .expr e => .exprMessagePart .none e.toDDM
 
 private def Assertion.toDDM (a : Assertion) : DDM.Assertion SourceRange :=
-  .mkAssertion .none a.formula.toDDM ⟨.none, a.message⟩
+  .mkAssertion .none a.formula.toDDM ⟨.none, a.message.map (·.toDDM)⟩
 
 private def FunctionDecl.toDDM (d : FunctionDecl) : DDM.FunDecl SourceRange :=
   .mkFunDecl
@@ -247,7 +290,8 @@ private partial def ClassDef.toDDMDecl (d : ClassDef) : DDM.ClassDecl SourceRang
   .mkClassDecl d.loc (.mk .none d.name)
     ⟨.none, d.bases.map (·.toDDM)⟩
     ⟨.none, d.fields.map fun f =>
-      .mkClassFieldDecl .none ⟨.none, f.name⟩ f.type.toDDM⟩
+      .mkClassFieldDecl .none ⟨.none, f.name⟩ f.type.toDDM
+        ⟨.none, f.constValue.map (⟨.none, ·⟩)⟩⟩
     ⟨.none, d.classVars.map (·.toDDM)⟩
     ⟨.none, d.subclasses.map (·.toDDMDecl)⟩
     ⟨.none, d.methods.map (·.toDDM)⟩
@@ -323,11 +367,27 @@ private def DDM.SpecExprDecl.fromDDM (d : DDM.SpecExprDecl SourceRange) : Specs.
   | .intExpr _ i => .intLit i.ofDDM
   | .intGeExpr _ subj bound => .intGe subj.fromDDM bound.fromDDM
   | .intLeExpr _ subj bound => .intLe subj.fromDDM bound.fromDDM
+  | .floatExpr _ ⟨_, v⟩ => .floatLit v
+  | .floatGeExpr _ subj bound => .floatGe subj.fromDDM bound.fromDDM
+  | .floatLeExpr _ subj bound => .floatLe subj.fromDDM bound.fromDDM
   | .enumMemberExpr _ subj ⟨_, values⟩ => .enumMember subj.fromDDM (values.map (·.2))
+  | .regexMatchExpr _ subj ⟨_, pattern⟩ => .regexMatch subj.fromDDM pattern
+  | .containsKeyExpr _ container ⟨_, key⟩ => .containsKey container.fromDDM key
+  | .impliesExpr _ cond body => .implies cond.fromDDM body.fromDDM
+  | .notExpr _ e => .not e.fromDDM
+  | .forallListExpr _ list ⟨_, varName⟩ body =>
+    .forallList list.fromDDM varName body.fromDDM
+  | .forallDictExpr _ dict ⟨_, keyVar⟩ ⟨_, valVar⟩ body =>
+    .forallDict dict.fromDDM keyVar valVar body.fromDDM
+
+private def DDM.MessagePart.fromDDM (d : DDM.MessagePart SourceRange) : Specs.MessagePart :=
+  match d with
+  | .strMessagePart _ ⟨_, s⟩ => .str s
+  | .exprMessagePart _ e => .expr e.fromDDM
 
 private def DDM.Assertion.fromDDM (d : DDM.Assertion SourceRange) : Specs.Assertion :=
   let .mkAssertion _ formula ⟨_, message⟩ := d
-  { message := message, formula := formula.fromDDM }
+  { message := message.map (·.fromDDM), formula := formula.fromDDM }
 
 private def DDM.FunDecl.fromDDM (d : DDM.FunDecl SourceRange) : Specs.FunctionDecl :=
   let .mkFunDecl loc ⟨nameLoc, name⟩ ⟨_, args⟩ ⟨_, kwonly⟩
@@ -363,8 +423,8 @@ private def DDM.ClassDecl.fromDDM (d : DDM.ClassDecl SourceRange) : Specs.ClassD
       match PythonIdent.ofString s with
       | some id => id
       | none => panic! s!"Bad base class identifier: '{s}'"
-    fields := fields.map fun (.mkClassFieldDecl _ ⟨_, n⟩ tp) =>
-      { name := n, type := tp.fromDDM : ClassField }
+    fields := fields.map fun (.mkClassFieldDecl _ ⟨_, n⟩ tp ⟨_, cv⟩) =>
+      { name := n, type := tp.fromDDM, constValue := cv.map (·.2) : ClassField }
     classVars := classVars.map fun (.mkClassVarDecl _ ⟨_, n⟩ ⟨_, v⟩) =>
       { name := n, value := v : ClassVariable }
     subclasses := subclasses.map (·.fromDDM)

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -334,11 +334,40 @@ inductive SpecExpr where
 | intLit (value : Int)
 | intGe (subject : SpecExpr) (bound : SpecExpr)
 | intLe (subject : SpecExpr) (bound : SpecExpr)
+/-- A floating-point literal, stored as a string to preserve precision. -/
+| floatLit (value : String)
+| floatGe (subject : SpecExpr) (bound : SpecExpr)
+| floatLe (subject : SpecExpr) (bound : SpecExpr)
 | enumMember (subject : SpecExpr) (values : Array String)
+/-- `regexMatch subject pattern` asserts that `subject` matches the regular
+    expression `pattern`. Corresponds to `compile(pattern).search(subject) is not None`
+    in the Python source. -/
+| regexMatch (subject : SpecExpr) (pattern : String)
+/-- `containsKey container key` asserts that `key` is present in `container`.
+    Corresponds to `"key" in container` in the Python source. -/
+| containsKey (container : SpecExpr) (key : String)
+/-- `implies condition body` asserts that if `condition` holds then `body` holds.
+    Used to represent conditional assertions like `if "field" in kwargs: assert ...`. -/
+| implies (condition : SpecExpr) (body : SpecExpr)
+/-- Logical negation. Used for else-branch conditions. -/
+| not (e : SpecExpr)
+/-- `forallList list varName body` asserts that `body` holds for every element
+    of `list`, with `varName` bound to each element in turn. Only `body` may
+    refer to `varName`. Corresponds to `for varName in list: assert body`. -/
+| forallList (list : SpecExpr) (varName : String) (body : SpecExpr)
+/-- `forallDict dict keyVar valVar body` asserts that `body` holds for every
+    key-value pair in `dict`. Both `keyVar` and `valVar` are bound in `body`.
+    Corresponds to `for keyVar, valVar in dict.items(): assert body`. -/
+| forallDict (dict : SpecExpr) (keyVar : String) (valVar : String) (body : SpecExpr)
+deriving Inhabited
+
+inductive MessagePart where
+| str (s : String)
+| expr (e : SpecExpr)
 deriving Inhabited
 
 structure Assertion where
-  message : String
+  message : Array MessagePart
   formula : SpecExpr
 deriving Inhabited
 
@@ -356,6 +385,8 @@ deriving Inhabited
 structure ClassField where
   name : String
   type : SpecType
+  /-- An optional constant value for the field (e.g., from `self.x = expr` in `__init__`). -/
+  constValue : Option String := none
 deriving Inhabited
 
 structure ClassVariable where

--- a/Strata/Util/IO.lean
+++ b/Strata/Util/IO.lean
@@ -89,6 +89,8 @@ def readStrataText (fm : Strata.DialectFileMap) (path : System.FilePath) (bytes 
     | .ok program => pure (.program program)
     | .error errors => throw (IO.userError (← mkErrorReport path errors))
   | .dialect stx dialect =>
+    if dialect ∈ (←fm.loaded.get).dialects then
+      throw <| IO.userError s!"{dialect} already loaded"
     let (d, s) ←
       Strata.Elab.elabDialectRest fm inputContext stx dialect (startPos := startPos)
     if s.errors.size > 0 then
@@ -112,6 +114,8 @@ def readStrataIon (fm : Strata.DialectFileMap)
       pure p
   match hdr with
   | .dialect dialect =>
+    if dialect ∈ (←fm.loaded.get).dialects then
+      throw <| IO.userError s!"{dialect} already loaded"
     match ← Strata.Elab.loadDialectFromIonFragment fm #[] dialect frag with
     | .error msg =>
       throw (IO.userError (fileReadErrorMsg path msg))

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -126,6 +126,11 @@ def printCommand : Command where
   help := "Pretty-print a Strata file (text or Ion) to stdout."
   callback := fun v pflags => do
     let searchPath ← pflags.buildDialectFileMap
+    -- Special case for already loaded dialects.
+    let ld ← searchPath.getLoaded
+    if mem : v[0] ∈ ld.dialects then
+      IO.print <| ld.dialects.format v[0] mem
+      return
     let pd ← Strata.readStrataFile searchPath v[0]
     match pd with
     | .dialect d =>

--- a/StrataTest/Languages/Python/Specs/main.py
+++ b/StrataTest/Languages/Python/Specs/main.py
@@ -1,6 +1,6 @@
 from re import compile
 from basetypes import BaseClass
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict, List, Mapping, NotRequired, Sequence, TypedDict, Unpack
 
 def dict_function(x : Dict[int, Any]):
     pass
@@ -24,3 +24,57 @@ def main_function(x : MainClass):
 def kwargs_function(**kw: int) -> Any:
     assert isinstance(kw["name"], str), 'Expected name to be str'
     assert kw["count"] >= 1, 'Expected count >= 1'
+
+# Test f-string messages, regex, nested subscripts, and for-loops
+TestRequest = TypedDict('TestRequest', {
+    'Name': str,
+    'Items': NotRequired[List[str]],
+    'Tags': NotRequired[Mapping[str, str]],
+})
+
+def fstring_and_regex(**params: Unpack[TestRequest]) -> None:
+    assert len(params["Name"]) >= 1, f'Expected len(params["Name"]) >= 1, got {len(params["Name"])}'
+    assert len(params["Name"]) <= 100, f'Expected len(params["Name"]) <= 100, got {len(params["Name"])}'
+    assert compile("^[a-zA-Z]+$").search(params["Name"]) is not None, f'params["Name"] did not match pattern'
+    if "Items" in params:
+        for item in params["Items"]:
+            assert len(item) >= 1, f'Expected len(item) >= 1, got {len(item)}'
+            assert len(item) <= 50, f'Expected len(item) <= 50, got {len(item)}'
+    if "Tags" in params:
+        for tag_key, tag_val in params["Tags"].items():
+            assert len(tag_key) >= 1, f'Expected len(tag_key) >= 1, got {len(tag_key)}'
+
+# Test float comparisons, negative int bounds, and __init__ class fields
+FloatRequest = TypedDict('FloatRequest', {
+    'SampleSize': NotRequired[float],
+    'Score': NotRequired[float],
+    'Count': NotRequired[int],
+})
+
+def float_and_negative_bounds(**fp: Unpack[FloatRequest]) -> None:
+    # Float field with float literal bound
+    if "Score" in fp:
+        assert fp["Score"] >= 0.0, f'Expected Score >= 0.0'
+        assert fp["Score"] <= 1.0, f'Expected Score <= 1.0'
+    else:
+        assert fp["SampleSize"] >= 0, f'Expected SampleSize >= 0 when no Score'
+    # Float field with integer literal bound (the SampleSize pattern)
+    if "SampleSize" in fp:
+        assert fp["SampleSize"] >= 0, f'Expected SampleSize >= 0'
+    # Float field with negative float bound
+    if "Score" in fp:
+        assert fp["Score"] >= -0.5, f'Expected Score >= -0.5'
+    # Int field with negative bound
+    if "Count" in fp:
+        assert fp["Count"] >= -1, f'Expected Count >= -1'
+
+class InnerHelper:
+    pass
+
+class ClassWithInit:
+    def __init__(self):
+        self.helper = self._InnerHelper()
+
+    class _InnerHelper(InnerHelper):
+        def do_work(self) -> None:
+            pass

--- a/StrataTest/Languages/Python/Specs/warnings.py
+++ b/StrataTest/Languages/Python/Specs/warnings.py
@@ -1,0 +1,32 @@
+from typing import Any, Dict, List, NotRequired, TypedDict, Unpack
+
+# Unsupported assert pattern: equality comparison
+def unsupported_assert(**kw: int) -> None:
+    assert kw["x"] == 1, 'x must be 1'
+
+# Unsupported __init__ assignment value (not self._ClassName() pattern)
+class BadInit:
+    def __init__(self):
+        self.name = "hello"
+
+# Skipped Assign in function body
+def skipped_assign(**kw: int) -> None:
+    x = kw["a"]
+    assert x >= 1, 'x >= 1'
+
+# For loop with unsupported target (attribute, not simple Name)
+LoopRequest = TypedDict('LoopRequest', {
+    'Items': NotRequired[List[str]],
+    'Data': NotRequired[Dict[str, str]],
+})
+
+# For loop with unsupported orelse (for/else)
+def for_else_loop(**kw: Unpack[LoopRequest]) -> None:
+    for item in kw["Items"]:
+        assert len(item) >= 1, f'Expected len >= 1'
+    else:
+        pass
+
+# Skipped Expr in function body (non-ellipsis expression statement)
+def skipped_expr(**kw: int) -> None:
+    kw["a"]

--- a/StrataTest/Languages/Python/SpecsTest.lean
+++ b/StrataTest/Languages/Python/SpecsTest.lean
@@ -3,14 +3,16 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
-import Strata.Languages.Python.Specs
-import Strata.Languages.Python.Specs.DDM
+module
+meta import Strata.Languages.Python.Specs
+meta import Strata.Languages.Python.Specs.DDM
+import Strata.DDM.Ion
 import Strata.Languages.Python.PythonDialect
-import StrataTest.Util.Python
+meta import StrataTest.Util.Python
 
 namespace Strata.Python.Specs
 
-def expectedPySpec :=
+meta def expectedPySpec :=
 #strata
 program PythonSpecs;
 extern "BaseClass" from "basetypes.BaseClass";
@@ -109,19 +111,109 @@ function "kwargs_function"{
   overload: false
   preconditions: [
     ensure(isinstance(kw[name], "str"), "Expected name to be str")
-    ensure(kw[count] >= 1, "Expected count >= 1")
+    ensure(kw[count] >=_int 1, "Expected count >= 1")
   ]
   postconditions: [
+  ]
+}
+type "TestRequest" = dict(
+  Name : ident("builtins.str") [required=true]
+  Items : ident("typing.List", ident("builtins.str")) [required=false]
+  Tags : ident("typing.Mapping", ident("builtins.str"), ident("builtins.str")) [required=false]
+)
+function "fstring_and_regex"{
+  args: [
+  ]
+  kwonly: [
+  ]
+  kwargs: params : dict(
+    Name : ident("builtins.str") [required=true]
+    Items : ident("typing.List", ident("builtins.str")) [required=false]
+    Tags : ident("typing.Mapping", ident("builtins.str"), ident("builtins.str")) [required=false]
+  )
+  return: ident("_types.NoneType")
+  overload: false
+  preconditions: [
+    ensure(len(params[Name]) >=_int 1, "Expected len(params[\"Name\"]) >= 1, got "{len(params[Name])})
+    ensure(len(params[Name]) <=_int 100, "Expected len(params[\"Name\"]) <= 100, got "{len(params[Name])})
+    ensure(regex(params[Name], "^[a-zA-Z]+$"), "params[\"Name\"] did not match pattern")
+    ensure(Items in params => forall(params[Items], item, len(item) >=_int 1), "Expected len(item) >= 1, got "{len(item)})
+    ensure(Items in params => forall(params[Items], item, len(item) <=_int 50), "Expected len(item) <= 50, got "{len(item)})
+    ensure(Tags in params => forallDict(params[Tags], tag_key, tag_val, len(tag_key) >=_int 1), "Expected len(tag_key) >= 1, got "{len(tag_key)})
+  ]
+  postconditions: [
+  ]
+}
+type "FloatRequest" = dict(
+  SampleSize : ident("builtins.float") [required=false]
+  Score : ident("builtins.float") [required=false]
+  Count : ident("builtins.int") [required=false]
+)
+function "float_and_negative_bounds"{
+  args: [
+  ]
+  kwonly: [
+  ]
+  kwargs: fp : dict(
+    SampleSize : ident("builtins.float") [required=false]
+    Score : ident("builtins.float") [required=false]
+    Count : ident("builtins.int") [required=false]
+  )
+  return: ident("_types.NoneType")
+  overload: false
+  preconditions: [
+    ensure(Score in fp => fp[Score] >=_float "0.0", "Expected Score >= 0.0")
+    ensure(Score in fp => fp[Score] <=_float "1.0", "Expected Score <= 1.0")
+    ensure(not(Score in fp) => fp[SampleSize] >=_float "0", "Expected SampleSize >= 0 when no Score")
+    ensure(SampleSize in fp => fp[SampleSize] >=_float "0", "Expected SampleSize >= 0")
+    ensure(Score in fp => fp[Score] >=_float "-0.5", "Expected Score >= -0.5")
+    ensure(Count in fp => fp[Count] >=_int -1, "Expected Count >= -1")
+  ]
+  postconditions: [
+  ]
+}
+class "InnerHelper" {
+  bases: []
+  fields: []
+  classVars: []
+  subclasses: []
+}
+class "ClassWithInit" {
+  bases: []
+  fields: [
+    helper : class(_InnerHelper) "_InnerHelper()"
+  ]
+  classVars: []
+  subclasses: [
+    class "_InnerHelper" {
+      bases: [".InnerHelper"]
+      fields: []
+      classVars: []
+      subclasses: []
+      function "do_work"{
+        args: [
+          self : class(_InnerHelper) [hasDefault: false]
+        ]
+        kwonly: [
+        ]
+        return: ident("_types.NoneType")
+        overload: false
+        preconditions: [
+        ]
+        postconditions: [
+        ]
+      }
+    }
   ]
 }
 #end
 
 -- We use an environment variable to allow the build process
 -- to require the Python test is run.
-def pythonTestRequired : IO Bool :=
+meta def pythonTestRequired : IO Bool :=
   return (← IO.getEnv "PYTHON_TEST").isSome
 
-def testCase : IO Unit := do
+meta def testCase : IO Unit := do
   let pythonCmd ←
     match ← findPython3 (minVersion := 11) (maxVersion := 14) |>.toBaseIO with
     | .ok cmd =>
@@ -153,13 +245,94 @@ def testCase : IO Unit := do
         let pgm := toDDMProgram sigs
         let pgmCommands := pgm.commands.map (·.mapAnn (fun _ => ()))
         let expCommands := expectedPySpec.commands.map (·.mapAnn (fun _ => ()))
-        assert! pgmCommands == expCommands
+        if pgmCommands != expCommands then
+          -- Find first differing command index
+          let mut diffMsg := s!"actual has {pgmCommands.size} commands, expected {expCommands.size}"
+          for i in [:pgmCommands.size.max expCommands.size] do
+            let actual := pgmCommands[i]?
+            let expected := expCommands[i]?
+            if actual != expected then
+              diffMsg := s!"Command {i} differs."
+              break
+          throw <| IO.userError s!"PySpec output mismatch. {diffMsg}"
         -- from re import compile resolves via prelude without warnings
-        assert! warnings.isEmpty
+        if !warnings.isEmpty then
+          let warnStr := warnings.foldl (init := "") fun acc w => s!"{acc}\n  {w}"
+          throw <| IO.userError s!"Unexpected warnings:{warnStr}"
       | .error e =>
         throw <| IO.userError e
 
 #guard_msgs in
 #eval testCase
+
+/-- Check if `needle` is a substring of `haystack`. -/
+meta def containsSubstr (haystack needle : String) : Bool :=
+  (haystack.splitOn needle).length != 1
+
+/-- Test that unsupported patterns emit appropriate warnings. -/
+meta def warningTestCase : IO Unit := do
+  let pythonCmd ←
+    match ← findPython3 (minVersion := 11) (maxVersion := 14) |>.toBaseIO with
+    | .ok cmd => pure cmd
+    | .error msg =>
+      if ← pythonTestRequired then throw msg
+      return ()
+  if not (← pythonCheckModule pythonCmd "strata.gen") then
+    if ← pythonTestRequired then
+      throw <| .userError s!"Python Strata libraries not installed in {pythonCmd}."
+    return ()
+  IO.FS.withTempFile fun _handle dialectFile => do
+    IO.FS.writeBinFile dialectFile Strata.Python.Python.toIon
+    let pythonFile : System.FilePath := "StrataTest/Languages/Python/Specs/warnings.py"
+    IO.FS.withTempDir fun strataDir => do
+      let r ←
+        translateFile
+          (pythonCmd := toString pythonCmd)
+          (dialectFile := dialectFile)
+          (strataDir := strataDir)
+          (pythonFile := pythonFile)
+          |>.toBaseIO
+      match r with
+      | .ok (sigs, warnings) =>
+        -- Check that we still produced some output despite warnings
+        if sigs.isEmpty then
+          throw <| IO.userError "Expected signatures from warnings.py but got none"
+        -- Check that we got warnings (not zero)
+        if warnings.isEmpty then
+          throw <| IO.userError "Expected warnings from warnings.py but got none"
+        -- Check for specific expected warning substrings
+        let expectedWarnings := #[
+          "unrecognized assert pattern",       -- assert kw["x"] == 1
+          "unsupported __init__ assignment",   -- self.name = "hello"
+          "skipped Assign in function body",   -- x = kw["a"]
+          "For: else clause not supported",    -- for/else loop
+          "skipped Expr in function body"      -- kw["a"] (bare expression)
+        ]
+        for expected in expectedWarnings do
+          if !warnings.any (containsSubstr · expected) then
+            let warnStr := warnings.foldl (init := "") fun acc w => s!"{acc}\n  {w}"
+            throw <| IO.userError
+              s!"Missing expected warning containing \"{expected}\". Actual warnings:{warnStr}"
+      | .error e =>
+        throw <| IO.userError e
+
+#guard_msgs in
+#eval warningTestCase
+
+
+meta def testNegRoundTrip (v : Nat) : Bool :=
+  DDM.Int.ofDDM (.negInt SourceRange.none ⟨.none, v⟩) = .negOfNat v
+
+#guard testNegRoundTrip 0
+#guard testNegRoundTrip 1
+
+meta def testIntRoundTrip (v : Int) : Bool :=
+  DDM.Int.ofDDM (toDDMInt SourceRange.none v) = v
+
+#guard testIntRoundTrip 0
+#guard testIntRoundTrip 1
+#guard testIntRoundTrip (-1)
+#guard testIntRoundTrip (42)
+#guard testIntRoundTrip (-100)
 
 end Strata.Python.Specs

--- a/review_notes.md
+++ b/review_notes.md
@@ -1,0 +1,110 @@
+# Review Notes — PR #537
+
+## Summary
+
+Extends the pySpecs Python-to-spec translator with f-string message handling, for-loop quantifiers (list and dict), conditional implication, `__init__` class field extraction, type-checked float/int comparisons, and negative integer bounds — enabling it to translate all assertion patterns found in the service specification files without warnings.
+
+## Details
+
+1. **F-string assertion messages**: Assertion messages using Python f-strings are now preserved as `MessagePart` arrays (string literals vs interpolated expressions) instead of flattened strings. The DDM `Assertion` op signature changed from `Str` to `Seq MessagePart`.
+2. **For-loop quantification**: `for item in list` loops produce `forallList` quantifiers with element type inference from `typing.List`/`typing.Sequence` annotations. `for k, v in dict.items()` tuple unpacking produces `forallDict` with key/value type inference from `Dict`/`Mapping` annotations.
+3. **Conditional implication**: `if` blocks wrapping assertions become `implies(condition, body)` via `assumeCondition`, which captures assertions from the body and wraps them. Currently handles `"key" in container` patterns.
+4. **`__init__` class field extraction**: A dedicated handler for `__init__` methods extracts `self.field = self._ClassName()` assignments as `ClassField` entries with optional `constValue`, replacing the previous approach of treating `__init__` as a regular method.
+5. **Type-checked numeric comparisons**: Comparison assertions dispatch to `intGe`/`intLe` or `floatGe`/`floatLe` based on inferred subject type. Float-typed fields with integer literal bounds fall back via int-to-float string conversion.
+6. **Negative integer bounds**: `extractIntBound` handles `ConNeg` and `UnaryOp(USub, ConPos)`. The DDM `negSucc` encoding was fixed so `-1` round-trips correctly (stores `n+1` rather than raw `n`).
+7. **DDM operator precedences**: Subscript at prec 50, comparisons at prec 15, implication at prec 10 (right-associative) to avoid unnecessary parentheses.
+8. **Test coverage**: Positive tests for all new features in `main.py`/`SpecsTest.lean`. Separate negative tests in `warnings.py` checking warning emission for unsupported patterns. Test assertions throw errors instead of panicking.
+
+## Findings
+
+### Features
+
+- **Clean `SpecAssertionM` monad design**: The new monad with its own `SpecAssertionContext` and `SpecAssertionState` provides a well-scoped environment for assertion extraction, with idiomatic use of `withReader` for scoped local type bindings in for-loops.
+- **Thorough DDM round-trip coverage**: Every new `SpecExpr` constructor has corresponding `toDDM`/`fromDDM` arms, and the `negSucc` encoding bug fix is correctly reflected in both directions.
+- **Warning-based negative testing**: The `warnings.py` + `warningTestCase` pattern cleanly separates positive and negative testing concerns, making it easy to extend.
+- **Improved test diagnostics**: Tests use `throw IO.userError` with detailed diff messages showing the first diverging command index, replacing opaque `assert!` panics.
+- **Zero-warnings assertion**: The positive test verifies `warnings.isEmpty`, catching regressions where clean patterns start producing warnings.
+
+### Potential Issues
+
+**1. ~~Missing `s!` string interpolation in 3 error messages~~ (Correctness)** — FIXED
+- Added `s!` prefix to `"{dialect} already loaded"` in `Strata/Util/IO.lean` (2 occurrences) and `Strata/DDM/Elab.lean` (1 occurrence).
+
+**2. ~~`transCondition` silently drops unrecognized if-conditions~~ (Correctness)** — FIXED
+- Added warning `"if: unrecognized condition pattern: ..."` in the `If` handler when `transCondition` returns `none`. Assertions still pass through (unwrapped), but the user is now alerted.
+
+**3. ~~`assert!` panics in For handler and class-body FunctionDef on valid Python~~ (Safety)** — FIXED
+- Replaced `assert!` with `specWarning` for `type_comment` and `orelse`/`type_params` checks in both the `For` handler and the class-body `FunctionDef` handler. Valid but unsupported constructs (e.g., `for/else`) now warn instead of panicking.
+
+**4. ~~`negSuccInt 0` edge case in `DDM.Int.ofDDM`~~ (Correctness)** — FIXED
+- Renamed `negSuccInt` to `negInt` with format `"-" x`. `toDDMInt` stores `n+1` for `negSucc n`. `ofDDM` handles `negInt 0` explicitly (maps to `0`). Added round-trip `#guard` tests in `SpecsTest.lean`.
+
+**5. ~~No test for `else`-branch / `not` expression~~ (Test Coverage)** — FIXED
+- Added `else` branch to `float_and_negative_bounds` in `main.py`. Expected DDM output includes `not(Score in fp) => ...`. The `not` expression path through `toDDM`/`fromDDM` is now tested.
+
+**6. ~~Dead code: `Pred` inductive type~~ (Structure)** — FIXED
+- Removed `Pred` type, its `not` function, and the FIXME comment.
+
+**7. ~~Dead code: `Iterable` inductive type~~ (Structure)** — FIXED
+- Removed `Iterable` type.
+
+**8. ~~`warnings.py` declares unused `LoopRequest` TypedDict~~ (Test Coverage)** — FIXED
+- Added `for_else_loop` test function using `LoopRequest`. Warning test now checks for `"For: else clause not supported"`.
+
+**9. ~~Duplicated comparison logic in `GtE`/`LtE` arms~~ (Structure)** — FIXED
+- Extracted `makeComparison` helper parameterized by float/int constructors. Net reduction of ~30 lines.
+
+**10. ~~Duplicated base-class resolution logic~~ (Structure)** — FIXED
+- Extracted `resolveBaseClasses` helper used by both `pySpecClassBody` and `translate`.
+
+**11. ~~No test for negative float bounds~~ (Test Coverage)** — FIXED
+- Added `assert fp["Score"] >= -0.5` test case. Expected DDM output includes `>=_float "-0.5"`.
+
+**12. ~~Warning test does not verify translator output~~ (Test Coverage)** — FIXED
+- `warningTestCase` now checks `sigs.isEmpty` to verify the translator still produces output despite warnings.
+
+**13. ~~Hard line-length violations in DDM.lean~~ (Style)** — FIXED
+- Wrapped 2 lines exceeding 100 characters in DDM.lean.
+
+## Agent Findings
+
+### Correctness
+
+- ~~**Missing `s!` interpolation**~~ — FIXED
+- ~~**`transCondition` silent drops**~~ — FIXED
+- ~~**`negSuccInt 0` edge case**~~ — FIXED: renamed to `negInt`, explicit `0` handling, round-trip tests added.
+- **`__init__` ignores constructor args**: Only self-assignment patterns are extracted; constructor arguments are silently dropped.
+- **`lookupTypedDictField` fragile indexing**: Uses `args.val[1]!` which could fail on malformed Python AST.
+
+### Safety
+
+- ~~**Missing `s!`** in 3 error messages~~ — FIXED
+- ~~**`assert!` panics** in For handler and class-body FunctionDef~~ — FIXED
+- ~~**`negSucc` fragile round-trip**~~ — FIXED: `negInt 0` now handled explicitly.
+- Various forced indexing sites (`val[0]!`, `val[1]!`) were reviewed and found to be safe given the match guards.
+
+### Style
+
+- ~~**Missing `s!`** in 3 error messages~~ — FIXED
+- ~~**Hard line violations** in DDM.lean~~ — FIXED.
+- **Missing docstring** on `transAssertExpr`.
+- ~~**Duplicated comparison logic** in GtE/LtE arms~~ — FIXED
+- ~~**FIXME comment** on `Pred` should be resolved~~ — FIXED (removed with dead code in #6).
+- **Stray blank lines** in a few locations.
+
+### Structure
+
+- ~~**Dead code**: `Pred` type (with FIXME), `Iterable` type~~ — FIXED (removed).
+- ~~**Duplicated base-class resolution**~~ — FIXED (`resolveBaseClasses` helper).
+- ~~**Duplicated comparison dispatch**~~ — FIXED (`makeComparison` helper).
+- **Generic utilities** (`compareHLex`, `removeAdjDups`) in Decls.lean could belong in a utility module (pre-existing).
+- **Positive**: Clean `SpecAssertionM` monad design, good `withReader` scoping, thorough DDM round-trip coverage, `baseLogEvent` refactoring.
+
+### Test Adequacy
+
+- ~~**No `else`-branch / `not` expression test**~~ — FIXED
+- ~~**Unused `LoopRequest` in warnings.py**~~ — FIXED (added `for_else_loop` test)
+- ~~**No negative float bound test**~~ — FIXED
+- ~~**Warning test doesn't verify output**~~ — FIXED
+- **Only `-1` tested for negSucc**: Testing with `-2` would better validate the encoding.
+- **Positive**: Comprehensive happy-path coverage, improved diagnostics, zero-warnings assertion, clean negative test pattern.


### PR DESCRIPTION
## Summary

Extend the Strata `pySpecs` Python-to-spec translator to handle the full
range of assertion patterns found across service specification files.
Before this change the translator emitted warnings on many common
patterns; after, it handles all constructs without warnings.

Builds on the robustness and API improvements from #512.

## Details

- **F-string messages.**  Assertion messages that use Python f-strings
  are now preserved semantically (distinguishing literal text from
  interpolated expressions) rather than being flattened to a single
  string.
- **For-loop quantifiers.**  `for item in kwargs["field"]` loops are
  translated to `forallList` quantifiers.  The element type is inferred
  from `typing.List` or `typing.Sequence` annotations in the
  corresponding TypedDict.  `for k, v in dict.items()` tuple unpacking
  is handled similarly via `forallDict`, with key/value types inferred
  from `Dict` or `Mapping` annotations.
- **Conditional implication.**  When assertions appear inside an `if`
  block (e.g. `if "Items" in kwargs:`), the condition becomes an
  antecedent: `implies(condition, assertion)`.  Else-branch assertions
  receive the negated condition.
- **`__init__` as class fields.**  Rather than treating `__init__` as a
  regular method, the translator now extracts
  `self.field = self._ClassName()` assignments as typed class fields
  with an optional constant value.  Unhandled `__init__` patterns
  emit warnings.
- **Type-checked numeric comparisons.**  Comparison assertions
  (`>=`, `<=`) now use type inference to choose between integer and
  floating-point operators.  When a float-typed field is compared
  against an integer literal (e.g. `SampleSize >= 0`), the bound is
  promoted to float automatically.  Negative integer bounds (`>= -1`)
  are also supported.
- **Negative-integer DDM encoding.**  Fixed the `negSucc` round-trip in
  the DDM serialization layer so that `-1` renders as `"-1"` rather
  than `"-0"`.
- **DDM operator precedences.**  Subscript, comparison, and implication
  operators have explicit precedences so the pretty-printer no longer
  emits unnecessary parentheses.
- **Test coverage.**  Positive tests cover f-strings, for-loops, dict
  iteration, conditionals, `__init__` fields, float/int comparisons,
  and negative bounds.  A separate negative-test file (`warnings.py`)
  verifies that unsupported patterns produce the expected warnings.
  Test assertions now throw descriptive errors instead of panicking.

By submitting this pull request, I confirm that you can use, modify,
copy, and redistribute this contribution, under the terms of your choice.