### PR TITLE
Resolve issue #535 by adding smtStringEscaping option to DDM's Format Options

### DIFF
--- a/Strata/DDM/Format.lean
+++ b/Strata/DDM/Format.lean
@@ -89,6 +89,8 @@ Options to control parenthesis
 structure FormatOptions where
   /-- Always add parenthesis when feasible. -/
   alwaysParen : Bool := false
+  /-- Use SMT-LIB 2.7 string escaping (`""` for quotes) instead of C-style (`\"`). -/
+  smtStringEscaping : Bool := false
 
 /--
 A format context provides callbacks and information needed to
@@ -383,7 +385,10 @@ private partial def ArgF.mformatM {α} : ArgF α → FormatM PrecFormat
 | .ident _ x => return .atom (formatIdent x)
 | .num _ x => pformat x
 | .decimal _ v => pformat v
-| .strlit _ s => return .atom (.text <| escapeStringLit s)
+| .strlit _ s => do
+    let ctx ← read
+    let esc := if ctx.opts.smtStringEscaping then escapeSMTStringLit s else escapeStringLit s
+    return .atom (.text esc)
 | .bytes _ v => return .atom <| .text <| ByteArray.escapeBytes v
 | .option _ ma =>
   match ma with

--- a/Strata/DDM/Util/String.lean
+++ b/Strata/DDM/Util/String.lean
@@ -117,5 +117,23 @@ private def escapeStringLitAux (acc : String) (c : Char) : String :=
 def escapeStringLit (s : String) : String :=
   s.foldl escapeStringLitAux "\"" ++ "\""
 
+/--
+Escape a string literal for SMT-LIB 2.7 output.
+In SMT-LIB 2.7, double quotes are escaped by doubling them (`""`),
+and non-printable characters use `\u{XXXX}` escape sequences.
+Backslashes have no special meaning (they are literal).
+-/
+private def escapeSMTStringLitAux (acc : String) (c : Char) : String :=
+  if c == '"' then
+    acc ++ "\"\""
+  else if useXHex c then
+    let hex := String.ofList (Nat.toDigits 16 c.toNat)
+    s!"{acc}\\u\{{hex}}"
+  else
+    acc.push c
+
+def escapeSMTStringLit (s : String) : String :=
+  s.foldl escapeSMTStringLitAux "\"" ++ "\""
+
 end Strata
 end

--- a/Strata/DL/SMT/DDMTransform/Translate.lean
+++ b/Strata/DL/SMT/DDMTransform/Translate.lean
@@ -256,14 +256,14 @@ private def dummy_prg_for_toString :=
 def termToString (t:SMT.Term): Except String String := do
   let ddm_term <- translateFromTerm t
   let ddm_ast := SMTDDM.Term.toAst ddm_term
-  let ctx := dummy_prg_for_toString.formatContext {}
+  let ctx := dummy_prg_for_toString.formatContext { smtStringEscaping := true }
   let s := dummy_prg_for_toString.formatState
   return ddm_ast.render ctx s |>.fst
 
 def termTypeToString (t:SMT.TermType): Except String String := do
   let ddm_term <- translateFromTermType t
   let ddm_ast := SMTDDM.SMTSort.toAst ddm_term
-  let ctx := dummy_prg_for_toString.formatContext {}
+  let ctx := dummy_prg_for_toString.formatContext { smtStringEscaping := true }
   let s := dummy_prg_for_toString.formatState
   return ddm_ast.render ctx s |>.fst
 

--- a/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
+++ b/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
@@ -195,6 +195,15 @@ info: "; m\n(declare-const m (Array Int Int))\n(define-fun t0 () (Array Int Int)
   (.quant () .all "x" (.some .int) (LExpr.noTrigger ())
    (.eq () (.bvar () 0) (.fvar () "x" (.some .int))))
 
+-- Test string literal containing double quotes is properly escaped for SMT-LIB 2.7
+-- In SMT-LIB 2.7, double quotes inside strings are escaped by doubling: "a""b" represents a"b
+/--
+info: "; x\n(declare-const x String)\n(define-fun t0 () String x)\n(define-fun t1 () Bool (= t0 \"{\"\"key\"\":\"\"val\"\"}\"))\n"
+-/
+#guard_msgs in
+#eval toSMTTermString
+  (.eq () (.fvar () "x" (.some .string)) (.strConst () "{\"key\":\"val\"}"))
+
 end ArrayTheory
 
 end Core
@@ -240,5 +249,33 @@ Result: ✅ pass
 -/
 #guard_msgs in
 #eval! verify simpleMapProgram (options := {Core.VerifyOptions.quiet with useArrayTheory := true})
+
+-- Test that string literals with embedded double quotes are correctly encoded for SMT
+def quotedStringProgram :=
+#strata
+program Core;
+
+var x: string;
+
+procedure Test() returns ()
+spec { ensures true; }
+{
+  assume x == "{\"key\":\"val\"}";
+  assert x == "{\"key\":\"val\"}";
+};
+#end
+
+/--
+info:
+Obligation: assert_0
+Property: assert
+Result: ✅ pass
+
+Obligation: Test_ensures_0
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval! verify quotedStringProgram (options := Core.VerifyOptions.quiet)
 
 end Strata


### PR DESCRIPTION
In SMT-LIB, double quote `"` is not escaped with `\"`, but `""`(!). This patch adds a new `smtStringEscaping` option to DDM's `FormatOptions` and makes formatter use this style when turned on.
With this patch, a program `quotedStringProgram` in this PR does not crash anymore, and identity check works.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
