### PR TITLE
ci: speedup CBMC job from 26 to under 2 minutes

### DIFF
--- a/.github/workflows/cbmc.yml
+++ b/.github/workflows/cbmc.yml
@@ -73,6 +73,13 @@ jobs:
           ninja -C build cbmc symtab2gb goto-cc goto-instrument
           ccache -s
           echo "$GITHUB_WORKSPACE/cbmc-src/build/bin/" >> $GITHUB_PATH
+      - name: Restore lake cache
+        uses: actions/cache/restore@v4
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
+          restore-keys: |
+            lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}
       - name: Build Strata
         uses: leanprover/lean-action@v1
         with:


### PR DESCRIPTION
*Description of changes:*

Add ccache + GitHub cache action to the CBMC workflow to avoid recompiling CBMC from source on every run, which changes the time spent in this step from just under 9 minutes to less than 1 minute. Follows the same pattern used by the CBMC project itself in their pull-request-checks workflow.

Also add a missing lake cache restore step, removing 16 minutes of Strata build time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
