### PR TITLE
fix(Core): correctly typecheck 0-ary functions with lambda bodies

### DIFF
--- a/Strata/DL/Lambda/LExpr.lean
+++ b/Strata/DL/Lambda/LExpr.lean
@@ -589,9 +589,18 @@ private def formatLExpr (T : LExprParamsT) [ToFormat T.base.IDMeta] [ToFormat T.
     match ty with
     | none => f!"{x}"
     | some ty => f!"({x} : {ty})"
-  | .abs _ _ _ e1 => Format.paren (f!"λ {formatLExpr T e1}")
-  | .quant _ .all _ _ _ e1 => Format.paren (f!"∀ {formatLExpr T e1}")
-  | .quant _ .exist _ _ _ e1 => Format.paren (f!"∃ {formatLExpr T e1}")
+  | .abs _ _ ty e1 =>
+    match ty with
+    | none => Format.paren (f!"λ {formatLExpr T e1}")
+    | some ty => Format.paren (f!"λ (bvar:{ty}) {formatLExpr T e1}")
+  | .quant _ .all _ ty _ e1 =>
+      match ty with
+      | none => Format.paren (f!"∀ {formatLExpr T e1}")
+      | some ty => Format.paren (f!"∀ (bvar:{ty}) {formatLExpr T e1}")
+  | .quant _ .exist _ ty _ e1 =>
+      match ty with
+      | none => Format.paren (f!"∃ {formatLExpr T e1}")
+      | some ty => Format.paren (f!"∃ (bvar:{ty}) {formatLExpr T e1}")
   | .app m fn arg =>
     let fmts := (collectAppSpine e).attach.map (fun ⟨ec, hec⟩ =>
       have : sizeOf ec < sizeOf e := collectAppSpine_lt e ec hec ⟨m, fn, arg, by subst_vars; rfl⟩

--- a/Strata/DL/Lambda/LExprT.lean
+++ b/Strata/DL/Lambda/LExprT.lean
@@ -68,8 +68,8 @@ def toLMonoTy {T : LExprParamsT} (e : LExprT T) : LMonoTy :=
 
 /--
 Remove any type annotation stored in metadata for all
-expressions, except the `.op`s and free variables
-`.fvar`s.
+expressions, except the `.op`s, free variables
+`.fvar`s, and bound variables in `.abs` and `.quant`.
 -/
 def unresolved {T : LExprParamsT} (e : LExprT T) : LExpr T.base.mono :=
   match e with

--- a/Strata/Languages/Core/Core.lean
+++ b/Strata/Languages/Core/Core.lean
@@ -88,15 +88,15 @@ def typeCheckAndPartialEval (options : VerifyOptions) (program : Program)
       dbg_trace f!"{formatProofObligations E.deferred}"
   return pEs
 
-instance : ToString (Program) where
+instance instCoreProgramString : ToString (Program) where
   toString p := toString (Core.formatProgram p)
 
-instance : Std.ToFormat Program where
+instance instCoreProgramFormat : Std.ToFormat Program where
   format := Core.formatProgram
 
 /-- Format a single `Core.Expression.Expr` using the DDM pretty-printer.
     This instance shadows the generic `ToFormat (LExpr T)` from `LExpr.lean`. -/
-instance : Std.ToFormat Expression.Expr where
+instance instCoreExprFormat : Std.ToFormat Expression.Expr where
   format e := Core.formatExprs [e]
 
 end -- public section

--- a/Strata/Languages/Core/FunctionType.lean
+++ b/Strata/Languages/Core/FunctionType.lean
@@ -29,8 +29,17 @@ def typeCheck (C: Core.Expression.TyContext) (Env : Core.Expression.TyEnv) (func
   let type ← func.type
   let (monoty, Env) ← LTy.instantiateWithCheck type C Env
   let monotys := monoty.destructArrow
-  let input_mtys := monotys.dropLast
-  let output_mty := monotys.getLast (by exact LMonoTy.destructArrow_non_empty monoty)
+  -- Use the number of formal parameters to determine which arrow components are
+  -- inputs.
+  let numInputs := func.inputs.keys.length
+  let input_mtys := monotys.take numInputs
+  let remaining := monotys.drop numInputs
+  -- Reconstruct the output type from the arrow components after the `numInputs`
+  -- inputs.
+  let output_mty : LMonoTy :=
+    let last := remaining.getLast? |>.getD
+      (monotys.getLast (by exact LMonoTy.destructArrow_non_empty monoty))
+    LMonoTy.mkArrow' last remaining.dropLast
   -- Resolve type aliases and monomorphize inputs and output.
   let func := { func with
                   typeArgs := monoty.freeVars.eraseDups,
@@ -49,6 +58,9 @@ def typeCheck (C: Core.Expression.TyContext) (Env : Core.Expression.TyEnv) (func
     let (retty, Env) ← (LFunc.outputPolyType func).instantiateWithCheck C Env
     let S ← Constraints.unify [(retty, bodyty)] (TEnv.stateSubstInfo Env) |>.mapError format
     let Env := TEnv.updateSubst Env S
+    -- Apply the outer unification substitution back to the body so that type
+    -- variables introduced inside it are resolved.
+    let bodya := LExpr.applySubstT bodya S.subst
     let Env := TEnv.popContext Env
     -- Resolve type aliases and monomorphize the body.
     let new_func := { func with body := some bodya.unresolved }

--- a/StrataTest/DL/Lambda/LExprTTests.lean
+++ b/StrataTest/DL/Lambda/LExprTTests.lean
@@ -46,17 +46,17 @@ private instance : Coe String TestParams.Identifier where
                                esM[if #true then (x == #5) else (x == #6)]
          return (format $ ans.fst)
 
-/-- info: ok: (λ %0) -/
+/-- info: ok: (λ (bvar:$__ty0) %0) -/
 #guard_msgs in
 #eval do let ans ← LExpr.annotate (T:=TestParams) LContext.default TEnv.default esM[λ(%0)]
          return format ans.fst
 
-/-- info: ok: (∀ (%0 == #5)) -/
+/-- info: ok: (∀ (bvar:int) (%0 == #5)) -/
 #guard_msgs in
 #eval do let ans ← LExpr.annotate (T:=TestParams) LContext.default TEnv.default esM[∀ (%0 == #5)]
          return format ans.fst
 
-/-- info: ok: (λ ((succ : (arrow int int)) %0)) -/
+/-- info: ok: (λ (bvar:int) ((succ : (arrow int int)) %0)) -/
 #guard_msgs in
 #eval do let ans ← LExpr.annotate (T:=TestParams) LContext.default ( TEnv.default.updateContext { types := [[("succ", t[int → int])]] })
                                esM[λ(succ %0)]

--- a/StrataTest/DL/Lambda/Lambda.lean
+++ b/StrataTest/DL/Lambda/Lambda.lean
@@ -60,7 +60,7 @@ info: (λ ((~Int.Div : (arrow int (arrow int int))) #3 %0))
                esM[((~Int.Div ((~Int.Add #2) #1)))]
 /--
 info: Annotated expression:
-((λ (%0 #2)) ((~Int.Div : (arrow int (arrow int int))) #300))
+((λ (bvar:(arrow int int)) (%0 #2)) ((~Int.Div : (arrow int (arrow int int))) #300))
 
 ---
 info: #150

--- a/StrataTest/DL/Lambda/PreconditionsTests.lean
+++ b/StrataTest/DL/Lambda/PreconditionsTests.lean
@@ -63,7 +63,7 @@ private def factoryWithAdd : Factory TestParams := #[safeDivFunc, addFunc]
 -- Test: Function call inside a lambda abstraction
 -- Expression: \x : int. safeDiv(x, x)
 -- The obligation should be: forall x :: x != 0
-/-- info: [WFObligation(safeDiv, (∀ (~!= %0 #0)), ())] -/
+/-- info: [WFObligation(safeDiv, (∀ (bvar:int) (~!= %0 #0)), ())] -/
 #guard_msgs in
 #eval collectWFObligations testFactory
   esM[λ (int): ((~safeDiv %0) %0)]
@@ -80,7 +80,9 @@ private def factoryWithImplies : Factory TestParams :=
 
 -- forall x :: (x > 0) ==> (safeDiv(y, x) > 0)
 -- The WF obligation is: forall x :: (x > 0) ==> (x != 0)
-/-- info: [WFObligation(safeDiv, (∀ ((~Bool.Implies : (arrow bool (arrow bool bool))) (~Int.Gt %0 #0) (~!= %0 #0))), ())] -/
+/--
+info: [WFObligation(safeDiv, (∀ (bvar:int) ((~Bool.Implies : (arrow bool (arrow bool bool))) (~Int.Gt %0 #0) (~!= %0 #0))), ())]
+-/
 #guard_msgs in
 #eval collectWFObligations factoryWithImplies
   esM[∀ (int):{#true}
@@ -90,7 +92,7 @@ private def factoryWithImplies : Factory TestParams :=
 -- Test: let x := a in safeDiv(2, x)
 -- Encoded as (λ (int): ((~safeDiv #2) %0)) a
 -- The obligation should be: let x := a in (x != 0)
-/-- info: [WFObligation(safeDiv, ((λ (~!= %0 #0)) a), ())] -/
+/-- info: [WFObligation(safeDiv, ((λ (bvar:int) (~!= %0 #0)) a), ())] -/
 #guard_msgs in
 #eval collectWFObligations testFactory
   esM[((λ (int): ((~safeDiv #2) %0)) a)]

--- a/StrataTest/DL/Lambda/RecursiveAxiomsTests.lean
+++ b/StrataTest/DL/Lambda/RecursiveAxiomsTests.lean
@@ -72,10 +72,12 @@ private def listLenAxioms := genRecursiveAxioms listLenFunc tf pe ()
   | .ok axs => return format axs[0]!
 
 -- Cons axiom: ∀ hd:int, tl:IntList with trigger on listLen(Cons(hd, tl))
-/-- info: (∀ (∀ (((~listLen : (arrow IntList int))
+/--
+info: (∀ (bvar:int) (∀ (bvar:IntList) (((~listLen : (arrow IntList int))
     ((~Cons : (arrow int (arrow IntList IntList)))
      %1
-     %0)) == ((~Int.Add : (arrow int (arrow int int))) #1 ((~listLen : (arrow IntList int)) %0))))) -/
+     %0)) == ((~Int.Add : (arrow int (arrow int int))) #1 ((~listLen : (arrow IntList int)) %0)))))
+-/
 #guard_msgs in
 #eval do
   match listLenAxioms with
@@ -144,7 +146,7 @@ private def lookupAxioms := genRecursiveAxioms lookupFunc tf pe2 ()
 
 -- Nil axiom: ∀ key:int. lookup(key, Nil) = false
 /--
-info: (∀ (((~lookup : (arrow int (arrow IntList bool))) %0 (~Nil : IntList)) == #false))
+info: (∀ (bvar:int) (((~lookup : (arrow int (arrow IntList bool))) %0 (~Nil : IntList)) == #false))
 -/
 #guard_msgs in
 #eval do
@@ -154,7 +156,7 @@ info: (∀ (((~lookup : (arrow int (arrow IntList bool))) %0 (~Nil : IntList)) =
 
 -- Cons axiom: ∀ key:int, hd:int, tl:IntList. lookup(key, Cons(hd,tl)) = ...
 /--
-info: (∀ (∀ (∀ (((~lookup : (arrow int (arrow IntList bool)))
+info: (∀ (bvar:int) (∀ (bvar:int) (∀ (bvar:IntList) (((~lookup : (arrow int (arrow IntList bool)))
      %2
      ((~Cons : (arrow int (arrow IntList IntList)))
       %1
@@ -223,7 +225,10 @@ private def replaceAxioms := genRecursiveAxioms replaceFunc tf pe3 ()
 
 -- Nil axiom: ∀ key:int, val:int. replace(key, Nil, val) = Nil
 /--
-info: (∀ (∀ (((~replace : (arrow int (arrow IntList (arrow int IntList)))) %1 (~Nil : IntList) %0) == (~Nil : IntList))))
+info: (∀ (bvar:int) (∀ (bvar:int) (((~replace : (arrow int (arrow IntList (arrow int IntList))))
+    %1
+    (~Nil : IntList)
+    %0) == (~Nil : IntList))))
 -/
 #guard_msgs in
 #eval do
@@ -233,7 +238,7 @@ info: (∀ (∀ (((~replace : (arrow int (arrow IntList (arrow int IntList)))) %
 
 -- Cons axiom: ∀ key:int, hd:int, tl:IntList, val:int. replace(key, Cons(hd,tl), val) = ...
 /--
-info: (∀ (∀ (∀ (∀ (((~replace : (arrow int (arrow IntList (arrow int IntList))))
+info: (∀ (bvar:int) (∀ (bvar:int) (∀ (bvar:int) (∀ (bvar:IntList) (((~replace : (arrow int (arrow IntList (arrow int IntList))))
       %3
       ((~Cons : (arrow int (arrow IntList IntList))) %1 %0)
       %2) == (if (%1 == %3) then ((~Cons : (arrow int (arrow IntList IntList)))

--- a/StrataTest/DL/Lambda/TypeFactoryTests.lean
+++ b/StrataTest/DL/Lambda/TypeFactoryTests.lean
@@ -127,7 +127,7 @@ def prod (e1 e2: LExpr TestParams.mono) : LExpr TestParams.mono := (LExpr.op () 
 info: Annotated expression:
 ((~Tup$Elim : (arrow (Tup int string) (arrow (arrow int (arrow string int)) int)))
  ((~Prod : (arrow int (arrow string (Tup int string)))) #3 #a)
- (λ (λ %1)))
+ (λ (bvar:int) (λ (bvar:string) %1)))
 
 ---
 info: #3
@@ -140,7 +140,7 @@ info: #3
 info: Annotated expression:
 ((~Tup$Elim : (arrow (Tup int string) (arrow (arrow int (arrow string string)) string)))
  ((~Prod : (arrow int (arrow string (Tup int string)))) #3 #a)
- (λ (λ %0)))
+ (λ (bvar:int) (λ (bvar:string) %0)))
 
 ---
 info: #a
@@ -157,8 +157,8 @@ info: Annotated expression:
   ((~Prod : (arrow string (arrow (Tup int string) (Tup string (Tup int string)))))
    #a
    ((~Prod : (arrow int (arrow string (Tup int string)))) #1 #b))
-  (λ (λ %0)))
- (λ (λ %1)))
+  (λ (bvar:string) (λ (bvar:(Tup int string)) %0)))
+ (λ (bvar:int) (λ (bvar:string) %1)))
 
 ---
 info: #1
@@ -194,7 +194,7 @@ info: Annotated expression:
 ((~List$Elim : (arrow (List $__ty5) (arrow int (arrow (arrow $__ty5 (arrow (List $__ty5) (arrow int int))) int))))
  (~Nil : (List $__ty5))
  #1
- (λ (λ (λ #1))))
+ (λ (bvar:$__ty5) (λ (bvar:(List $__ty5)) (λ (bvar:int) #1))))
 
 ---
 info: #1
@@ -212,7 +212,7 @@ info: Annotated expression:
 ((~List$Elim : (arrow (List int) (arrow int (arrow (arrow int (arrow (List int) (arrow int int))) int))))
  ((~Cons : (arrow int (arrow (List int) (List int)))) #2 (~Nil : (List int)))
  #0
- (λ (λ (λ %2))))
+ (λ (bvar:int) (λ (bvar:(List int)) (λ (bvar:int) %2))))
 
 ---
 info: #2
@@ -351,14 +351,16 @@ info: Annotated expression:
    ((~Prod : (arrow int (arrow string (Tup int string)))) #4 #b)
    (~Nil : (List (Tup int string)))))
  #0
- (λ (λ (λ ((~Int.Add : (arrow int (arrow int int)))
-     ((~Tup$Elim : (arrow (Tup int string) (arrow (arrow int (arrow string int)) int))) %2 (λ (λ %1)))
+ (λ (bvar:(Tup int string)) (λ (bvar:(List (Tup int string))) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int)))
+     ((~Tup$Elim : (arrow (Tup int string) (arrow (arrow int (arrow string int)) int)))
+      %2
+      (λ (bvar:int) (λ (bvar:string) %1)))
      ((~List$Elim : (arrow (List (Tup int string)) (arrow int (arrow (arrow (Tup int string) (arrow (List (Tup int string)) (arrow int int))) int))))
       %1
       #1
-      (λ (λ (λ ((~Tup$Elim : (arrow (Tup int string) (arrow (arrow int (arrow string int)) int)))
+      (λ (bvar:(Tup int string)) (λ (bvar:(List (Tup int string))) (λ (bvar:int) ((~Tup$Elim : (arrow (Tup int string) (arrow (arrow int (arrow string int)) int)))
           %2
-          (λ (λ %1))))))))))))
+          (λ (bvar:int) (λ (bvar:string) %1))))))))))))
 
 ---
 info: #7
@@ -390,7 +392,7 @@ info: Annotated expression:
    #b
    ((~Cons : (arrow string (arrow (List string) (List string)))) #c (~Nil : (List string)))))
  #0
- (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 %0)))))
+ (λ (bvar:string) (λ (bvar:(List string)) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int))) #1 %0)))))
 
 ---
 info: #3
@@ -433,7 +435,7 @@ info: Annotated expression:
                #13
                ((~Cons : (arrow int (arrow (List int) (List int)))) #14 (~Nil : (List int)))))))))))))))))
  #0
- (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 %0)))))
+ (λ (bvar:int) (λ (bvar:(List int)) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int))) #1 %0)))))
 
 ---
 info: #15
@@ -464,8 +466,10 @@ info: Annotated expression:
   ((~Cons : (arrow int (arrow (List int) (List int))))
    #4
    ((~Cons : (arrow int (arrow (List int) (List int)))) #6 (~Nil : (List int)))))
- (λ %0)
- (λ (λ (λ (λ ((~Cons : (arrow int (arrow (List int) (List int)))) %3 (%1 %0))))))
+ (λ (bvar:(List int)) %0)
+ (λ (bvar:int) (λ (bvar:(List int)) (λ (bvar:(arrow (List int) (List int))) (λ (bvar:(List int)) ((~Cons : (arrow int (arrow (List int) (List int))))
+      %3
+      (%1 %0))))))
  ((~Cons : (arrow int (arrow (List int) (List int))))
   #1
   ((~Cons : (arrow int (arrow (List int) (List int))))
@@ -558,12 +562,14 @@ info: Annotated expression:
      (~Leaf : (binTree int))
      (~Leaf : (binTree int))))))
  (~Nil : (List int))
- (λ (λ (λ (λ (λ ((~Cons : (arrow int (arrow (List int) (List int))))
+ (λ (bvar:int) (λ (bvar:(binTree int)) (λ (bvar:(binTree int)) (λ (bvar:(List int)) (λ (bvar:(List int)) ((~Cons : (arrow int (arrow (List int) (List int))))
        %4
        ((~List$Elim : (arrow (List int) (arrow (arrow (List int) (List int)) (arrow (arrow int (arrow (List int) (arrow (arrow (List int) (List int)) (arrow (List int) (List int))))) (arrow (List int) (List int))))))
         %1
-        (λ %0)
-        (λ (λ (λ (λ ((~Cons : (arrow int (arrow (List int) (List int)))) %3 (%1 %0))))))
+        (λ (bvar:(List int)) %0)
+        (λ (bvar:int) (λ (bvar:(List int)) (λ (bvar:(arrow (List int) (List int))) (λ (bvar:(List int)) ((~Cons : (arrow int (arrow (List int) (List int))))
+             %3
+             (%1 %0))))))
         %0))))))))
 
 ---
@@ -622,13 +628,13 @@ def height (n: Nat) (t: LExpr TestParams.mono) : LExpr TestParams.mono :=
 info: Annotated expression:
 ((~tree$Elim : (arrow (tree int) (arrow (arrow int int) (arrow (arrow (arrow int (tree int)) (arrow (arrow int int) int)) int))))
  ((~Node : (arrow (arrow int (tree int)) (tree int)))
-  (λ ((~Node : (arrow (arrow int (tree int)) (tree int)))
-    (λ (if (((~Int.Add : (arrow int (arrow int int)))
+  (λ (bvar:int) ((~Node : (arrow (arrow int (tree int)) (tree int)))
+    (λ (bvar:int) (if (((~Int.Add : (arrow int (arrow int int)))
         %1
         %0) == #0) then ((~Node : (arrow (arrow int (tree int)) (tree int)))
-       (λ ((~Leaf : (arrow int (tree int))) #3))) else ((~Leaf : (arrow int (tree int))) #4))))))
- (λ #0)
- (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 (%0 #0)))))
+       (λ (bvar:int) ((~Leaf : (arrow int (tree int))) #3))) else ((~Leaf : (arrow int (tree int))) #4))))))
+ (λ (bvar:int) #0)
+ (λ (bvar:(arrow int (tree int))) (λ (bvar:(arrow int int)) ((~Int.Add : (arrow int (arrow int int))) #1 (%0 #0)))))
 
 ---
 info: #3
@@ -641,13 +647,13 @@ info: #3
 info: Annotated expression:
 ((~tree$Elim : (arrow (tree int) (arrow (arrow int int) (arrow (arrow (arrow int (tree int)) (arrow (arrow int int) int)) int))))
  ((~Node : (arrow (arrow int (tree int)) (tree int)))
-  (λ ((~Node : (arrow (arrow int (tree int)) (tree int)))
-    (λ (if (((~Int.Add : (arrow int (arrow int int)))
+  (λ (bvar:int) ((~Node : (arrow (arrow int (tree int)) (tree int)))
+    (λ (bvar:int) (if (((~Int.Add : (arrow int (arrow int int)))
         %1
         %0) == #0) then ((~Node : (arrow (arrow int (tree int)) (tree int)))
-       (λ ((~Leaf : (arrow int (tree int))) #3))) else ((~Leaf : (arrow int (tree int))) #4))))))
- (λ #0)
- (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 (%0 #1)))))
+       (λ (bvar:int) ((~Leaf : (arrow int (tree int))) #3))) else ((~Leaf : (arrow int (tree int))) #4))))))
+ (λ (bvar:int) #0)
+ (λ (bvar:(arrow int (tree int))) (λ (bvar:(arrow int int)) ((~Int.Add : (arrow int (arrow int int))) #1 (%0 #1)))))
 
 ---
 info: #2
@@ -949,9 +955,11 @@ def roseTree5 : LExpr TestParams.mono :=
 info: Annotated expression:
 ((~RoseTree$Elim : (arrow (RoseTree int) (arrow (arrow int (arrow (Forest int) (arrow int int))) (arrow int (arrow (arrow (RoseTree int) (arrow (Forest int) (arrow int (arrow int int)))) int)))))
  ((~Node : (arrow int (arrow (Forest int) (RoseTree int)))) #1 (~FNil : (Forest int)))
- (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 %0))))
+ (λ (bvar:int) (λ (bvar:(Forest int)) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int))) #1 %0))))
  #0
- (λ (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) %1 %0))))))
+ (λ (bvar:(RoseTree int)) (λ (bvar:(Forest int)) (λ (bvar:int) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int)))
+      %1
+      %0))))))
 
 ---
 info: #1
@@ -978,9 +986,11 @@ info: Annotated expression:
     ((~FCons : (arrow (RoseTree int) (arrow (Forest int) (Forest int))))
      ((~Node : (arrow int (arrow (Forest int) (RoseTree int)))) #4 (~FNil : (Forest int)))
      (~FNil : (Forest int))))))
- (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 %0))))
+ (λ (bvar:int) (λ (bvar:(Forest int)) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int))) #1 %0))))
  #0
- (λ (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) %1 %0))))))
+ (λ (bvar:(RoseTree int)) (λ (bvar:(Forest int)) (λ (bvar:int) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int)))
+      %1
+      %0))))))
 
 ---
 info: #5
@@ -1106,10 +1116,12 @@ info: Annotated expression:
       ((~NodeC : (arrow TyA (arrow TyA TyC)))
        ((~MkA : (arrow TyB TyA)) ((~MkB : (arrow TyC TyB)) ((~LeafC : (arrow int TyC)) #2)))
        ((~MkA : (arrow TyB TyA)) ((~MkB : (arrow TyC TyB)) ((~LeafC : (arrow int TyC)) #3)))))))))
- (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 %0)))
- (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 %0)))
- (λ #1)
- (λ (λ (λ (λ ((~Int.Add : (arrow int (arrow int int))) #1 ((~Int.Add : (arrow int (arrow int int))) %1 %0)))))))
+ (λ (bvar:TyB) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int))) #1 %0)))
+ (λ (bvar:TyC) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int))) #1 %0)))
+ (λ (bvar:int) #1)
+ (λ (bvar:TyA) (λ (bvar:TyA) (λ (bvar:int) (λ (bvar:int) ((~Int.Add : (arrow int (arrow int int)))
+      #1
+      ((~Int.Add : (arrow int (arrow int int))) %1 %0)))))))
 
 ---
 info: #15

--- a/StrataTest/Languages/Core/Tests/ProgramTypeTests.lean
+++ b/StrataTest/Languages/Core/Tests/ProgramTypeTests.lean
@@ -394,6 +394,40 @@ procedure Test () returns ()
   let ans ← typeCheck .default polyFuncProg
   return (format ans)
 
+
+section
+def intIdentityFnPgm : Program := { decls := [
+  .func { name := "intID",
+          typeArgs := [],
+          inputs := [],
+          output := .arrow .int .int,
+          body := some eb[λ %0]
+          }
+]}
+
+-- Overriding Core's formatter since Core's DDM doesn't support lambda
+-- abstractions yet.
+instance : ToFormat Core.Program where
+  format p := f!"{p.decls}"
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+
+---
+info: ok: [func intID :  () → (arrow int int) := ((λ (bvar:int) %0))]
+-/
+#guard_msgs in
+#eval do let ans ← typeCheckAndPartialEval .default intIdentityFnPgm
+          if h : ans.length == 1 then
+            let (pgm, _) := ans[0]'(by grind)
+            return (format pgm)
+          else
+            return (format "Unexpected output")
+end
+
 ---------------------------------------------------------------------
 
 end Tests


### PR DESCRIPTION
Fixed two bugs in `Function.typeCheck` (FunctionType.lean):

1. Previously, input/output type splitting used `monotys.dropLast`/`getLast` regardless of how many formal parameters the function actually has.

2. Apply substitution to the body of a function after unification.

_Note: we don't yet fully support lambdas in Core (we don't even have concrete syntax for it). However, we will eventually do so._

Also, other misc. printing changes: updated default `formatLExpr` to render binder types when present, showing `(bvar:T)` for `.abs` and `.quant` nodes, making resolved types visible in pretty-printed output. Update `unresolved`'s doc comment to reflect that `.abs`/`.quant` binder types are preserved. Name the three formatter instances in Core.lean for easier `attribute [-instance]` reference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
