### PR TITLE
Remove specific users from codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,10 +1,3 @@
 # Defaults owners for everything in the repo. unless a later match
 # takes precedence
 *       @strata-org/reviewers
-
-# Laurel language
-/Strata/Languages/Laurel        @strata-org/reviewers @keyboardDrummer @fabiomadge
-/StrataTest/Languages/Laurel    @strata-org/reviewers @keyboardDrummer @fabiomadge
-/Strata/Languages/Python        @strata-org/reviewers @keyboardDrummer @fabiomadge
-/StrataTest/Languages/Python    @strata-org/reviewers @keyboardDrummer @fabiomadge
-/docs/verso                     @strata-org/reviewers @keyboardDrummer @fabiomadge


### PR DESCRIPTION
### Changes
- Remove specific users from codeowners file. We're not using this functionality right now and it makes it less clear who is assigned as a reviewer to a particular PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
