### PR TITLE
Add ListStr datatype to Core and Laurel preludes

### DIFF
--- a/Strata/Languages/Python/PythonLaurelCorePrelude.lean
+++ b/Strata/Languages/Python/PythonLaurelCorePrelude.lean
@@ -83,6 +83,11 @@ datatype ListAny () {
   ListAny_cons (head: Any, tail: ListAny)
 }
 
+datatype ListStr () {
+  ListStr_nil (),
+  ListStr_cons (head: string, tail: ListStr)
+}
+
 datatype DictStrAny () {
   DictStrAny_empty (),
   DictStrAny_cons (key: string, val: Any, tail: DictStrAny)

--- a/Strata/Languages/Python/PythonRuntimeLaurelPart.lean
+++ b/Strata/Languages/Python/PythonRuntimeLaurelPart.lean
@@ -79,6 +79,11 @@ datatype ListAny {
   ListAny_cons (head: Any, tail: ListAny)
 }
 
+datatype ListStr {
+  ListStr_nil (),
+  ListStr_cons (head: string, tail: ListStr)
+}
+
 datatype DictStrAny {
   DictStrAny_empty (),
   DictStrAny_cons (key: string, val: Any, tail: DictStrAny)


### PR DESCRIPTION
Add `ListStr` datatype to the Laurel pipeline preludes, fixing `List[str]` type annotation support in `pyAnalyzeLaurel`.

- Add `ListStr` datatype with `ListStr_nil` and `ListStr_cons` constructors to `PythonLaurelCorePrelude.lean`
- Add matching `ListStr` datatype to `PythonRuntimeLaurelPart.lean` (Laurel DDM)
- Fixes "Type ListStr is not an instance of a previously registered type" error for Python code using `List[str]`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.