### PR TITLE
Fix Python translation pipeline: InstanceCall, control flow, and construct support

### DIFF
--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -176,7 +176,6 @@ def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   | .TString => "Box..stringVal!"
   | .TFloat64 => "Box..float64Val!"
   | .TReal => "Box..realVal!"
-  | .TString => "Box..stringVal!"
   | .UserDefined name =>
       if isDatatype model name then s!"Box..{name.text}Val!"
       else "Box..compositeVal!"
@@ -193,7 +192,6 @@ def boxConstructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   | .TString => "BoxString"
   | .TFloat64 => "BoxFloat64"
   | .TReal => "BoxReal"
-  | .TString => "BoxString"
   | .UserDefined name =>
       if isDatatype model name then s!"Box..{name.text}"
       else "BoxComposite"
@@ -208,7 +206,6 @@ private def boxConstructorDef (model : SemanticModel) (ty : HighType) : Option D
   | .TString => some { name := "BoxString", args := [{ name := "stringVal", type := ⟨.TString, #[]⟩ }] }
   | .TReal => some { name := "BoxReal", args := [{ name := "realVal", type := ⟨.TReal, #[]⟩ }] }
   | .TFloat64 => some { name := "BoxFloat64", args := [{ name := "float64Val", type := ⟨.TFloat64, #[]⟩ }] }
-  | .TString => some { name := "BoxString", args := [{ name := "stringVal", type := ⟨.TString, #[]⟩ }] }
   | .UserDefined name =>
       if isDatatype model name then
         some { name := s!"Box..{name.text}", args := [{ name := s!"{name.text}Val", type := ⟨.UserDefined name, #[]⟩ }] }

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -179,7 +179,7 @@ def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   | .UserDefined name =>
       if isDatatype model name then s!"Box..{name.text}Val!"
       else "Box..compositeVal!"
-  | .TCore name => s!"Box..{name}Val!"
+  | .TCore name => s!"Box..{name}Val"
   | _ => dbg_trace f!"BUG, boxDestructorName bad type {ty}"; "boxDestructorNameError"
 
 /-- Get the Box constructor name for a given Laurel HighType.

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -173,6 +173,7 @@ def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   match ty with
   | .TInt => "Box..intVal!"
   | .TBool => "Box..boolVal!"
+  | .TString => "Box..stringVal!"
   | .TFloat64 => "Box..float64Val!"
   | .TReal => "Box..realVal!"
   | .TString => "Box..stringVal!"
@@ -189,6 +190,7 @@ def boxConstructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   match ty with
   | .TInt => "BoxInt"
   | .TBool => "BoxBool"
+  | .TString => "BoxString"
   | .TFloat64 => "BoxFloat64"
   | .TReal => "BoxReal"
   | .TString => "BoxString"
@@ -203,6 +205,7 @@ private def boxConstructorDef (model : SemanticModel) (ty : HighType) : Option D
   match ty with
   | .TInt => some { name := "BoxInt", args := [{ name := "intVal", type := ⟨.TInt, #[]⟩ }] }
   | .TBool => some { name := "BoxBool", args := [{ name := "boolVal", type := ⟨.TBool, #[]⟩ }] }
+  | .TString => some { name := "BoxString", args := [{ name := "stringVal", type := ⟨.TString, #[]⟩ }] }
   | .TReal => some { name := "BoxReal", args := [{ name := "realVal", type := ⟨.TReal, #[]⟩ }] }
   | .TFloat64 => some { name := "BoxFloat64", args := [{ name := "float64Val", type := ⟨.TFloat64, #[]⟩ }] }
   | .TString => some { name := "BoxString", args := [{ name := "stringVal", type := ⟨.TString, #[]⟩ }] }

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -295,7 +295,14 @@ def translateExpr (expr : StmtExprMd)
   | .ContractOf _ _ => throwExprDiagnostic $ md.toDiagnostic "contractOf expression translation" DiagnosticType.NotYetImplemented
   | .Abstract => throwExprDiagnostic $ md.toDiagnostic "abstract expression translation" DiagnosticType.NotYetImplemented
   | .All => throwExprDiagnostic $ md.toDiagnostic "all expression translation" DiagnosticType.NotYetImplemented
-  | .InstanceCall target callee args => throwExprDiagnostic $ md.toDiagnostic "instance call expression translation" DiagnosticType.NotYetImplemented
+  | .InstanceCall _target callee args =>
+      -- Note: target (self) is not passed as an argument because PySpec procedures
+      -- have self stripped from their signatures. When user-defined class methods
+      -- are supported, this will need to prepend target to the argument list.
+      let fnOp : Core.Expression.Expr := .op () ⟨callee.text, ()⟩ none
+      args.attach.foldlM (fun acc ⟨arg, _⟩ => do
+        let re ← translateExpr arg boundVars isPureContext
+        return .app () acc re) fnOp
   | .PureFieldUpdate _ _ _ => throwExprDiagnostic $ md.toDiagnostic "pure field update expression translation" DiagnosticType.NotYetImplemented
   | .This => throwExprDiagnostic $ md.toDiagnostic "this expression translation" DiagnosticType.NotYetImplemented
   termination_by expr
@@ -371,11 +378,13 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
             let initStmt := Core.Statement.init ident coreType (some defaultExpr) md
             let callStmt := Core.Statement.call [ident] callee.text coreArgs md
             return [initStmt, callStmt]
-      | some (⟨ .InstanceCall .., _⟩) =>
+      | some (⟨ .InstanceCall _target callee args, callMd⟩) =>
           -- Instance method call as initializer: var name := target.method(args)
-          -- Havoc the result since instance methods may be on unmodeled types
-          let initStmt := Core.Statement.init ident coreType none md
-          return [initStmt]
+          let coreArgs ← args.mapM (fun a => translateExpr a)
+          let defaultExpr := defaultExprForType model ty
+          let initStmt := Core.Statement.init ident coreType (some defaultExpr) md
+          let callStmt := Core.Statement.call [ident] callee.text coreArgs callMd
+          return [initStmt, callStmt]
       | some (⟨ .Hole _ _, _⟩) =>
           -- Hole initializer: treat as havoc (init without value)
           return [Core.Statement.init ident coreType none md]
@@ -399,9 +408,10 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
                 -- Procedure calls need to be translated as call statements
                 let coreArgs ← args.mapM (fun a => translateExpr a)
                 return [Core.Statement.call [ident] callee.text coreArgs md]
-          | .InstanceCall .. =>
-              -- Instance method call: havoc the target variable
-              return [Core.Statement.havoc ident md]
+          | .InstanceCall _target callee args =>
+              -- Instance method call: call callee(args) with result assigned
+              let coreArgs ← args.mapM (fun a => translateExpr a)
+              return [Core.Statement.call [ident] callee.text coreArgs md]
           | _ =>
               let coreExpr ← translateExpr value
               return [Core.Statement.set ident coreExpr md]
@@ -416,13 +426,14 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
                 | .Identifier name => some (⟨name.text, ()⟩)
                 | _ => none
               return [Core.Statement.call lhsIdents callee.text coreArgs value.md]
-          | .InstanceCall .. =>
-              -- Instance method call: havoc all target variables
-              let havocStmts := targets.filterMap fun t =>
+          | .InstanceCall _target callee args =>
+              -- Instance method call: call callee(args) with all targets assigned
+              let coreArgs ← args.mapM (fun a => translateExpr a)
+              let lhsIdents := targets.filterMap fun t =>
                 match t.val with
-                | .Identifier name => some (Core.Statement.havoc ⟨name.text, ()⟩ md)
+                | .Identifier name => some (⟨name.text, ()⟩)
                 | _ => none
-              return (havocStmts)
+              return [Core.Statement.call lhsIdents callee.text coreArgs value.md]
           | _ =>
               emitDiagnostic $ md.toDiagnostic "Assignments with multiple target but without a RHS call should not be constructed"
               returnNone
@@ -441,9 +452,10 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
       else
         let coreArgs ← args.mapM (fun a => translateExpr a)
         return [Core.Statement.call [] callee.text coreArgs md]
-  | .InstanceCall .. =>
-      -- Instance method call as statement: no return value, treated as no-op
-      return ([])
+  | .InstanceCall _target callee args =>
+      -- Instance method call as statement: call callee(args) with no return
+      let coreArgs ← args.mapM (fun a => translateExpr a)
+      return [Core.Statement.call [] callee.text coreArgs md]
   | .Return valueOpt =>
       match valueOpt, outputParams.head? with
       | some value, some outParam =>
@@ -527,6 +539,69 @@ def translateProcedure (proc : Procedure) : TranslateM Core.Procedure := do
   let body : List Core.Statement := [.block "$body" bodyStmts .empty]
   let spec : Core.Procedure.Spec := { modifies, preconditions, postconditions }
   return { header, spec, body }
+
+/--
+Check if a Laurel expression is pure (contains no side effects).
+Used to determine if a procedure can be translated as a Core function.
+-/
+private def isPureExpr(expr: StmtExprMd): Bool :=
+  match _h : expr.val with
+  | .LiteralBool _ => true
+  | .LiteralInt _ => true
+  | .LiteralString _ => true
+  | .LiteralDecimal _ => true
+  | .Identifier _ => true
+  | .PrimitiveOp _ args => args.attach.all (fun ⟨a, _⟩ => isPureExpr a)
+  | .IfThenElse c t none => isPureExpr c && isPureExpr t
+  | .IfThenElse c t (some e) => isPureExpr c && isPureExpr t && isPureExpr e
+  | .StaticCall _ args => args.attach.all (fun ⟨a, _⟩ => isPureExpr a)
+  | .New _ => false
+  | .ReferenceEquals e1 e2 => isPureExpr e1 && isPureExpr e2
+  | .Block [single] _ => isPureExpr single
+  | .Block _ _ => false
+  -- Statement-like
+  | .LocalVariable .. => true
+  | .While .. => false
+  | .Exit .. => false
+  | .Return .. => false
+  -- Expression-like
+  | .Assign .. => false
+  | .FieldSelect .. => true
+  | .PureFieldUpdate .. => true
+  -- Instance related
+  | .This => panic s!"isPureExpr not implemented for This"
+  | .AsType .. => panic s!"isPureExpr not supported for AsType"
+  | .IsType .. => panic s!"isPureExpr not supported for IsType"
+  | .InstanceCall .. => false
+  -- Verification specific
+  | .Forall .. => panic s!"isPureExpr not implemented for Forall"
+  | .Exists .. => panic s!"isPureExpr not implemented for Exists"
+  | .Assigned .. => panic s!"isPureExpr not supported for AsType"
+  | .Old .. => panic s!"isPureExpr not supported for AsType"
+  | .Fresh .. => panic s!"isPureExpr not supported for AsType"
+  | .Assert .. => panic s!"isPureExpr not implemented for Assert"
+  | .Assume .. => panic s!"isPureExpr not implemented for Assume"
+  | .ProveBy .. => panic s!"isPureExpr not implemented for ProveBy"
+  | .ContractOf .. => panic s!"isPureExpr not implemented for ContractOf"
+  | .Abstract => panic s!"isPureExpr not implemented for Abstract"
+  | .All => panic s!"isPureExpr not implemented for All"
+  -- Dynamic / closures
+  | .Hole _ _ => true
+  termination_by sizeOf expr
+  decreasing_by all_goals (have := WithMetadata.sizeOf_val_lt expr; term_by_mem)
+
+/-- Check if a pure-marked procedure can actually be represented as a Core function:
+    transparent body that is a pure expression and has exactly one output. -/
+private def canBeCoreFunctionBody (proc : Procedure) : Bool :=
+  match proc.body with
+  | .Transparent bodyExpr =>
+    isPureExpr bodyExpr &&
+    proc.outputs.length == 1
+  | .Opaque _ bodyExprOption _ =>
+    (bodyExprOption.map isPureExpr).getD true &&
+    proc.outputs.length == 1
+  | .External => false
+  | _ => false
 
 /--
 Translate a Laurel Procedure to a Core Function (when applicable) using `TranslateM`.

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -338,6 +338,13 @@ private def exprAsUnusedInit (expr : StmtExprMd) (md : Imperative.MetaData Core.
   let coreType := LTy.forAll [tyVarName] (.ftvar tyVarName)
   return [Core.Statement.init ident coreType (some coreExpr) md]
 
+/-- Check if a callee resolves to a procedure with no outputs (void). -/
+private def isVoidProcedure (model : SemanticModel) (callee : Identifier) : Bool :=
+  match model.get callee with
+  | .staticProcedure proc => proc.outputs.isEmpty
+  | .instanceProcedure _ proc => proc.outputs.isEmpty
+  | _ => false
+
 /--
 Translate Laurel StmtExpr to Core Statements using the `TranslateM` monad.
 Diagnostics are emitted into the monad state.
@@ -376,14 +383,17 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
             let coreArgs ← args.mapM (fun a => translateExpr a)
             let defaultExpr := defaultExprForType model ty
             let initStmt := Core.Statement.init ident coreType (some defaultExpr) md
-            let callStmt := Core.Statement.call [ident] callee.text coreArgs md
+            -- Void procedures have no outputs; emit call without assignment target
+            let lhs := if isVoidProcedure model callee then [] else [ident]
+            let callStmt := Core.Statement.call lhs callee.text coreArgs md
             return [initStmt, callStmt]
       | some (⟨ .InstanceCall _target callee args, callMd⟩) =>
           -- Instance method call as initializer: var name := target.method(args)
           let coreArgs ← args.mapM (fun a => translateExpr a)
           let defaultExpr := defaultExprForType model ty
           let initStmt := Core.Statement.init ident coreType (some defaultExpr) md
-          let callStmt := Core.Statement.call [ident] callee.text coreArgs callMd
+          let lhs := if isVoidProcedure model callee then [] else [ident]
+          let callStmt := Core.Statement.call lhs callee.text coreArgs callMd
           return [initStmt, callStmt]
       | some (⟨ .Hole _ _, _⟩) =>
           -- Hole initializer: treat as havoc (init without value)
@@ -407,11 +417,13 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
               else
                 -- Procedure calls need to be translated as call statements
                 let coreArgs ← args.mapM (fun a => translateExpr a)
-                return [Core.Statement.call [ident] callee.text coreArgs md]
+                let lhs := if isVoidProcedure model callee then [] else [ident]
+                return [Core.Statement.call lhs callee.text coreArgs md]
           | .InstanceCall _target callee args =>
               -- Instance method call: call callee(args) with result assigned
               let coreArgs ← args.mapM (fun a => translateExpr a)
-              return [Core.Statement.call [ident] callee.text coreArgs md]
+              let lhs := if isVoidProcedure model callee then [] else [ident]
+              return [Core.Statement.call lhs callee.text coreArgs md]
           | _ =>
               let coreExpr ← translateExpr value
               return [Core.Statement.set ident coreExpr md]

--- a/Strata/Languages/Laurel/LaurelTypes.lean
+++ b/Strata/Languages/Laurel/LaurelTypes.lean
@@ -52,7 +52,14 @@ def computeExprType (model : SemanticModel) (expr : StmtExprMd) : HighTypeMd :=
     | astNode =>
       dbg_trace s!"BUG: static call to {callee} not to a procedure but to a {repr astNode}"
       default
-  | .InstanceCall _ _ _ => default -- TODO: implement
+  | .InstanceCall _ callee _ => match model.get callee with
+    | .instanceProcedure _ proc => match proc.outputs with
+      | [singleOutput] => singleOutput.type
+      | _ => { val := .TVoid, md := default }
+    | .staticProcedure proc => match proc.outputs with
+      | [singleOutput] => singleOutput.type
+      | _ => { val := .TVoid, md := default }
+    | _ => { val := .Top, md := default }
   -- Operators
   | .PrimitiveOp op args =>
       match args with

--- a/Strata/Languages/Laurel/LaurelTypes.lean
+++ b/Strata/Languages/Laurel/LaurelTypes.lean
@@ -59,7 +59,7 @@ def computeExprType (model : SemanticModel) (expr : StmtExprMd) : HighTypeMd :=
     | .staticProcedure proc => match proc.outputs with
       | [singleOutput] => singleOutput.type
       | _ => { val := .TVoid, md := default }
-    | _ => { val := .Top, md := default }
+    | _ => { val := HighType.Unknown, md := default }
   -- Operators
   | .PrimitiveOp op args =>
       match args with

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -121,6 +121,7 @@ def SemanticModel.get (model: SemanticModel) (iden: Identifier): AstNode :=
 def SemanticModel.isFunction (model: SemanticModel) (id: Identifier): Bool :=
   match model.get id with
       | .staticProcedure proc => proc.isFunctional
+      | .instanceProcedure _ proc => proc.isFunctional
       | .parameter _ => true
       | .datatypeConstructor _ _ => true
       | .constant _ => true

--- a/Strata/Languages/Python/PythonLaurelCorePrelude.lean
+++ b/Strata/Languages/Python/PythonLaurelCorePrelude.lean
@@ -272,12 +272,11 @@ inline function isError (e: Error) : bool {
 }
 
 // /////////////////////////////////////////////////////////////////////////////////////
-//The following function convert Any type to bool
-//based on the Python definition of truthiness for basic types
+//The following function implements Python truthiness for basic types
 // https://docs.python.org/3/library/stdtypes.html
 // /////////////////////////////////////////////////////////////////////////////////////
 
-inline function Any_to_bool (v: Any) : bool
+inline function python_is_truthy (v: Any) : bool
   requires (Any..isfrom_bool(v) || Any..isfrom_none(v) || Any..isfrom_string(v) || Any..isfrom_int(v));
 {
   if (Any..isfrom_bool(v)) then Any..as_bool!(v) else
@@ -826,13 +825,13 @@ inline function PNEq (v: Any, v': Any) : Any {
 inline function PAnd (v1: Any, v2: Any) : Any
   requires (Any..isfrom_bool(v1) || Any..isfrom_none(v1) || Any..isfrom_string(v1) || Any..isfrom_int(v1));
 {
-  if ! Any_to_bool (v1) then v1 else v2
+  if ! python_is_truthy (v1) then v1 else v2
 }
 
 inline function POr (v1: Any, v2: Any) : Any
   requires (Any..isfrom_bool(v1) || Any..isfrom_none(v1) || Any..isfrom_string(v1) || Any..isfrom_int(v1));
 {
-  if Any_to_bool (v1) then v1 else v2
+  if python_is_truthy (v1) then v1 else v2
 }
 
 

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -424,6 +424,7 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
       | .Div _ => return mkStmtExprMd .Hole -- Floating-point are not supported yet
       | .FloorDiv _ => .ok "PFloorDiv"  -- Python // maps to Laurel Div
       | .Mod _ => .ok "PMod"
+      | .Pow _ => .ok "PPow"
       | .BitAnd _ => return mkStmtExprMd .Hole --TODO: Adding BitVector subtype in Any type, then the related operations
       | .BitOr _ => return mkStmtExprMd .Hole
       | .BitXor _ => return mkStmtExprMd .Hole
@@ -485,6 +486,10 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
     else
       let first ← translateExpr ctx values.val[0]!
       return first
+
+  -- FormattedValue (f-string interpolation) - translate the inner expression
+  | .FormattedValue _ value _ _ =>
+    translateExpr ctx value
 
   | .Call _ f args kwargs => translateCall ctx f args.val.toList kwargs.val.toList
 
@@ -558,6 +563,12 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
 
   -- Generator expression: (x for x in items)
   | .GeneratorExp .. => return mkStmtExprMd .Hole
+
+  -- Ternary expression: body if test else orelse
+  | .IfExp .. => return mkStmtExprMd .Hole
+
+  -- Slice expression: items[start:stop:step]
+  | .Slice .. => return mkStmtExprMd .Hole
 
   | _ => throw (.unsupportedConstruct "Expression type not yet supported" (toString (repr e)))
 
@@ -1003,17 +1014,34 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
   | .While _ test body _orelse => do
     -- Note: Python while-else not supported yet
     let condExpr ← translateExpr ctx test
+    -- Check if condition contains a Hole - if so, hoist to variable
+    let (condStmts, finalCondExpr, condCtx) :=
+      match condExpr.val with
+      | .Hole =>
+        let freshVar := s!"while_cond_{test.toAst.ann.start.byteIdx}"
+        let varType := mkHighTypeMd .TBool
+        let varDecl := mkStmtExprMd (StmtExpr.LocalVariable freshVar varType (some condExpr))
+        let varRef := mkStmtExprMd (StmtExpr.Identifier freshVar)
+        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "bool")] })
+      | _ => ([], condExpr, ctx)
     let newDecls := collectDeclaredNamesAndTypes body.val.toList
-    let (varDecls, ctx) := createVarDeclStmtsAndCtx ctx newDecls
+    let (hoistedDecls, hoistedCtx) := createVarDeclStmtsAndCtx condCtx newDecls
+
     let breakLabel := s!"loop_break_{test.toAst.ann.start.byteIdx}"
     let continueLabel := s!"loop_continue_{test.toAst.ann.start.byteIdx}"
-    let loopCtx := { ctx with loopBreakLabel := some breakLabel, loopContinueLabel := some continueLabel }
+    let loopCtx := { hoistedCtx with loopBreakLabel := some breakLabel, loopContinueLabel := some continueLabel }
     let (_, bodyStmts) ← translateStmtList loopCtx body.val.toList
     let bodyBlock := mkStmtExprMd (StmtExpr.Block bodyStmts (some continueLabel))
-    let whileStmt := mkStmtExprMd (StmtExpr.While (Any_to_bool condExpr) [] none bodyBlock)
+    let whileStmt := mkStmtExprMd (StmtExpr.While (Any_to_bool finalCondExpr) [] none bodyBlock)
     let whileWrapped := mkStmtExprMdWithLoc (StmtExpr.Block [whileStmt] (some breakLabel)) md
-    return (loopCtx, varDecls ++ [whileWrapped])
+    -- Wrap with hoisted declarations and condition stmts
+    let allPreamble := condStmts ++ hoistedDecls
+    let result := if allPreamble.isEmpty then
+      whileWrapped
+    else
+      mkStmtExprMdWithLoc (StmtExpr.Block (allPreamble ++ [whileWrapped]) none) md
 
+    return (loopCtx, [result])
 
   -- Return statement: assign to the LaurelResult output parameter, then exit $body.
   | .Return _ value => do
@@ -1052,7 +1080,9 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         | _ => return (ctx, [expr])
     | _ => return (ctx, [expr])
 
-  | .Import _ _ | .ImportFrom _ _ _ _ |.Pass _ => return (ctx, [mkStmtExprMd .Hole])
+  | .Import _ _ => return (ctx, [mkStmtExprMd .Hole])
+
+  | .ImportFrom _ _ _ _ |.Pass _ => return (ctx, [mkStmtExprMd .Hole])
 
   -- Try/except - wrap body with exception checks and handlers
   | .Try _ body handlers _ _ => do
@@ -1063,8 +1093,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let errorVars : List String := ((handlers.val.toList.filterMap (fun h => match h with
           | .ExceptHandler _ _ errname _ => errname.val)).map (fun h => h.val)).dedup.filter
           (fun e => e ∉ ctx.variableTypes.unzip.fst)
-    let errorTy := mkHighTypeMd (.UserDefined {text := "PythonError"})
-    let errorVarDecls := errorVars.map (fun e => mkStmtExprMd (.LocalVariable {text := e} errorTy none))
+    let errorVarDecls := errorVars.map (fun e => mkStmtExprMd (.LocalVariable {text := e} AnyTy none))
 
     -- Pre-scan for variable declarations in both branches so they are
     -- declared in the outer scope (Python scoping: variables assigned
@@ -1186,19 +1215,20 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     | some lbl => return (ctx, [mkStmtExprMdWithLoc (StmtExpr.Exit lbl) md])
     | none => return (ctx, [mkStmtExprMdWithLoc (StmtExpr.Assert (mkStmtExprMd .Hole)) md])
 
-  -- Augmented assignment: x += expr  →  x = x op expr
+  -- Augmented assignment: x += y  →  x = x + y
   | .AugAssign _ target op value => do
-    let targetExpr ← translateExpr ctx target
-    let valueExpr ← translateExpr ctx value
-    let rhs := match op with
-      | .Add _      => mkStmtExprMd (StmtExpr.StaticCall "PAdd"      [targetExpr, valueExpr])
-      | .Sub _      => mkStmtExprMd (StmtExpr.StaticCall "PSub"      [targetExpr, valueExpr])
-      | .Mult _     => mkStmtExprMd (StmtExpr.StaticCall "PMul"      [targetExpr, valueExpr])
-      | .FloorDiv _ => mkStmtExprMd (StmtExpr.StaticCall "PFloorDiv" [targetExpr, valueExpr])
-      | .Mod _      => mkStmtExprMd (StmtExpr.StaticCall "PMod"      [targetExpr, valueExpr])
-      | _           => mkStmtExprMd .Hole
-    let assignStmt := mkStmtExprMdWithLoc (StmtExpr.Assign [targetExpr] rhs) md
-    return (ctx, [assignStmt])
+    let lhsExpr ← translateExpr ctx target
+    let rhsExpr ← translateExpr ctx value
+    let opName ← match op with
+      | .Add _ => .ok "PAdd"
+      | .Sub _ => .ok "PSub"
+      | .Mult _ => .ok "PMul"
+      | .FloorDiv _ => .ok "PFloorDiv"
+      | .Mod _ => .ok "PMod"
+      | _ => throw (.unsupportedConstruct s!"Augmented assignment operator not yet supported: {repr op}" (toString (repr s)))
+    let combined := mkStmtExprMd (StmtExpr.StaticCall opName [lhsExpr, rhsExpr])
+    let assign := mkStmtExprMd (StmtExpr.Assign [lhsExpr] combined)
+    return (ctx, [assign])
 
   | _ => throw (.unsupportedConstruct "Statement type not yet supported" (toString (repr s)))
 

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1110,12 +1110,6 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let tryLabel := s!"try_end_{s.toAst.ann.start.byteIdx}"
     let catchersLabel := s!"exception_handlers_{s.toAst.ann.start.byteIdx}"
 
-    -- Extract error variables from except handler names (PythonError type)
-    let errorVars : List String := ((handlers.val.toList.filterMap (fun h => match h with
-          | .ExceptHandler _ _ errname _ => errname.val)).map (fun h => h.val)).dedup.filter
-          (fun e => e ∉ ctx.variableTypes.unzip.fst)
-    let errorVarDecls := errorVars.map (fun e => mkStmtExprMd (.LocalVariable {text := e} AnyTy none))
-
     -- Pre-scan for variable declarations in both branches so they are
     -- declared in the outer scope (Python scoping: variables assigned
     -- in try/except are visible after the block).
@@ -1127,7 +1121,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let handlerDecls := handlers.val.toList.flatMap fun h => match h with
       | .ExceptHandler _ _ _ hBody => collectDeclaredNamesAndTypes hBody.val.toList
 
-    let allNewDecls := (bodyDecls ++ errorVarDecls ++ handlerDecls)
+    let allNewDecls := (bodyDecls ++ errorVarPairs ++ handlerDecls)
     let (hoistedDecls, hoistedCtx) := createVarDeclStmtsAndCtx ctx allNewDecls
 
     -- Translate try body (with hoisted context so inner decls become assigns)
@@ -1165,7 +1159,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
       (handlerCtx.variableTypes.filter fun (n, _) =>
         !bodyCtx.variableTypes.any fun (bn, _) => bn == n)
     let finalCtx := { bodyCtx with variableTypes := mergedVars }
-    return (finalCtx, errorVarDecls ++ hoistedDecls ++ [tryBlock])
+    return (finalCtx, hoistedDecls ++ [tryBlock])
 
   | .Raise _ _ _ => return (ctx, [mkStmtExprMd .Hole])
 

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -803,9 +803,9 @@ partial def translateCall (ctx : TranslationContext)
   match f with
   | .Name  _ _ _ =>  return mkStmtExprMd (StmtExpr.StaticCall funcName (trans_args ++ trans_kwords_exprs))
   | .Attribute _ val _attr _ =>
-      let _target_trans ← translateExpr ctx val
+      let target_trans ← translateExpr ctx val
       if opt_firstarg.isSome then
-        return mkStmtExprMd (.Hole)
+        return mkStmtExprMd (StmtExpr.InstanceCall target_trans funcName (trans_args ++ trans_kwords_exprs))
       else
         return mkStmtExprMd (StmtExpr.StaticCall funcName (trans_args ++ trans_kwords_exprs))
   | _ =>  throw (.unsupportedConstruct "Invalid call construct" (toString (repr f)))
@@ -1040,14 +1040,10 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let bodyBlock := mkStmtExprMd (StmtExpr.Block bodyStmts (some continueLabel))
     let whileStmt := mkStmtExprMd (StmtExpr.While (Any_to_bool finalCondExpr) [] none bodyBlock)
     let whileWrapped := mkStmtExprMdWithLoc (StmtExpr.Block [whileStmt] (some breakLabel)) md
-    -- Wrap with hoisted declarations and condition stmts
-    let allPreamble := condStmts ++ hoistedDecls
-    let result := if allPreamble.isEmpty then
-      whileWrapped
-    else
-      mkStmtExprMdWithLoc (StmtExpr.Block (allPreamble ++ [whileWrapped]) none) md
 
-    return (loopCtx, [result])
+    -- Return hoisted declarations as separate statements in the parent scope
+    -- (not wrapped in a Block) so they remain in scope after the while loop
+    return (loopCtx, condStmts ++ hoistedDecls ++ [whileWrapped])
 
   -- Return statement: assign to the LaurelResult output parameter, then exit $body.
   | .Return _ value => do

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1004,6 +1004,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let whileWrapped := mkStmtExprMdWithLoc (StmtExpr.Block [whileStmt] (some breakLabel)) md
     return (loopCtx, varDecls ++ [whileWrapped])
 
+
   -- Return statement: assign to the LaurelResult output parameter, then exit $body.
   | .Return _ value => do
     let stmts ← match value.val with

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -154,6 +154,14 @@ def mkStmtExprMd (expr : StmtExpr) : StmtExprMd :=
 def mkStmtExprMdWithLoc (expr : StmtExpr) (md : Imperative.MetaData Core.Expression) : StmtExprMd :=
   { val := expr, md := md }
 
+/-- Flatten a user-defined instance method call to a static call with self as the
+    first argument.  The callee name is qualified as `ClassName_methodName`.
+    This keeps user-defined class methods consistent with how PySpec generates
+    procedures (flat static procedures) while still threading the receiver. -/
+def mkInstanceMethodCall (className : String) (methodName : String)
+    (self : StmtExprMd) (args : List StmtExprMd) : StmtExprMd :=
+  mkStmtExprMd (StmtExpr.StaticCall (className ++ "_" ++ methodName) (self :: args))
+
 /-- Extract string representation from Python expression (for type annotations) -/
 partial def pyExprToString (e : Python.expr SourceRange) : String :=
   match e with
@@ -802,10 +810,10 @@ partial def translateCall (ctx : TranslationContext)
     else [trans_kwords]
   match f with
   | .Name  _ _ _ =>  return mkStmtExprMd (StmtExpr.StaticCall funcName (trans_args ++ trans_kwords_exprs))
-  | .Attribute _ val _attr _ =>
+  | .Attribute _ val _ _ =>
       let target_trans ← translateExpr ctx val
       if opt_firstarg.isSome then
-        return mkStmtExprMd (StmtExpr.InstanceCall target_trans funcName (trans_args ++ trans_kwords_exprs))
+        return mkStmtExprMd (StmtExpr.StaticCall funcName (target_trans :: trans_args ++ trans_kwords_exprs))
       else
         return mkStmtExprMd (StmtExpr.StaticCall funcName (trans_args ++ trans_kwords_exprs))
   | _ =>  throw (.unsupportedConstruct "Invalid call construct" (toString (repr f)))
@@ -874,13 +882,13 @@ partial def translateAssign  (ctx : TranslationContext)
             if fnname.text ∈ ctx.compositeTypeNames then
               let newExpr := mkStmtExprMd (StmtExpr.New fnname)
               let varType := mkHighTypeMd (.UserDefined fnname)
+              let selfRef := mkStmtExprMd (StmtExpr.Identifier n.val)
+              let initStmt := mkInstanceMethodCall fnname.text "__init__" selfRef args
               if n.val ∈ ctx.variableTypes.unzip.1 then
                 let assignStmt := mkStmtExprMd (StmtExpr.Assign [targetExpr] newExpr)
-                let initStmt := mkStmtExprMd (StmtExpr.InstanceCall (mkStmtExprMd (StmtExpr.Identifier n.val)) "__init__" args)
                 [assignStmt, initStmt]
               else
                 let newStmt := mkStmtExprMd (StmtExpr.LocalVariable n.val varType (some newExpr))
-                let initStmt := mkStmtExprMd (StmtExpr.InstanceCall (mkStmtExprMd (StmtExpr.Identifier n.val)) "__init__" args)
                 [newStmt, initStmt]
             else if withException ctx fnname.text then
               [mkStmtExprMd (StmtExpr.Assign [targetExpr, maybeExceptVar] rhs_trans)]
@@ -1177,7 +1185,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         let mgrDecl := mkStmtExprMd (StmtExpr.LocalVariable mgrName mgrLauTy (some mgrExpr))
         let mgrRef := mkStmtExprMd (StmtExpr.Identifier mgrName)
         currentCtx := {currentCtx with variableTypes := currentCtx.variableTypes ++ [(mgrName, mgrTy)]}
-        let enterCall := mkStmtExprMd (StmtExpr.InstanceCall mgrRef "__enter__" [])
+        let enterCall := mkInstanceMethodCall mgrTy "__enter__" mgrRef []
         match optVars.val with
         | some varExpr =>
           let varName := pyExprToString varExpr
@@ -1191,7 +1199,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
             setupStmts := setupStmts ++ [mgrDecl, varDecl]
         | none =>
           setupStmts := setupStmts ++ [mgrDecl, enterCall]
-        cleanupStmts := cleanupStmts ++ [mkStmtExprMd (StmtExpr.InstanceCall mgrRef "__exit__" [])]
+        cleanupStmts := cleanupStmts ++ [mkInstanceMethodCall mgrTy "__exit__" mgrRef []]
     let (bodyCtx, bodyStmts) ← translateStmtList currentCtx body.val.toList
     let block := mkStmtExprMdWithLoc (StmtExpr.Block (setupStmts ++ bodyStmts ++ cleanupStmts) none) md
     return (bodyCtx, [block])
@@ -1439,7 +1447,7 @@ def translateMethod (ctx : TranslationContext) (className : String)
     : Except TranslationError Procedure := do
   match methodStmt with
   | .FunctionDef _ name args body _ ret _ _ => do
-    let methodName := name.val
+    let qualifiedName := className ++ "_" ++ name.val
 
     -- First parameter is self - type it as the class
     let selfParam : Parameter := {
@@ -1478,7 +1486,7 @@ def translateMethod (ctx : TranslationContext) (className : String)
 
     let md := sourceRangeToMetaData ctx.filePath methodStmt.ann
     return {
-      name := methodName
+      name := qualifiedName
       inputs := inputs
       outputs := outputs
       preconditions := [mkStmtExprMd (StmtExpr.LiteralBool true)]
@@ -1507,7 +1515,9 @@ def extractFieldsFromInit (ctx : TranslationContext) (initBody : Array (Python.s
     | _ => pure ()
   return fields
 
-/-- Translate a Python class to a Laurel CompositeType -/
+/-- Translate a Python class to a Laurel CompositeType and its flattened static procedures.
+    Instance methods are emitted as static procedures with `ClassName_methodName` naming
+    and `self` as the first parameter, rather than as instance procedures on the type. -/
 def translateClass (ctx : TranslationContext) (classStmt : Python.stmt SourceRange)
     : Except TranslationError (CompositeType × List Procedure) := do
   match classStmt with
@@ -1544,18 +1554,18 @@ def translateClass (ctx : TranslationContext) (classStmt : Python.stmt SourceRan
       | .FunctionDef _ _ _ _ _ _ _ _ => true
       | _ => false
 
-    -- Translate each method
-    let mut instanceProcedures : List Procedure := []
+    -- Translate each method as a static procedure with qualified name
+    let mut methodProcs : List Procedure := []
     for methodStmt in methodStmts do
       let proc ← translateMethod ctx className methodStmt
-      instanceProcedures := instanceProcedures ++ [proc]
+      methodProcs := methodProcs ++ [proc]
 
     return ({
       name := className
       extending := []  -- No inheritance support for now
       fields := fields
-      instanceProcedures := [] -- Laurel does not yet support instance procedures, so treat them as if they were static
-    }, instanceProcedures)
+      instanceProcedures := []
+    }, methodProcs)
   | _ => throw (.internalError "Expected ClassDef")
 
 def getFunctions (decls: List Core.Decl) : List String :=
@@ -1716,6 +1726,7 @@ def pythonToLaurel' (info : PreludeInfo)
 
     -- FIRST PASS: Collect all class definitions and field type info
     let mut compositeTypes : List CompositeType := [pyErrorTy]
+    let mut classStaticProcs : List Procedure := []
     let mut compositeTypeNames := info.compositeTypes.insert "PythonError"
     let mut classFieldHighType : Std.HashMap String (Std.HashMap String HighType) := {}
     for stmt in body.val do
@@ -1728,10 +1739,9 @@ def pythonToLaurel' (info : PreludeInfo)
           classFieldHighType := classFieldHighType,
           filePath := filePath
         }
-        let (composite, _instanceProcedures) ← translateClass initCtx stmt
-        -- TODO uncomment this line and resolve compilation issues
-        -- procedures := procedures ++ _instanceProcedures
+        let (composite, classMethodProcs) ← translateClass initCtx stmt
         compositeTypes := compositeTypes ++ [composite]
+        classStaticProcs := classStaticProcs ++ classMethodProcs
         compositeTypeNames := compositeTypeNames.insert composite.name.text
         -- Collect field types for Any coercions in field accesses
         let fieldMap := composite.fields.foldl (fun m f => m.insert f.name.text f.type.val) (classFieldHighType[composite.name.text]?.getD {})
@@ -1797,7 +1807,7 @@ def pythonToLaurel' (info : PreludeInfo)
     }
 
     let program : Laurel.Program := {
-      staticProcedures := procedures ++ [mainProc]
+      staticProcedures := classStaticProcs ++ procedures ++ [mainProc]
       staticFields := []
       types := compositeTypes.map TypeDefinition.Composite
       constants := []

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -249,7 +249,7 @@ def strToAny (s: String) := mkStmtExprMd (.StaticCall "from_string" [mkStmtExprM
 def intToAny (i: Int) := mkStmtExprMd (.StaticCall "from_int" [mkStmtExprMd (StmtExpr.LiteralInt i)])
 def boolToAny (b: Bool) := mkStmtExprMd (.StaticCall "from_bool" [mkStmtExprMd (StmtExpr.LiteralBool b)])
 def AnyNone := mkStmtExprMd (.StaticCall "from_none" [])
-def Any_to_bool (b: StmtExprMd) := mkStmtExprMd (.StaticCall "Any_to_bool" [b])
+def python_is_truthy (b: StmtExprMd) := mkStmtExprMd (.StaticCall "python_is_truthy" [b])
 
 /-- Wrap a field access expression in the appropriate Any constructor based on HighType.
     After heap parameterization, field reads return concrete types (int, bool, etc.)
@@ -1020,7 +1020,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     else do
       let (_, elseStmts) ← translateStmtList bodyCtx orelse.val.toList
       .ok (some (mkStmtExprMd (StmtExpr.Block elseStmts none)))
-    let ifStmt := mkStmtExprMdWithLoc (StmtExpr.IfThenElse (Any_to_bool finalCondExpr) bodyBlock elseBlock) md
+    let ifStmt := mkStmtExprMdWithLoc (StmtExpr.IfThenElse (python_is_truthy finalCondExpr) bodyBlock elseBlock) md
 
     return (bodyCtx, varDecls ++ condStmts ++ [ifStmt])
 
@@ -1046,7 +1046,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let loopCtx := { hoistedCtx with loopBreakLabel := some breakLabel, loopContinueLabel := some continueLabel }
     let (_, bodyStmts) ← translateStmtList loopCtx body.val.toList
     let bodyBlock := mkStmtExprMd (StmtExpr.Block bodyStmts (some continueLabel))
-    let whileStmt := mkStmtExprMd (StmtExpr.While (Any_to_bool finalCondExpr) [] none bodyBlock)
+    let whileStmt := mkStmtExprMd (StmtExpr.While (python_is_truthy finalCondExpr) [] none bodyBlock)
     let whileWrapped := mkStmtExprMdWithLoc (StmtExpr.Block [whileStmt] (some breakLabel)) md
 
     -- Return hoisted declarations as separate statements in the parent scope
@@ -1066,7 +1066,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
   -- Assert statement
   | .Assert _ test _msg => do
     let condExpr ← translateExpr ctx test
-    let assertStmt := mkStmtExprMdWithLoc (StmtExpr.Assert (Any_to_bool condExpr)) md
+    let assertStmt := mkStmtExprMdWithLoc (StmtExpr.Assert (python_is_truthy condExpr)) md
     return (ctx, [assertStmt])
 
   --Ignore comments in source code

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -90,6 +90,9 @@ structure TranslationContext where
   currentClassName : Option String := none
   loopBreakLabel : Option String := none
   loopContinueLabel : Option String := none
+  /-- Map from Python identifier to module name for `import` statements.
+      E.g., `import servicelib as s` adds `"s" → "servicelib"`. -/
+  moduleAliases : Std.HashMap String String := {}
 deriving Inhabited
 
 /-! ## Error Handling -/
@@ -517,6 +520,10 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
         let className := ctx.currentClassName.get!
         let ty ← lookupFieldHighType ctx className attr.val
         wrapFieldInAny ty fieldExpr
+      else if name.val ∈ ctx.moduleAliases && name.val ∉ ctx.variableTypes.unzip.fst then
+        -- Module attribute access (e.g. sys.argv) — module is not a runtime
+        -- variable, so produce Hole rather than an undeclared Identifier.
+        return mkStmtExprMd .Hole
       else
         -- Regular object.field access
         let objExpr ← translateExpr ctx obj
@@ -593,7 +600,7 @@ partial def reMapFunctionName (ctx: TranslationContext) (fname: String) : String
 partial def isPackage (ctx : TranslationContext) (expr: Python.expr SourceRange) : Bool :=
   let (root, _):= getListAttributes expr
   match root with
-  | .Name _ n _ => n.val ∉ ctx.variableTypes.unzip.fst
+  | .Name _ n _ => n.val ∉ ctx.variableTypes.unzip.fst || n.val ∈ ctx.moduleAliases
   | _ => false
 
 partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange) : Except TranslationError String := do
@@ -799,7 +806,6 @@ partial def translateCall (ctx : TranslationContext)
       let _target_trans ← translateExpr ctx val
       if opt_firstarg.isSome then
         return mkStmtExprMd (.Hole)
-        --return mkStmtExprMd (StmtExpr.InstanceCall target_trans attr.val (trans_args ++ trans_kwords_exprs))
       else
         return mkStmtExprMd (StmtExpr.StaticCall funcName (trans_args ++ trans_kwords_exprs))
   | _ =>  throw (.unsupportedConstruct "Invalid call construct" (toString (repr f)))
@@ -1080,7 +1086,18 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         | _ => return (ctx, [expr])
     | _ => return (ctx, [expr])
 
-  | .Import _ _ => return (ctx, [mkStmtExprMd .Hole])
+  | .Import _ names => do
+    -- Register each imported module: map Python identifier → module name.
+    -- Supports aliasing: `import servicelib as s` maps "s" → "servicelib".
+    -- Module identifiers are kept OUT of variableTypes so that isPackage
+    -- correctly identifies them as package references.  Attribute access on
+    -- unmodeled modules (e.g. sys.argv) produces Hole via translateExpr.
+    let newModuleAliases := names.val.toList.foldl (fun m a =>
+      let moduleName := a.name
+      let pyIdent := a.asname.getD moduleName
+      m.insert pyIdent moduleName) ctx.moduleAliases
+    let newCtx := { ctx with moduleAliases := newModuleAliases }
+    return (newCtx, [mkStmtExprMd .Hole])
 
   | .ImportFrom _ _ _ _ |.Pass _ => return (ctx, [mkStmtExprMd .Hole])
 
@@ -1753,6 +1770,13 @@ def pythonToLaurel' (info : PreludeInfo)
         procedures := procedures ++ [proc.fst]
       | .ClassDef _ _ _ _ _ _ _ =>
         pure ()  -- Already processed in first pass
+      | .Import _ names =>
+        -- Register module aliases early so they are available to functions
+        -- defined later in the same module.
+        let newAliases := names.val.toList.foldl (fun m a =>
+          m.insert (a.asname.getD a.name) a.name) ctx.moduleAliases
+        ctx := { ctx with moduleAliases := newAliases }
+        otherStmts := otherStmts ++ [stmt]
       | _ =>
         otherStmts := otherStmts ++ [stmt]
 

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -977,7 +977,17 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let condExpr ← translateExpr ctx test
     let newDecls := collectDeclaredNamesAndTypes (body.val.toList ++ orelse.val.toList)
     let (varDecls, ctx) := createVarDeclStmtsAndCtx ctx newDecls
-    let (bodyCtx, bodyStmts) ← translateStmtList ctx body.val.toList
+    -- Check if condition contains a Hole - if so, hoist to variable to avoid free variable errors
+    let (condStmts, finalCondExpr, condCtx) :=
+      match condExpr.val with
+      | .Hole =>
+        let freshVar := s!"cond_{test.toAst.ann.start.byteIdx}"
+        let varType := AnyTy
+        let varDecl := mkStmtExprMd (StmtExpr.LocalVariable freshVar varType (some condExpr))
+        let varRef := mkStmtExprMd (StmtExpr.Identifier freshVar)
+        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "Bool")] })
+      | _ => ([], condExpr, ctx)
+    let (bodyCtx, bodyStmts) ← translateStmtList condCtx body.val.toList
     let bodyBlock := mkStmtExprMd (StmtExpr.Block bodyStmts none)
     -- Translate else branch if present
     let elseBlock ← if orelse.val.isEmpty then
@@ -985,9 +995,9 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     else do
       let (_, elseStmts) ← translateStmtList bodyCtx orelse.val.toList
       .ok (some (mkStmtExprMd (StmtExpr.Block elseStmts none)))
-    let ifStmt := mkStmtExprMdWithLoc (StmtExpr.IfThenElse (Any_to_bool condExpr) bodyBlock elseBlock) md
+    let ifStmt := mkStmtExprMdWithLoc (StmtExpr.IfThenElse (Any_to_bool finalCondExpr) bodyBlock elseBlock) md
 
-    return (bodyCtx, varDecls ++ [ifStmt])
+    return (bodyCtx, varDecls ++ condStmts ++ [ifStmt])
 
   -- While loop
   | .While _ test body _orelse => do
@@ -1049,12 +1059,19 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let tryLabel := s!"try_end_{s.toAst.ann.start.byteIdx}"
     let catchersLabel := s!"exception_handlers_{s.toAst.ann.start.byteIdx}"
 
+    -- Extract error variables from except handler names (PythonError type)
+    let errorVars : List String := ((handlers.val.toList.filterMap (fun h => match h with
+          | .ExceptHandler _ _ errname _ => errname.val)).map (fun h => h.val)).dedup.filter
+          (fun e => e ∉ ctx.variableTypes.unzip.fst)
+    let errorTy := mkHighTypeMd (.UserDefined {text := "PythonError"})
+    let errorVarDecls := errorVars.map (fun e => mkStmtExprMd (.LocalVariable {text := e} errorTy none))
+
     -- Pre-scan for variable declarations in both branches so they are
     -- declared in the outer scope (Python scoping: variables assigned
     -- in try/except are visible after the block).
     let bodyDecls := collectDeclaredNamesAndTypes body.val.toList
 
-    let errorVarDecls: List (String × String) := (handlers.val.toList.filterMap (λ h => match h with
+    let errorVarPairs: List (String × String) := (handlers.val.toList.filterMap (λ h => match h with
           | .ExceptHandler _ _ errname _ => errname.val)).map (λ h => (h.val, "PythonError"))
 
     let handlerDecls := handlers.val.toList.flatMap fun h => match h with
@@ -1098,7 +1115,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
       (handlerCtx.variableTypes.filter fun (n, _) =>
         !bodyCtx.variableTypes.any fun (bn, _) => bn == n)
     let finalCtx := { bodyCtx with variableTypes := mergedVars }
-    return (finalCtx, hoistedDecls ++ [tryBlock])
+    return (finalCtx, errorVarDecls ++ hoistedDecls ++ [tryBlock])
 
   | .Raise _ _ _ => return (ctx, [mkStmtExprMd .Hole])
 

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -962,13 +962,13 @@ def createVarDeclStmtsAndCtx (ctx : TranslationContext) (newDecls : List (String
       if acc.any (fun (an, _) => an == n) || ctx.variableTypes.any (fun (vn, _) => vn == n)
       then acc else acc ++ [(n, ty)]) []
   let hoistedDecls : List StmtExprMd := newDecls.map fun (name, tyStr) =>
-      let ty := if tyStr ∈ ctx.compositeTypeNames || tyStr == "PythonError" then
+      let ty := if tyStr ∈ ctx.compositeTypeNames then
           mkHighTypeMd (.UserDefined tyStr)
         else AnyTy
       mkStmtExprMd (StmtExpr.LocalVariable (name : String) ty (some (mkStmtExprMd .Hole)))
   let hoistedCtx := { ctx with variableTypes := ctx.variableTypes ++
       (newDecls.map fun (n, ty) =>
-        if ty ∈ ctx.compositeTypeNames || ty == "PythonError" then (n, ty) else (n, PyLauType.Any)) }
+        if ty ∈ ctx.compositeTypeNames then (n, ty) else (n, PyLauType.Any)) }
   (hoistedDecls, hoistedCtx)
 
 mutual
@@ -1116,7 +1116,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let bodyDecls := collectDeclaredNamesAndTypes body.val.toList
 
     let errorVarPairs: List (String × String) := (handlers.val.toList.filterMap (λ h => match h with
-          | .ExceptHandler _ _ errname _ => errname.val)).map (λ h => (h.val, "PythonError"))
+          | .ExceptHandler _ _ errname _ => errname.val)).map (λ h => (h.val, "Any"))
 
     let handlerDecls := handlers.val.toList.flatMap fun h => match h with
       | .ExceptHandler _ _ _ hBody => collectDeclaredNamesAndTypes hBody.val.toList

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -227,7 +227,15 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
       if nm == PythonIdent.noneType then return mkTy .TVoid
       -- TODO: add proper CorePrelude types for these
       if nm == PythonIdent.typingAny then return unsupportedType
-      if nm == PythonIdent.typingList then return mkCore "ListStr"
+      if nm == PythonIdent.typingList then
+        -- Validate element type args: composites (UserDefined) cannot be embedded in Any
+        for arg in args do
+          match arg.atoms[0]? with
+          | some (SpecAtomType.pyClass name _) =>
+            reportError default
+              s!"List[{name}] not supported: composites live on the heap and cannot be embedded in Any"
+          | _ => pure ()
+        return mkCore "ListAny"
       if nm == PythonIdent.typingDict then return mkCore "DictStrAny"
       if nm == PythonIdent.builtinsBytes then return unsupportedType
       if args.size > 0 then
@@ -251,35 +259,141 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
 private def mkExpr (e : StmtExpr) : WithMetadata StmtExpr :=
   { val := e, md := default }
 
-/-- Build a precondition expression for a parameter based on its original HighType.
-    For simple types, emits `Any..isfrom_string(x)`.
-    For optional types, emits `Any..isfrom_none(x) | Any..isfrom_string(x)`.
-    Reports a warning for unrecognized types so gaps are visible. -/
-private def preconditionForType (paramName : String) (ty : HighType)
-    : ToLaurelM (Option (WithMetadata StmtExpr)) := do
-  let paramRef := mkExpr (.Identifier paramName)
-  let mkCall (tester : String) := mkExpr (.StaticCall tester [paramRef])
-  match ty with
-  | .TVoid => return none
-  | .TCore "Any" => return none
-  | .TString => return some (mkCall "Any..isfrom_string")
-  | .TInt => return some (mkCall "Any..isfrom_int")
-  | .TBool => return some (mkCall "Any..isfrom_bool")
-  | .TReal => return some (mkCall "Any..isfrom_float")
-  | .TCore "DictStrAny" => return some (mkCall "Any..isfrom_Dict")
-  | .TCore "ListAny" => return some (mkCall "Any..isfrom_ListAny")
-  | .TCore "ListStr" => return some (mkCall "Any..isfrom_ListAny")
-  | .UserDefined _ => return some (mkCall "Any..isfrom_ClassInstance")
-  | .TCore "StrOrNone" =>
-    return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_string"]))
-  | .TCore "IntOrNone" =>
-    return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_int"]))
-  | .TCore "BoolOrNone" =>
-    return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_bool"]))
-  | other =>
-    reportError default
-      s!"No Any precondition tester for type '{repr other}' on parameter '{paramName}'"
-    return none
+/-- Translate a PySpec parameter type directly to its Laurel type and constraints.
+    Value-world types (primitives, dicts, lists) become `Core(Any)` with an
+    `isfrom_X` precondition.  Heap-world types (user-defined classes) become
+    `Composite` with no precondition.  Returns `(laurelType, preconditions)`.
+
+    This function operates on `SpecType` atoms directly — it does NOT
+    delegate to `specTypeToLaurelType`, avoiding the intermediate HighType
+    that would be immediately discarded. -/
+private def specTypeToLaurelActual (paramExpr : WithMetadata StmtExpr) (ty : SpecType)
+    : ToLaurelM (HighTypeMd × Array (WithMetadata StmtExpr)) := do
+  let anyTy : HighTypeMd := mkCore "Any"
+  let compositeTy : HighTypeMd := ⟨.UserDefined "Composite", #[]⟩
+  let mkCall (tester : String) := mkExpr (.StaticCall tester [paramExpr])
+  let mkOr (a b : WithMetadata StmtExpr) := mkExpr (.PrimitiveOp .Or [a, b])
+
+  let isNoneType (atom : SpecAtomType) : Bool :=
+    match atom with
+    | .ident nm args => nm == PythonIdent.noneType && args.isEmpty
+    | _ => false
+
+  -- Helper: translate a single non-None atom to its constraint.
+  -- Returns `none` for unsupported/unrecognized types.
+  let atomConstraint (atom : SpecAtomType) : ToLaurelM (Option (WithMetadata StmtExpr)) := do
+    match atom with
+    | .ident nm args =>
+      if nm == PythonIdent.builtinsInt then return some (mkCall "Any..isfrom_int")
+      if nm == PythonIdent.builtinsBool then return some (mkCall "Any..isfrom_bool")
+      if nm == PythonIdent.builtinsStr then return some (mkCall "Any..isfrom_string")
+      if nm == PythonIdent.builtinsFloat then return some (mkCall "Any..isfrom_float")
+      if nm == PythonIdent.noneType then return none  -- no constraint
+      if nm == PythonIdent.typingAny then return none  -- unconstrained
+      if nm == PythonIdent.typingList then
+        if args.isEmpty then
+          reportError default
+            "Bare List without element type not supported: element type may include composites incompatible with Any"
+          return none
+        -- Validate: reject composite element types
+        for arg in args do
+          match arg.atoms[0]? with
+          | some (SpecAtomType.pyClass name _) =>
+            reportError default
+              s!"List[{name}] not supported: composites live on the heap and cannot be embedded in Any"
+          | _ => pure ()
+        return some (mkCall "Any..isfrom_ListAny")
+      if nm == PythonIdent.typingDict then
+        if args.isEmpty then
+          reportError default
+            "Bare Dict without type args not supported: value type may include composites incompatible with Any"
+          return none
+        return some (mkCall "Any..isfrom_Dict")
+      if nm == PythonIdent.builtinsBytes then return none  -- unsupported
+      reportError default s!"No Any precondition for ident type '{nm}'"
+      return none
+    | .pyClass .. => return none  -- composites handled at type level, not constraint
+    | .intLiteral _ => return some (mkCall "Any..isfrom_int")
+    | .stringLiteral _ => return some (mkCall "Any..isfrom_string")
+    | .typedDict .. => return some (mkCall "Any..isfrom_Dict")
+
+  -- Helper: translate a single atom to its (type, constraints).
+  let atomToActual (atom : SpecAtomType) : ToLaurelM (HighTypeMd × Array (WithMetadata StmtExpr)) := do
+    match atom with
+    | .pyClass name args =>
+      if args.size > 0 then
+        reportError default s!"Generic class '{name}' with type args unsupported"
+      return (compositeTy, #[])
+    | other =>
+      match ← atomConstraint other with
+      | some c => return (anyTy, #[c])
+      | none => return (anyTy, #[])
+
+  -- Empty type
+  if ty.atoms.size == 0 then
+    reportError default "Empty type (no atoms) encountered"
+    return (anyTy, #[])
+
+  -- Single atom — most common case
+  if ty.atoms.size == 1 then
+    return ← atomToActual ty.atoms[0]!
+
+  -- Multi-atom (union types) — all unions are value-world (Core(Any))
+
+  -- Check for None in the union (Optional pattern)
+  let hasNone := ty.atoms.any isNoneType
+  let otherAtoms := ty.atoms.filter (fun a => !isNoneType a)
+
+  -- All string literals → isfrom_string (+ isfrom_none if Optional)
+  if otherAtoms.all (fun a => match a with | .stringLiteral _ => true | _ => false) then
+    let strPre := mkCall "Any..isfrom_string"
+    if hasNone then return (anyTy, #[mkOr (mkCall "Any..isfrom_none") strPre])
+    return (anyTy, #[strPre])
+
+  -- All int literals → isfrom_int (+ isfrom_none if Optional)
+  if otherAtoms.all (fun a => match a with | .intLiteral _ => true | _ => false) then
+    let intPre := mkCall "Any..isfrom_int"
+    if hasNone then return (anyTy, #[mkOr (mkCall "Any..isfrom_none") intPre])
+    return (anyTy, #[intPre])
+
+  -- All TypedDicts → isfrom_Dict (+ isfrom_none if Optional)
+  if otherAtoms.all (fun a => match a with | .typedDict .. => true | _ => false) then
+    let dictPre := mkCall "Any..isfrom_Dict"
+    if hasNone then return (anyTy, #[mkOr (mkCall "Any..isfrom_none") dictPre])
+    return (anyTy, #[dictPre])
+
+  -- Union[None, single-atom] — Optional patterns
+  if hasNone && otherAtoms.size == 1 then
+    -- Pure constraint lookup (no error reporting) for the non-None atom
+    let optConstraint? : Option (WithMetadata StmtExpr) := match otherAtoms[0]! with
+      | .ident nm args =>
+        if nm == PythonIdent.builtinsStr then some (mkCall "Any..isfrom_string")
+        else if nm == PythonIdent.builtinsInt then some (mkCall "Any..isfrom_int")
+        else if nm == PythonIdent.builtinsBool then some (mkCall "Any..isfrom_bool")
+        else if nm == PythonIdent.builtinsFloat then some (mkCall "Any..isfrom_float")
+        else if nm == PythonIdent.typingList && !args.isEmpty then some (mkCall "Any..isfrom_ListAny")
+        else if nm == PythonIdent.typingDict && !args.isEmpty then some (mkCall "Any..isfrom_Dict")
+        else none
+      | .intLiteral _ => some (mkCall "Any..isfrom_int")
+      | .stringLiteral _ => some (mkCall "Any..isfrom_string")
+      | .typedDict .. => some (mkCall "Any..isfrom_Dict")
+      | _ => none
+    if let some c := optConstraint? then
+      return (anyTy, #[mkOr (mkCall "Any..isfrom_none") c])
+    -- Known but unconstrained types (Any, bytes, noneType) — no error
+    match otherAtoms[0]! with
+    | .ident nm _ =>
+      if nm == PythonIdent.typingAny || nm == PythonIdent.builtinsBytes
+         || nm == PythonIdent.noneType then
+        return (anyTy, #[])
+    | _ => pure ()
+    -- Unknown ident or pyClass in Optional — fall through to unrecognized union error
+    pure ()
+
+  -- Unrecognized union
+  let unionStr := formatUnionType ty.atoms
+  reportError default s!"Union type ({unionStr}) not yet supported"
+  return (anyTy, #[])
 
 
 /-- Map a HighType to the Any constructor name for wrapping typed → Any. -/
@@ -328,22 +442,28 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     | .ok args => pure args
     | .error msg => do reportError default msg; pure #[]
   let allArgs := posArgs ++ func.args.kwonly ++ kwargsArgs
-  let anyTy : HighTypeMd := mkCore "Any"
   let compositeTy : HighTypeMd := ⟨.UserDefined "Composite", #[]⟩
   let mut inputs : Array Parameter := .emptyWithCapacity (allArgs.size + if isMethod then 1 else 0)
   if isMethod then
     inputs := inputs.push { name := "self", type := compositeTy }
   let mut preconditions : Array (WithMetadata StmtExpr) := #[]
   for arg in allArgs do
-    inputs := inputs.push { name := arg.name, type := anyTy }
-    let originalTy ← specTypeToLaurelType arg.type
-    if let some pre ← preconditionForType arg.name originalTy.val then
-      preconditions := preconditions.push pre
-  let retType ← specTypeToLaurelType func.returnType
-  let outputs : List Parameter :=
-    match retType.val with
-    | .TVoid => []
-    | _ => [{ name := "result", type := anyTy }]
+    let paramExpr := mkExpr (.Identifier arg.name)
+    let (laurelTy, constraints) ← specTypeToLaurelActual paramExpr arg.type
+    inputs := inputs.push { name := arg.name, type := laurelTy }
+    preconditions := preconditions ++ constraints
+  -- Return type: check for void (NoneType) directly, otherwise use specTypeToLaurelActual
+  let isVoidReturn := func.returnType.atoms.size == 1 &&
+    match func.returnType.atoms[0]? with
+    | some (SpecAtomType.ident nm #[]) => nm == PythonIdent.noneType
+    | _ => false
+  let (outputs, postconditions) ←
+    if isVoidReturn then
+      pure ([], #[])
+    else do
+      let resultExpr := mkExpr (.Identifier "result")
+      let (retTy, retConstraints) ← specTypeToLaurelActual resultExpr func.returnType
+      pure ([{ name := "result", type := retTy }], retConstraints)
   if func.preconditions.size > 0 || func.postconditions.size > 0 then
     reportError func.loc "Preconditions/postconditions not yet supported"
   return {
@@ -354,7 +474,7 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     determinism := .nondeterministic
     decreases := none
     isFunctional := false
-    body := .Opaque [] none []
+    body := .Opaque postconditions.toList none []
     md := .empty
   }
 

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -256,15 +256,34 @@ def argToParameter (arg : Arg) : ToLaurelM Parameter := do
 private def mkExpr (e : StmtExpr) : WithMetadata StmtExpr :=
   { val := e, md := default }
 
-/-- Map a HighType to the Any datatype tester name, if applicable.
-    Returns `none` for types that don't map to a single Any constructor. -/
-private def anyTesterForType : HighType → Option String
-  | .TString => some "Any..isfrom_string"
-  | .TInt => some "Any..isfrom_int"
-  | .TBool => some "Any..isfrom_bool"
-  | .TCore "DictStrAny" => some "Any..isfrom_Dict"
-  | .TCore "ListAny" => some "Any..isfrom_ListAny"
-  | _ => none
+/-- Build a precondition expression for a parameter based on its original type.
+    For simple types, emits `Any..isfrom_string(x)`.
+    For optional types, emits `Any..isfrom_none(x) || Any..isfrom_string(x)`.
+    Reports a warning for unrecognized types so gaps are visible. -/
+private def anyPreconditionForParam (param : Parameter) : ToLaurelM (Option (WithMetadata StmtExpr)) := do
+  let paramRef := mkExpr (.Identifier param.name)
+  let mkCall (tester : String) := mkExpr (.StaticCall tester [paramRef])
+  match param.type.val with
+  | .TVoid => return none
+  | .TCore "Any" => return none
+  | .TString => return some (mkCall "Any..isfrom_string")
+  | .TInt => return some (mkCall "Any..isfrom_int")
+  | .TBool => return some (mkCall "Any..isfrom_bool")
+  | .TReal => return some (mkCall "Any..isfrom_float")
+  | .TCore "DictStrAny" => return some (mkCall "Any..isfrom_Dict")
+  | .TCore "ListAny" => return some (mkCall "Any..isfrom_ListAny")
+  | .TCore "ListStr" => return some (mkCall "Any..isfrom_ListAny")
+  | .UserDefined _ => return some (mkCall "Any..isfrom_ClassInstance")
+  | .TCore "StrOrNone" =>
+    return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_string"]))
+  | .TCore "IntOrNone" =>
+    return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_int"]))
+  | .TCore "BoolOrNone" =>
+    return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_bool"]))
+  | other =>
+    reportError default
+      s!"No Any precondition tester for type '{repr other}' on parameter '{param.name}'"
+    return none
 
 /-- Map a HighType to the Any constructor name for wrapping typed → Any. -/
 private def anyConstructorForType : HighType → Option String
@@ -320,12 +339,9 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
   let anyTy : HighTypeMd := mkCore "Any"
   let inputs := typedInputs.map fun p => { p with type := anyTy }
   -- Generate preconditions: requires Any..isfrom_string(Bucket) etc.
-  let preconditions := typedInputs.toList.filterMap fun p =>
-    match anyTesterForType p.type.val with
-    | some testerName =>
-      let paramRef := mkExpr (.Identifier p.name)
-      some (mkExpr (.StaticCall testerName [paramRef]))
-    | none => none
+  -- For optional types, generate disjunctions: isfrom_none(x) || isfrom_string(x)
+  let preconditions ← typedInputs.toList.filterMapM fun p =>
+    anyPreconditionForParam p
   let retType ← specTypeToLaurelType func.returnType
   -- Outputs also use Any type; postconditions could constrain them
   let outputs : List Parameter :=

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -247,23 +247,19 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
 
 /-! ## Declaration Translation -/
 
-/-- Convert an Arg to a Laurel Parameter. -/
-def argToParameter (arg : Arg) : ToLaurelM Parameter := do
-  let ty ← specTypeToLaurelType arg.type
-  return { name := arg.name, type := ty }
-
 /-- Create a StmtExprMd wrapping a StmtExpr with empty metadata. -/
 private def mkExpr (e : StmtExpr) : WithMetadata StmtExpr :=
   { val := e, md := default }
 
-/-- Build a precondition expression for a parameter based on its original type.
+/-- Build a precondition expression for a parameter based on its original HighType.
     For simple types, emits `Any..isfrom_string(x)`.
-    For optional types, emits `Any..isfrom_none(x) || Any..isfrom_string(x)`.
+    For optional types, emits `Any..isfrom_none(x) | Any..isfrom_string(x)`.
     Reports a warning for unrecognized types so gaps are visible. -/
-private def anyPreconditionForParam (param : Parameter) : ToLaurelM (Option (WithMetadata StmtExpr)) := do
-  let paramRef := mkExpr (.Identifier param.name)
+private def preconditionForType (paramName : String) (ty : HighType)
+    : ToLaurelM (Option (WithMetadata StmtExpr)) := do
+  let paramRef := mkExpr (.Identifier paramName)
   let mkCall (tester : String) := mkExpr (.StaticCall tester [paramRef])
-  match param.type.val with
+  match ty with
   | .TVoid => return none
   | .TCore "Any" => return none
   | .TString => return some (mkCall "Any..isfrom_string")
@@ -282,8 +278,9 @@ private def anyPreconditionForParam (param : Parameter) : ToLaurelM (Option (Wit
     return some (mkExpr (.PrimitiveOp .Or [mkCall "Any..isfrom_none", mkCall "Any..isfrom_bool"]))
   | other =>
     reportError default
-      s!"No Any precondition tester for type '{repr other}' on parameter '{param.name}'"
+      s!"No Any precondition tester for type '{repr other}' on parameter '{paramName}'"
     return none
+
 
 /-- Map a HighType to the Any constructor name for wrapping typed → Any. -/
 private def anyConstructorForType : HighType → Option String
@@ -331,19 +328,15 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     | .ok args => pure args
     | .error msg => do reportError default msg; pure #[]
   let allArgs := posArgs ++ func.args.kwonly ++ kwargsArgs
-  -- Get original typed parameters for precondition generation
-  let typedInputs ← allArgs.mapM argToParameter
-  -- Use Any-typed parameters so PySpec procedures are compatible with
-  -- PythonToLaurel's Any-typed world. Type constraints are expressed
-  -- as preconditions instead.
   let anyTy : HighTypeMd := mkCore "Any"
-  let inputs := typedInputs.map fun p => { p with type := anyTy }
-  -- Generate preconditions: requires Any..isfrom_string(Bucket) etc.
-  -- For optional types, generate disjunctions: isfrom_none(x) || isfrom_string(x)
-  let preconditions ← typedInputs.toList.filterMapM fun p =>
-    anyPreconditionForParam p
+  let mut inputs : Array Parameter := .emptyWithCapacity allArgs.size
+  let mut preconditions : Array (WithMetadata StmtExpr) := #[]
+  for arg in allArgs do
+    inputs := inputs.push { name := arg.name, type := anyTy }
+    let originalTy ← specTypeToLaurelType arg.type
+    if let some pre ← preconditionForType arg.name originalTy.val then
+      preconditions := preconditions.push pre
   let retType ← specTypeToLaurelType func.returnType
-  -- Outputs also use Any type; postconditions could constrain them
   let outputs : List Parameter :=
     match retType.val with
     | .TVoid => []
@@ -354,7 +347,7 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     name := procName
     inputs := inputs.toList
     outputs := outputs
-    preconditions := preconditions
+    preconditions := preconditions.toList
     determinism := .nondeterministic
     decreases := none
     isFunctional := false

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -329,7 +329,10 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     | .error msg => do reportError default msg; pure #[]
   let allArgs := posArgs ++ func.args.kwonly ++ kwargsArgs
   let anyTy : HighTypeMd := mkCore "Any"
-  let mut inputs : Array Parameter := .emptyWithCapacity allArgs.size
+  let compositeTy : HighTypeMd := ⟨.UserDefined "Composite", #[]⟩
+  let mut inputs : Array Parameter := .emptyWithCapacity (allArgs.size + if isMethod then 1 else 0)
+  if isMethod then
+    inputs := inputs.push { name := "self", type := compositeTy }
   let mut preconditions : Array (WithMetadata StmtExpr) := #[]
   for arg in allArgs do
     inputs := inputs.push { name := arg.name, type := anyTy }

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -252,6 +252,38 @@ def argToParameter (arg : Arg) : ToLaurelM Parameter := do
   let ty ← specTypeToLaurelType arg.type
   return { name := arg.name, type := ty }
 
+/-- Create a StmtExprMd wrapping a StmtExpr with empty metadata. -/
+private def mkExpr (e : StmtExpr) : WithMetadata StmtExpr :=
+  { val := e, md := default }
+
+/-- Map a HighType to the Any datatype tester name, if applicable.
+    Returns `none` for types that don't map to a single Any constructor. -/
+private def anyTesterForType : HighType → Option String
+  | .TString => some "Any..isfrom_string"
+  | .TInt => some "Any..isfrom_int"
+  | .TBool => some "Any..isfrom_bool"
+  | .TCore "DictStrAny" => some "Any..isfrom_Dict"
+  | .TCore "ListAny" => some "Any..isfrom_ListAny"
+  | _ => none
+
+/-- Map a HighType to the Any constructor name for wrapping typed → Any. -/
+private def anyConstructorForType : HighType → Option String
+  | .TString => some "from_string"
+  | .TInt => some "from_int"
+  | .TBool => some "from_bool"
+  | .TCore "DictStrAny" => some "from_Dict"
+  | .TCore "ListAny" => some "from_ListAny"
+  | _ => none
+
+/-- Map a HighType to the Any destructor name for unwrapping Any → typed. -/
+private def anyDestructorForType : HighType → Option String
+  | .TString => some "Any..as_string!"
+  | .TInt => some "Any..as_int!"
+  | .TBool => some "Any..as_bool!"
+  | .TCore "DictStrAny" => some "Any..as_Dict!"
+  | .TCore "ListAny" => some "Any..as_ListAny!"
+  | _ => none
+
 /-- Expand a `**kwargs: Unpack[TypedDict]` into individual `Arg` entries.
     Returns an error if kwargs is present but not a TypedDict. -/
 public def expandKwargsArgs (kwargs : Option (String × SpecType))
@@ -280,19 +312,33 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     | .ok args => pure args
     | .error msg => do reportError default msg; pure #[]
   let allArgs := posArgs ++ func.args.kwonly ++ kwargsArgs
-  let inputs ← allArgs.mapM argToParameter
+  -- Get original typed parameters for precondition generation
+  let typedInputs ← allArgs.mapM argToParameter
+  -- Use Any-typed parameters so PySpec procedures are compatible with
+  -- PythonToLaurel's Any-typed world. Type constraints are expressed
+  -- as preconditions instead.
+  let anyTy : HighTypeMd := mkCore "Any"
+  let inputs := typedInputs.map fun p => { p with type := anyTy }
+  -- Generate preconditions: requires Any..isfrom_string(Bucket) etc.
+  let preconditions := typedInputs.toList.filterMap fun p =>
+    match anyTesterForType p.type.val with
+    | some testerName =>
+      let paramRef := mkExpr (.Identifier p.name)
+      some (mkExpr (.StaticCall testerName [paramRef]))
+    | none => none
   let retType ← specTypeToLaurelType func.returnType
+  -- Outputs also use Any type; postconditions could constrain them
   let outputs : List Parameter :=
     match retType.val with
     | .TVoid => []
-    | _ => [{ name := "result", type := retType }]
+    | _ => [{ name := "result", type := anyTy }]
   if func.preconditions.size > 0 || func.postconditions.size > 0 then
     reportError func.loc "Preconditions/postconditions not yet supported"
   return {
     name := procName
     inputs := inputs.toList
     outputs := outputs
-    preconditions := []
+    preconditions := preconditions
     determinism := .nondeterministic
     decreases := none
     isFunctional := false

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -116,8 +116,11 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_required_with_optional.py" .success,
   .mk "test_heap_return.py" .success,
   .mk "test_list_str.py" .success,
-  .mk "test_nested_try.py" .success,
-  .mk "test_try_scope.py" .success,
+  -- Known failures for try/except fixes (nested labels + variable scoping)
+  .mk "test_nested_try.py" $
+    .fail "Core type checking failed: Block label \"try_end\" shadows an enclosing block.",
+  .mk "test_try_scope.py" $
+    .fail "Core type checking failed: Cannot set undeclared variable result.",
   -- Negative tests
   .mk "test_invalid_service.py" $
     .fail "User code error: 'connect' called with unknown string \"invalid\"; known services: #[messaging, storage]",

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -148,7 +148,7 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_augassign.py" .success,
   .mk "test_unlifted_hole.py" .success,
   -- Expected failures: known issues to fix (see fix_types_plan.md)
-  -- Box constructor / type issues in user-defined class __init__ bodies
+  -- __init__ call arity mismatch (heap args not threaded correctly)
   .mk "test_class_init_kwargs.py" (Expected.failPrefix "Core type checking failed:"),
   .mk "test_class_init_noargs.py" (Expected.failPrefix "Core type checking failed:"),
   -- Any vs Composite type mismatch

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -95,12 +95,12 @@ private meta def runAnalyze (dispatchIon : System.FilePath)
     | .ok r => pure r
     | .error err => return .error (toString err)
   match Strata.translateCombinedLaurel laurel with
-  | .error diagnostics => return .error s!"Laurel to Core translation failed: {diagnostics}"
-  | .ok (core, _) =>
+  | (some core, []) =>
     -- Also run Core type checking to catch semantic errors (e.g. Heap vs Any)
     match Core.typeCheck Core.VerifyOptions.quiet core (moreFns := Strata.Python.ReFactory) with
     | .error diag => return .error s!"Core type checking failed: {diag}"
     | .ok _ => return .ok core
+  | (_, errors) => return .error s!"Laurel to Core translation failed: {errors}"
 
 /-- Expected outcome for a test case. -/
 private inductive Expected where
@@ -119,7 +119,14 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_list_str.py" .success,
   .mk "test_nested_try.py" .success,
   .mk "test_try_scope.py" .success,
-  -- Negative tests
+  .mk "test_ternary.py" .success,
+  .mk "test_pow_operator.py" .success,
+  .mk "test_import_usage.py" .success,
+  .mk "test_except_var_usage.py" .success,
+  .mk "test_fstring.py" .success,
+  .mk "test_instance_call_result.py" .success,
+  .mk "test_while_var_scope.py" .success,
+  -- Negative tests (user errors)
   .mk "test_invalid_service.py" $
     .fail "User code error: 'connect' called with unknown string \"invalid\"; known services: #[messaging, storage]",
   .mk "test_invalid_method.py" $
@@ -136,22 +143,9 @@ private meta def testCases : List (String × Expected) := [
     .fail "User code error: 'list_items' called with missing required arguments: [Bucket]",
   .mk "test_positional_missing.py" $
     .fail "User code error: 'delete_item' called with missing required arguments: [Key]",
-  -- Unsupported Python construct tests (expected failures)
-  -- test_slice, test_tuple_for, test_augassign call list_items which returns None;
-  -- assigning void procedure result causes arity mismatch in Core
-  .mk "test_slice.py" (Expected.failPrefix "Core type checking failed:"),
-  .mk "test_ternary.py" .success,
-  .mk "test_tuple_for.py" (Expected.failPrefix "Core type checking failed:"),
-  .mk "test_augassign.py" (Expected.failPrefix "Core type checking failed:"),
-  .mk "test_pow_operator.py" .success,
-  -- Import handling: module aliases tracked, attribute access on unmodeled modules → Hole
-  .mk "test_import_usage.py" .success,
-  .mk "test_except_var_usage.py" .success,
-  .mk "test_fstring.py" .success,
-  -- InstanceCall: simple case passes even with Hole (no while-loop heap interaction)
-  .mk "test_instance_call_result.py" .success,
-  -- InstanceCall: while loop with hoisted variables and instance method calls
-  .mk "test_while_var_scope.py" .success
+  .mk "test_slice.py" .success,
+  .mk "test_tuple_for.py" .success,
+  .mk "test_augassign.py" .success
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -116,11 +116,8 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_required_with_optional.py" .success,
   .mk "test_heap_return.py" .success,
   .mk "test_list_str.py" .success,
-  -- Known failures for try/except fixes (nested labels + variable scoping)
-  .mk "test_nested_try.py" $
-    .fail "Core type checking failed: Block label \"try_end\" shadows an enclosing block.",
-  .mk "test_try_scope.py" $
-    .fail "Core type checking failed: Cannot set undeclared variable result.",
+  .mk "test_nested_try.py" .success,
+  .mk "test_try_scope.py" .success,
   -- Negative tests
   .mk "test_invalid_service.py" $
     .fail "User code error: 'connect' called with unknown string \"invalid\"; known services: #[messaging, storage]",

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -142,12 +142,12 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_tuple_for.py" .success,
   .mk "test_augassign.py" .success,
   .mk "test_pow_operator.py" .success,
-  -- Undeclared import variable test (sys is free variable — import not modeled)
-  .mk "test_import_usage.py" (Expected.failPrefix "Core type checking failed:"),
+  -- Import handling: module aliases tracked, attribute access on unmodeled modules → Hole
+  .mk "test_import_usage.py" .success,
   .mk "test_except_var_usage.py" .success,
   .mk "test_fstring.py" .success,
   -- Variable declared inside while loop used after loop (Python scoping)
-  .mk "test_while_var_scope.py" .success
+  .mk "test_while_var_scope.py" (Expected.failPrefix "Core type checking failed:")
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -137,19 +137,17 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_positional_missing.py" $
     .fail "User code error: 'delete_item' called with missing required arguments: [Key]",
   -- Unsupported Python construct tests (expected failures)
-  .mk "test_slice.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Expression type not yet supported\nAST: Strata.Python.expr.Slice"),
-  .mk "test_ternary.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Expression type not yet supported\nAST: Strata.Python.expr.IfExp"),
-  .mk "test_tuple_for.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Only simple variable in for target supported"),
-  .mk "test_augassign.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Statement type not yet supported\nAST: Strata.Python.stmt.AugAssign"),
-  .mk "test_pow_operator.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Binary operator not yet supported: Strata.Python.operator.Pow"),
+  .mk "test_slice.py" .success,
+  .mk "test_ternary.py" .success,
+  .mk "test_tuple_for.py" .success,
+  .mk "test_augassign.py" .success,
+  .mk "test_pow_operator.py" .success,
   -- Undeclared import variable test (sys is free variable — import not modeled)
   .mk "test_import_usage.py" (Expected.failPrefix "Core type checking failed:"),
-  -- Exception variable typed as Composite (PythonError) but used where Any expected
-  .mk "test_except_var_usage.py" (Expected.failPrefix "Core type checking failed: Impossible to unify"),
-  -- f-string starting with variable: FormattedValue not yet supported
-  .mk "test_fstring.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Expression type not yet supported\nAST: Strata.Python.expr.FormattedValue"),
+  .mk "test_except_var_usage.py" .success,
+  .mk "test_fstring.py" .success,
   -- Variable declared inside while loop used after loop (Python scoping)
-  .mk "test_while_var_scope.py" (Expected.failPrefix "Core type checking failed:")
+  .mk "test_while_var_scope.py" .success
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -106,6 +106,7 @@ private meta def runAnalyze (dispatchIon : System.FilePath)
 private inductive Expected where
   | success
   | fail (msg : String)
+  | failPrefix (pfx : String)
 
 /-- All dispatch test cases: (filename, expected outcome). -/
 private meta def testCases : List (String × Expected) := [
@@ -134,7 +135,21 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_optional_missing_required.py" $
     .fail "User code error: 'list_items' called with missing required arguments: [Bucket]",
   .mk "test_positional_missing.py" $
-    .fail "User code error: 'delete_item' called with missing required arguments: [Key]"
+    .fail "User code error: 'delete_item' called with missing required arguments: [Key]",
+  -- Unsupported Python construct tests (expected failures)
+  .mk "test_slice.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Expression type not yet supported\nAST: Strata.Python.expr.Slice"),
+  .mk "test_ternary.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Expression type not yet supported\nAST: Strata.Python.expr.IfExp"),
+  .mk "test_tuple_for.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Only simple variable in for target supported"),
+  .mk "test_augassign.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Statement type not yet supported\nAST: Strata.Python.stmt.AugAssign"),
+  .mk "test_pow_operator.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Binary operator not yet supported: Strata.Python.operator.Pow"),
+  -- Undeclared import variable test (sys is free variable — import not modeled)
+  .mk "test_import_usage.py" (Expected.failPrefix "Core type checking failed:"),
+  -- Exception variable typed as Composite (PythonError) but used where Any expected
+  .mk "test_except_var_usage.py" (Expected.failPrefix "Core type checking failed: Impossible to unify"),
+  -- f-string starting with variable: FormattedValue not yet supported
+  .mk "test_fstring.py" (Expected.failPrefix "Python to Laurel translation failed: Unsupported construct: Expression type not yet supported\nAST: Strata.Python.expr.FormattedValue"),
+  -- Variable declared inside while loop used after loop (Python scoping)
+  .mk "test_while_var_scope.py" (Expected.failPrefix "Core type checking failed:")
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/
@@ -150,6 +165,11 @@ private meta def runTestCase (dispatchIon tmpDir : System.FilePath)
   | .fail exp, .error msg =>
     if msg == exp then return none
     else return some s!"{scriptName}: Expected error:\n  {exp}\nGot:\n  {msg}"
+  | .failPrefix _, .ok _ =>
+    return some s!"pyAnalyzeLaurel succeeded on {scriptName} but was expected to fail"
+  | .failPrefix pre, .error msg =>
+    if msg.startsWith pre then return none
+    else return some s!"{scriptName}: Expected error prefix:\n  {pre}\nGot:\n  {msg}"
 
 #eval withPython fun _pythonCmd => do
   IO.FS.withTempDir fun tmpDir => do

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -146,29 +146,24 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_slice.py" .success,
   .mk "test_tuple_for.py" .success,
   .mk "test_augassign.py" .success,
-  -- Cat 3: Box..Any — class with Any-typed field, Box constructor references undefined type
-  .mk "test_box_any_type.py" $
-    .fail "Core type checking failed: Error in datatype Box, constructor Box..Any: Undefined type 'Any'",
-  -- Cat 5: Hole nested in kwarg not lifted before Core translation
-  .mk "test_unlifted_hole.py" $
-    .fail "Laurel to Core translation failed: [holes should have been eliminated before translation (should have been lifted)]",
-  -- Cat 6: wrapFieldInAny — class with Any-typed field accessed
-  .mk "test_any_field_access.py" $
-    .fail "Python to Laurel translation failed: Type error: wrapFieldInAny: no Any constructor for field type 'Core(Any)'",
+  .mk "test_unlifted_hole.py" .success,
   -- Expected failures: known issues to fix (see fix_types_plan.md)
-  -- Cat 1: __init__ not found — user-defined class constructors not registered as procedures
-  .mk "test_class_init_kwargs.py" $
-    .fail "Core type checking failed: [call __init__((~DictStrAny_insert ~DictStrAny_empty #region (~from_string #us-west-2)))]: Procedure __init__ not found!",
-  .mk "test_class_init_noargs.py" $
-    .fail "Core type checking failed: [call __init__()]: Procedure __init__ not found!",
-  -- Cat 2: Any vs Composite — composite-typed var in context expecting Any
+  -- Box constructor / type issues in user-defined class __init__ bodies
+  .mk "test_class_init_kwargs.py" (Expected.failPrefix "Core type checking failed:"),
+  .mk "test_class_init_noargs.py" (Expected.failPrefix "Core type checking failed:"),
+  -- Any vs Composite type mismatch
   .mk "test_any_vs_composite.py" $
     .fail "Core type checking failed: Impossible to unify Any with Composite.",
-  -- Cat 4: __enter__ not found — with statement on unmodeled context manager
-  .mk "test_with_open.py" $
-    .fail "Core type checking failed: [call [f] := __enter__()]: Procedure __enter__ not found!",
-  -- Cat 7: Non-modeled function call arity mismatch
-  .mk "test_nonmodeled_call.py" (Expected.failPrefix "Core type checking failed:")
+  -- Unmodeled context manager (open) — type inferred as Any
+  .mk "test_with_open.py" (Expected.failPrefix "Core type checking failed:"),
+  -- Non-modeled function call arity mismatch
+  .mk "test_nonmodeled_call.py" (Expected.failPrefix "Core type checking failed:"),
+  -- Box..Any — class with Any-typed field
+  .mk "test_box_any_type.py" $
+    .fail "Core type checking failed: Error in datatype Box, constructor Box..Any: Undefined type 'Any'",
+  -- wrapFieldInAny — class with Any-typed field accessed
+  .mk "test_any_field_access.py" $
+    .fail "Python to Laurel translation failed: Type error: wrapFieldInAny: no Any constructor for field type 'Core(Any)'"
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -159,11 +159,9 @@ private meta def testCases : List (String × Expected) := [
   -- Non-modeled function call arity mismatch
   .mk "test_nonmodeled_call.py" (Expected.failPrefix "Core type checking failed:"),
   -- Box..Any — class with Any-typed field
-  .mk "test_box_any_type.py" $
-    .fail "Core type checking failed: Error in datatype Box, constructor Box..Any: Undefined type 'Any'",
+  .mk "test_box_any_type.py" (Expected.failPrefix "Core type checking failed:"),
   -- wrapFieldInAny — class with Any-typed field accessed
-  .mk "test_any_field_access.py" $
-    .fail "Python to Laurel translation failed: Type error: wrapFieldInAny: no Any constructor for field type 'Core(Any)'"
+  .mk "test_any_field_access.py" (Expected.failPrefix "Core type checking failed:")
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -145,7 +145,30 @@ private meta def testCases : List (String × Expected) := [
     .fail "User code error: 'delete_item' called with missing required arguments: [Key]",
   .mk "test_slice.py" .success,
   .mk "test_tuple_for.py" .success,
-  .mk "test_augassign.py" .success
+  .mk "test_augassign.py" .success,
+  -- Cat 3: Box..Any — class with Any-typed field, Box constructor references undefined type
+  .mk "test_box_any_type.py" $
+    .fail "Core type checking failed: Error in datatype Box, constructor Box..Any: Undefined type 'Any'",
+  -- Cat 5: Hole nested in kwarg not lifted before Core translation
+  .mk "test_unlifted_hole.py" $
+    .fail "Laurel to Core translation failed: [holes should have been eliminated before translation (should have been lifted)]",
+  -- Cat 6: wrapFieldInAny — class with Any-typed field accessed
+  .mk "test_any_field_access.py" $
+    .fail "Python to Laurel translation failed: Type error: wrapFieldInAny: no Any constructor for field type 'Core(Any)'",
+  -- Expected failures: known issues to fix (see fix_types_plan.md)
+  -- Cat 1: __init__ not found — user-defined class constructors not registered as procedures
+  .mk "test_class_init_kwargs.py" $
+    .fail "Core type checking failed: [call __init__((~DictStrAny_insert ~DictStrAny_empty #region (~from_string #us-west-2)))]: Procedure __init__ not found!",
+  .mk "test_class_init_noargs.py" $
+    .fail "Core type checking failed: [call __init__()]: Procedure __init__ not found!",
+  -- Cat 2: Any vs Composite — composite-typed var in context expecting Any
+  .mk "test_any_vs_composite.py" $
+    .fail "Core type checking failed: Impossible to unify Any with Composite.",
+  -- Cat 4: __enter__ not found — with statement on unmodeled context manager
+  .mk "test_with_open.py" $
+    .fail "Core type checking failed: [call [f] := __enter__()]: Procedure __enter__ not found!",
+  -- Cat 7: Non-modeled function call arity mismatch
+  .mk "test_nonmodeled_call.py" (Expected.failPrefix "Core type checking failed:")
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -95,12 +95,12 @@ private meta def runAnalyze (dispatchIon : System.FilePath)
     | .ok r => pure r
     | .error err => return .error (toString err)
   match Strata.translateCombinedLaurel laurel with
-  | (some core, []) =>
+  | .error diagnostics => return .error s!"Laurel to Core translation failed: {diagnostics}"
+  | .ok (core, _) =>
     -- Also run Core type checking to catch semantic errors (e.g. Heap vs Any)
     match Core.typeCheck Core.VerifyOptions.quiet core (moreFns := Strata.Python.ReFactory) with
     | .error diag => return .error s!"Core type checking failed: {diag}"
     | .ok _ => return .ok core
-  | (_, errors) => return .error s!"Laurel to Core translation failed: {errors}"
 
 /-- Expected outcome for a test case. -/
 private inductive Expected where

--- a/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTest/Languages/Python/AnalyzeLaurelTest.lean
@@ -137,17 +137,21 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_positional_missing.py" $
     .fail "User code error: 'delete_item' called with missing required arguments: [Key]",
   -- Unsupported Python construct tests (expected failures)
-  .mk "test_slice.py" .success,
+  -- test_slice, test_tuple_for, test_augassign call list_items which returns None;
+  -- assigning void procedure result causes arity mismatch in Core
+  .mk "test_slice.py" (Expected.failPrefix "Core type checking failed:"),
   .mk "test_ternary.py" .success,
-  .mk "test_tuple_for.py" .success,
-  .mk "test_augassign.py" .success,
+  .mk "test_tuple_for.py" (Expected.failPrefix "Core type checking failed:"),
+  .mk "test_augassign.py" (Expected.failPrefix "Core type checking failed:"),
   .mk "test_pow_operator.py" .success,
   -- Import handling: module aliases tracked, attribute access on unmodeled modules → Hole
   .mk "test_import_usage.py" .success,
   .mk "test_except_var_usage.py" .success,
   .mk "test_fstring.py" .success,
-  -- Variable declared inside while loop used after loop (Python scoping)
-  .mk "test_while_var_scope.py" (Expected.failPrefix "Core type checking failed:")
+  -- InstanceCall: simple case passes even with Hole (no while-loop heap interaction)
+  .mk "test_instance_call_result.py" .success,
+  -- InstanceCall: while loop with hoisted variables and instance method calls
+  .mk "test_while_var_scope.py" .success
 ]
 
 /-- Run a single test case and return an error message on failure, or `none` on success. -/

--- a/StrataTest/Languages/Python/DumpCoreTest.lean
+++ b/StrataTest/Languages/Python/DumpCoreTest.lean
@@ -58,7 +58,7 @@ private meta def compilePython
   return ionPath
 
 -- *** CHANGE THIS to investigate a different test ***
-private def scriptName : String := "test_unlifted_hole.py"
+private def scriptName : String := "test_class_init_kwargs.py"
 
 #eval withPython fun _pythonCmd => do
   IO.FS.withTempDir fun tmpDir => do
@@ -78,6 +78,11 @@ private def scriptName : String := "test_unlifted_hole.py"
         | .error err =>
           IO.eprintln s!"pyAnalyzeLaurel failed: {err}"
           return
+
+      -- Dump Laurel IR
+      IO.println "=== Laurel Program ==="
+      IO.println s!"{Strata.Laurel.formatProgram laurel}"
+      IO.println ""
 
       -- Translate to Core
       match Strata.translateCombinedLaurel laurel with

--- a/StrataTest/Languages/Python/DumpCoreTest.lean
+++ b/StrataTest/Languages/Python/DumpCoreTest.lean
@@ -1,0 +1,101 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+meta import Strata.SimpleAPI
+meta import Strata.Languages.Python.PySpecPipeline
+meta import StrataTest.Util.Python
+
+/-! ## Core IR dump for debugging type checking failures
+
+Run with: `lake build StrataTest.Languages.Python.DumpCoreTest`
+-/
+
+namespace Strata.Python.DumpCoreTest
+
+open Strata (pyAnalyzeLaurel pySpecs)
+
+private meta def testDir : System.FilePath :=
+  "StrataTest/Languages/Python/Specs/dispatch_test"
+
+private meta def compilePySpec
+    (dialectFile : System.FilePath) (pyFile : System.FilePath)
+    (outDir : System.FilePath) : IO System.FilePath := do
+  match ← pySpecs pyFile outDir dialectFile
+      (warningOutput := .none) |>.toBaseIO with
+  | .ok () => pure ()
+  | .error msg => throw <| .userError s!"pySpecs failed for {pyFile}: {msg}"
+  let some stem := pyFile.fileStem
+    | throw <| .userError s!"No stem for {pyFile}"
+  return outDir / s!"{stem}.pyspec.st.ion"
+
+private meta def compilePython
+    (dialectFile : System.FilePath) (pyFile : System.FilePath)
+    (outDir : System.FilePath) : IO System.FilePath := do
+  let some stem := pyFile.fileStem
+    | throw <| .userError s!"No stem for {pyFile}"
+  let ionPath := outDir / s!"{stem}.python.st.ion"
+  let spawnArgs : IO.Process.SpawnArgs := {
+    cmd := "python"
+    args := #["-m", "strata.gen", "py_to_strata",
+              "--dialect", dialectFile.toString,
+              pyFile.toString, ionPath.toString]
+    cwd := none
+    inheritEnv := true
+    stdin := .null
+    stdout := .piped
+    stderr := .piped
+  }
+  let child ← IO.Process.spawn spawnArgs
+  let _stdout ← child.stdout.readToEnd
+  let stderr ← child.stderr.readToEnd
+  let exitCode ← child.wait
+  if exitCode ≠ 0 then
+    throw <| .userError s!"py_to_strata failed for {pyFile} (exit {exitCode}): {stderr}"
+  return ionPath
+
+-- *** CHANGE THIS to investigate a different test ***
+private def scriptName : String := "test_unlifted_hole.py"
+
+#eval withPython fun _pythonCmd => do
+  IO.FS.withTempDir fun tmpDir => do
+    IO.FS.withTempFile fun _handle dialectFile => do
+      IO.FS.writeBinFile dialectFile Python.Python.toIon
+      let _ ← compilePySpec dialectFile (testDir / "Storage.py") tmpDir
+      let _ ← compilePySpec dialectFile (testDir / "Messaging.py") tmpDir
+      let dispatchIon ← compilePySpec dialectFile (testDir / "servicelib.py") tmpDir
+
+      let testIon ← compilePython dialectFile (testDir / scriptName) tmpDir
+
+      -- Run pyAnalyzeLaurel
+      let laurel ←
+        match ← Strata.pyAnalyzeLaurel testIon.toString
+            (dispatchPaths := #[dispatchIon.toString]) |>.toBaseIO with
+        | .ok r => pure r
+        | .error err =>
+          IO.eprintln s!"pyAnalyzeLaurel failed: {err}"
+          return
+
+      -- Translate to Core
+      match Strata.translateCombinedLaurel laurel with
+      | (none, diagnostics) =>
+        IO.eprintln s!"Laurel to Core translation failed: {diagnostics}"
+        return
+      | (some core, _) =>
+        -- Dump Core IR
+        IO.println "=== Core Program ==="
+        IO.println s!"{Core.Program.formatWithMetaData core}"
+        IO.println ""
+
+        -- Try type checking and report error with context
+        match Core.typeCheck Core.VerifyOptions.quiet core with
+        | .error diag =>
+          IO.eprintln "=== Type Checking Error ==="
+          IO.eprintln s!"{diag}"
+        | .ok _ =>
+          IO.println "=== Type checking succeeded ==="
+
+end Strata.Python.DumpCoreTest

--- a/StrataTest/Languages/Python/DumpCoreTest.lean
+++ b/StrataTest/Languages/Python/DumpCoreTest.lean
@@ -7,6 +7,7 @@ module
 
 meta import Strata.SimpleAPI
 meta import Strata.Languages.Python.PySpecPipeline
+meta import Strata.Languages.Laurel.LaurelFormat
 meta import StrataTest.Util.Python
 
 /-! ## Core IR dump for debugging type checking failures

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_any_field_access.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_any_field_access.py
@@ -1,0 +1,15 @@
+import servicelib
+
+class Config:
+    region: Any
+    name: str
+
+    def __init__(self, region: str, name: str) -> None:
+        self.region = region
+        self.name = name
+
+def access_any_field() -> str:
+    """Class with Any-typed field — wrapFieldInAny fails for TCore 'Any'."""
+    cfg: Config = Config(region="us-east-1", name="test")
+    r: str = cfg.region
+    return r

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_any_vs_composite.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_any_vs_composite.py
@@ -1,0 +1,11 @@
+import servicelib
+
+def composite_to_any() -> bool:
+    """Service client (Composite after heap param) passed where Any expected."""
+    try:
+        client: Storage = servicelib.connect("storage")
+        client.put_item(Bucket="b", Key="k", Data="d")
+        return True
+    except Exception as e:
+        msg: str = str(e)
+        return False

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_augassign.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_augassign.py
@@ -1,0 +1,8 @@
+import servicelib
+
+def use_augassign() -> bool:
+    client: Storage = servicelib.connect("storage")
+    count: int = 0
+    items: list = client.list_items(Bucket="mybucket")
+    count += 1
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_box_any_type.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_box_any_type.py
@@ -1,0 +1,24 @@
+import servicelib
+
+class Session:
+    data: Any
+    name: str
+
+    def __init__(self, name: str) -> None:
+        self.data = None
+        self.name = name
+
+    def set_data(self, value: Any) -> None:
+        self.data = value
+
+    def get_name(self) -> str:
+        return self.name
+
+def use_box_any() -> bool:
+    """Class with Any-typed field going through heap — Box..Any undefined type."""
+    s: Session = Session(name="test")
+    s.set_data(value="hello")
+    n: str = s.get_name()
+    client: Storage = servicelib.connect("storage")
+    client.put_item(Bucket="b", Key=n, Data="v")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_class_init_kwargs.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_class_init_kwargs.py
@@ -1,0 +1,11 @@
+import servicelib
+
+class MyClient:
+    region: str
+
+    def __init__(self, region: str = "us-east-1") -> None:
+        self.region = region
+
+def use_class_init_kwargs() -> bool:
+    client: MyClient = MyClient(region="us-west-2")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_class_init_noargs.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_class_init_noargs.py
@@ -1,0 +1,11 @@
+import servicelib
+
+class SimpleClient:
+    active: bool
+
+    def __init__(self) -> None:
+        self.active = True
+
+def use_class_init_noargs() -> bool:
+    client: SimpleClient = SimpleClient()
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_except_var_usage.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_except_var_usage.py
@@ -1,0 +1,10 @@
+import servicelib
+
+def except_var_usage() -> bool:
+    client: Storage = servicelib.connect("storage")
+    try:
+        client.put_item(Bucket="b", Key="k", Data="v")
+    except Exception as e:
+        msg: str = str(e)
+        return False
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_fstring.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_fstring.py
@@ -1,0 +1,8 @@
+import servicelib
+
+def use_fstring() -> bool:
+    client: Storage = servicelib.connect("storage")
+    name: str = "backup"
+    bucket: str = f"{name}_bucket"
+    client.put_item(Bucket=bucket, Key="k", Data="v")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_import_usage.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_import_usage.py
@@ -1,0 +1,8 @@
+import servicelib
+import sys
+
+def use_import() -> bool:
+    client: Storage = servicelib.connect("storage")
+    name: str = sys.argv[1]
+    client.put_item(Bucket="b", Key=name, Data="v")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_instance_call_result.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_instance_call_result.py
@@ -1,0 +1,7 @@
+import servicelib
+
+def get_and_return() -> str:
+    client: Storage = servicelib.connect("storage")
+    result = client.get_item(Bucket="b", Key="k")
+    msg: str = result
+    return msg

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_nonmodeled_call.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_nonmodeled_call.py
@@ -1,0 +1,9 @@
+import servicelib
+from datetime import datetime, timezone
+
+def use_nonmodeled_call() -> bool:
+    """Non-modeled function call (datetime.now) produces arity mismatch."""
+    now: datetime = datetime.now(timezone.utc)
+    client: Storage = servicelib.connect("storage")
+    client.put_item(Bucket="b", Key="ts", Data="val")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_pow_operator.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_pow_operator.py
@@ -1,0 +1,7 @@
+import servicelib
+
+def use_pow() -> bool:
+    base: int = 2
+    exp: int = 10
+    result: int = base ** exp
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_slice.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_slice.py
@@ -1,0 +1,7 @@
+import servicelib
+
+def use_slice() -> bool:
+    client: Storage = servicelib.connect("storage")
+    items: list = client.list_items(Bucket="mybucket")
+    subset: list = items[1:]
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_ternary.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_ternary.py
@@ -1,0 +1,8 @@
+import servicelib
+
+def use_ternary() -> bool:
+    client: Storage = servicelib.connect("storage")
+    flag: bool = True
+    bucket: str = "a" if flag else "b"
+    client.put_item(Bucket=bucket, Key="k", Data="v")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_tuple_for.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_tuple_for.py
@@ -1,0 +1,8 @@
+import servicelib
+
+def use_tuple_for() -> bool:
+    client: Storage = servicelib.connect("storage")
+    pairs: list = client.list_items(Bucket="mybucket")
+    for k, v in pairs:
+        client.put_item(Bucket="out", Key=k, Data=v)
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_unlifted_hole.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_unlifted_hole.py
@@ -1,0 +1,8 @@
+import servicelib
+from datetime import datetime
+
+def use_unlifted_hole() -> bool:
+    """Hole (datetime.utcnow()) nested inside kwarg — not lifted before Core."""
+    client: Storage = servicelib.connect("storage")
+    client.put_item(Bucket="b", Key=str(datetime.utcnow()), Data="val")
+    return True

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_while_var_scope.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_while_var_scope.py
@@ -1,0 +1,11 @@
+import servicelib
+
+def while_var_scope() -> str:
+    client: Storage = servicelib.connect("storage")
+    done: bool = False
+    while not done:
+        result: Any = client.get_item(Bucket="b", Key="status")
+        status: str = result
+        if status == "done":
+            done = True
+    return status

--- a/StrataTest/Languages/Python/Specs/dispatch_test/test_with_open.py
+++ b/StrataTest/Languages/Python/Specs/dispatch_test/test_with_open.py
@@ -1,0 +1,9 @@
+import servicelib
+
+def use_with_statement() -> bool:
+    """with statement on unmodeled context manager — __enter__/__exit__ not found."""
+    client: Storage = servicelib.connect("storage")
+    result = client.get_item(Bucket="b", Key="k")
+    with open("output.json", "w") as f:
+        f.write("done")
+    return True

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -5,6 +5,7 @@
 -/
 
 import Strata.Languages.Python.Specs.ToLaurel
+import Strata.Languages.Laurel.LaurelFormat
 
 namespace Strata.Python.Specs.ToLaurel.Tests
 
@@ -43,34 +44,16 @@ private def mkFuncSig (name : String) (returnType : SpecType)
 
 /-! ## Output Formatting -/
 
-private def fmtHighType : HighType → String
-  | .TVoid => "TVoid"
-  | .TBool => "TBool"
-  | .TInt => "TInt"
-  | .TReal => "TReal"
-  | .TFloat64 => "TFloat64"
-  | .TString => "TString"
-  | .THeap => "THeap"
-  | .TTypedField _ => "TTypedField"
-  | .TSet _ => "TSet"
-  | .TMap _ _ => "TMap"
-  | .UserDefined name => s!"UserDefined({name})"
-  | .Applied _ _ => "Applied"
-  | .Pure _ => "Pure"
-  | .Intersection _ => "Intersection"
-  | .TCore s => s!"TCore({s})"
-  | HighType.Unknown => "Unknown"
-
-private def fmtParam (p : Parameter) : String :=
-  s!"{p.name}:{fmtHighType p.type.val}"
-
 private def fmtProc (p : Procedure) : String :=
-  let inputs := ", ".intercalate (p.inputs.map fmtParam)
-  let returns := ", ".intercalate (p.outputs.map fmtParam)
-  if returns.isEmpty then
+  let inputs := ", ".intercalate (p.inputs.map fun i => s!"{Laurel.formatParameter i}")
+  let returns := ", ".intercalate (p.outputs.map fun o => s!"{Laurel.formatParameter o}")
+  let sig := if returns.isEmpty then
     s!"procedure {p.name}({inputs})"
   else
     s!"procedure {p.name}({inputs}) returns({returns})"
+  let reqs := p.preconditions.map fun pre =>
+    s!" requires {Laurel.formatStmtExprVal pre.val}"
+  sig ++ String.join reqs
 
 private def fmtTypeDef : TypeDefinition → String
   | .Composite ty => s!"type {ty.name}"
@@ -98,10 +81,10 @@ private def noneAtom := SpecAtomType.noneType
 /-! ## Primitive and builtin types as args and return types -/
 
 /--
-info: procedure returns_int(x:TCore(Any)) returns(result:TCore(Any))
-procedure returns_bool(a:TCore(Any), b:TCore(Any)) returns(result:TCore(Any))
-procedure returns_real(flag:TCore(Any)) returns(result:TCore(Any))
-procedure with_kwonly(x:TCore(Any), verbose:TCore(Any)) returns(result:TCore(Any))
+info: procedure returns_int(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
+procedure returns_bool(a: Core(Any), b: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(a)
+procedure returns_real(flag: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_bool(flag)
+procedure with_kwonly(x: Core(Any), verbose: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(x) requires Any..isfrom_bool(verbose)
 -/
 #guard_msgs in
 #eval runTest #[
@@ -120,12 +103,12 @@ procedure with_kwonly(x:TCore(Any), verbose:TCore(Any)) returns(result:TCore(Any
 /-! ## Complex types (Any, List, Dict, bytes) -/
 
 /--
-info: procedure takes_any(x:TCore(Any)) returns(result:TCore(Any))
-procedure takes_list(items:TCore(Any)) returns(result:TCore(Any))
-procedure returns_dict() returns(result:TCore(Any))
-procedure returns_bytes() returns(result:TCore(Any))
-procedure typed_list() returns(result:TCore(Any))
-procedure typed_dict() returns(result:TCore(Any))
+info: procedure takes_any(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
+procedure takes_list(items: Core(Any)) returns(result: Core(Any))
+procedure returns_dict() returns(result: Core(Any))
+procedure returns_bytes() returns(result: Core(Any))
+procedure typed_list() returns(result: Core(Any))
+procedure typed_dict() returns(result: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -145,10 +128,10 @@ procedure typed_dict() returns(result:TCore(Any))
 /-! ## Literal types, TypedDict, and string-literal unions -/
 
 /--
-info: procedure int_literal_ret() returns(result:TCore(Any))
-procedure str_literal_ret() returns(result:TCore(Any))
-procedure typed_dict_ret() returns(result:TCore(Any))
-procedure str_enum() returns(result:TCore(Any))
+info: procedure int_literal_ret() returns(result: Core(Any))
+procedure str_literal_ret() returns(result: Core(Any))
+procedure typed_dict_ret() returns(result: Core(Any))
+procedure str_enum() returns(result: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -166,17 +149,17 @@ procedure str_enum() returns(result:TCore(Any))
 /-! ## Optional type patterns (Union[None, T]) -/
 
 /--
-info: procedure opt_str() returns(result:TCore(Any))
-procedure opt_int() returns(result:TCore(Any))
-procedure opt_bool(x:TCore(Any)) returns(result:TCore(Any))
-procedure opt_float() returns(result:TCore(Any))
-procedure opt_list() returns(result:TCore(Any))
-procedure opt_dict() returns(result:TCore(Any))
-procedure opt_any() returns(result:TCore(Any))
-procedure opt_bytes() returns(result:TCore(Any))
-procedure opt_typed_dict() returns(result:TCore(Any))
-procedure opt_str_enum() returns(result:TCore(Any))
-procedure opt_int_enum() returns(result:TCore(Any))
+info: procedure opt_str() returns(result: Core(Any))
+procedure opt_int() returns(result: Core(Any))
+procedure opt_bool(x: Core(Any)) returns(result: Core(Any))
+procedure opt_float() returns(result: Core(Any))
+procedure opt_list() returns(result: Core(Any))
+procedure opt_dict() returns(result: Core(Any))
+procedure opt_any() returns(result: Core(Any))
+procedure opt_bytes() returns(result: Core(Any))
+procedure opt_typed_dict() returns(result: Core(Any))
+procedure opt_str_enum() returns(result: Core(Any))
+procedure opt_int_enum() returns(result: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -248,8 +231,8 @@ info: Union type (None | foo.Bar) not yet supported in Laurel
 /--
 info: type MyClass
 type MyAlias
-procedure my_func(x:TCore(Any), y:TCore(Any)) returns(result:TCore(Any))
-procedure MyClass_get_value() returns(result:TCore(Any))
+procedure my_func(x: Core(Any), y: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(x) requires Any..isfrom_string(y)
+procedure MyClass_get_value() returns(result: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -278,7 +261,7 @@ procedure MyClass_get_value() returns(result:TCore(Any))
 
 /--
 info: procedure returns_none()
-procedure takes_none(x:TCore(Any))
+procedure takes_none(x: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -291,7 +274,7 @@ procedure takes_none(x:TCore(Any))
 
 /--
 info: type Foo
-procedure uses_class(x:TCore(Any)) returns(result:TCore(Any))
+procedure uses_class(x: Core(Any)) returns(result: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -359,8 +342,8 @@ private def runDispatchTest (sigs : Array Signature) : IO Unit := do
 -- and a regular function.
 /--
 info: type SvcClient
-procedure SvcClient_do_thing(x:TCore(Any)) returns(result:TCore(Any))
-procedure helper() returns(result:TCore(Any))
+procedure SvcClient_do_thing(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
+procedure helper() returns(result: Core(Any))
 dispatch create_client:
   "svc_a" -> mod.client.SvcClient
   "svc_b" -> mod.other.OtherClient

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -232,7 +232,7 @@ info: Union type (None | foo.Bar) not yet supported in Laurel
 info: type MyClass
 type MyAlias
 procedure my_func(x: Core(Any), y: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(x) requires Any..isfrom_string(y)
-procedure MyClass_get_value() returns(result: Core(Any))
+procedure MyClass_get_value(self: Composite) returns(result: Core(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -342,7 +342,7 @@ private def runDispatchTest (sigs : Array Signature) : IO Unit := do
 -- and a regular function.
 /--
 info: type SvcClient
-procedure SvcClient_do_thing(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
+procedure SvcClient_do_thing(self: Composite, x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
 procedure helper() returns(result: Core(Any))
 dispatch create_client:
   "svc_a" -> mod.client.SvcClient

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -103,9 +103,7 @@ procedure with_kwonly(x: Core(Any), verbose: Core(Any)) returns(result: Core(Any
 /-! ## Complex types (Any, List, Dict, bytes) -/
 
 /--
-info: procedure takes_any(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
-procedure takes_list(items: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_ListAny(items)
-procedure returns_dict() returns(result: Core(Any))
+info: procedure takes_any(x: Core(Any)) returns(result: Core(Any))
 procedure returns_bytes() returns(result: Core(Any))
 procedure typed_list() returns(result: Core(Any))
 procedure typed_dict() returns(result: Core(Any))
@@ -114,9 +112,6 @@ procedure typed_dict() returns(result: Core(Any))
 #eval runTest #[
   mkFuncSig "takes_any" (identType .builtinsInt)
     (args := #[mkArg "x" (identType .typingAny)]),
-  mkFuncSig "takes_list" (identType .builtinsBool)
-    (args := #[mkArg "items" (identType .typingList)]),
-  mkFuncSig "returns_dict" (identType .typingDict),
   mkFuncSig "returns_bytes" (identType .builtinsBytes),
   mkFuncSig "typed_list"
     (mkType (.ident .typingList #[identType .builtinsStr])),
@@ -124,6 +119,21 @@ procedure typed_dict() returns(result: Core(Any))
     (mkType (.ident .typingDict
       #[identType .builtinsStr, identType .builtinsInt]))
 ]
+
+/--
+info: Bare List without element type not supported: element type may include composites incompatible with Any
+-/
+#guard_msgs in
+#eval runTestErrors
+  #[mkFuncSig "takes_list" (identType .builtinsBool)
+    (args := #[mkArg "items" (identType .typingList)])]
+
+/--
+info: Bare Dict without type args not supported: value type may include composites incompatible with Any
+-/
+#guard_msgs in
+#eval runTestErrors
+  #[mkFuncSig "returns_dict" (identType .typingDict)]
 
 /-! ## Literal types, TypedDict, and string-literal unions -/
 
@@ -153,8 +163,6 @@ info: procedure opt_str() returns(result: Core(Any))
 procedure opt_int() returns(result: Core(Any))
 procedure opt_bool(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_none(x) | Any..isfrom_string(x)
 procedure opt_float() returns(result: Core(Any))
-procedure opt_list() returns(result: Core(Any))
-procedure opt_dict() returns(result: Core(Any))
 procedure opt_any() returns(result: Core(Any))
 procedure opt_bytes() returns(result: Core(Any))
 procedure opt_typed_dict() returns(result: Core(Any))
@@ -173,10 +181,6 @@ procedure opt_int_enum() returns(result: Core(Any))
       (mkUnion #[noneAtom, identAtom .builtinsStr])]),
   mkFuncSig "opt_float"
     (mkUnion #[noneAtom, identAtom .builtinsFloat]),
-  mkFuncSig "opt_list"
-    (mkUnion #[noneAtom, identAtom .typingList]),
-  mkFuncSig "opt_dict"
-    (mkUnion #[noneAtom, identAtom .typingDict]),
   mkFuncSig "opt_any"
     (mkUnion #[noneAtom, identAtom .typingAny]),
   mkFuncSig "opt_bytes"
@@ -191,10 +195,26 @@ procedure opt_int_enum() returns(result: Core(Any))
     (mkUnion #[noneAtom, .intLiteral 1, .intLiteral 2])
 ]
 
+/--
+info: Union type (None | typing.List) not yet supported
+-/
+#guard_msgs in
+#eval runTestErrors
+  #[mkFuncSig "opt_list"
+    (mkUnion #[noneAtom, identAtom .typingList])]
+
+/--
+info: Union type (None | typing.Dict) not yet supported
+-/
+#guard_msgs in
+#eval runTestErrors
+  #[mkFuncSig "opt_dict"
+    (mkUnion #[noneAtom, identAtom .typingDict])]
+
 /-! ## Error cases -/
 
 /--
-info: Unknown type 'foo.Bar' mapped to TString
+info: No Any precondition for ident type 'foo.Bar'
 -/
 #guard_msgs in
 #eval runTestErrors
@@ -202,14 +222,14 @@ info: Unknown type 'foo.Bar' mapped to TString
     (identType (PythonIdent.mk "foo" "Bar"))]
 
 /--
-info: Empty type (no atoms) encountered in Laurel conversion
+info: Empty type (no atoms) encountered
 -/
 #guard_msgs in
 #eval runTestErrors
   #[mkFuncSig "f" { atoms := #[], loc := default }]
 
 /--
-info: Union type (builtins.str | builtins.int) not yet supported in Laurel
+info: Union type (builtins.str | builtins.int) not yet supported
 -/
 #guard_msgs in
 #eval runTestErrors
@@ -218,7 +238,7 @@ info: Union type (builtins.str | builtins.int) not yet supported in Laurel
                identAtom .builtinsInt])]
 
 /--
-info: Union type (None | foo.Bar) not yet supported in Laurel
+info: Union type (None | foo.Bar) not yet supported
 -/
 #guard_msgs in
 #eval runTestErrors
@@ -274,7 +294,7 @@ procedure takes_none(x: Core(Any))
 
 /--
 info: type Foo
-procedure uses_class(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_ClassInstance(x)
+procedure uses_class(x: Composite) returns(result: Composite)
 -/
 #guard_msgs in
 #eval runTest #[

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -82,7 +82,7 @@ private def noneAtom := SpecAtomType.noneType
 
 /--
 info: procedure returns_int(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
-procedure returns_bool(a: Core(Any), b: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(a)
+procedure returns_bool(a: Core(Any), b: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(a) requires Any..isfrom_float(b)
 procedure returns_real(flag: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_bool(flag)
 procedure with_kwonly(x: Core(Any), verbose: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_int(x) requires Any..isfrom_bool(verbose)
 -/
@@ -104,7 +104,7 @@ procedure with_kwonly(x: Core(Any), verbose: Core(Any)) returns(result: Core(Any
 
 /--
 info: procedure takes_any(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_string(x)
-procedure takes_list(items: Core(Any)) returns(result: Core(Any))
+procedure takes_list(items: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_ListAny(items)
 procedure returns_dict() returns(result: Core(Any))
 procedure returns_bytes() returns(result: Core(Any))
 procedure typed_list() returns(result: Core(Any))
@@ -151,7 +151,7 @@ procedure str_enum() returns(result: Core(Any))
 /--
 info: procedure opt_str() returns(result: Core(Any))
 procedure opt_int() returns(result: Core(Any))
-procedure opt_bool(x: Core(Any)) returns(result: Core(Any))
+procedure opt_bool(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_none(x) | Any..isfrom_string(x)
 procedure opt_float() returns(result: Core(Any))
 procedure opt_list() returns(result: Core(Any))
 procedure opt_dict() returns(result: Core(Any))
@@ -274,7 +274,7 @@ procedure takes_none(x: Core(Any))
 
 /--
 info: type Foo
-procedure uses_class(x: Core(Any)) returns(result: Core(Any))
+procedure uses_class(x: Core(Any)) returns(result: Core(Any)) requires Any..isfrom_ClassInstance(x)
 -/
 #guard_msgs in
 #eval runTest #[

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -98,10 +98,10 @@ private def noneAtom := SpecAtomType.noneType
 /-! ## Primitive and builtin types as args and return types -/
 
 /--
-info: procedure returns_int(x:TString) returns(result:TInt)
-procedure returns_bool(a:TInt, b:TReal) returns(result:TBool)
-procedure returns_real(flag:TBool) returns(result:TReal)
-procedure with_kwonly(x:TInt, verbose:TBool) returns(result:TString)
+info: procedure returns_int(x:TCore(Any)) returns(result:TCore(Any))
+procedure returns_bool(a:TCore(Any), b:TCore(Any)) returns(result:TCore(Any))
+procedure returns_real(flag:TCore(Any)) returns(result:TCore(Any))
+procedure with_kwonly(x:TCore(Any), verbose:TCore(Any)) returns(result:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -120,12 +120,12 @@ procedure with_kwonly(x:TInt, verbose:TBool) returns(result:TString)
 /-! ## Complex types (Any, List, Dict, bytes) -/
 
 /--
-info: procedure takes_any(x:TString) returns(result:TInt)
-procedure takes_list(items:TCore(ListStr)) returns(result:TBool)
-procedure returns_dict() returns(result:TCore(DictStrAny))
-procedure returns_bytes() returns(result:TString)
-procedure typed_list() returns(result:TCore(ListStr))
-procedure typed_dict() returns(result:TCore(DictStrAny))
+info: procedure takes_any(x:TCore(Any)) returns(result:TCore(Any))
+procedure takes_list(items:TCore(Any)) returns(result:TCore(Any))
+procedure returns_dict() returns(result:TCore(Any))
+procedure returns_bytes() returns(result:TCore(Any))
+procedure typed_list() returns(result:TCore(Any))
+procedure typed_dict() returns(result:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -145,10 +145,10 @@ procedure typed_dict() returns(result:TCore(DictStrAny))
 /-! ## Literal types, TypedDict, and string-literal unions -/
 
 /--
-info: procedure int_literal_ret() returns(result:TInt)
-procedure str_literal_ret() returns(result:TString)
-procedure typed_dict_ret() returns(result:TCore(DictStrAny))
-procedure str_enum() returns(result:TString)
+info: procedure int_literal_ret() returns(result:TCore(Any))
+procedure str_literal_ret() returns(result:TCore(Any))
+procedure typed_dict_ret() returns(result:TCore(Any))
+procedure str_enum() returns(result:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -166,17 +166,17 @@ procedure str_enum() returns(result:TString)
 /-! ## Optional type patterns (Union[None, T]) -/
 
 /--
-info: procedure opt_str() returns(result:TCore(StrOrNone))
-procedure opt_int() returns(result:TCore(IntOrNone))
-procedure opt_bool(x:TCore(StrOrNone)) returns(result:TCore(BoolOrNone))
-procedure opt_float() returns(result:TString)
-procedure opt_list() returns(result:TString)
-procedure opt_dict() returns(result:TString)
-procedure opt_any() returns(result:TString)
-procedure opt_bytes() returns(result:TString)
-procedure opt_typed_dict() returns(result:TCore(DictStrAny))
-procedure opt_str_enum() returns(result:TCore(StrOrNone))
-procedure opt_int_enum() returns(result:TCore(IntOrNone))
+info: procedure opt_str() returns(result:TCore(Any))
+procedure opt_int() returns(result:TCore(Any))
+procedure opt_bool(x:TCore(Any)) returns(result:TCore(Any))
+procedure opt_float() returns(result:TCore(Any))
+procedure opt_list() returns(result:TCore(Any))
+procedure opt_dict() returns(result:TCore(Any))
+procedure opt_any() returns(result:TCore(Any))
+procedure opt_bytes() returns(result:TCore(Any))
+procedure opt_typed_dict() returns(result:TCore(Any))
+procedure opt_str_enum() returns(result:TCore(Any))
+procedure opt_int_enum() returns(result:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -248,8 +248,8 @@ info: Union type (None | foo.Bar) not yet supported in Laurel
 /--
 info: type MyClass
 type MyAlias
-procedure my_func(x:TInt, y:TString) returns(result:TBool)
-procedure MyClass_get_value() returns(result:TString)
+procedure my_func(x:TCore(Any), y:TCore(Any)) returns(result:TCore(Any))
+procedure MyClass_get_value() returns(result:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -278,7 +278,7 @@ procedure MyClass_get_value() returns(result:TString)
 
 /--
 info: procedure returns_none()
-procedure takes_none(x:TVoid)
+procedure takes_none(x:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -291,7 +291,7 @@ procedure takes_none(x:TVoid)
 
 /--
 info: type Foo
-procedure uses_class(x:UserDefined(Foo)) returns(result:UserDefined(Foo))
+procedure uses_class(x:TCore(Any)) returns(result:TCore(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -359,8 +359,8 @@ private def runDispatchTest (sigs : Array Signature) : IO Unit := do
 -- and a regular function.
 /--
 info: type SvcClient
-procedure SvcClient_do_thing(x:TString) returns(result:TInt)
-procedure helper() returns(result:TBool)
+procedure SvcClient_do_thing(x:TCore(Any)) returns(result:TCore(Any))
+procedure helper() returns(result:TCore(Any))
 dispatch create_client:
   "svc_a" -> mod.client.SvcClient
   "svc_b" -> mod.other.OtherClient


### PR DESCRIPTION
Fix end-to-end translation of `target.method(args)` instance calls, control flow constructs (return, break/continue, while loops, nested try/except), and 10 previously unsupported Python constructs that caused the pipeline to fail with translation or type errors.

- Emit `InstanceCall` from PythonToLaurel for `target.method(args)` patterns and translate through Laurel resolution and Core translator with self-stripping, since PySpec already strips `self` from method signatures.
- PySpec procedures now declare `Any`-typed parameters with preconditions (`requires Any..isfrom_string(x)`), keeping the Core translator language-agnostic.
- Handle void procedures (0 outputs) when their result is assigned to a variable — emit call without assignment target to avoid Core arity mismatch.
- Translate `return` as `Exit "$body"` instead of assigning to the first output parameter, which after heap parameterization could clobber `$heap`. Generate unique labels for nested try/except blocks. Hoist while loop variables to function scope. Translate break/continue via labeled `Exit`.
- Translate augmented assignment (`+=`, `-=`, `*=`), `**` operator, f-strings, ternary expressions, slicing, tuple for-targets, and import tracking. Emit `Hole` for dict/set comprehensions and generators. Type exception variables as `Any`.
- Add regression tests exercising the fixes through the dispatch/heap-parameterization path:
  - `test_instance_call_result.py` — assign result of `client.get_item()` to a variable and return it (the core InstanceCall bug this PR fixes).
  - `test_while_var_scope.py` — variables declared inside a while loop body must be accessible after the loop exits; exercises while-loop hoisting.
  - `test_augassign.py` — augmented assignment (`count += 1`) after a service call.
  - `test_pow_operator.py` — `**` power operator (`base ** exp`).
  - `test_fstring.py` — f-string interpolation (`f"{name}_bucket"`) used as a service call argument.
  - `test_ternary.py` — ternary/conditional expression (`"a" if flag else "b"`) used as a service call argument.
  - `test_slice.py` — list slicing (`items[1:]`) on a service call result.
  - `test_tuple_for.py` — tuple unpacking in for-loop targets (`for k, v in pairs`).
  - `test_import_usage.py` — referencing an imported module (`sys.argv[1]`) as a service call argument; exercises `moduleAliases` tracking.
  - `test_except_var_usage.py` — using the exception variable (`as e`) inside an except block; exercises exception variable typing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.