### PR TITLE
fix(laurel): local variable no longer shadows output parameter

### DIFF
--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -358,33 +358,45 @@ def translateStmt (outputParams : List Parameter) (stmt : StmtExprMd)
       let coreMonoType := translateType model ty
       let coreType := LTy.forAll [] coreMonoType
       let ident := ⟨id.text, ()⟩
+      -- When a local variable has the same name as an output parameter, the
+      -- variable already exists in Core.  Emit `set`/`havoc` instead of `init`
+      -- to avoid shadowing the output parameter (see issue #567).
+      let isOutputParam := outputParams.any (fun p => p.name.text == id.text)
+      let intro (e : Option Core.Expression.Expr) : List Core.Statement :=
+        if isOutputParam then
+          match e with
+          | some v => [Core.Statement.set ident v md]
+          | none   => [Core.Statement.havoc ident md]
+        else
+          [Core.Statement.init ident coreType e md]
       match initializer with
       | some (⟨ .StaticCall callee args, callMd⟩) =>
           -- Check if this is a function or a procedure call
           if model.isFunction callee then
             -- Translate as expression (function application)
             let coreExpr ← translateExpr (⟨ .StaticCall callee args, callMd ⟩)
-            return [Core.Statement.init ident coreType (some coreExpr) md]
+            return intro (some coreExpr)
           else
-            -- Translate as: var name; call name := callee(args)
+            -- Procedure call: call name := callee(args)
             let coreArgs ← args.mapM (fun a => translateExpr a)
-            let defaultExpr := defaultExprForType model ty
-            let initStmt := Core.Statement.init ident coreType (some defaultExpr) md
             let callStmt := Core.Statement.call [ident] callee.text coreArgs md
-            return [initStmt, callStmt]
+            if isOutputParam then
+              return [callStmt]
+            else
+              let defaultExpr := defaultExprForType model ty
+              return [Core.Statement.init ident coreType (some defaultExpr) md, callStmt]
       | some (⟨ .InstanceCall .., _⟩) =>
           -- Instance method call as initializer: var name := target.method(args)
           -- Havoc the result since instance methods may be on unmodeled types
-          let initStmt := Core.Statement.init ident coreType none md
-          return [initStmt]
+          return intro none
       | some (⟨ .Hole _ _, _⟩) =>
           -- Hole initializer: treat as havoc (init without value)
-          return [Core.Statement.init ident coreType none md]
+          return intro none
       | some initExpr =>
           let coreExpr ← translateExpr initExpr
-          return [Core.Statement.init ident coreType (some coreExpr) md]
+          return intro (some coreExpr)
       | none =>
-          return [Core.Statement.init ident coreType none md]
+          return intro none
   | .Assign targets value =>
       match targets with
       | [⟨ .Identifier targetId, _ ⟩] =>

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T18_LocalVarShadowsOutput.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T18_LocalVarShadowsOutput.lean
@@ -1,0 +1,91 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import StrataTest.Util.TestDiagnostics
+import StrataTest.Languages.Laurel.TestExamples
+
+open StrataTest.Util
+open Strata
+
+namespace Strata.Laurel
+
+def program := r"
+// Issue #567: local variable with the same name as an output parameter
+// shadows it, causing the return value to be lost.
+
+// Case 1: expression initializer (auto-generated `result` name)
+procedure double(x: int) returns (result: int)
+  ensures result == x + x
+{
+  var result: int := x + x;
+  return result
+};
+
+procedure testDouble() {
+  var y: int := double(3);
+  assert y == 6
+};
+
+// Case 2: expression initializer (user-named output param)
+procedure triple(x: int) returns (r: int)
+  ensures r == x + x + x
+{
+  var r: int := x + x + x;
+  return r
+};
+
+procedure testTriple() {
+  var y: int := triple(2);
+  assert y == 6
+};
+
+// Case 3: no initializer (havoc path)
+procedure nondetPositive() returns (r: int)
+  ensures r > 0
+{
+  var r: int;
+  assume r > 0;
+  return r
+};
+
+// Case 4: procedure call as initializer
+procedure helper(x: int) returns (out: int)
+  ensures out == x * 2
+{
+  out := x * 2
+};
+
+procedure callInit(x: int) returns (out: int)
+  ensures out == x * 2
+{
+  var out: int := helper(x);
+  return out
+};
+
+procedure testCallInit() {
+  var y: int := callInit(5);
+  assert y == 10
+};
+
+// Case 5: output param used as scratch, then overwritten by return
+procedure scratch(x: int) returns (r: int)
+  ensures r == x
+{
+  var r: int := 99;
+  r := x;
+  return r
+};
+
+procedure testScratch() {
+  var y: int := scratch(7);
+  assert y == 7
+};
+"
+
+#guard_msgs (drop info, error) in
+#eval testInputWithOffset "LocalVarShadowsOutput" program 15 processLaurelFile
+
+end Laurel


### PR DESCRIPTION
Fixes #567.

## Problem

When a Laurel procedure declares a local variable with the same name as an output parameter (e.g. `var result: int := x + x` in a procedure with `returns (result: int)`), the generated Core emits `init result` inside the `$body` block, which shadows the output parameter. The `return` statement then assigns the local to itself, and the output parameter is never written.

## Fix

In `translateStmt` for `LocalVariable`: when the variable name matches an output parameter, emit `set`/`havoc` instead of `init`, since the variable already exists in Core as the output parameter.

- `init name type (some expr)` → `set name expr`
- `init name type none` → `havoc name`
- `init` before `call` → dropped (the `call` writes to the existing variable directly)

## Before

```
procedure double (x : int) returns (result : int)
{
  $body: {
    var result : int := x + x;   // shadows output param
    result := result;            // self-assignment on local
    exit $body;
  }
};
```

## After

```
procedure double (x : int) returns (result : int)
{
  $body: {
    result := x + x;             // assigns to output param
    result := result;            // harmless self-assignment
    exit $body;
  }
};
```

## Tests

New test `T18_LocalVarShadowsOutput` covers five cases:
1. Expression initializer with auto-generated `result` name
2. Expression initializer with user-named output param
3. No initializer (havoc path)
4. Procedure call as initializer
5. Output param used as scratch, then overwritten by return