### PR TITLE
ci: run lake test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,8 @@ jobs:
           key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
       - name: Build and run StrataVerify
         run: lake exe StrataVerify Examples/SimpleProc.core.st
+      - name: Run Lean tests
+        run: lake test
       - name: Build BoogieToStrata
         run: dotnet build -warnaserror ${SOLUTION}
       - name: Test BoogieToStrata


### PR DESCRIPTION
The Lean test suite (`lake test`) has not been run in CI since July 2025 (commit 66740c64). This means 213 test files are not checked, and test regressions go unnoticed.

This PR re-enables `lake test`. It is expected to fail due to a pre-existing test regression in `FailingAssertion.lean` caused by the SMT model output change in e9f9024b (merged 2026-03-25).