### PR TITLE
cleanup: rename redundant Optional* grammar categories

### DIFF
--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -189,7 +189,7 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let cond ← translateStmtExpr arg0
       let md' ← match errMsgArg with
         | .option _ (some (.op errOp)) => match errOp.name, errOp.args with
-          | q`Laurel.errorMessage, #[strArg] => do
+          | q`Laurel.errorSummary, #[strArg] => do
             let msg ← translateString strArg
             pure (md.withPropertySummary msg)
           | _, _ => pure md
@@ -224,7 +224,7 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let name ← translateIdent arg0
       let varType ← match typeArg with
         | .option _ (some (.op typeOp)) => match typeOp.name, typeOp.args with
-          | q`Laurel.optionalType, #[typeArg0] => translateHighType typeArg0
+          | q`Laurel.typeAnnotation, #[typeArg0] => translateHighType typeArg0
           | _, _ => TransM.error s!"Variable {name} requires explicit type"
         | _ => TransM.error s!"Variable {name} requires explicit type"
       let value ← match assignArg with
@@ -270,7 +270,7 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let thenBranch ← translateStmtExpr arg1
       let elseBranch ← match elseArg with
         | .option _ (some (.op elseOp)) => match elseOp.name, elseOp.args with
-          | q`Laurel.optionalElse, #[elseArg0] => translateStmtExpr elseArg0 >>= (pure ∘ some)
+          | q`Laurel.elseBranch, #[elseArg0] => translateStmtExpr elseArg0 >>= (pure ∘ some)
           | _, _ => pure none
         | _ => pure none
       return mkStmtExprMd (.IfThenElse cond thenBranch elseBranch) md
@@ -310,7 +310,7 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let ty ← translateHighType tyArg
       let trigger ← match triggerArg with
         | .option _ (some (.op triggerOp)) => match triggerOp.name, triggerOp.args with
-          | q`Laurel.optionalTrigger, #[triggerExprArg] =>
+          | q`Laurel.trigger, #[triggerExprArg] =>
             translateStmtExpr triggerExprArg >>= (pure ∘ some)
           | _, _ => pure none
         | _ => pure none
@@ -321,7 +321,7 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let ty ← translateHighType tyArg
       let trigger ← match triggerArg with
         | .option _ (some (.op triggerOp)) => match triggerOp.name, triggerOp.args with
-          | q`Laurel.optionalTrigger, #[triggerExprArg] =>
+          | q`Laurel.trigger, #[triggerExprArg] =>
             translateStmtExpr triggerExprArg >>= (pure ∘ some)
           | _, _ => pure none
         | _ => pure none
@@ -387,7 +387,7 @@ def translateRequiresClauses (arg : Arg) : TransM (List StmtExprMd) := do
           let expr ← translateStmtExpr exprArg
           let expr' ← match errMsgArg with
             | .option _ (some (.op errOp)) => match errOp.name, errOp.args with
-              | q`Laurel.errorMessage, #[strArg] => do
+              | q`Laurel.errorSummary, #[strArg] => do
                 let msg ← translateString strArg
                 pure { expr with md := expr.md.withPropertySummary msg }
               | _, _ => pure expr
@@ -409,7 +409,7 @@ def translateEnsuresClauses (arg : Arg) : TransM (List StmtExprMd) := do
           let expr ← translateStmtExpr exprArg
           let expr' ← match errMsgArg with
             | .option _ (some (.op errOp)) => match errOp.name, errOp.args with
-              | q`Laurel.errorMessage, #[strArg] => do
+              | q`Laurel.errorSummary, #[strArg] => do
                 let msg ← translateString strArg
                 pure { expr with md := expr.md.withPropertySummary msg }
               | _, _ => pure expr
@@ -436,7 +436,7 @@ def parseProcedure (arg : Arg) : TransM Procedure := do
     -- If returnTypeArg is set, create a single "result" parameter
     let returnParameters ← match returnTypeArg with
       | .option _ (some (.op returnTypeOp)) => match returnTypeOp.name, returnTypeOp.args with
-        | q`Laurel.optionalReturnType, #[typeArg] =>
+        | q`Laurel.returnType, #[typeArg] =>
           let retType ← translateHighType typeArg
           pure [{ name := "result", type := retType : Parameter }]
         | _, _ => TransM.error s!"Expected optionalReturnType operation, got {repr returnTypeOp.name}"
@@ -463,11 +463,11 @@ def parseProcedure (arg : Arg) : TransM Procedure := do
       | _ => pure false
     let body ← match bodyArg with
       | .option _ (some (.op bodyOp)) => match bodyOp.name, bodyOp.args with
-        | q`Laurel.optionalBody, #[exprArg] => translateCommand exprArg >>= (pure ∘ some)
+        | q`Laurel.body, #[exprArg] => translateCommand exprArg >>= (pure ∘ some)
         | q`Laurel.externalBody, #[] => pure none
-        | _, _ => TransM.error s!"Expected optionalBody or externalBody operation, got {repr bodyOp.name}"
+        | _, _ => TransM.error s!"Expected body or externalBody operation, got {repr bodyOp.name}"
       | .option _ none => pure none
-      | _ => TransM.error s!"Expected optionalBody, got {repr bodyArg}"
+      | _ => TransM.error s!"Expected body, got {repr bodyArg}"
     -- Determine procedure body kind
     let procBody :=
       if isExternal then Body.External
@@ -515,7 +515,7 @@ def parseComposite (arg : Arg) : TransM TypeDefinition := do
     let name ← translateIdent nameArg
     let extending ← match extendsArg with
       | .option _ (some (.op extendsOp)) => match extendsOp.name, extendsOp.args with
-        | q`Laurel.optionalExtends, #[parentsArg] =>
+        | q`Laurel.extends, #[parentsArg] =>
           match parentsArg with
           | .seq _ .comma args => args.toList.mapM translateIdent
           | singleArg => do let parent ← translateIdent singleArg; pure [parent]

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+-- Grammar updated: renamed Optional* categories (op names updated)
 module
 
 -- Laurel dialect definition, loaded from LaurelGrammar.st

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -23,13 +23,13 @@ op hole: StmtExpr => "<?>";
 op nondetHole: StmtExpr => "<??>";
 
 // Variable declarations
-category OptionalType;
-op optionalType(varType: LaurelType): OptionalType => ":" varType;
+category TypeAnnotation;
+op typeAnnotation(varType: LaurelType): TypeAnnotation => ":" varType;
 
-category OptionalAssignment;
-op optionalAssignment(value: StmtExpr): OptionalAssignment => ":=" value:0;
+category Initializer;
+op initializer(value: StmtExpr): Initializer => ":=" value:0;
 
-op varDecl (name: Ident, varType: Option OptionalType, assignment: Option OptionalAssignment): StmtExpr
+op varDecl (name: Ident, varType: Option TypeAnnotation, assignment: Option Initializer): StmtExpr
   => @[prec(0)] "var " name varType assignment;
 
 op call(callee: StmtExpr, args: CommaSepBy StmtExpr): StmtExpr => callee "(" args ")";
@@ -73,26 +73,26 @@ op not (inner: StmtExpr): StmtExpr => @[prec(80)] "!" inner;
 op neg (inner: StmtExpr): StmtExpr => @[prec(80)] "-" inner;
 
 // Quantifiers
-category OptionalTrigger;
-op optionalTrigger(trigger: StmtExpr): OptionalTrigger => "{" trigger "}";
+category Trigger;
+op trigger(trigger: StmtExpr): Trigger => "{" trigger "}";
 
-op forallExpr (name: Ident, ty: LaurelType, trigger: Option OptionalTrigger, body: StmtExpr): StmtExpr
+op forallExpr (name: Ident, ty: LaurelType, trigger: Option Trigger, body: StmtExpr): StmtExpr
   => "forall(" name ": " ty ")" trigger " => " body:0;
-op existsExpr (name: Ident, ty: LaurelType, trigger: Option OptionalTrigger, body: StmtExpr): StmtExpr
+op existsExpr (name: Ident, ty: LaurelType, trigger: Option Trigger, body: StmtExpr): StmtExpr
   => "exists(" name ": " ty ")" trigger " => " body:0;
 
 // Error messages (used in assert, requires, ensures)
-category OptionalErrorMessage;
-op errorMessage(msg: Str): OptionalErrorMessage => "summary" msg;
+category ErrorSummary;
+op errorSummary(msg: Str): ErrorSummary => "summary" msg;
 
 // If-else
-category OptionalElse;
-op optionalElse(stmts : StmtExpr) : OptionalElse => @[prec(0)] "else" stmts;
+category ElseBranch;
+op elseBranch(stmts : StmtExpr) : ElseBranch => @[prec(0)] "else" stmts;
 
-op ifThenElse (cond: StmtExpr, thenBranch: StmtExpr, elseBranch: Option OptionalElse): StmtExpr =>
+op ifThenElse (cond: StmtExpr, thenBranch: StmtExpr, elseBranch: Option ElseBranch): StmtExpr =>
   @[prec(20)] "if (" cond ") " thenBranch:0 elseBranch:0;
 
-op assert (cond : StmtExpr, errorMessage: Option OptionalErrorMessage) : StmtExpr => @[prec(0)] "assert " cond:0 errorMessage:0;
+op assert (cond : StmtExpr, errorMessage: Option ErrorSummary) : StmtExpr => @[prec(0)] "assert " cond:0 errorMessage:0;
 op assume (cond : StmtExpr) : StmtExpr => @[prec(0)] "assume " cond:0;
 op return (value : StmtExpr) : StmtExpr => @[prec(0)] "return " value:0;
 op block (stmts : SemicolonSepBy StmtExpr) : StmtExpr => @[prec(1000)] "{" stmts "}";
@@ -122,8 +122,8 @@ op isType (target: StmtExpr, typeName: Ident): StmtExpr => @[prec(40)] target " 
 op asType (target: StmtExpr, typeName: Ident): StmtExpr => @[prec(40)] target " as " typeName;
 
 // Composite types with optional extends
-category OptionalExtends;
-op optionalExtends(parents: CommaSepBy Ident): OptionalExtends => "extends " parents;
+category Extends;
+op extends(parents: CommaSepBy Ident): Extends => "extends " parents;
 
 category Composite;
 
@@ -142,14 +142,14 @@ category Datatype;
 op datatype (name: Ident, constructors: DatatypeConstructorList): Datatype => "datatype " name "{" constructors "}";
 
 // Procedures
-category OptionalReturnType;
-op optionalReturnType(returnType: LaurelType): OptionalReturnType => ":" returnType;
+category ReturnType;
+op returnType(returnType: LaurelType): ReturnType => ":" returnType;
 
 category RequiresClause;
-op requiresClause(cond: StmtExpr, errorMessage: Option OptionalErrorMessage): RequiresClause => "requires" cond:0 errorMessage;
+op requiresClause(cond: StmtExpr, errorMessage: Option ErrorSummary): RequiresClause => "requires" cond:0 errorMessage;
 
 category EnsuresClause;
-op ensuresClause(cond: StmtExpr, errorMessage: Option OptionalErrorMessage): EnsuresClause => "ensures" cond:0 errorMessage;
+op ensuresClause(cond: StmtExpr, errorMessage: Option ErrorSummary): EnsuresClause => "ensures" cond:0 errorMessage;
 
 category ModifiesClause;
 op modifiesClause(refs: CommaSepBy StmtExpr): ModifiesClause => "modifies" refs;
@@ -157,30 +157,30 @@ op modifiesClause(refs: CommaSepBy StmtExpr): ModifiesClause => "modifies" refs;
 category ReturnParameters;
 op returnParameters(parameters: CommaSepBy Parameter): ReturnParameters => "returns" "(" parameters ")";
 
-category OptionalBody;
-op optionalBody(body: StmtExpr): OptionalBody => body:0;
-op externalBody: OptionalBody => "external";
+category Body;
+op body(body: StmtExpr): Body => body:0;
+op externalBody: Body => "external";
 
 category Procedure;
 op procedure (name : Ident, parameters: CommaSepBy Parameter,
-  returnType: Option OptionalReturnType,
+  returnType: Option ReturnType,
   returnParameters: Option ReturnParameters,
   requires: Seq RequiresClause,
   ensures: Seq EnsuresClause,
   modifies: Seq ModifiesClause,
-  body : Option OptionalBody) : Procedure =>
+  body : Option Body) : Procedure =>
   "procedure " name "(" parameters ")" returnType returnParameters requires ensures modifies body ";";
 
 op function (name : Ident, parameters: CommaSepBy Parameter,
-  returnType: Option OptionalReturnType,
+  returnType: Option ReturnType,
   returnParameters: Option ReturnParameters,
   requires: Seq RequiresClause,
   ensures: Seq EnsuresClause,
   modifies: Seq ModifiesClause,
-  body : Option OptionalBody) : Procedure =>
+  body : Option Body) : Procedure =>
   "function " name "(" parameters ")" returnType returnParameters requires ensures modifies body ";";
 
-op composite (name: Ident, extending: Option OptionalExtends, fields: Seq Field, procedures: Seq Procedure): Composite => "composite " name extending "{" fields procedures "}";
+op composite (name: Ident, extending: Option Extends, fields: Seq Field, procedures: Seq Procedure): Composite => "composite " name extending "{" fields procedures "}";
 
 category ConstrainedType;
 op constrainedType (name: Ident, valueName: Ident, base: LaurelType,


### PR DESCRIPTION
Renames grammar categories to remove the redundant `Optional` prefix, since they are already wrapped in `Option`:

| Before | After |
|--------|-------|
| `OptionalType` | `TypeAnnotation` |
| `OptionalAssignment` | `Initializer` |
| `OptionalTrigger` | `Trigger` |
| `OptionalErrorMessage` | `ErrorSummary` |
| `OptionalElse` | `ElseBranch` |
| `OptionalExtends` | `Extends` |
| `OptionalReturnType` | `ReturnType` |
| `OptionalBody` | `Body` |

Pure rename — no functional changes.