### PR TITLE
fix: tolerate temp dir cleanup failures on Windows

### DIFF
--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -74,14 +74,14 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
     Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
       (message := ("sat-message", s!"\"Property can be satisfied\""))
     let obligationStr ← Solver.termToSMTString obligationId
-    let _ ← Solver.checkSatAssuming [obligationStr] ids
+    let _ ← Solver.checkSatAssuming [obligationStr] []
 
     -- Validity check: P ∧ ¬Q satisfiable?
     Solver.comment "Validity"
     Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
       (message := ("unsat-message", s!"\"Property is always true\""))
     let negObligationStr := s!"(not {obligationStr})"
-    let _ ← Solver.checkSatAssuming [negObligationStr] ids
+    let _ ← Solver.checkSatAssuming [negObligationStr] []
   else
     if satisfiabilityCheck then
       -- P ∧ Q satisfiable?
@@ -89,14 +89,14 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
       Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
         (message := ("sat-message", s!"\"Property can be satisfied\""))
       Solver.assert obligationId
-      let _ ← Solver.checkSat ids
+      let _ ← Solver.checkSat []
     else if validityCheck then
       -- P ∧ ¬Q satisfiable?
       Solver.comment "Validity"
       Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
         (message := ("unsat-message", s!"\"Property is always true\""))
       Solver.assert (← encodeTerm False (Factory.not obligationTerm) |>.run estate).1
-      let _ ← Solver.checkSat ids
+      let _ ← Solver.checkSat []
 
   return (ids, estate)
 

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -695,7 +695,15 @@ def verifyToVcResults (program : Program)
       EIO.toIO (fun f => IO.Error.userError (toString f))
           (Core.verify coreProgram tempDir .none options)
     let ioResult ← match options.vcDirectory with
-      | .none => IO.FS.withTempDir runner
+      | .none =>
+        -- Use a temp dir that we clean up manually, tolerating cleanup failures.
+        -- On Windows, z3 may exit with a non-zero code (e.g., from get-value after
+        -- unsat), and the OS may not release the SMT file handle immediately,
+        -- causing IO.FS.withTempDir's cleanup to fail.
+        let tempDir ← IO.FS.createTempDir
+        let result ← runner tempDir
+        try IO.FS.removeDirAll tempDir catch _ => pure ()
+        pure result
       | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
     return (some ioResult, translateDiags)
   | none => return (none, translateDiags)


### PR DESCRIPTION
On Windows, z3 may exit with a non-zero code (e.g., from `get-value` after `unsat`), and the OS may not release the SMT file handle immediately. This caused `IO.FS.withTempDir`'s cleanup to throw, crashing the process before diagnostics were emitted.

Replace `withTempDir` with manual `createTempDir` + `removeDirAll` wrapped in `try`/`catch`.

Root cause: `(get-value)` is emitted unconditionally after `(check-sat)` in the file-based solver. When z3 returns `unsat`, `(get-value)` errors with "model is not available" and z3 exits with code 1. The SMT file handle may remain locked briefly on Windows, causing the temp directory cleanup to fail.