### PR TITLE
Fix #689, check isRecursive for .func

### DIFF
--- a/Strata/Languages/Core/ProgramType.lean
+++ b/Strata/Languages/Core/ProgramType.lean
@@ -123,6 +123,9 @@ C are already well-typed.
         .ok (Decl.proc proc' md, C, Env)
 
       | .func func md => try
+        if func.isRecursive then
+          .error (DiagnosticModel.withRange fileRange <|
+            f!"Decl.func does not allow recursive functions. Use recFuncBlock instead: '{func.name}'")
         let Env := Env.pushEmptySubstScope
         let (func', Env) ← Function.typeCheck C Env func |>.mapError (fun e => DiagnosticModel.withRange fileRange e)
         let C := C.addFactoryFunction func'

--- a/Strata/Languages/Core/ProgramWF.lean
+++ b/Strata/Languages/Core/ProgramWF.lean
@@ -478,6 +478,8 @@ private theorem Program.typeCheckFunctionDisjoint :
         grind
     | func f =>
       split_contra_case Hty; rename_i Hty
+      split at Hty <;> try contradiction
+      simp only[pure, Except.pure] at Hty
       split_contra_case Hty; rename_i Hty
       specialize (IH tcok)
       match hx with
@@ -594,6 +596,8 @@ private theorem Program.typeCheckFunctionNoDup : Program.typeCheck.go p C T decl
       simp_all; grind
     | func f =>
       split_contra_case Hty; rename_i Hty
+      split at Hty <;> try contradiction
+      simp only[pure, Except.pure] at Hty
       split_contra_case Hty; rename_i Hty
       specialize (IH tcok)
       apply List.nodup_append.mpr; (repeat (constructor <;> try grind)); apply IH

--- a/StrataTest/Languages/Core/Tests/ProgramTypeTests.lean
+++ b/StrataTest/Languages/Core/Tests/ProgramTypeTests.lean
@@ -439,5 +439,21 @@ end
 
 ---------------------------------------------------------------------
 
+/-- A `Decl.func` with `isRecursive := true` should be rejected.
+    `Decl.func` is for non-recursive functions only; recursive functions
+    must use `Decl.recFuncBlock`. -/
+def recursiveFuncDeclProg : Program := { decls := [
+  .func { name := "bad", isRecursive := true, inputs := [("x", .int)], output := .int } .empty
+]}
+
+/--
+info: error: Decl.func does not allow recursive functions. Use recFuncBlock instead: 'bad'
+-/
+#guard_msgs in
+#eval do let ans ← typeCheckAndPartialEval .default recursiveFuncDeclProg
+         return (format ans)
+
+---------------------------------------------------------------------
+
 end Tests
 end Core


### PR DESCRIPTION
*Issue #, if available:* #689

*Description of changes:* Ensure `.isRecursive = false` for `.func`. This is not permitted in the concrete syntax, but was not checked if someone creates an AST node directly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
