### PR TITLE
Fix #653 and other bugs with iterated substitution

### DIFF
--- a/Strata/DL/Imperative/PureExpr.lean
+++ b/Strata/DL/Imperative/PureExpr.lean
@@ -89,7 +89,7 @@ class HasSubstFvar (P : PureExpr) where
   /-- Simultaneously substitute multiple free variables with expressions.
       Replaces all variables in a single pass, avoiding capture between
       substitutions. -/
-  substMultiFvars : P.Expr → List (P.Ident × P.Expr) → P.Expr
+  substFvars : P.Expr → List (P.Ident × P.Expr) → P.Expr
 
 /--
 A function declaration for use with `PureExpr` - instantiation of `Func` for

--- a/Strata/DL/Lambda/LExprEval.lean
+++ b/Strata/DL/Lambda/LExprEval.lean
@@ -238,7 +238,7 @@ def eval (n : Nat) (σ : LState TBase) (e : (LExpr TBase.mono))
           -- Inline a function only if it has a body.
           let body := lfunc.body.get (by simp_all)
           let input_map := lfunc.inputs.keys.zip args
-          let new_e := substMultiFvarsLifting body input_map
+          let new_e := substFvarsLifting body input_map
           eval n' σ new_e
         else
           let new_e := @mkApp TBase.mono e.metadata op_expr args

--- a/Strata/DL/Lambda/LExprWF.lean
+++ b/Strata/DL/Lambda/LExprWF.lean
@@ -352,20 +352,20 @@ in a single pass, avoiding variable capture between substitutions.
 Does NOT lift de Bruijn indices when going under binders. Safe only when all
 replacement expressions contain no bvars.
 -/
-def substMultiFvars [BEq T.IDMeta] (e : LExpr ⟨T, GenericTy⟩) (sm : Map T.Identifier (LExpr ⟨T, GenericTy⟩))
+def substFvars [BEq T.IDMeta] (e : LExpr ⟨T, GenericTy⟩) (sm : Map T.Identifier (LExpr ⟨T, GenericTy⟩))
   : LExpr ⟨T, GenericTy⟩ :=
-  if sm.isEmpty then e else substMultiFvarsAux e sm
+  if sm.isEmpty then e else substFvarsAux e sm
 where
-  substMultiFvarsAux (e : LExpr ⟨T, GenericTy⟩) (sm : Map T.Identifier (LExpr ⟨T, GenericTy⟩))
+  substFvarsAux (e : LExpr ⟨T, GenericTy⟩) (sm : Map T.Identifier (LExpr ⟨T, GenericTy⟩))
     : LExpr ⟨T, GenericTy⟩ :=
     match e with
     | .const _ _ => e | .bvar _ _ => e | .op _ _ _ => e
     | .fvar _ name _ => match sm.find? name with | some to => to | none => e
-    | .abs m name ty e' => .abs m name ty (substMultiFvarsAux e' sm)
-    | .quant m qk name ty tr' e' => .quant m qk name ty (substMultiFvarsAux tr' sm) (substMultiFvarsAux e' sm)
-    | .app m fn e' => .app m (substMultiFvarsAux fn sm) (substMultiFvarsAux e' sm)
-    | .ite m c t e' => .ite m (substMultiFvarsAux c sm) (substMultiFvarsAux t sm) (substMultiFvarsAux e' sm)
-    | .eq m e1 e2 => .eq m (substMultiFvarsAux e1 sm) (substMultiFvarsAux e2 sm)
+    | .abs m name ty e' => .abs m name ty (substFvarsAux e' sm)
+    | .quant m qk name ty tr' e' => .quant m qk name ty (substFvarsAux tr' sm) (substFvarsAux e' sm)
+    | .app m fn e' => .app m (substFvarsAux fn sm) (substFvarsAux e' sm)
+    | .ite m c t e' => .ite m (substFvarsAux c sm) (substFvarsAux t sm) (substFvarsAux e' sm)
+    | .eq m e1 e2 => .eq m (substFvarsAux e1 sm) (substFvarsAux e2 sm)
 
 /--
 Simultaneous substitution of multiple free variables with bvar-safe lifting.
@@ -375,7 +375,7 @@ substitutions.
 Properly lifts de Bruijn indices in replacement expressions when going under
 binders. Use this when replacement expressions may contain bvars.
 -/
-def substMultiFvarsLifting [BEq T.IDMeta] (e : LExpr ⟨T, GenericTy⟩) (sm : Map T.Identifier (LExpr ⟨T, GenericTy⟩))
+def substFvarsLifting [BEq T.IDMeta] (e : LExpr ⟨T, GenericTy⟩) (sm : Map T.Identifier (LExpr ⟨T, GenericTy⟩))
   : LExpr ⟨T, GenericTy⟩ :=
   if sm.isEmpty then e else go e 0
 where

--- a/Strata/DL/Lambda/LState.lean
+++ b/Strata/DL/Lambda/LState.lean
@@ -162,7 +162,7 @@ The replacement expressions must be closed (no dangling bvars).
 -/
 def LExpr.substFvarsFromState (σ : (LState T)) (e : (LExpr T.mono)) : (LExpr T.mono) :=
   let sm := σ.state.toSingleMap.map (fun (x, (_, v)) => (x, v))
-  Lambda.LExpr.substMultiFvars e sm
+  Lambda.LExpr.substFvars e sm
 
 ---------------------------------------------------------------------
 

--- a/Strata/DL/Lambda/Preconditions.lean
+++ b/Strata/DL/Lambda/Preconditions.lean
@@ -51,7 +51,7 @@ def substitutePrecondition
     (actuals : List (LExpr T.mono))
     : LExpr T.mono :=
   let substitution := formals.zip actuals |>.map fun ((name, _), actual) => (name, actual)
-  LExpr.substMultiFvarsLifting precond substitution
+  LExpr.substFvarsLifting precond substitution
 
 /--
 Collect all WF obligations from an expression by traversing it and finding

--- a/Strata/DL/Lambda/Semantics.lean
+++ b/Strata/DL/Lambda/Semantics.lean
@@ -144,7 +144,7 @@ result. Note that this rule does not enforce an evaluation order. -/
   ∀ (e callee fnbody new_body:LExpr Tbase.mono) args fn,
     F.callOfLFunc e = .some (callee,args,fn) →
     fn.body = .some fnbody →
-    new_body = LExpr.substMultiFvarsLifting fnbody (fn.inputs.keys.zip args) →
+    new_body = LExpr.substFvarsLifting fnbody (fn.inputs.keys.zip args) →
     Step F rf e new_body
 
 /-- Evaluate a built-in function when a concrete evaluation function is

--- a/Strata/Languages/Core/CmdEval.lean
+++ b/Strata/Languages/Core/CmdEval.lean
@@ -49,7 +49,7 @@ def lookup (E : Env) (v : Expression.Ident) : Option Expression.TypedExpr :=
 def preprocess (E : Env) (c : Cmd Expression) (e : Expression.Expr) : Expression.Expr × Env :=
   -- Substitute "old g" variables with their pre-state values.
   -- substMap contains only "old g" → pre-state value entries (set by ProcedureEval).
-  let e := if E.substMap.isEmpty then e else Lambda.LExpr.substMultiFvars e E.substMap
+  let e := if E.substMap.isEmpty then e else Lambda.LExpr.substFvars e E.substMap
   match c with
   | .init _ _ eOpt _ =>
     -- The type checker only allows free variables to appear in `init`

--- a/Strata/Languages/Core/SMTEncoder.lean
+++ b/Strata/Languages/Core/SMTEncoder.lean
@@ -621,9 +621,9 @@ partial def toSMTOp (E : Env) (fn : CoreIdent) (fnty : LMonoTy) (ctx : SMT.Conte
           | none => .ok (ctx.addUF uf, !ctx.ufs.contains uf)
           | some body =>
             -- Substitute the formals in the function body with appropriate
-            -- `.bvar`s. Use substMultiFvarsLifting to properly lift indices under binders.
+            -- `.bvar`s. Use substFvarsLifting to properly lift indices under binders.
             let bvars := (List.range formals.length).map (fun i => LExpr.bvar () i)
-            let body := LExpr.substMultiFvarsLifting body (formals.zip bvars)
+            let body := LExpr.substFvarsLifting body (formals.zip bvars)
             let (term, ctx) ← toSMTTerm E bvs body ctx
             .ok (ctx.addIF uf term,  !ctx.ifs.contains ({ uf := uf, body := term }))
         -- For recursive functions, generate per-constructor axioms

--- a/Strata/Languages/Core/StatementEval.lean
+++ b/Strata/Languages/Core/StatementEval.lean
@@ -53,7 +53,7 @@ private def callConditions (proc : Procedure)
   let sm := subst.map (fun (x, v) => (x.fst, v))
   let exprs := List.map
                 (fun p =>
-                  { p with expr := LExpr.substMultiFvars p.expr sm })
+                  { p with expr := LExpr.substFvars p.expr sm })
                 conditions.values
   List.zip names exprs
 
@@ -366,7 +366,7 @@ def captureFreevars (env : Env) (paramNames : List CoreIdent) (e : Expression.Ex
     match env.exprEnv.state.find? fv.fst with
     | some (_, val) => some (fv.fst, val)
     | none => none)
-  Lambda.LExpr.substMultiFvars e sm
+  Lambda.LExpr.substFvars e sm
 
 @[expose]
 abbrev StmtsStack := List Statements

--- a/Strata/Languages/Core/StatementSemantics.lean
+++ b/Strata/Languages/Core/StatementSemantics.lean
@@ -36,7 +36,7 @@ instance : HasFvar Core.Expression where
 
 instance : HasSubstFvar Core.Expression where
   substFvar := Lambda.LExpr.substFvar
-  substMultiFvars := Lambda.LExpr.substMultiFvars
+  substFvars := Lambda.LExpr.substFvars
 
 instance : HasIntOrder Core.Expression where
   eq    e1 e2 := .eq () e1 e2
@@ -237,8 +237,8 @@ def closureCapture
   let substs := buildSubstitutions σ allFreeVars
   -- The replacement expressions must be closed (no dangling bvars).
   { decl with
-    body := decl.body.map (fun b => HasSubstFvar.substMultiFvars b substs)
-    axioms := decl.axioms.map (fun ax => HasSubstFvar.substMultiFvars ax substs) }
+    body := decl.body.map (fun b => HasSubstFvar.substFvars b substs)
+    axioms := decl.axioms.map (fun ax => HasSubstFvar.substFvars ax substs) }
 
 /--
 Extend the evaluator with a new function definition by capturing the closure.

--- a/Strata/Transform/CallElim.lean
+++ b/Strata/Transform/CallElim.lean
@@ -79,10 +79,9 @@ def callElimCmd (cmd: Command)
             | _ => none
         let oldSubst := createOldVarsSubst oldTrips ++ unmodifiedOldSubst
 
-        -- Iterated substitution is safe here: keys are "old g" identifiers (prefixed
-        -- with "old "), and values are fresh variables that cannot contain "old g" names.
+        -- Non-lifting substitution is safe here: values are fresh variables
         let postconditions : List Expression.Expr := proc.spec.postconditions.values.map
-          (fun c => Lambda.LExpr.substMultiFvars c.expr oldSubst)
+          (fun c => Lambda.LExpr.substFvars c.expr oldSubst)
 
         -- generate havoc for return variables, modified variables
         let havoc_ret := createHavocs lhs md

--- a/Strata/Transform/CoreTransform.lean
+++ b/Strata/Transform/CoreTransform.lean
@@ -253,7 +253,7 @@ def createAsserts
     := conds.mapM (fun (l, check) => do
           let newLabel ← genIdent l (fun s => s!"callElimAssert_{s}")
           -- Non-lifting: the replacement expressions must be closed (no dangling bvars).
-          return Statement.assert newLabel.toPretty (Lambda.LExpr.substMultiFvars check.expr subst) md)
+          return Statement.assert newLabel.toPretty (Lambda.LExpr.substFvars check.expr subst) md)
 
 /-- turns a list of preconditions into assumes with substitution -/
 def createAssumes
@@ -265,7 +265,7 @@ def createAssumes
     conds.mapM (fun (l, check) => do
       let newLabel ← genIdent l (fun s => s!"callElimAssume_{s}")
       -- Non-lifting: the replacement expressions must be closed (no dangling bvars).
-      return Statement.assume newLabel.toPretty (Lambda.LExpr.substMultiFvars check.expr subst) md)
+      return Statement.assume newLabel.toPretty (Lambda.LExpr.substFvars check.expr subst) md)
 
 /--
 Generate the substitution pairs needed for the body of the procedure

--- a/StrataTest/DL/Lambda/LExprWFTests.lean
+++ b/StrataTest/DL/Lambda/LExprWFTests.lean
@@ -94,12 +94,12 @@ def qa (e : MonoExpr) : MonoExpr := .quant () .all "" .none (bv 0) e
 /-! ### substFvarsLifting tests -/
 
 -- Multiple substitutions under abs: both lifted by 1
-#guard substMultiFvarsLifting
+#guard substFvarsLifting
     (lam (ap (fv "x") (fv "y")))
     [("x", bv 0), ("y", bv 1)]
     == lam (ap (bv 1) (bv 2))
 
 -- Empty substitution is identity
-#guard substMultiFvarsLifting (fv "x") [] == fv "x"
+#guard substFvarsLifting (fv "x") [] == fv "x"
 
 end Lambda.LExpr.WFTests

--- a/StrataTest/Languages/Core/Examples/SubstFvarsCaptureTests.lean
+++ b/StrataTest/Languages/Core/Examples/SubstFvarsCaptureTests.lean
@@ -8,9 +8,9 @@ import Strata.Languages.Core.Verifier
 
 /-! # Simultaneous substitution tests (Issue 653)
 
-Tests verifying that simultaneous substitution (`substMultiFvars` /
-`substMultiFvarsLifting`) avoids variable capture that occurrs with the
-iterated `substFvars`.
+Tests verifying that simultaneous substitution (`substFvars` /
+`substFvarsLifting`) avoids variable capture that occurs with the
+iterated `substFvar`.
 -/
 
 ---------------------------------------------------------------------


### PR DESCRIPTION
*Issue #, if available:* #653

*Description of changes:* The use of `substFvars` for repeated substitution is unsound whenever either (a) the substituted expressions are not guaranteed to use only `fvars` that do not appear in the substitution list or (b) the substituted expressions contain bound variables. This PR instead adds simulatenous substitution operators that safely substitute multiple free variables at once, with both `bvar`-safe and standard versions. It classifies each place where iterated substitution was used as safe or requiring one of the new functions, adding an appropriate comment for each to make the assumptions explicit (for example, for some cases, the substituted terms are closed, so it safe to use a non-lifting substitution function). 
It includes tests that formerly failed illustrating soundness issues with the prior approach: for the Lambda partial evaluator, for `substFvarsFromState`, for the precondition generation, closure capture, and procedure call capture.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
