### PR TITLE
Replace Json.pretty/compress with streaming writer to fix stack overflow

### DIFF
--- a/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
@@ -260,8 +260,8 @@ def writeToGotoJson (programName symTabFileName gotoFileName : String) (env : Pr
   let json ← getGotoJson programName env
   let symtabObj := match json.symtab with | .obj m => m | _ => .empty
   let symtab := CProverGOTO.wrapSymtab symtabObj (moduleName := programName)
-  IO.FS.writeFile symTabFileName symtab.pretty
-  IO.FS.writeFile gotoFileName json.goto.pretty
+  writeJsonFile symTabFileName symtab
+  writeJsonFile gotoFileName json.goto
 
 end CoreToGOTO
 

--- a/Strata/Backends/CBMC/GOTO/CoreToGOTOPipeline.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToGOTOPipeline.lean
@@ -504,10 +504,10 @@ public def coreToGotoFiles (tcPgm : Core.Program) (Env : Core.Expression.TyEnv)
       | .error e => throw s!"{e}"
     let symTabFile := s!"{baseName}.symtab.json"
     let gotoFile := s!"{baseName}.goto.json"
-    match ← IO.FS.writeFile symTabFile symtab.pretty |>.toBaseIO with
+    match ← writeJsonFile symTabFile symtab |>.toBaseIO with
     | .ok () => pure ()
     | .error e => throw s!"Error writing {symTabFile}: {e}"
-    match ← IO.FS.writeFile gotoFile goto.pretty |>.toBaseIO with
+    match ← writeJsonFile gotoFile goto |>.toBaseIO with
     | .ok () => pure ()
     | .error e => throw s!"Error writing {gotoFile}: {e}"
     let _ ← IO.println s!"Written {symTabFile} and {gotoFile}" |>.toBaseIO

--- a/Strata/Backends/CBMC/GOTO/InstToJson.lean
+++ b/Strata/Backends/CBMC/GOTO/InstToJson.lean
@@ -7,6 +7,7 @@
 import Strata.Backends.CBMC.GOTO.Program
 import Strata.Backends.CBMC.Common
 import Strata.Util.Tactics
+import Strata.Util.Json
 
 namespace CProverGOTO
 open Lean
@@ -256,7 +257,7 @@ def programToJson (name : String) (program : Program) : Except String Json := do
 /-- Write a program to JSON file -/
 def writeProgramToFile (fileName : String) (programName : String) (program : Program) : IO Unit := do
   let json ← IO.ofExcept (programToJson programName program)
-  IO.FS.writeFile fileName json.pretty
+  writeJsonFile fileName json
 
 /-- Convert `Program`s to JSON containing GOTO functions -/
 def programsToJson (programs : List (String × Program)) : Except String Json := do
@@ -268,7 +269,7 @@ def programsToJson (programs : List (String × Program)) : Except String Json :=
 /-- Write programs to JSON file -/
 def writeProgramsToFile (fileName : String) (programs : List (String × Program)) : IO Unit := do
   let json ← IO.ofExcept (programsToJson programs)
-  IO.FS.writeFile fileName json.pretty
+  writeJsonFile fileName json
 
 -------------------------------------------------------------------------------
 

--- a/Strata/Util/Json.lean
+++ b/Strata/Util/Json.lean
@@ -1,0 +1,39 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Lean.Data.Json.Printer
+
+/-! Streaming JSON writer that avoids stack overflow on large values. -/
+
+/-- Write a `Lean.Json` value to a file handle without building an intermediate string. -/
+partial def writeJsonTo (h : IO.FS.Handle) : Lean.Json → IO Unit
+  | .null => h.putStr "null"
+  | .bool b => h.putStr (if b then "true" else "false")
+  | .num n => h.putStr (toString n)
+  | .str s => h.putStr (Lean.Json.renderString s)
+  | .arr elems => do
+    h.putStr "["
+    for i in [:elems.size] do
+      if i > 0 then h.putStr ","
+      writeJsonTo h elems[i]!
+    h.putStr "]"
+  | .obj kvs => do
+    h.putStr "{"
+    let _ ← kvs.foldlM (init := true) fun first k v => do
+      if !first then h.putStr ","
+      h.putStr (Lean.Json.renderString k)
+      h.putStr ":"
+      writeJsonTo h v
+      pure false
+    h.putStr "}"
+
+/-- Write a `Lean.Json` value to a file, ensuring the handle is flushed even on exception. -/
+def writeJsonFile (path : String) (json : Lean.Json) : IO Unit := do
+  let h ← IO.FS.Handle.mk path .write
+  try
+    writeJsonTo h json
+  finally
+    h.flush

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -691,6 +691,34 @@ def pyAnalyzeLaurelCommand : Command where
       Core.Sarif.writeSarifOutput checkMode files vcResults (filePath ++ ".sarif")
     printPyAnalyzeSummary vcResults checkMode
 
+/-- Write JSON to a file handle iteratively to avoid stack overflow on large trees. -/
+partial def writeJsonTo (h : IO.FS.Handle) : Lean.Json → IO Unit
+  | .null => h.putStr "null"
+  | .bool b => h.putStr (if b then "true" else "false")
+  | .num n => h.putStr (toString n)
+  | .str s => h.putStr (Lean.Json.renderString s)
+  | .arr elems => do
+    h.putStr "["
+    for i in [:elems.size] do
+      if i > 0 then h.putStr ","
+      writeJsonTo h elems[i]!
+    h.putStr "]"
+  | .obj kvs => do
+    h.putStr "{"
+    let mut first := true
+    for (k, v) in kvs.toList do
+      if !first then h.putStr ","
+      first := false
+      h.putStr (Lean.Json.renderString k)
+      h.putStr ":"
+      writeJsonTo h v
+    h.putStr "}"
+
+def writeJsonFile (path : String) (json : Lean.Json) : IO Unit := do
+  let h ← IO.FS.Handle.mk path .write
+  writeJsonTo h json
+  h.flush
+
 def pyAnalyzeToGotoCommand : Command where
   name := "pyAnalyzeToGoto"
   args := [ "file" ]
@@ -737,8 +765,8 @@ def pyAnalyzeToGotoCommand : Command where
               (moduleName := baseName)
         let symTabFile := s!"{baseName}.symtab.json"
         let gotoFile := s!"{baseName}.goto.json"
-        IO.FS.writeFile symTabFile symtab.pretty
-        IO.FS.writeFile gotoFile goto.pretty
+        writeJsonFile symTabFile symtab
+        writeJsonFile gotoFile goto
         IO.println s!"Written {symTabFile} and {gotoFile}"
 
 def pyTranslateLaurelCommand : Command where
@@ -1010,8 +1038,8 @@ def laurelAnalyzeToGotoCommand : Command where
         let goto := Lean.Json.mkObj [("functions", Lean.Json.arr gotoFns)]
         let symTabFile := s!"{baseName}.symtab.json"
         let gotoFile := s!"{baseName}.goto.json"
-        IO.FS.writeFile symTabFile symtab.pretty
-        IO.FS.writeFile gotoFile goto.pretty
+        writeJsonFile symTabFile symtab
+        writeJsonFile gotoFile goto
         IO.println s!"Written {symTabFile} and {gotoFile}"
 
 def laurelPrintCommand : Command where

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -22,6 +22,7 @@ import Strata.Backends.CBMC.GOTO.CoreToGOTOPipeline
 
 import Strata.SimpleAPI
 import Strata.Util.Profile
+import Strata.Util.Json
 
 open Strata
 
@@ -690,34 +691,6 @@ def pyAnalyzeLaurelCommand : Command where
         | none => Map.empty
       Core.Sarif.writeSarifOutput checkMode files vcResults (filePath ++ ".sarif")
     printPyAnalyzeSummary vcResults checkMode
-
-/-- Write JSON to a file handle iteratively to avoid stack overflow on large trees. -/
-partial def writeJsonTo (h : IO.FS.Handle) : Lean.Json → IO Unit
-  | .null => h.putStr "null"
-  | .bool b => h.putStr (if b then "true" else "false")
-  | .num n => h.putStr (toString n)
-  | .str s => h.putStr (Lean.Json.renderString s)
-  | .arr elems => do
-    h.putStr "["
-    for i in [:elems.size] do
-      if i > 0 then h.putStr ","
-      writeJsonTo h elems[i]!
-    h.putStr "]"
-  | .obj kvs => do
-    h.putStr "{"
-    let mut first := true
-    for (k, v) in kvs.toList do
-      if !first then h.putStr ","
-      first := false
-      h.putStr (Lean.Json.renderString k)
-      h.putStr ":"
-      writeJsonTo h v
-    h.putStr "}"
-
-def writeJsonFile (path : String) (json : Lean.Json) : IO Unit := do
-  let h ← IO.FS.Handle.mk path .write
-  writeJsonTo h json
-  h.flush
 
 def pyAnalyzeToGotoCommand : Command where
   name := "pyAnalyzeToGoto"


### PR DESCRIPTION
Json.pretty and Json.compress are recursive and overflow the stack on large JSON trees (e.g. 49MB GOTO output from PySpec-enriched programs).

Add writeJsonFile/writeJsonTo that writes JSON to a file handle iteratively using IO.FS.Handle.putStr, avoiding deep recursion.

Fixes stack overflow (exit 134) on benchmarks that previously crashed the GOTO pipeline with PySpec dispatch enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
