### PR TITLE
Use DOCGEN_SRC=file instead of SSH URL rewriting for doc generation

### DIFF
--- a/docs/verso/generate.sh
+++ b/docs/verso/generate.sh
@@ -1,12 +1,12 @@
 set -ex
 
-# Normalize SSH git remote to HTTPS so doc-gen4 can parse it (see #427).
+# Fall back to local file references when the git remote uses an SSH URL
+# that doc-gen4 cannot parse.  See #427 and
+# https://github.com/leanprover/doc-gen4/issues/376
 repo_root=$(git -C "$(dirname "$0")/../.." rev-parse --show-toplevel)
-orig_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null || true)
-if echo "$orig_url" | grep -q '^git@github\.com:'; then
-  https_url=$(echo "$orig_url" | sed 's|^git@github\.com:|https://github.com/|; s|\.git$||')
-  git -C "$repo_root" remote set-url origin "$https_url"
-  trap 'git -C "$repo_root" remote set-url origin "$orig_url"' EXIT
+origin_url=$(git -C "$repo_root" remote get-url origin 2>/dev/null || true)
+if [ -z "${DOCGEN_SRC:-}" ] && echo "$origin_url" | grep -q '^git@github\.com:'; then
+  export DOCGEN_SRC="file"
 fi
 
 curpwd=$(pwd)


### PR DESCRIPTION
Replace the workaround from PR #732 that temporarily mutated the git remote URL (SSH→HTTPS) with the doc-gen4-recommended DOCGEN_SRC variable. When the origin remote uses an SSH URL (git@github.com:...), the script sets DOCGEN_SRC="file" so doc-gen4 uses local file references instead of failing to parse the remote. HTTPS clones and explicit DOCGEN_SRC settings are unaffected.

See https://github.com/leanprover/doc-gen4/issues/376

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
