### PR TITLE
feat(laurel): Add Seq<T> and Array<T> types with sequence/array operations

### DIFF
--- a/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
+++ b/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
@@ -369,15 +369,18 @@ def lconstToExpr {M} [Inhabited M] (c : Lambda.LConst) :
 
 /-- Handle 0-ary operations -/
 def handleZeroaryOps {M} [Inhabited M] (name : String)
-    : ToCSTM M (CoreDDM.Expr M) :=
+    : ToCSTM M (CoreDDM.Expr M) := do
   match name with
   | "Re.All" => pure (.re_all default)
   | "Re.AllChar" => pure (.re_allchar default)
   | "Re.None" => pure (.re_none default)
-  -- TODO: seq_empty is not yet parseable (see Grammar.lean); handle here when added.
-  | _ => do
-    ToCSTM.logError "lopToExpr" "0-ary op not found" name
-    pure (.re_none default)
+  | _ =>
+    -- Built-in 0-ary ops without grammar support (e.g. Sequence.empty,
+    -- Triggers.empty). Register as a free variable so they format as
+    -- their name rather than producing an error.
+    modify (·.addGlobalFreeVars #[name])
+    let ctx ← get
+    pure (.fvar default (ctx.allFreeVars.size - 1))
 
 /-- Handle unary operations -/
 def handleUnaryOps {M} [Inhabited M] (name : String) (arg : CoreDDM.Expr M)

--- a/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
+++ b/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
@@ -367,7 +367,11 @@ def lconstToExpr {M} [Inhabited M] (c : Lambda.LConst) :
     pure (.bv64Lit default ⟨default, w⟩)
 
 
-/-- Handle 0-ary operations -/
+/-- Handle 0-ary operations.
+    Ops with dedicated CST nodes (Re.*) are converted directly.
+    Other 0-ary builtins (e.g. Sequence.empty) lack grammar rules
+    (the DDM parser can't infer type params from zero arguments),
+    so they are registered as free variables to format as their name. -/
 def handleZeroaryOps {M} [Inhabited M] (name : String)
     : ToCSTM M (CoreDDM.Expr M) := do
   match name with
@@ -375,12 +379,13 @@ def handleZeroaryOps {M} [Inhabited M] (name : String)
   | "Re.AllChar" => pure (.re_allchar default)
   | "Re.None" => pure (.re_none default)
   | _ =>
-    -- Built-in 0-ary ops without grammar support (e.g. Sequence.empty,
-    -- Triggers.empty). Register as a free variable so they format as
-    -- their name rather than producing an error.
-    modify (·.addGlobalFreeVars #[name])
-    let ctx ← get
-    pure (.fvar default (ctx.allFreeVars.size - 1))
+    if name ∈ zeroAryBuiltinFunctions then
+      modify (·.addGlobalFreeVars #[name])
+      let ctx ← get
+      pure (.fvar default (ctx.allFreeVars.size - 1))
+    else
+      ToCSTM.logError "lopToExpr" "0-ary op not found" name
+      pure (.re_none default)
 
 /-- Handle unary operations -/
 def handleUnaryOps {M} [Inhabited M] (name : String) (arg : CoreDDM.Expr M)

--- a/Strata/Languages/Core/Factory.lean
+++ b/Strata/Languages/Core/Factory.lean
@@ -829,5 +829,14 @@ Get all the built-in functions supported by Strata Core.
 def builtinFunctions : Array String :=
   Core.Factory.toArray.map (fun f => CoreIdent.toPretty f.name)
 
+/--
+Get the names of 0-ary built-in functions (no value-level arguments).
+These need special handling in ASTtoCST because they lack grammar rules
+(the DDM parser can't infer type parameters from zero arguments).
+-/
+def zeroAryBuiltinFunctions : Array String :=
+  Core.Factory.toArray.filterMap (fun f =>
+    if f.inputs.isEmpty then some (CoreIdent.toPretty f.name) else none)
+
 end
 end Core

--- a/Strata/Languages/Laurel/CoreDefinitionsForLaurel.lean
+++ b/Strata/Languages/Laurel/CoreDefinitionsForLaurel.lean
@@ -38,6 +38,35 @@ function update(map: int, key: int, value: int) : int
 function const(value: int) : int
   external;
 
+// Sequence operations. Types use int as placeholder (like Map operations).
+// Core infers actual types via WFFactory.
+function Sequence.empty() : int
+  external;
+
+function Sequence.build(s: int, v: int) : int
+  external;
+
+function Sequence.select(s: int, i: int) : int
+  external;
+
+function Sequence.update(s: int, i: int, v: int) : int
+  external;
+
+function Sequence.length(s: int) : int
+  external;
+
+function Sequence.append(s1: int, s2: int) : int
+  external;
+
+function Sequence.contains(s: int, v: int) : bool
+  external;
+
+function Sequence.take(s: int, n: int) : int
+  external;
+
+function Sequence.drop(s: int, n: int) : int
+  external;
+
 #end
 
 /--

--- a/Strata/Languages/Laurel/CoreDefinitionsForLaurel.lean
+++ b/Strata/Languages/Laurel/CoreDefinitionsForLaurel.lean
@@ -67,6 +67,10 @@ function Sequence.take(s: int, n: int) : int
 function Sequence.drop(s: int, n: int) : int
   external;
 
+// Array operations. Desugared by SubscriptElim into Sequence operations on $data.
+function Array.length(a: int) : int
+  external;
+
 #end
 
 /--

--- a/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
+++ b/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
@@ -32,6 +32,8 @@ def collectTypeRefs : HighTypeMd → List String
   | ⟨.UserDefined name, _⟩ => [name.text]
   | ⟨.TSet elem, _⟩ => collectTypeRefs elem
   | ⟨.TMap k v, _⟩ => collectTypeRefs k ++ collectTypeRefs v
+  | ⟨.TSeq elem, _⟩ => collectTypeRefs elem
+  | ⟨.TArray elem, _⟩ => collectTypeRefs elem
   | ⟨.TTypedField vt, _⟩ => collectTypeRefs vt
   | ⟨.Applied base args, _⟩ =>
       collectTypeRefs base ++ args.flatMap collectTypeRefs

--- a/Strata/Languages/Laurel/FilterPrelude.lean
+++ b/Strata/Languages/Laurel/FilterPrelude.lean
@@ -73,6 +73,8 @@ private partial def collectHighTypeNames (ty : HighTypeMd) : CollectM Unit := do
   | .TTypedField vt => collectHighTypeNames vt
   | .TSet et => collectHighTypeNames et
   | .TMap kt vt => collectHighTypeNames kt; collectHighTypeNames vt
+  | .TSeq et => collectHighTypeNames et
+  | .TArray et => collectHighTypeNames et
   | .Applied base args =>
     collectHighTypeNames base; args.forM collectHighTypeNames
   | .Pure base => collectHighTypeNames base
@@ -122,6 +124,8 @@ private partial def collectExprNames (expr : StmtExprMd) : CollectM Unit := do
   | .ContractOf _ func => collectExprNames func
   | .ReferenceEquals lhs rhs => collectExprNames lhs; collectExprNames rhs
   | .Hole _ ty => ty.forM collectHighTypeNames
+  | .Subscript target index update =>
+    collectExprNames target; collectExprNames index; update.forM collectExprNames
   | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _
   | .Identifier _ | .This | .Abstract | .All => pure ()
 

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -97,6 +97,12 @@ partial def translateHighType (arg : Arg) : TransM HighTypeMd := do
       let keyType ← translateHighType keyArg
       let valType ← translateHighType valArg
       return mkHighTypeMd (.TMap keyType valType) md
+    | q`Laurel.seqType, #[elemArg] =>
+      let elemType ← translateHighType elemArg
+      return mkHighTypeMd (.TSeq elemType) md
+    | q`Laurel.arrayType, #[elemArg] =>
+      let elemType ← translateHighType elemArg
+      return mkHighTypeMd (.TArray elemType) md
     | q`Laurel.compositeType, #[nameArg] =>
       let name ← translateIdent nameArg
       return mkHighTypeMd (.UserDefined name) md
@@ -328,6 +334,21 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
         | _ => pure none
       let body ← translateStmtExpr bodyArg
       return mkStmtExprMd (.Exists { name := name, type := ty } trigger body) md
+    | q`Laurel.seqLiteral, #[elementsSeq] =>
+      let elements ← match elementsSeq with
+        | .seq _ .comma args => args.toList.mapM translateStmtExpr
+        | _ => pure []
+      let empty := mkStmtExprMd (.StaticCall (mkId "Sequence.empty") []) md
+      return elements.foldl (fun acc e => mkStmtExprMd (.StaticCall (mkId "Sequence.build") [acc, e]) md) empty
+    | q`Laurel.subscript, #[targetArg, indexArg, updateArg] =>
+      let target ← translateStmtExpr targetArg
+      let index ← translateStmtExpr indexArg
+      let update ← match updateArg with
+        | .option _ (some (.op updateOp)) => match updateOp.name, updateOp.args with
+          | q`Laurel.seqUpdateValue, #[valArg] => some <$> translateStmtExpr valArg
+          | _, _ => pure none
+        | _ => pure none
+      return mkStmtExprMd (.Subscript target index update) md
     | _, #[arg0] => match getUnaryOp? op.name with
       | some primOp =>
         let inner ← translateStmtExpr arg0

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -338,8 +338,8 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let elements ← match elementsSeq with
         | .seq _ .comma args => args.toList.mapM translateStmtExpr
         | _ => pure []
-      let empty := mkStmtExprMd (.StaticCall (mkId "Sequence.empty") []) md
-      return elements.foldl (fun acc e => mkStmtExprMd (.StaticCall (mkId "Sequence.build") [acc, e]) md) empty
+      let empty := mkStmtExprMd (.StaticCall (mkId SeqOp.empty) []) md
+      return elements.foldl (fun acc e => mkStmtExprMd (.StaticCall (mkId SeqOp.build) [acc, e]) md) empty
     | q`Laurel.subscript, #[targetArg, indexArg, updateArg] =>
       let target ← translateStmtExpr targetArg
       let index ← translateStmtExpr indexArg

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -9,7 +9,7 @@ module
 -- Laurel dialect definition, loaded from LaurelGrammar.st
 -- NOTE: Changes to LaurelGrammar.st are not automatically tracked by the build system.
 -- Update this file (e.g. this comment) to trigger a recompile after modifying LaurelGrammar.st.
--- Last grammar change: added invokeOn clause before ensures in procedure/function ops.
+-- Last grammar change: added Array<T> type syntax.
 public import Strata.DDM.Integration.Lean
 public meta import Strata.DDM.Integration.Lean
 

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -200,10 +200,10 @@ op datatypeCommand(datatype: Datatype): Command => datatype;
 op constrainedTypeCommand(ct: ConstrainedType): Command => ct;
 
 // Sequence operations
-category OptionalUpdate;
-op seqUpdateValue(value: StmtExpr): OptionalUpdate => ":=" value;
-// index:11 excludes assign (prec 10) so `:=` in s[i := v] is parsed by OptionalUpdate, not assign
-op subscript(target: StmtExpr, index: StmtExpr, update: Option OptionalUpdate): StmtExpr
+category Update;
+op seqUpdateValue(value: StmtExpr): Update => ":=" value;
+// index:11 excludes assign (prec 10) so `:=` in s[i := v] is parsed by Update, not assign
+op subscript(target: StmtExpr, index: StmtExpr, update: Option Update): StmtExpr
   => target "[" index:11 update "]";
 op seqLiteral(elements: CommaSepBy StmtExpr): StmtExpr => "[" elements "]";
 

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -12,6 +12,8 @@ op stringType : LaurelType => "string";
 // Core type passthrough: parsed as Ident, translated to HighType.TCore
 op coreType (name: Ident): LaurelType => "Core " name;
 op mapType (keyType: LaurelType, valueType: LaurelType): LaurelType => "Map " keyType " " valueType;
+op seqType (elemType: LaurelType): LaurelType => "Seq<" elemType ">";
+op arrayType (elemType: LaurelType): LaurelType => "Array<" elemType ">";
 op compositeType (name: Ident): LaurelType => name;
 
 category StmtExpr;
@@ -196,4 +198,12 @@ op compositeCommand(composite: Composite): Command => composite;
 op procedureCommand(procedure: Procedure): Command => procedure;
 op datatypeCommand(datatype: Datatype): Command => datatype;
 op constrainedTypeCommand(ct: ConstrainedType): Command => ct;
+
+// Sequence operations
+category OptionalUpdate;
+op seqUpdateValue(value: StmtExpr): OptionalUpdate => ":=" value;
+// index:11 excludes assign (prec 10) so `:=` in s[i := v] is parsed by OptionalUpdate, not assign
+op subscript(target: StmtExpr, index: StmtExpr, update: Option OptionalUpdate): StmtExpr
+  => target "[" index:11 update "]";
+op seqLiteral(elements: CommaSepBy StmtExpr): StmtExpr => "[" elements "]";
 

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -180,6 +180,7 @@ def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
       if isDatatype model name then s!"Box..{name.text}Val!"
       else "Box..compositeVal!"
   | .TCore name => s!"Box..{name}Val!"
+  | .TSeq _ => "Box..SeqVal!"
   | _ => dbg_trace f!"BUG, boxDestructorName bad type {ty}"; "boxDestructorNameError"
 
 /-- Get the Box constructor name for a given Laurel HighType.
@@ -196,6 +197,7 @@ def boxConstructorName (model : SemanticModel) (ty : HighType) : Identifier :=
       if isDatatype model name then s!"Box..{name.text}"
       else "BoxComposite"
   | .TCore name => s!"Box..{name}"
+  | .TSeq _ => "BoxSeq"
   | ty => dbg_trace s!"BUG, boxConstructorName bad type: {repr ty}"; "boxConstructorNameError"
 
 /-- Build the DatatypeConstructor for a Box variant from a HighType, for datatype generation -/
@@ -213,6 +215,8 @@ private def boxConstructorDef (model : SemanticModel) (ty : HighType) : Option D
         some { name := "BoxComposite", args := [{ name := "compositeVal", type := ⟨.UserDefined "Composite", #[]⟩ }] }
   | .TCore name =>
         some { name := s!"Box..{name}", args := [{ name := s!"{name}Val", type := ⟨.TCore name, #[]⟩ }] }
+  | .TSeq _ =>
+        some { name := "BoxSeq", args := [{ name := "SeqVal", type := ⟨ty, #[]⟩ }] }
   | ty => dbg_trace s!"BUG, boxConstructorDef bad type: {repr ty}"; none
 
 /-- Record a Box constructor use in the transform state -/

--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -525,9 +525,12 @@ def SeqOp.build    := "Sequence.build"
 def SeqOp.select   := "Sequence.select"
 def SeqOp.update   := "Sequence.update"
 def SeqOp.append   := "Sequence.append"
+def SeqOp.length   := "Sequence.length"
 def SeqOp.dataField := "$data"
 
 /-- Name of the synthetic Array composite type injected by SubscriptElim. -/
 def arrayCompositeName := "Array"
+/-- Array.length static function, desugared by SubscriptElim. -/
+def arrayLengthName := "Array.length"
 
 end -- Strata.Laurel

--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -359,6 +359,8 @@ def highEq (a : HighTypeMd) (b : HighTypeMd) : Bool := match _a: a.val, _b: b.va
   | HighType.TTypedField t1, HighType.TTypedField t2 => highEq t1 t2
   | HighType.TSet t1, HighType.TSet t2 => highEq t1 t2
   | HighType.TMap k1 v1, HighType.TMap k2 v2 => highEq k1 k2 && highEq v1 v2
+  | HighType.TSeq t1, HighType.TSeq t2 => highEq t1 t2
+  | HighType.TArray t1, HighType.TArray t2 => highEq t1 t2
   | HighType.UserDefined r1, HighType.UserDefined r2 => r1.text == r2.text
   | HighType.Applied b1 args1, HighType.Applied b2 args2 =>
       highEq b1 b2 && args1.length == args2.length && (args1.attach.zip args2 |>.all (fun (a1, a2) => highEq a1.1 a2))
@@ -516,4 +518,16 @@ structure Program where
   constants : List Constant := []
   deriving Inhabited
 
-end
+/-- Well-known names for Sequence operations used in desugaring and subscript elimination. -/
+def SeqOp.namePrefix := "Sequence."
+def SeqOp.empty    := "Sequence.empty"
+def SeqOp.build    := "Sequence.build"
+def SeqOp.select   := "Sequence.select"
+def SeqOp.update   := "Sequence.update"
+def SeqOp.append   := "Sequence.append"
+def SeqOp.dataField := "$data"
+
+/-- Name of the synthetic Array composite type injected by SubscriptElim. -/
+def arrayCompositeName := "Array"
+
+end -- Strata.Laurel

--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -146,6 +146,10 @@ inductive HighType : Type where
   | TSet (elementType : WithMetadata HighType)
   /-- Map type. -/
   | TMap (keyType : WithMetadata HighType) (valueType : WithMetadata HighType)
+  /-- Immutable sequence type, e.g. `Seq<int>`. -/
+  | TSeq (elementType : WithMetadata HighType)
+  /-- Mutable heap-backed array type, e.g. `Array<int>`. -/
+  | TArray (elementType : WithMetadata HighType)
   /-- A Identifier to a user-defined composite or constrained type by name. -/
   | UserDefined (name : Identifier)
   /-- A generic type application, e.g. `List<Int>`. -/
@@ -319,6 +323,8 @@ inductive StmtExpr : Type where
         not allowed in functions.
       - `type`: inferred by the hole type inference pass; `none` means not yet inferred. -/
   | Hole (deterministic : Bool := true) (type : Option (WithMetadata HighType) := none)
+  /-- Subscript access or update, e.g. `s[i]` or `s[i := v]`. Eliminated by `SubscriptElim`. -/
+  | Subscript (target : WithMetadata StmtExpr) (index : WithMetadata StmtExpr) (update : Option (WithMetadata StmtExpr))
 
 inductive ContractType where
   | Reads | Modifies | Precondition | PostCondition

--- a/Strata/Languages/Laurel/LaurelFormat.lean
+++ b/Strata/Languages/Laurel/LaurelFormat.lean
@@ -55,6 +55,8 @@ def formatHighTypeVal : HighType → Format
   | .TTypedField valueType => "Field[" ++ formatHighType valueType ++ "]"
   | .TSet elementType => "Set[" ++ formatHighType elementType ++ "]"
   | .TMap keyType valueType => "Map[" ++ formatHighType keyType ++ ", " ++ formatHighType valueType ++ "]"
+  | .TSeq elementType => "Seq<" ++ formatHighType elementType ++ ">"
+  | .TArray elementType => "Array<" ++ formatHighType elementType ++ ">"
   | .UserDefined ref => format ref
   | .Applied base args =>
       Format.text "(" ++ formatHighType base ++ " " ++
@@ -154,6 +156,11 @@ def formatStmtExprVal (s : StmtExpr) : Format :=
   | .All => "all"
   | .Hole true _ => "<?>"
   | .Hole false _ => "<??>"
+  | .Subscript target index update =>
+      formatStmtExpr target ++ "[" ++ formatStmtExpr index ++
+      (match update with
+      | some v => " := " ++ formatStmtExpr v
+      | none => "") ++ "]"
   termination_by sizeOf s
   decreasing_by all_goals term_by_mem
 end

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -28,6 +28,7 @@ import Strata.DL.Imperative.MetaData
 import Strata.DL.Lambda.LExpr
 import Strata.Languages.Laurel.LaurelFormat
 import Strata.Languages.Laurel.ConstrainedTypeElim
+import Strata.Languages.Laurel.SubscriptElim
 import Strata.Util.Tactics
 
 open Core (VCResult VCResults VerifyOptions)
@@ -58,6 +59,8 @@ def translateType (model : SemanticModel) (ty : HighTypeMd) : LMonoTy :=
   | .TTypedField _ => .tcons "Field" []
   | .TSet elementType => Core.mapTy (translateType model elementType) LMonoTy.bool
   | .TMap keyType valueType => Core.mapTy (translateType model keyType) (translateType model valueType)
+  | .TSeq elementType => Core.seqTy (translateType model elementType)
+  | .TArray _ => .tcons "Composite" []
   | .UserDefined name =>
     match name.uniqueId.bind model.refToDef.get? with
     | some (.compositeType _) => .tcons "Composite" []
@@ -301,6 +304,7 @@ def translateExpr (expr : StmtExprMd)
   | .InstanceCall target callee args => throwExprDiagnostic $ md.toDiagnostic "instance call expression translation" DiagnosticType.NotYetImplemented
   | .PureFieldUpdate _ _ _ => throwExprDiagnostic $ md.toDiagnostic "pure field update expression translation" DiagnosticType.NotYetImplemented
   | .This => throwExprDiagnostic $ md.toDiagnostic "this expression translation" DiagnosticType.NotYetImplemented
+  | .Subscript _ _ _ => throwExprDiagnostic $ md.toDiagnostic "Subscript should have been eliminated by SubscriptElim" DiagnosticType.StrataBug
   termination_by expr
   decreasing_by
     all_goals (have := WithMetadata.sizeOf_val_lt expr; term_by_mem)
@@ -693,6 +697,10 @@ def translateWithLaurel (options: LaurelTranslateOptions) (program : Program): T
   let resolutionErrors: List DiagnosticModel := if options.emitResolutionErrors then result.errors.toList else []
   let (program, model) := (result.program, result.model)
   let diamondErrors := validateDiamondFieldAccesses model program
+
+  let program := subscriptElim model program
+  let result := resolve program (some model)
+  let (program, model) := (result.program, result.model)
 
   let (program, nonCompositeDiags) := filterNonCompositeModifies model program
 

--- a/Strata/Languages/Laurel/LaurelTypes.lean
+++ b/Strata/Languages/Laurel/LaurelTypes.lean
@@ -101,6 +101,8 @@ def computeExprType (model : SemanticModel) (expr : StmtExprMd) : HighTypeMd :=
   | .Abstract =>default -- TODO: implement
   | .All => default -- TODO: implement
   | .Hole _ typeOption => typeOption.getD  ⟨ HighType.Unknown, md ⟩
+  -- Subscript (eliminated before downstream passes, but needed for exhaustiveness)
+  | .Subscript _ _ _ => default
 
 /-- Classification of a heap-relevant modifies type. -/
 inductive ModifiesTypeKind where
@@ -112,6 +114,7 @@ non-heap-relevant types. Single source of truth for which types participate
 in modifies clauses and heap parameterization. -/
 def classifyModifiesHighType : HighType → Option ModifiesTypeKind
   | .UserDefined _ => some .composite
+  | .TArray _      => some .composite
   | .TSet _        => some .compositeSet
   | _              => none
 

--- a/Strata/Languages/Laurel/LaurelTypes.lean
+++ b/Strata/Languages/Laurel/LaurelTypes.lean
@@ -101,8 +101,12 @@ def computeExprType (model : SemanticModel) (expr : StmtExprMd) : HighTypeMd :=
   | .Abstract =>default -- TODO: implement
   | .All => default -- TODO: implement
   | .Hole _ typeOption => typeOption.getD  ⟨ HighType.Unknown, md ⟩
-  -- Subscript (eliminated before downstream passes, but needed for exhaustiveness)
-  | .Subscript _ _ _ => default
+  -- Subscript: derive element type from target's Seq/Array type
+  | .Subscript target _ update =>
+    match (computeExprType model target).val with
+    | .TSeq elemType => if update.isSome then computeExprType model target else elemType
+    | .TArray elemType => if update.isSome then computeExprType model target else elemType
+    | _ => default
 
 /-- Classification of a heap-relevant modifies type. -/
 inductive ModifiesTypeKind where

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -100,6 +100,9 @@ def AstNode.getType (node: AstNode): HighTypeMd := match node with
  | .datatypeConstructor type _ => ⟨ .UserDefined type, default ⟩
  | .constant c => c.type
  | .quantifierVar _ type => type
+ | .staticProcedure proc => match proc.outputs with
+    | [singleOutput] => singleOutput.type
+    | _ => ⟨ HighType.Unknown, default ⟩
  | .unresolved =>
     -- The Python through Laurel pipeline does not resolve yet
     ⟨ .UserDefined "dummyName", default ⟩
@@ -206,6 +209,7 @@ private def targetTypeName (target : StmtExprMd) : ResolveM (Option String) := d
     | some (_, node) =>
       match node.getType.val with
       | .UserDefined typRef => pure (some typRef.text)
+      | .TArray _ => pure (some "Array")
       | _ => pure none
     | none => pure none
   | _ => pure none
@@ -267,6 +271,12 @@ def resolveHighType (ty : HighTypeMd) : ResolveM HighTypeMd := do
     let base' ← resolveHighType base
     let args' ← args.mapM resolveHighType
     pure (.Applied base' args')
+  | .TSeq et =>
+    let et' ← resolveHighType et
+    pure (.TSeq et')
+  | .TArray et =>
+    let et' ← resolveHighType et
+    pure (.TArray et')
   | .Pure base =>
     let base' ← resolveHighType base
     pure (.Pure base')
@@ -395,6 +405,11 @@ def resolveStmtExpr (exprMd : StmtExprMd) : ResolveM StmtExprMd := do
       let ty' ← resolveHighType ty
       pure (.Hole det ty')
     | none => pure (.Hole det none)
+  | .Subscript target index update =>
+    let target' ← resolveStmtExpr target
+    let index' ← resolveStmtExpr index
+    let update' ← update.attach.mapM (fun a => have := a.property; resolveStmtExpr a.val)
+    pure (.Subscript target' index' update')
   return ⟨val', md⟩
   termination_by exprMd
   decreasing_by all_goals term_by_mem
@@ -624,6 +639,10 @@ private def collectStmtExpr (map : Std.HashMap Nat AstNode) (expr : StmtExprMd)
     let map := collectStmtExpr map val
     collectStmtExpr map proof
   | .ContractOf _ fn => collectStmtExpr map fn
+  | .Subscript target index update =>
+    let map := collectStmtExpr map target
+    let map := collectStmtExpr map index
+    match update with | some v => collectStmtExpr map v | none => map
   | .New _ | .This | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _
   | .Abstract | .All | .Hole _ _ => map
 

--- a/Strata/Languages/Laurel/SubscriptElim.lean
+++ b/Strata/Languages/Laurel/SubscriptElim.lean
@@ -40,16 +40,6 @@ private def isArrayHighType (ty : HighType) : Bool :=
   | _ => false
 
 /-- Redirect Sequence.* args that are Array-typed to use $data field -/
-private def redirectArrayArgs (model : SemanticModel) (callee : Identifier)
-    (origArgs : List StmtExprMd) (args : List StmtExprMd)
-    (md : Imperative.MetaData Core.Expression) : List StmtExprMd :=
-  if callee.text.startsWith SeqOp.namePrefix then
-    args.mapIdx fun i a =>
-      if i == 0 && isArrayType model (origArgs[0]!) then mkFieldSelect a SeqOp.dataField md
-      else if i == 1 && callee.text == SeqOp.append && origArgs.length > 1 && isArrayType model (origArgs[1]!) then mkFieldSelect a SeqOp.dataField md
-      else a
-  else args
-
 def elimExpr (model : SemanticModel) : StmtExprMd → StmtExprMd
   | ⟨.Subscript target index none, md⟩ =>
     let target' := elimExpr model target
@@ -100,8 +90,11 @@ def elimExpr (model : SemanticModel) : StmtExprMd → StmtExprMd
     ⟨.Assign (targets.attach.map fun ⟨t, _⟩ => elimExpr model t) (elimExpr model value), md⟩
   | ⟨.StaticCall callee args, md⟩ =>
     let args' := args.attach.map fun ⟨a, _⟩ => elimExpr model a
-    let args' := redirectArrayArgs model callee args args' md
-    ⟨.StaticCall callee args', md⟩
+    -- Array.length(a) → Sequence.length(a.$data)
+    if callee.text == arrayLengthName then
+      mkCall SeqOp.length [mkFieldSelect (args'.headD ⟨.LiteralInt 0, md⟩) SeqOp.dataField md] md
+    else
+      ⟨.StaticCall callee args', md⟩
   | ⟨.PrimitiveOp op args, md⟩ =>
     ⟨.PrimitiveOp op (args.attach.map fun ⟨a, _⟩ => elimExpr model a), md⟩
   | ⟨.Return (some v), md⟩ => ⟨.Return (some (elimExpr model v)), md⟩

--- a/Strata/Languages/Laurel/SubscriptElim.lean
+++ b/Strata/Languages/Laurel/SubscriptElim.lean
@@ -43,10 +43,10 @@ private def isArrayHighType (ty : HighType) : Bool :=
 private def redirectArrayArgs (model : SemanticModel) (callee : Identifier)
     (origArgs : List StmtExprMd) (args : List StmtExprMd)
     (md : Imperative.MetaData Core.Expression) : List StmtExprMd :=
-  if callee.text.startsWith "Sequence." then
+  if callee.text.startsWith SeqOp.namePrefix then
     args.mapIdx fun i a =>
-      if i == 0 && isArrayType model (origArgs[0]!) then mkFieldSelect a "$data" md
-      else if i == 1 && callee.text == "Sequence.append" && origArgs.length > 1 && isArrayType model (origArgs[1]!) then mkFieldSelect a "$data" md
+      if i == 0 && isArrayType model (origArgs[0]!) then mkFieldSelect a SeqOp.dataField md
+      else if i == 1 && callee.text == SeqOp.append && origArgs.length > 1 && isArrayType model (origArgs[1]!) then mkFieldSelect a SeqOp.dataField md
       else a
   else args
 
@@ -55,26 +55,26 @@ def elimExpr (model : SemanticModel) : StmtExprMd → StmtExprMd
     let target' := elimExpr model target
     let index' := elimExpr model index
     if isArrayType model target then
-      mkCall "Sequence.select" [mkFieldSelect target' "$data" md, index'] md
+      mkCall SeqOp.select [mkFieldSelect target' SeqOp.dataField md, index'] md
     else
-      mkCall "Sequence.select" [target', index'] md
+      mkCall SeqOp.select [target', index'] md
   | ⟨.Subscript target index (some value), md⟩ =>
     let target' := elimExpr model target
     let index' := elimExpr model index
     let value' := elimExpr model value
     if isArrayType model target then
-      let data := mkFieldSelect target' "$data" md
-      ⟨.Assign [mkFieldSelect target' "$data" md] (mkCall "Sequence.update" [data, index', value'] md), md⟩
+      let data := mkFieldSelect target' SeqOp.dataField md
+      ⟨.Assign [mkFieldSelect target' SeqOp.dataField md] (mkCall SeqOp.update [data, index', value'] md), md⟩
     else
-      mkCall "Sequence.update" [target', index', value'] md
+      mkCall SeqOp.update [target', index', value'] md
   | ⟨.Block stmts label, md⟩ =>
     let expandStmt : (s : StmtExprMd) → s ∈ stmts → List StmtExprMd := fun stmt _ =>
       match stmt with
       | ⟨.LocalVariable n ty (some initExpr), smd⟩ =>
         if isArrayHighType ty.val && !isArrayType model initExpr then
           let initExpr' := elimExpr model initExpr
-          [⟨.LocalVariable n ty (some ⟨.New (mkId "Array"), smd⟩), smd⟩,
-           ⟨.Assign [mkFieldSelect ⟨.Identifier n, smd⟩ "$data" smd] initExpr', smd⟩]
+          [⟨.LocalVariable n ty (some ⟨.New (mkId arrayCompositeName), smd⟩), smd⟩,
+           ⟨.Assign [mkFieldSelect ⟨.Identifier n, smd⟩ SeqOp.dataField smd] initExpr', smd⟩]
         else [elimExpr model stmt]
       | _ => [elimExpr model stmt]
     ⟨.Block (stmts.attach.flatMap fun ⟨s, h⟩ => expandStmt s h) label, md⟩
@@ -91,11 +91,11 @@ def elimExpr (model : SemanticModel) : StmtExprMd → StmtExprMd
     let index' := elimExpr model index
     let value' := elimExpr model value
     if isArrayType model target then
-      let data := mkFieldSelect target' "$data" smd
-      ⟨.Assign [mkFieldSelect target' "$data" smd] (mkCall "Sequence.update" [data, index', value'] smd), md⟩
+      let data := mkFieldSelect target' SeqOp.dataField smd
+      ⟨.Assign [mkFieldSelect target' SeqOp.dataField smd] (mkCall SeqOp.update [data, index', value'] smd), md⟩
     else
       -- Seq is immutable — subscript assign is a user error. Downstream will reject.
-      ⟨.Assign [mkCall "Sequence.select" [target', index'] smd] value', md⟩
+      ⟨.Assign [mkCall SeqOp.select [target', index'] smd] value', md⟩
   | ⟨.Assign targets value, md⟩ =>
     ⟨.Assign (targets.attach.map fun ⟨t, _⟩ => elimExpr model t) (elimExpr model value), md⟩
   | ⟨.StaticCall callee args, md⟩ =>
@@ -140,20 +140,28 @@ private def elimProcedure (model : SemanticModel) (proc : Procedure) : Procedure
   { proc with
     preconditions := proc.preconditions.map (elimExpr model)
     body := elimBody model proc.body
-    decreases := proc.decreases.map (elimExpr model) }
+    decreases := proc.decreases.map (elimExpr model)
+    invokeOn := proc.invokeOn.map (elimExpr model) }
 
 public def subscriptElim (model : SemanticModel) (program : Program) : Program :=
   -- Always inject the Array composite type. Harmless if unused — just adds
   -- an Array_TypeTag constructor and an Array.$data field to the heap model.
   let arrayComposite : TypeDefinition := .Composite {
-    name := mkId "Array"
+    name := mkId arrayCompositeName
     extending := []
     -- $data field uses Seq<int> as placeholder. The element type is erased
     -- (Core's polymorphic type inference handles actual types).
-    fields := [{ name := mkId "$data", isMutable := true,
+    fields := [{ name := mkId SeqOp.dataField, isMutable := true,
                  type := ⟨.TSeq ⟨.TInt, #[]⟩, #[]⟩ }]
     instanceProcedures := [] }
   let program := { program with types := arrayComposite :: program.types }
-  { program with staticProcedures := program.staticProcedures.map (elimProcedure model) }
+  let types' := program.types.map fun td =>
+    match td with
+    | .Composite ct =>
+      .Composite { ct with instanceProcedures := ct.instanceProcedures.map (elimProcedure model) }
+    | other => other
+  { program with
+    types := types'
+    staticProcedures := program.staticProcedures.map (elimProcedure model) }
 
 end Strata.Laurel

--- a/Strata/Languages/Laurel/SubscriptElim.lean
+++ b/Strata/Languages/Laurel/SubscriptElim.lean
@@ -1,0 +1,159 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.Languages.Laurel.Resolution
+public import Strata.Languages.Laurel.LaurelTypes
+
+/-!
+# Subscript Elimination
+
+Type-aware pass that desugars `Subscript` nodes based on the target type:
+- `Seq<T>`: read → `Sequence.select`, update → `Sequence.update`
+- `Array<T>`: read → `Sequence.select(a#$data, i)`,
+              update → `Assign [FieldSelect a "$data"] (Sequence.update(a#$data, i, v))`
+
+After this pass, no `Subscript` nodes remain in the program.
+-/
+
+namespace Strata.Laurel
+
+open Strata
+
+private def mkCall (name : String) (args : List StmtExprMd) (md : Imperative.MetaData Core.Expression) : StmtExprMd :=
+  ⟨.StaticCall (mkId name) args, md⟩
+
+private def mkFieldSelect (target : StmtExprMd) (field : String) (md : Imperative.MetaData Core.Expression) : StmtExprMd :=
+  ⟨.FieldSelect target (mkId field), md⟩
+
+private def isArrayType (model : SemanticModel) (target : StmtExprMd) : Bool :=
+  match (computeExprType model target).val with
+  | .TArray _ => true
+  | _ => false
+
+private def isArrayHighType (ty : HighType) : Bool :=
+  match ty with
+  | .TArray _ => true
+  | _ => false
+
+/-- Redirect Sequence.* args that are Array-typed to use $data field -/
+private def redirectArrayArgs (model : SemanticModel) (callee : Identifier)
+    (origArgs : List StmtExprMd) (args : List StmtExprMd)
+    (md : Imperative.MetaData Core.Expression) : List StmtExprMd :=
+  if callee.text.startsWith "Sequence." then
+    args.mapIdx fun i a =>
+      if i == 0 && isArrayType model (origArgs[0]!) then mkFieldSelect a "$data" md
+      else if i == 1 && callee.text == "Sequence.append" && origArgs.length > 1 && isArrayType model (origArgs[1]!) then mkFieldSelect a "$data" md
+      else a
+  else args
+
+def elimExpr (model : SemanticModel) : StmtExprMd → StmtExprMd
+  | ⟨.Subscript target index none, md⟩ =>
+    let target' := elimExpr model target
+    let index' := elimExpr model index
+    if isArrayType model target then
+      mkCall "Sequence.select" [mkFieldSelect target' "$data" md, index'] md
+    else
+      mkCall "Sequence.select" [target', index'] md
+  | ⟨.Subscript target index (some value), md⟩ =>
+    let target' := elimExpr model target
+    let index' := elimExpr model index
+    let value' := elimExpr model value
+    if isArrayType model target then
+      let data := mkFieldSelect target' "$data" md
+      ⟨.Assign [mkFieldSelect target' "$data" md] (mkCall "Sequence.update" [data, index', value'] md), md⟩
+    else
+      mkCall "Sequence.update" [target', index', value'] md
+  | ⟨.Block stmts label, md⟩ =>
+    let expandStmt : (s : StmtExprMd) → s ∈ stmts → List StmtExprMd := fun stmt _ =>
+      match stmt with
+      | ⟨.LocalVariable n ty (some initExpr), smd⟩ =>
+        if isArrayHighType ty.val && !isArrayType model initExpr then
+          let initExpr' := elimExpr model initExpr
+          [⟨.LocalVariable n ty (some ⟨.New (mkId "Array"), smd⟩), smd⟩,
+           ⟨.Assign [mkFieldSelect ⟨.Identifier n, smd⟩ "$data" smd] initExpr', smd⟩]
+        else [elimExpr model stmt]
+      | _ => [elimExpr model stmt]
+    ⟨.Block (stmts.attach.flatMap fun ⟨s, h⟩ => expandStmt s h) label, md⟩
+  | ⟨.IfThenElse c t e, md⟩ =>
+    ⟨.IfThenElse (elimExpr model c) (elimExpr model t)
+      (match e with | some e => some (elimExpr model e) | none => none), md⟩
+  | ⟨.LocalVariable n ty init, md⟩ =>
+    ⟨.LocalVariable n ty (match init with | some i => some (elimExpr model i) | none => none), md⟩
+  | ⟨.While c invs dec body, md⟩ =>
+    ⟨.While (elimExpr model c) (invs.attach.map fun ⟨i, _⟩ => elimExpr model i)
+            (match dec with | some d => some (elimExpr model d) | none => none) (elimExpr model body), md⟩
+  | ⟨.Assign [⟨.Subscript target index none, smd⟩] value, md⟩ =>
+    let target' := elimExpr model target
+    let index' := elimExpr model index
+    let value' := elimExpr model value
+    if isArrayType model target then
+      let data := mkFieldSelect target' "$data" smd
+      ⟨.Assign [mkFieldSelect target' "$data" smd] (mkCall "Sequence.update" [data, index', value'] smd), md⟩
+    else
+      -- Seq is immutable — subscript assign is a user error. Downstream will reject.
+      ⟨.Assign [mkCall "Sequence.select" [target', index'] smd] value', md⟩
+  | ⟨.Assign targets value, md⟩ =>
+    ⟨.Assign (targets.attach.map fun ⟨t, _⟩ => elimExpr model t) (elimExpr model value), md⟩
+  | ⟨.StaticCall callee args, md⟩ =>
+    let args' := args.attach.map fun ⟨a, _⟩ => elimExpr model a
+    let args' := redirectArrayArgs model callee args args' md
+    ⟨.StaticCall callee args', md⟩
+  | ⟨.PrimitiveOp op args, md⟩ =>
+    ⟨.PrimitiveOp op (args.attach.map fun ⟨a, _⟩ => elimExpr model a), md⟩
+  | ⟨.Return (some v), md⟩ => ⟨.Return (some (elimExpr model v)), md⟩
+  | ⟨.Return none, md⟩ => ⟨.Return none, md⟩
+  | ⟨.Forall p t body, md⟩ =>
+    ⟨.Forall p (match t with | some t => some (elimExpr model t) | none => none) (elimExpr model body), md⟩
+  | ⟨.Exists p t body, md⟩ =>
+    ⟨.Exists p (match t with | some t => some (elimExpr model t) | none => none) (elimExpr model body), md⟩
+  | ⟨.Assert c, md⟩ => ⟨.Assert (elimExpr model c), md⟩
+  | ⟨.Assume c, md⟩ => ⟨.Assume (elimExpr model c), md⟩
+  | ⟨.Old v, md⟩ => ⟨.Old (elimExpr model v), md⟩
+  | ⟨.Fresh v, md⟩ => ⟨.Fresh (elimExpr model v), md⟩
+  | ⟨.Assigned v, md⟩ => ⟨.Assigned (elimExpr model v), md⟩
+  | ⟨.ProveBy v p, md⟩ => ⟨.ProveBy (elimExpr model v) (elimExpr model p), md⟩
+  | ⟨.ReferenceEquals l r, md⟩ => ⟨.ReferenceEquals (elimExpr model l) (elimExpr model r), md⟩
+  | ⟨.InstanceCall t c args, md⟩ =>
+    ⟨.InstanceCall (elimExpr model t) c (args.attach.map fun ⟨a, _⟩ => elimExpr model a), md⟩
+  | ⟨.FieldSelect t f, md⟩ => ⟨.FieldSelect (elimExpr model t) f, md⟩
+  | ⟨.PureFieldUpdate t f v, md⟩ => ⟨.PureFieldUpdate (elimExpr model t) f (elimExpr model v), md⟩
+  | ⟨.AsType t ty, md⟩ => ⟨.AsType (elimExpr model t) ty, md⟩
+  | ⟨.IsType t ty, md⟩ => ⟨.IsType (elimExpr model t) ty, md⟩
+  | ⟨.ContractOf ty fn, md⟩ => ⟨.ContractOf ty (elimExpr model fn), md⟩
+  | other => other
+termination_by expr => expr
+decreasing_by all_goals (have := WithMetadata.sizeOf_val_lt ‹_›; term_by_mem)
+
+private def elimBody (model : SemanticModel) (body : Body) : Body :=
+  match body with
+  | .Transparent b => .Transparent (elimExpr model b)
+  | .Opaque posts impl mods =>
+    .Opaque (posts.map (elimExpr model)) (impl.map (elimExpr model)) (mods.map (elimExpr model))
+  | .Abstract posts => .Abstract (posts.map (elimExpr model))
+  | .External => .External
+
+private def elimProcedure (model : SemanticModel) (proc : Procedure) : Procedure :=
+  { proc with
+    preconditions := proc.preconditions.map (elimExpr model)
+    body := elimBody model proc.body
+    decreases := proc.decreases.map (elimExpr model) }
+
+public def subscriptElim (model : SemanticModel) (program : Program) : Program :=
+  -- Always inject the Array composite type. Harmless if unused — just adds
+  -- an Array_TypeTag constructor and an Array.$data field to the heap model.
+  let arrayComposite : TypeDefinition := .Composite {
+    name := mkId "Array"
+    extending := []
+    -- $data field uses Seq<int> as placeholder. The element type is erased
+    -- (Core's polymorphic type inference handles actual types).
+    fields := [{ name := mkId "$data", isMutable := true,
+                 type := ⟨.TSeq ⟨.TInt, #[]⟩, #[]⟩ }]
+    instanceProcedures := [] }
+  let program := { program with types := arrayComposite :: program.types }
+  { program with staticProcedures := program.staticProcedures.map (elimProcedure model) }
+
+end Strata.Laurel

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T18_Sequences.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T18_Sequences.lean
@@ -96,6 +96,68 @@ procedure seqNested() {
   var s: Seq<Seq<int>> := [[1, 2], [3, 4]];
   assert Sequence.select(Sequence.select(s, 0), 1) == 2
 };
+
+// Append length
+procedure appendLength() {
+  var a: Seq<int> := [1, 2];
+  var b: Seq<int> := [3, 4, 5];
+  var c: Seq<int> := Sequence.append(a, b);
+  assert Sequence.length(c) == 5
+};
+
+// Append select from first half
+procedure appendSelectFirst() {
+  var a: Seq<int> := [10, 20];
+  var b: Seq<int> := [30];
+  var c: Seq<int> := Sequence.append(a, b);
+  assert c[0] == 10;
+  assert c[1] == 20
+};
+
+// Append select from second half
+procedure appendSelectSecond() {
+  var a: Seq<int> := [10, 20];
+  var b: Seq<int> := [30];
+  var c: Seq<int> := Sequence.append(a, b);
+  assert c[2] == 30
+};
+
+// Contains negative test
+procedure containsFalse() {
+  var s: Seq<int> := [1, 2, 3];
+  assert Sequence.contains(s, 99)
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+
+// Take length
+procedure takeLength() {
+  var s: Seq<int> := [10, 20, 30, 40];
+  var t: Seq<int> := Sequence.take(s, 2);
+  assert Sequence.length(t) == 2
+};
+
+// Take preserves elements
+procedure takeSelect() {
+  var s: Seq<int> := [10, 20, 30, 40];
+  var t: Seq<int> := Sequence.take(s, 2);
+  assert t[0] == 10;
+  assert t[1] == 20
+};
+
+// Drop length
+procedure dropLength() {
+  var s: Seq<int> := [10, 20, 30, 40];
+  var d: Seq<int> := Sequence.drop(s, 2);
+  assert Sequence.length(d) == 2
+};
+
+// Drop selects from offset
+procedure dropSelect() {
+  var s: Seq<int> := [10, 20, 30, 40];
+  var d: Seq<int> := Sequence.drop(s, 2);
+  assert d[0] == 30;
+  assert d[1] == 40
+};
 "
 
 #guard_msgs(drop info, error) in

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T18_Sequences.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T18_Sequences.lean
@@ -1,0 +1,105 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import StrataTest.Util.TestDiagnostics
+import StrataTest.Languages.Laurel.TestExamples
+
+open StrataTest.Util
+
+namespace Strata
+namespace Laurel
+
+def seqProgram := r"
+// Literal construction and select
+procedure literalSelect() returns (r: int) {
+  var s: Seq<int> := [10, 20, 30];
+  r := Sequence.select(s, 1);
+  assert r == 20
+};
+
+// Empty sequence has length 0
+procedure emptyLength() {
+  var s: Seq<int> := [];
+  assert Sequence.length(s) == 0
+};
+
+// Build and length
+procedure buildLength() {
+  var s: Seq<int> := [1, 2, 3];
+  assert Sequence.length(s) == 3
+};
+
+// Functional update preserves length
+procedure updateLength() {
+  var s: Seq<int> := [1, 2, 3];
+  var t: Seq<int> := s[0 := 99];
+  assert Sequence.length(t) == 3
+};
+
+// Functional update changes element
+procedure updateSelect() {
+  var s: Seq<int> := [1, 2, 3];
+  var t: Seq<int> := s[0 := 99];
+  assert Sequence.select(t, 0) == 99
+};
+
+// Subscript read sugar
+procedure subscriptRead(s: Seq<int>)
+  requires Sequence.length(s) > 0
+{
+  var x: int := s[0];
+  assert x == Sequence.select(s, 0)
+};
+
+// Subscript update sugar
+procedure subscriptUpdate(s: Seq<int>)
+  requires Sequence.length(s) > 0
+{
+  var t: Seq<int> := s[0 := 42];
+  assert Sequence.select(t, 0) == 42
+};
+
+// Sequence in requires/ensures
+procedure contractSeq(s: Seq<int>) returns (r: int)
+  requires Sequence.length(s) > 0
+  ensures r == Sequence.select(s, 0)
+{
+  r := s[0]
+};
+
+// Sequence in quantifiers
+procedure quantifierSeq(s: Seq<int>)
+  requires Sequence.length(s) > 0
+  requires forall(i: int) => 0 <= i && i < Sequence.length(s) ==> s[i] >= 0
+{
+  assert s[0] >= 0
+};
+
+// Invalid assertion should fail
+procedure failingAssert() {
+  var s: Seq<int> := [1, 2, 3];
+  assert Sequence.select(s, 0) == 999
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+
+// Bool element type
+procedure seqBool() {
+  var s: Seq<bool> := [true, false];
+  assert Sequence.select(s, 0) == true
+};
+
+// Nested sequences
+procedure seqNested() {
+  var s: Seq<Seq<int>> := [[1, 2], [3, 4]];
+  assert Sequence.select(Sequence.select(s, 0), 1) == 2
+};
+"
+
+#guard_msgs(drop info, error) in
+#eval testInputWithOffset "Sequences" seqProgram 14 processLaurelFile
+
+end Laurel
+end Strata

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T19_Arrays.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T19_Arrays.lean
@@ -23,21 +23,21 @@ procedure basicReadWrite() {
 // Length
 procedure length() {
   var a: Array<int> := [10, 20, 30];
-  assert Sequence.length(a) == 3
+  assert Array.length(a) == 3
 };
 
 // Empty array
 procedure emptyArray() {
   var a: Array<int> := [];
-  assert Sequence.length(a) == 0
+  assert Array.length(a) == 0
 };
 
 // Array in contracts
 procedure arrayContract(a: Array<int>)
-  requires Sequence.length(a) > 0
+  requires Array.length(a) > 0
 {
   var x: int := a[0];
-  assert x == Sequence.select(a, 0)
+  assert x == a[0]
 };
 
 // Multiple writes
@@ -72,7 +72,7 @@ procedure arrayLoop() {
   var i: int := 0;
   while (i < 3)
     invariant 0 <= i && i <= 3
-    invariant Sequence.length(a) == 3
+    invariant Array.length(a) == 3
     invariant forall(j: int) => 0 <= j && j < i ==> a[j] == 0
   {
     a[i] := 0;
@@ -85,7 +85,7 @@ procedure arrayLoop() {
 
 // Inter-procedural: callee modifies array
 procedure setFirst(a: Array<int>, v: int)
-  requires Sequence.length(a) > 0
+  requires Array.length(a) > 0
   ensures a[0] == v
   modifies a
 {
@@ -96,14 +96,6 @@ procedure callSetFirst() {
   var a: Array<int> := [1, 2, 3];
   setFirst(a, 42);
   assert a[0] == 42
-};
-
-// Sequence.append on arrays (tests redirectArrayArgs for arg index 1)
-procedure appendOnArrays() {
-  var a: Array<int> := [1, 2];
-  var b: Array<int> := [3, 4];
-  var c: Seq<int> := Sequence.append(a, b);
-  assert Sequence.length(c) == 4
 };
 "
 

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T19_Arrays.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T19_Arrays.lean
@@ -65,6 +65,46 @@ procedure failingAssert() {
   assert a[0] == 999
 //^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
 };
+
+// Array in a loop: zero-fill
+procedure arrayLoop() {
+  var a: Array<int> := [1, 2, 3];
+  var i: int := 0;
+  while (i < 3)
+    invariant 0 <= i && i <= 3
+    invariant Sequence.length(a) == 3
+    invariant forall(j: int) => 0 <= j && j < i ==> a[j] == 0
+  {
+    a[i] := 0;
+    i := i + 1
+  };
+  assert a[0] == 0;
+  assert a[1] == 0;
+  assert a[2] == 0
+};
+
+// Inter-procedural: callee modifies array
+procedure setFirst(a: Array<int>, v: int)
+  requires Sequence.length(a) > 0
+  ensures a[0] == v
+  modifies a
+{
+  a[0] := v
+};
+
+procedure callSetFirst() {
+  var a: Array<int> := [1, 2, 3];
+  setFirst(a, 42);
+  assert a[0] == 42
+};
+
+// Sequence.append on arrays (tests redirectArrayArgs for arg index 1)
+procedure appendOnArrays() {
+  var a: Array<int> := [1, 2];
+  var b: Array<int> := [3, 4];
+  var c: Seq<int> := Sequence.append(a, b);
+  assert Sequence.length(c) == 4
+};
 "
 
 #guard_msgs(drop info, error) in

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T19_Arrays.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T19_Arrays.lean
@@ -1,0 +1,74 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import StrataTest.Util.TestDiagnostics
+import StrataTest.Languages.Laurel.TestExamples
+
+open StrataTest.Util
+
+namespace Strata
+namespace Laurel
+
+def arrayProgram := r"
+// Basic read/write
+procedure basicReadWrite() {
+  var a: Array<int> := [1, 2, 3];
+  a[0] := 42;
+  assert a[0] == 42
+};
+
+// Length
+procedure length() {
+  var a: Array<int> := [10, 20, 30];
+  assert Sequence.length(a) == 3
+};
+
+// Empty array
+procedure emptyArray() {
+  var a: Array<int> := [];
+  assert Sequence.length(a) == 0
+};
+
+// Array in contracts
+procedure arrayContract(a: Array<int>)
+  requires Sequence.length(a) > 0
+{
+  var x: int := a[0];
+  assert x == Sequence.select(a, 0)
+};
+
+// Multiple writes
+procedure multipleWrites() {
+  var a: Array<int> := [0, 0, 0];
+  a[0] := 10;
+  a[1] := 20;
+  a[2] := 30;
+  assert a[0] == 10;
+  assert a[1] == 20;
+  assert a[2] == 30
+};
+
+// Aliasing: mutation through one reference visible through another
+procedure aliasing() {
+  var a: Array<int> := [1, 2, 3];
+  var b: Array<int> := a;
+  b[0] := 99;
+  assert a[0] == 99
+};
+
+// Failing assertion
+procedure failingAssert() {
+  var a: Array<int> := [1, 2, 3];
+  assert a[0] == 999
+//^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+"
+
+#guard_msgs(drop info, error) in
+#eval testInputWithOffset "Arrays" arrayProgram 14 processLaurelFile
+
+end Laurel
+end Strata

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -54,6 +54,8 @@ private def fmtHighType : HighType → String
   | .TTypedField _ => "TTypedField"
   | .TSet _ => "TSet"
   | .TMap _ _ => "TMap"
+  | .TSeq _ => "TSeq"
+  | .TArray _ => "TArray"
   | .UserDefined name => s!"UserDefined({name})"
   | .Applied _ _ => "Applied"
   | .Pure _ => "Pure"


### PR DESCRIPTION
## Summary

Adds immutable sequences and mutable heap-backed arrays to Laurel with end-to-end SMT verification.

### Sequences (immutable value types)
- `TSeq` variant in `HighType`; `Seq<T>` grammar syntax
- `[1, 2, 3]` sequence literals (desugared to `Sequence.build` chains)
- `s[i]` subscript read and `s[i := v]` functional update
- 9 external `Sequence.*` functions (empty, build, select, update, length, append, contains, take, drop)
- Works with `Seq<int>`, `Seq<bool>`, `Seq<Seq<int>>`, `Seq<Composite>`

### Arrays (mutable heap-backed)
- `TArray` variant in `HighType`; `Array<T>` grammar syntax
- `a[i]` read and `a[i] := v` write with heap semantics
- Aliasing: `b := a; b[0] := 99; assert a[0] == 99`
- Seq literal to Array conversion: `var a: Array<int> := [1, 2, 3]`
- Synthetic Array composite with \$data field, BoxSeq wrapping
- `Array<T>` recognized as composite in modifies clauses
- Currently supports `Array<int>`; other element types require heap model changes

### Shared infrastructure
- `Subscript` AST node with `SubscriptElim` type-aware pass (total, not partial)
- Generic fix for 0-ary op formatting in Core VC output
- Fix: `AstNode.getType` for `.staticProcedure`
- Fix: `targetTypeName` for `TArray` types

### Known limitations
- `Array<bool>`, `Array<Seq<T>>`, `Array<Array<T>>` don't work due to monomorphic Box/heap model
- Inter-procedural array contracts require bounds preconditions (by design — matches Sequence axiom guards)