### PR TITLE
Add workflow to label PRs with merge conflicts

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,19 @@
+name: Label merge conflicts
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label-conflicts:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: prince-chrismc/label-merge-conflicts-action@v3
+        with:
+          conflict_label_name: "Git conflicts"
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -13,7 +13,7 @@ jobs:
   label-conflicts:
     runs-on: ubuntu-slim
     steps:
-      - uses: prince-chrismc/label-merge-conflicts-action@v3
+      - uses: prince-chrismc/label-merge-conflicts-action@21e6705eaa6aab66e4e486279389c8e3e4c465b7 # v3
         with:
           conflict_label_name: "Git conflicts"
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Uses prince-chrismc/label-merge-conflicts-action to automatically add a 'Git conflicts' label to PRs that have merge conflicts with main, and remove it when the conflict is resolved.

Triggers on pushes to main (to re-check all open PRs) and on PR open/synchronize events. Uses explicit pull-requests: write permission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
