### PR TITLE
Share Lean build cache with Python CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           fail: true
 
   build_python:
+    needs: build_and_test_lean
     name: Build and test Python
     runs-on: ubuntu-latest
     permissions:
@@ -211,12 +212,17 @@ jobs:
     - name: Build using pip
       run: pip install .
       working-directory: Tools/Python
-    - name: Build Lean strata executable for testing purposes.
+    - name: Restore Lean build cache
+      uses: actions/cache/restore@v5
+      with:
+        path: .lake
+        key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ hashFiles('**/*.st') }}-${{ github.sha }}
+        fail-on-cache-miss: true
+    - name: Install Lean (for lake env)
       uses: leanprover/lean-action@v1
       with:
         auto-config: false
-        build: true
-        build-args: "strata:exe"
+        build: false
     - name: Install cvc5
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,7 @@ jobs:
       with:
         auto-config: false
         build: false
+        use-github-cache: false
     - name: Install cvc5
       shell: bash
       run: |


### PR DESCRIPTION
The Python matrix job (3.11-3.14) previously rebuilt the Lean strata executable from scratch in each of the 4 jobs. Since Lean build artifacts are Python-version-independent, this was redundant.

The Python job now depends on build_and_test_lean and restores the Lean build cache (saved with the SHA-keyed cache key) instead of rebuilding. lean-action with build: false installs the toolchain (needed for lake env) without compiling anything.

This eliminates 4 redundant Lean builds from the CI pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
