### PR TITLE
Add support for list negative and out of bound slice

### DIFF
--- a/Strata/Languages/Python/PythonRuntimeLaurelPart.lean
+++ b/Strata/Languages/Python/PythonRuntimeLaurelPart.lean
@@ -382,10 +382,30 @@ procedure List_drop_len(l : ListAny, i: int)
   invokeOn List_len(List_drop(l,i))
   ensures i >= 0 && i <= List_len(l) ==> List_len(List_drop(l,i)) == List_len(l) - i;
 
-function List_slice (l : ListAny, start : int, stop: int) : ListAny
-  requires start >= 0 && start < List_len(l) && stop >= 0 && stop <= List_len(l) && start <= stop
+function int_max (i1: int, i2: int) : int
 {
-  List_take (List_drop (l, start), stop - start)
+  if i1 >= i2 then i1 else i2
+};
+
+function int_min (i1: int, i2: int) : int
+{
+  if i1 <= i2 then i1 else i2
+};
+
+function List_slice_non_neg (l : ListAny, start : int, stop: int) : ListAny
+  requires start >= 0 && stop >= 0
+{
+  if (start >= List_len(l)) || (start >= stop) then ListAny_nil()
+  else List_take (List_drop (l, start), int_min(stop, List_len(l))  - start)
+};
+
+
+function List_slice (l : ListAny, start : int, stop: int) : ListAny
+{
+  List_slice_non_neg (l,
+    if start >= 0 then start else int_max (List_len(l) + start, 0),
+    if stop >= 0 then stop else int_max (List_len(l) + stop, 0)
+  )
 };
 
 function List_set_non_neg (l : ListAny, i : int, v: Any) : ListAny
@@ -454,18 +474,15 @@ function DictStrAny_insert (d : DictStrAny, key: string, val: Any) : DictStrAny
 function Any_get (dictOrList: Any, index: Any): Any
   requires  (Any..isfrom_DictStrAny(dictOrList) && Any..isfrom_str(index) && DictStrAny_contains(Any..as_Dict!(dictOrList), Any..as_string!(index))) ||
             (Any..isfrom_ListAny(dictOrList) && Any..isfrom_int(index) && Any..as_int!(index) >= - List_len(Any..as_ListAny!(dictOrList)) && Any..as_int!(index) < List_len(Any..as_ListAny!(dictOrList)))||
-            (Any..isfrom_ListAny(dictOrList) && Any..isfrom_Slice(index) && Any..start!(index) >= 0 && Any..start!(index) < List_len(Any..as_ListAny!(dictOrList)) &&
-                ((OptionInt..isOptSome(Any..stop!(index))) &&  OptionInt..unwrap!(Any..stop!(index)) >= 0 && OptionInt..unwrap!(Any..stop!(index)) <= List_len(Any..as_ListAny!(dictOrList)) && Any..start!(index) <= OptionInt..unwrap!(Any..stop!(index))
-                  || (OptionInt..isOptNone(Any..stop!(index)))))
+            (Any..isfrom_ListAny(dictOrList) && Any..isfrom_Slice(index))
 {
   if Any..isfrom_DictStrAny(dictOrList) then
     DictStrAny_get(Any..as_Dict!(dictOrList), Any..as_string!(index))
   else if Any..isfrom_ListAny(dictOrList) && Any..isfrom_int(index) then
       List_get(Any..as_ListAny!(dictOrList), Any..as_int!(index))
-  else if Any..isfrom_ListAny(dictOrList) && Any..isfrom_Slice(index) && OptionInt..isOptSome(Any..stop!(index)) then
-    from_ListAny(List_slice(Any..as_ListAny!(dictOrList), Any..start!(index), OptionInt..unwrap!(Any..stop!(index))))
   else
-    from_ListAny(List_drop(Any..as_ListAny!(dictOrList), Any..start!(index)))
+    from_ListAny(List_slice(Any..as_ListAny!(dictOrList), Any..start!(index),
+      if OptionInt..isOptSome(Any..stop!(index)) then OptionInt..unwrap!(Any..stop!(index)) else List_len(Any..as_ListAny!(dictOrList))))
 };
 
 function Any_get! (dictOrList: Any, index: Any): Any

--- a/StrataTest/Languages/Python/PreludeVerifyTest.lean
+++ b/StrataTest/Languages/Python/PreludeVerifyTest.lean
@@ -86,11 +86,15 @@ Obligation: List_get_body_calls_List_get_non_neg_1
 Property: assert
 Result: ✅ pass
 
-Obligation: List_slice_body_calls_List_drop_0
+Obligation: List_slice_non_neg_body_calls_List_drop_0
 Property: assert
 Result: ✅ pass
 
-Obligation: List_slice_body_calls_List_take_1
+Obligation: List_slice_non_neg_body_calls_List_take_1
+Property: assert
+Result: ✅ pass
+
+Obligation: List_slice_body_calls_List_slice_non_neg_0
 Property: assert
 Result: ✅ pass
 
@@ -119,14 +123,6 @@ Property: assert
 Result: ✅ pass
 
 Obligation: Any_get_body_calls_List_get_1
-Property: assert
-Result: ✅ pass
-
-Obligation: Any_get_body_calls_List_slice_2
-Property: assert
-Result: ✅ pass
-
-Obligation: Any_get_body_calls_List_drop_3
 Property: assert
 Result: ✅ pass
 
@@ -198,15 +194,15 @@ Obligation: postcondition
 Property: assert
 Result: ✅ pass
 
-Obligation: assert(43154)
+Obligation: assert(43078)
 Property: assert
 Result: ✅ pass
 
-Obligation: assert(43221)
+Obligation: assert(43145)
 Property: assert
 Result: ✅ pass
 
-Obligation: assert(43329)
+Obligation: assert(43253)
 Property: assert
 Result: ✅ pass
 

--- a/StrataTest/Languages/Python/expected_laurel/test_list_slice.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_list_slice.expected
@@ -10,5 +10,19 @@ test_list_slice.py(7, 0): ✅ pass - assert(145)
 test_list_slice.py(9, 0): ✅ pass - assert_assert(187)_calls_Any_get_0
 test_list_slice.py(9, 0): ✅ pass - assert_assert(187)_calls_Any_to_bool_1
 test_list_slice.py(9, 0): ✅ pass - assert(187)
-DETAIL: 12 passed, 0 failed, 0 inconclusive
+test_list_slice.py(11, 16): ✅ pass - Check PNeg exception
+test_list_slice.py(11, 19): ✅ pass - Check PNeg exception
+test_list_slice.py(11, 0): ✅ pass - assert_assert(220)_calls_Any_get_0
+test_list_slice.py(11, 0): ✅ pass - assert_assert(220)_calls_Any_to_bool_1
+test_list_slice.py(11, 0): ✅ pass - assert(220)
+test_list_slice.py(13, 16): ✅ pass - Check PNeg exception
+test_list_slice.py(13, 21): ✅ pass - Check PNeg exception
+test_list_slice.py(13, 0): ✅ pass - assert_assert(260)_calls_Any_get_0
+test_list_slice.py(13, 0): ✅ pass - assert_assert(260)_calls_Any_to_bool_1
+test_list_slice.py(13, 0): ✅ pass - assert(260)
+test_list_slice.py(15, 18): ✅ pass - Check PNeg exception
+test_list_slice.py(15, 0): ✅ pass - assert_assert(307)_calls_Any_get_0
+test_list_slice.py(15, 0): ✅ pass - assert_assert(307)_calls_Any_to_bool_1
+test_list_slice.py(15, 0): ✅ pass - assert(307)
+DETAIL: 26 passed, 0 failed, 0 inconclusive
 RESULT: Analysis success

--- a/StrataTest/Languages/Python/tests/test_list_slice.py
+++ b/StrataTest/Languages/Python/tests/test_list_slice.py
@@ -7,3 +7,9 @@ list_of_list_nums = [[1,2,3,4], [10, 20, 30, 40, 50], [100, 400, 300], [5,6,7,8]
 assert list_of_list_nums [2:][1][2] == 7
 
 assert numbers [:2] == [10, 20]
+
+assert numbers [-4:-1] == [20, 30, 40]
+
+assert numbers [-100:-1] == [10, 20, 30, 40] 
+
+assert numbers [1:-100] == []


### PR DESCRIPTION
*Description of changes:* This PR adds support for list negative and out of bound slice.

Semantic: For `list[start:stop]` , when `start` or `stop` is negative, Python firstly add `len(list)` to them, then clamp them to the range `[0, len(list)]`. If `start>=stop`, it returns an empty list. 

There should be no precondition for `start` and `stop`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
