### PR TITLE
Fix #827: Disable conflict comments in label-conflicts workflow

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           conflict_label_name: "Git conflicts"
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          conflict_comment: ""


### PR DESCRIPTION
Fixes #846

The `label-merge-conflicts-action` added in #827 posts a comment on PRs with merge conflicts, but does not remove the comment when the conflict is resolved. This pollutes the PR conversation.

This PR disables the comment by setting `conflict_comment: ""` (as documented by the action), while keeping the automatic label add/remove behavior intact.
