### PR TITLE
Add icontract verification tooling: format_results.py, verify script, and example

### DIFF
--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -1212,14 +1212,34 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
                        (decorators : Array (expr SourceRange))
                        (returns : Option (expr SourceRange)) : PySpecM FunctionDecl := do
   let mut overload : Bool := false
+  -- Collect icontract preconditions and postconditions from decorators
+  let mut icontractRequires : Array (expr SourceRange) := #[]
+  let mut icontractEnsures : Array (expr SourceRange) := #[]
   for pyd in decorators do
-    let (success, d) ← runChecked <| pySpecValue pyd
-    if success then
-      match d with
-      | .typingOverload =>
-        overload := true
-      | _ =>
-        specError pyd.ann s!"Decorator {repr d} not supported."
+    -- Check for @icontract.require(lambda ...: cond) or @icontract.ensure(lambda ...: cond)
+    match pyd with
+    | .Call _ (.Attribute _ (.Name _ ⟨_, "icontract"⟩ (.Load _)) ⟨_, attr⟩ (.Load _)) args _ =>
+      if args.val.size ≥ 1 then
+        match args.val[0]! with
+        | .Lambda _ _lamArgs lamBody =>
+          if attr == "require" then
+            icontractRequires := icontractRequires.push lamBody
+          else if attr == "ensure" then
+            icontractEnsures := icontractEnsures.push lamBody
+          else
+            specWarning pyd.ann s!"Unknown icontract decorator: icontract.{attr}"
+        | _ =>
+          specWarning pyd.ann s!"icontract.{attr} expects a lambda argument"
+      else
+        specWarning pyd.ann s!"icontract.{attr} requires at least one argument"
+    | _ =>
+      let (success, d) ← runChecked <| pySpecValue pyd
+      if success then
+        match d with
+        | .typingOverload =>
+          overload := true
+        | _ =>
+          specError pyd.ann s!"Decorator {repr d} not supported."
 
   let .mk_arguments _ posonly ⟨_, posArgs⟩ vararg kwonly kw_defaults kwarg defaults := arguments
   assert! posonly.val.size = 0
@@ -1282,7 +1302,21 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
         match returns with
         | none => pure <| .ident fnLoc .typingAny
         | some tp => pySpecType tp
-  let as ← collectAssertions argDecls returnType <|
+  let as ← collectAssertions argDecls returnType <| do
+    -- Process icontract @require decorators as preconditions
+    for reqExpr in icontractRequires do
+      let formula ← transAssertExpr reqExpr
+      let message := #[MessagePart.str (toString (repr reqExpr))]
+      modify fun s => { s with
+        assertions := s.assertions.push { message, formula }
+      }
+    -- Process icontract @ensure decorators as postconditions
+    for ensExpr in icontractEnsures do
+      let formula ← transAssertExpr ensExpr
+      modify fun s => { s with
+        postconditions := s.postconditions.push formula
+      }
+    -- Process body assertions (assert statements)
     if overload then
       -- Overload stubs should have `...` as their only body statement.
       unless body.size = 1 &&

--- a/Tools/Python/scripts/examples/withdraw.py
+++ b/Tools/Python/scripts/examples/withdraw.py
@@ -1,0 +1,38 @@
+"""Banking with safe withdrawals."""
+import icontract
+
+
+@icontract.require(lambda a: a >= 0)
+@icontract.require(lambda b: b >= 0)
+@icontract.ensure(lambda a, b, result: result >= 0)
+@icontract.ensure(lambda a, result: result <= a)
+@icontract.ensure(lambda b, result: result >= b)
+def cap(a: int, b: int) -> int:
+    """Return the smaller of a and b."""
+    if a <= b:
+        return a
+    return b
+
+
+@icontract.require(lambda balance: balance >= 0)
+@icontract.require(lambda amount: amount >= 0)
+@icontract.ensure(lambda result: result >= 0)
+def withdraw(balance: int, amount: int) -> int:
+    """Withdraw at most what's available."""
+    safe_amount = cap(amount, balance)
+    return balance - safe_amount
+
+
+@icontract.ensure(lambda result: result >= 0)
+def test_good() -> int:
+    return withdraw(100, 50)
+
+
+@icontract.ensure(lambda result: result >= 0)
+def test_good2() -> int:
+    return withdraw(100, 200)
+
+
+@icontract.ensure(lambda result: result >= 0)
+def test_bad() -> int:
+    return withdraw(-10, 5)

--- a/Tools/Python/scripts/verify_icontract.sh
+++ b/Tools/Python/scripts/verify_icontract.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Verify Python user code against icontract specs using Strata.
+#
+# Usage: ./verify_icontract.sh [--spec extra_spec.py]... <file.py> [user_file]
+#
+# If user_file is omitted, file.py is used as both spec and user code.
+# Use --spec to add additional spec files (e.g., stdlib contracts).
+#
+# Examples:
+#   ./verify_icontract.sh withdraw.py                          # single file
+#   ./verify_icontract.sh --spec builtins_spec.py user_code.py # stdlib spec + user code
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STRATA_DIR="${STRATA_DIR:-$(dirname "$SCRIPT_DIR")}"
+STRATA_BIN="$STRATA_DIR/.lake/build/bin/strata"
+STRATA_PYTHON="$STRATA_DIR/Tools/Python"
+DIALECT="$STRATA_PYTHON/dialects/Python.dialect.st.ion"
+
+# Ensure strata Python package is importable
+export PYTHONPATH="${STRATA_PYTHON}:${PYTHONPATH:-}"
+export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+if command -v mise &>/dev/null; then
+    eval "$(mise activate bash 2>/dev/null)" || true
+fi
+
+# Parse --spec flags
+EXTRA_SPECS=()
+while [[ $# -gt 0 && "$1" == "--spec" ]]; do
+    shift
+    EXTRA_SPECS+=("$(realpath "$1")")
+    shift
+done
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 [--spec extra_spec.py]... <spec_file> [user_file]"
+    exit 1
+fi
+
+SPEC_FILE="$(realpath "$1")"
+USER_FILE="$(realpath "${2:-$1}")"
+ORIG_USER_FILE="${2:-$1}"
+MODULE_NAME="$(basename "$USER_FILE" .py)"
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+# Collect all spec files into a temporary directory for pySpecs
+SPEC_SRC_DIR="$TMPDIR/specs"
+mkdir -p "$SPEC_SRC_DIR"
+cp "$SPEC_FILE" "$SPEC_SRC_DIR/"
+for EXTRA in "${EXTRA_SPECS[@]+"${EXTRA_SPECS[@]}"}"; do
+    cp "$EXTRA" "$SPEC_SRC_DIR/"
+done
+
+# Step 1: Convert icontract specs to pyspec Ion using pySpecs (Lean)
+PYSPEC_DIR="$TMPDIR/pyspec"
+SPEC_MODULE="$(basename "$SPEC_FILE" .py)"
+"$STRATA_BIN" pySpecs "$SPEC_SRC_DIR" "$PYSPEC_DIR" --quiet --module "$SPEC_MODULE" 2>/dev/null || {
+    echo "Error converting icontract specs to pyspec Ion" >&2
+    exit 1
+}
+
+# Build --pyspec args
+PYSPEC_ARGS="--pyspec $SPEC_MODULE"
+for EXTRA in "${EXTRA_SPECS[@]+"${EXTRA_SPECS[@]}"}"; do
+    EXTRA_MOD="$(basename "$EXTRA" .py)"
+    PYSPEC_ARGS="$PYSPEC_ARGS --pyspec $EXTRA_MOD"
+done
+
+# Step 2: Convert user code to Python Ion
+USER_ION="$TMPDIR/${MODULE_NAME}.python.st.ion"
+(cd "$STRATA_PYTHON" && python3 -m strata.gen py_to_strata --dialect "$DIALECT" "$USER_FILE" "$USER_ION") 2>/dev/null || {
+    echo "Error converting $USER_FILE to Python Ion" >&2
+    exit 1
+}
+
+# Step 3: Run Strata verification
+RAW_OUTPUT=$("$STRATA_BIN" pyAnalyzeLaurel \
+    --spec-dir "$PYSPEC_DIR" \
+    $PYSPEC_ARGS \
+    "$USER_ION" 2>&1) || true
+
+# Step 4: Format results
+ALL_SPECS="$SPEC_FILE"
+for EXTRA in "${EXTRA_SPECS[@]+"${EXTRA_SPECS[@]}"}"; do
+    ALL_SPECS="$ALL_SPECS:$EXTRA"
+done
+echo "$RAW_OUTPUT" | python3 -m strata.format_results "$ALL_SPECS" "$USER_FILE" "$ORIG_USER_FILE"

--- a/Tools/Python/strata/format_results.py
+++ b/Tools/Python/strata/format_results.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Post-process Strata verification output into human-readable format."""
+import ast
+import os
+import re
+import sys
+
+
+def find_decorated_funcs(spec_file: str) -> dict:
+    """Returns {func_name: [param_names]} for decorated functions."""
+    tree = ast.parse(open(spec_file).read())
+    decorated = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Call):
+                    func = dec.func
+                    if (isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name)
+                            and func.value.id == 'icontract'):
+                        decorated[node.name] = [a.arg for a in node.args.args]
+                        break
+                    elif isinstance(func, ast.Name) and func.id in ('require', 'ensure'):
+                        decorated[node.name] = [a.arg for a in node.args.args]
+                        break
+    return decorated
+
+
+def find_call_sites(user_file: str, decorated: dict) -> list:
+    """Returns call sites: [(caller_name, lineno, callee_name, col, end_col)]."""
+    tree = ast.parse(open(user_file).read())
+    sites = []
+    for parent in ast.walk(tree):
+        if isinstance(parent, ast.FunctionDef):
+            for child in ast.walk(parent):
+                if isinstance(child, ast.Call):
+                    name = None
+                    if isinstance(child.func, ast.Name) and child.func.id in decorated:
+                        name = child.func.id
+                    if name and hasattr(child, 'lineno'):
+                        sites.append((parent.name, child.lineno, name,
+                                      getattr(child, 'col_offset', 0),
+                                      getattr(child, 'end_col_offset', 0)))
+    return sites
+
+
+def identify_callee(assertions: list, decorated: dict) -> str:
+    """Try to identify which decorated function a call-site group targets
+    by matching assertion parameter names to function signatures."""
+    assertion_params = set()
+    for assertion_text, _, _ in assertions:
+        # Extract parameter names from assertion text like "balance >= amount"
+        for token in re.findall(r'\b[a-zA-Z_]\w*\b', assertion_text):
+            if token not in ('int', 'result', 'pass', 'fail', 'Assertion', 'failed'):
+                assertion_params.add(token)
+    # Match against decorated function parameter lists
+    best_match = None
+    best_score = 0
+    for fname, params in decorated.items():
+        param_set = set(params)
+        overlap = len(assertion_params & param_set)
+        if overlap > best_score:
+            best_score = overlap
+            best_match = fname
+    return best_match
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: format_results.py <spec_file> <user_file> [display_file]", file=sys.stderr)
+        sys.exit(1)
+
+    spec_file = sys.argv[1]
+    user_file = sys.argv[2]
+    display_file = sys.argv[3] if len(sys.argv) > 3 else user_file
+    raw = sys.stdin.read()
+
+    # spec_file can be colon-separated list of spec files
+    spec_files = spec_file.split(':')
+    decorated = {}
+    for sf in spec_files:
+        decorated.update(find_decorated_funcs(sf))
+    call_sites = find_call_sites(user_file, decorated)
+
+    noise = ['Verification Results', 'DETAIL:', 'RESULT:', 'ite_cond_calls',
+             'Required parameter', 'assert(0):', 'PySpec translation', 'BUG:',
+             'SARIF output']
+
+    results = []
+    postcond_pyspec = []
+    postcond_user = []
+    module_name = os.path.splitext(os.path.basename(user_file))[0]
+    module_prefix = module_name + '_'
+    for line in raw.strip().split('\n'):
+        if not line.strip():
+            continue
+        if any(n in line for n in noise):
+            continue
+        if ('✅' in line or '❌' in line or '❓' in line):
+            stripped = line.strip()
+            # Postcondition body checks have [procname] prefix
+            if stripped.startswith('['):
+                bracket_end = stripped.find(']')
+                if bracket_end > 0:
+                    proc_name = stripped[1:bracket_end]
+                    if proc_name.startswith(module_prefix):
+                        postcond_pyspec.append(stripped)
+                    else:
+                        postcond_user.append(stripped)
+                    continue
+            # Postcondition summary lines (procname:postcondition_N)
+            if ':postcondition' in stripped:
+                label = stripped.split(':postcondition')[0]
+                if label.startswith(module_prefix):
+                    postcond_pyspec.append(stripped)
+                else:
+                    postcond_user.append(stripped)
+                continue
+            # Call-site results
+            site_match = re.search(r'\(call site (\d+)\)', line)
+            site_id = site_match.group(1) if site_match else None
+            clean = re.sub(r' \(call site \d+\)', '', line).strip()
+            if site_id is not None:
+                results.append((site_id, clean))
+
+    # --- Terminal output ---
+    print('==== Verification Results ====')
+    passes = 0
+    fails = 0
+    unknowns = 0
+
+    if postcond_user:
+        user_passes = sum(1 for line in postcond_user if '✅' in line)
+        user_fails = sum(1 for line in postcond_user if '❌' in line or '❓' in line)
+        if user_passes > 0 and user_fails == 0:
+            print(f'  postcondition body checks: ✅ {user_passes} verified')
+            print()
+        elif user_fails > 0:
+            # Show which functions failed
+            failed_funcs = []
+            for line in postcond_user:
+                if '❌' in line or '❓' in line:
+                    func_name = line.split(':postcondition')[0].strip()
+                    if func_name not in failed_funcs:
+                        failed_funcs.append(func_name)
+            if user_passes > 0:
+                print(f'  postcondition body checks: ✅ {user_passes} verified, ❌ {user_fails} unproven ({", ".join(failed_funcs)})')
+            else:
+                print(f'  postcondition body checks: ❌ {user_fails} unproven ({", ".join(failed_funcs)})')
+            print()
+
+    # Group results by call site (consecutive IDs = same call).
+    grouped = []
+    last_id = None
+    for site_id, line in results:
+        sid = int(site_id)
+        if last_id is None or sid != last_id + 1:
+            grouped.append([])
+        last_id = sid
+        is_pass = '✅' in line
+        assertion = re.sub(r':.*$', '', line).strip()
+        grouped[-1].append((assertion, is_pass, line))
+
+    # Match each group to a call site by identifying the callee from assertions,
+    # then finding the next unmatched call site for that callee.
+    callee_site_idx = {}  # callee_name -> next index into filtered call_sites
+    for group in grouped:
+        callee = identify_callee(group, decorated)
+        if callee is None:
+            # Can't identify — show raw
+            print(f'\n  unknown call:')
+            for assertion, is_pass, line in group:
+                if is_pass: passes += 1
+                elif '❓' in line: unknowns += 1
+                else: fails += 1
+                print(f'    {line}')
+            continue
+
+        # Find the next call site for this callee
+        idx = callee_site_idx.get(callee, 0)
+        matching_sites = [(i, s) for i, s in enumerate(call_sites) if s[2] == callee]
+        if idx < len(matching_sites):
+            _, (caller, lineno, callee_name, col, end_col) = matching_sites[idx]
+            callee_site_idx[callee] = idx + 1
+            print(f'\n  {caller}() line {lineno} → {callee_name}():')
+        else:
+            print(f'\n  → {callee}():')
+            col, end_col, lineno, caller = 0, 0, 0, '?'
+
+        for assertion, is_pass, line in group:
+            if is_pass: passes += 1
+            elif '❓' in line: unknowns += 1
+            else: fails += 1
+            print(f'    {line}')
+
+    total = passes + fails + unknowns
+    print()
+    if fails == 0 and unknowns == 0 and passes > 0:
+        print(f'RESULT: ✅ Verified ({passes}/{total} passed)')
+    elif fails > 0:
+        summary = f'RESULT: ❌ {fails}/{total} failed'
+        if unknowns > 0:
+            summary += f', {unknowns} inconclusive'
+        print(summary)
+    elif unknowns > 0:
+        print(f'RESULT: ⚠️  {unknowns}/{total} inconclusive (no failures)')
+    else:
+        print('RESULT: No icontract assertions found')
+
+    # --- Diagnostics output (gcc-style for VS Code problemMatcher) ---
+    # Postcondition body check failures → underline the function definition
+    if postcond_user:
+        tree = ast.parse(open(user_file).read())
+        func_lines = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                func_lines[node.name] = (node.lineno, node.col_offset, node.end_col_offset or 0)
+        # Collect failing functions with their postcondition text from [procname] lines
+        failing = {}  # func_name -> list of postcondition texts
+        for line in postcond_user:
+            if '❌' in line or '❓' in line:
+                if line.startswith('['):
+                    func_name = line[1:line.find(']')]
+                    # Extract postcondition text: "[cap] b >= result: ❌ fail" → "b >= result"
+                    text = line[line.find(']') + 2:].split(':')[0].strip()
+                elif ':postcondition' in line:
+                    func_name = line.split(':postcondition')[0].strip()
+                    text = 'postcondition'
+                else:
+                    continue
+                failing.setdefault(func_name, []).append(text)
+        for func_name in sorted(failing):
+            if func_name in func_lines:
+                lineno, col, end_col = func_lines[func_name]
+                name_col = col + 4  # len("def ")
+                texts = failing[func_name]
+                # Filter out internal postconditions (isfrom_int etc)
+                texts = [t for t in texts if t != 'postcondition' and 'isfrom' not in t]
+                if texts:
+                    msg = ', '.join(f'`{t}`' for t in texts)
+                    print(f'{display_file}:{lineno}:{name_col + 1}: error: '
+                          f'postcondition {msg} unproven for {func_name}()')
+                else:
+                    print(f'{display_file}:{lineno}:{name_col + 1}: error: '
+                          f'postcondition unproven for {func_name}()')
+
+    # Call-site precondition failures
+    callee_site_idx2 = {}
+    for group in grouped:
+        callee = identify_callee(group, decorated)
+        if callee is None:
+            continue
+        idx = callee_site_idx2.get(callee, 0)
+        matching_sites = [(i, s) for i, s in enumerate(call_sites) if s[2] == callee]
+        if idx < len(matching_sites):
+            _, (caller, lineno, callee_name, col, end_col) = matching_sites[idx]
+            callee_site_idx2[callee] = idx + 1
+        else:
+            continue
+        for assertion, is_pass, line in group:
+            if is_pass or '❓' in line:
+                continue
+            print(f'{display_file}:{lineno}:{col + 1}: error: '
+                  f'precondition `{assertion}` violated in call to {callee_name}()')
+
+    has_unproven = any('❌' in line or '❓' in line for line in postcond_user) if postcond_user else False
+    sys.exit(2 if (fails > 0 or has_unproven) else 0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
> ⚠️ **Stacked PR** — This builds on the pySpecs icontract decorator support PR. Currently targeting `main` so the diff includes that PR's `Specs.lean` change. The diff will automatically clean up once that PR merges into main.

### Summary

Adds supporting tooling for end-to-end icontract verification: a result formatter, a one-command verify script, and a worked example.

### Changes

- `Tools/Python/strata/format_results.py` — Post-processes raw `pyAnalyzeLaurel` output into human-readable terminal format (grouping results by call site with pass/fail indicators) and emits gcc-style `file:line:col: error: msg` diagnostics that editors and CI systems can parse via problem matchers.

- `Tools/Python/scripts/verify_icontract.sh` — End-to-end verification wrapper. Given a Python file with `@icontract.require`/`@icontract.ensure` decorators, it runs `pySpecs` to convert specs to Ion, `py_to_strata` to convert user code to Ion, `pyAnalyzeLaurel` to verify, and `format_results.py` to format the output.

- `Tools/Python/scripts/examples/withdraw.py` — Worked example: a banking module with `cap()` (min of two values) and `withdraw()` (safe withdrawal), plus test functions that exercise valid and invalid call sites.
