### PR TITLE
CallElim before inlining + human-readable output in pyAnalyzeLaurel

### DIFF
--- a/Strata/DL/Imperative/MetaData.lean
+++ b/Strata/DL/Imperative/MetaData.lean
@@ -187,6 +187,8 @@ abbrev MetaData.fullCheck : MetaDataElem.Field P := .label "fullCheck"
 abbrev MetaData.validityCheck : MetaDataElem.Field P := .label "validityCheck"
 @[match_pattern]
 abbrev MetaData.satisfiabilityCheck : MetaDataElem.Field P := .label "satisfiabilityCheck"
+@[match_pattern]
+abbrev MetaData.message : MetaDataElem.Field P := .label "message"
 
 def MetaData.hasReachCheck {P : PureExpr} [BEq P.Ident] (md : MetaData P) : Bool :=
   match md.findElem MetaData.reachCheck with

--- a/Strata/Languages/Python/PySpecPipeline.lean
+++ b/Strata/Languages/Python/PySpecPipeline.lean
@@ -40,6 +40,8 @@ public structure PySpecLaurelResult where
   typeAliases : Std.HashMap String String := {}
   /-- Classes whose spec is considered exhaustive (lists all methods). -/
   exhaustiveClasses : Std.HashSet String := {}
+  /-- Module prefixes used when building pyspec Laurel names. -/
+  modulePrefixes : List String := []
 
 /-! ### Private Helpers -/
 
@@ -174,7 +176,8 @@ public def buildPySpecLaurel (pyspecEntries : Array (String × String))
   }
   return { laurelProgram := combinedLaurel, overloads := allOverloads
            functionSignatures := funcSigs, typeAliases := allTypeAliases
-           exhaustiveClasses := allExhaustiveClasses }
+           exhaustiveClasses := allExhaustiveClasses
+           modulePrefixes := (pyspecEntries.map (·.1)).toList }
 
 /-- Read dispatch Ion files and merge their overload tables. -/
 public def readDispatchOverloads
@@ -287,6 +290,23 @@ public def buildPreludeInfo (result : PySpecLaurelResult) : Python.PreludeInfo :
   -- Register functions under their Laurel names
   let symbols := merged.functions.foldl (init := symbols) fun m name =>
     m.insert name (.function name)
+  -- Register unprefixed procedure aliases for pyspec top-level functions.
+  -- When a pyspec module "heapq" defines "heappop", the Laurel procedure
+  -- is "heapq_heappop". User code that does `from heapq import heappop`
+  -- calls it as plain "heappop", so we register that alias here.
+  let symbols := result.modulePrefixes.foldl (init := symbols) fun syms pfx =>
+    if pfx.isEmpty then syms
+    else
+      let pfxUnderscore := pfx ++ "_"
+      merged.procedures.fold (init := syms) fun m name sig =>
+        if name.startsWith pfxUnderscore then
+          let shortName := name.drop pfxUnderscore.length |>.toString
+          -- Skip class methods (contain @) and don't overwrite existing
+          if !shortName.contains '@' && !m.contains shortName then
+            let inlinable := merged.inlinableProcedures.contains name
+            m.insert shortName (.procedure name sig inlinable)
+          else m
+        else m
   -- Add unprefixed aliases from typeAliases
   let symbols := result.typeAliases.fold (init := symbols)
     fun syms unprefixed prefixed =>
@@ -315,12 +335,87 @@ public def buildPreludeInfo (result : PySpecLaurelResult) : Python.PreludeInfo :
     importedSymbols := symbols
     exhaustiveClasses := exhaustive }
 
+/-- Recursively rename identifiers in a StmtExpr tree. -/
+private partial def renameIdent (oldName newName : String) : Laurel.StmtExprMd → Laurel.StmtExprMd
+  | ⟨.Identifier id, md⟩ =>
+    if id.text == oldName then ⟨.Identifier { id with text := newName }, md⟩
+    else ⟨.Identifier id, md⟩
+  | ⟨.PrimitiveOp op args, md⟩ =>
+    ⟨.PrimitiveOp op (args.map (renameIdent oldName newName)), md⟩
+  | ⟨.StaticCall callee args, md⟩ =>
+    ⟨.StaticCall callee (args.map (renameIdent oldName newName)), md⟩
+  | ⟨.IfThenElse c t e, md⟩ =>
+    ⟨.IfThenElse (renameIdent oldName newName c) (renameIdent oldName newName t)
+      (e.map (renameIdent oldName newName)), md⟩
+  | ⟨.Block stmts lbl, md⟩ =>
+    ⟨.Block (stmts.map (renameIdent oldName newName)) lbl, md⟩
+  | ⟨.Assign tgts val, md⟩ =>
+    ⟨.Assign (tgts.map (renameIdent oldName newName)) (renameIdent oldName newName val), md⟩
+  | ⟨.FieldSelect tgt fld, md⟩ =>
+    ⟨.FieldSelect (renameIdent oldName newName tgt) fld, md⟩
+  | other => other
+
 /-- Combine PySpec and user Laurel programs into a single program,
     prepending External stubs so the Laurel `resolve` pass can see
-    prelude names (e.g. `print`, `from_string`). -/
+    prelude names (e.g. `print`, `from_string`).
+    Also copies preconditions and postconditions from pyspec procedures
+    to matching user-code procedures. -/
 public def combinePySpecLaurel
-    (pySpec user : Laurel.Program) : Laurel.Program :=
-  { staticProcedures := pySpec.staticProcedures ++ user.staticProcedures
+    (pySpec user : Laurel.Program)
+    (modulePrefixes : List String := []) : Laurel.Program :=
+  -- Build a map from unprefixed name → pyspec preconditions
+  let pyspecPreconds : Std.HashMap String (List Laurel.StmtExprMd) :=
+    modulePrefixes.foldl (init := {}) fun m pfx =>
+      if pfx.isEmpty then m
+      else
+        let pfxUnderscore := pfx ++ "_"
+        pySpec.staticProcedures.foldl (init := m) fun m proc =>
+          if proc.name.text.startsWith pfxUnderscore && !proc.preconditions.isEmpty then
+            let shortName := proc.name.text.drop pfxUnderscore.length |>.toString
+            if !shortName.contains '@' then m.insert shortName proc.preconditions
+            else m
+          else m
+  -- Extract postconditions from pyspec procedure bodies (Body.Opaque postconds ...)
+  let pyspecPostconds : Std.HashMap String (List Laurel.StmtExprMd) :=
+    modulePrefixes.foldl (init := {}) fun m pfx =>
+      if pfx.isEmpty then m
+      else
+        let pfxUnderscore := pfx ++ "_"
+        pySpec.staticProcedures.foldl (init := m) fun m proc =>
+          if proc.name.text.startsWith pfxUnderscore then
+            match proc.body with
+            | .Opaque postconds _ _ =>
+              if !postconds.isEmpty then
+                let shortName := proc.name.text.drop pfxUnderscore.length |>.toString
+                if !shortName.contains '@' then m.insert shortName postconds
+                else m
+              else m
+            | _ => m
+          else m
+  -- Copy preconditions and postconditions to matching user-code procedures.
+  -- When postconditions are present, wrap the user body in Body.Opaque so
+  -- the Laurel pipeline can verify the body against the postconditions.
+  -- Postconditions reference "result" but user code uses "LaurelResult",
+  -- so we rename the identifier in the postcondition expressions.
+  let userProcs := user.staticProcedures.map fun proc =>
+    let proc := match pyspecPreconds[proc.name.text]? with
+      | some preconds => { proc with preconditions := preconds }
+      | none => proc
+    match pyspecPostconds[proc.name.text]? with
+    | some postconds =>
+      match proc.body with
+      | .Transparent bodyExpr =>
+        -- Rename "result" → "LaurelResult" in postconditions to match user code output
+        let renamedPostconds := postconds.map (renameIdent "result" "LaurelResult")
+        -- Prepend assume(isfrom_int(param)) for each input parameter.
+        let mkMd (e : Laurel.StmtExpr) : Laurel.StmtExprMd := ⟨e, bodyExpr.md⟩
+        let assumes := proc.inputs.map fun param =>
+          mkMd (.Assume (mkMd (.StaticCall (Laurel.mkId "Any..isfrom_int") [mkMd (.Identifier param.name)])))
+        let wrappedBody := mkMd (.Block (assumes ++ [bodyExpr]) none)
+        { proc with body := .Opaque renamedPostconds (some wrappedBody) [] }
+      | _ => proc
+    | none => proc
+  { staticProcedures := pySpec.staticProcedures ++ userProcs
     staticFields := pySpec.staticFields ++ user.staticFields
     types := pySpec.types ++ user.types
     constants := pySpec.constants ++ user.constants
@@ -434,6 +529,6 @@ public def pyAnalyzeLaurel
     | .error msg => throw (.internal msg)
 
   profileStep profile "Combine PySpec and user Laurel" do
-    return combinePySpecLaurel filteredPrelude laurelProgram
+    return combinePySpecLaurel filteredPrelude laurelProgram result.modulePrefixes
 
 end Strata

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -957,6 +957,11 @@ partial def translateCall (ctx : TranslationContext)
               else funcName
             | .error _ => funcName
           else funcName
+        -- Resolve pyspec alias: if funcName maps to a different Laurel name, use it
+        let funcName' := match ctx.importedSymbols[funcName']? with
+          | some (ImportedSymbol.procedure laurelName _ _) =>
+            if laurelName != funcName' then laurelName else funcName'
+          | _ => funcName'
         return mkCall funcName'
     | .Attribute _ val _attr _ =>
         let target_trans ← translateExprAsReceiver ctx val
@@ -977,7 +982,12 @@ partial def translateCall (ctx : TranslationContext)
             return callWithSelf
           else
             return mkStmtExprMdWithLoc (.Hole) callMd
-        else return mkCall funcName
+        else
+          -- Use Laurel name if available (handles pyspec aliases)
+          let resolvedName := match ctx.importedSymbols[funcName]? with
+            | some (ImportedSymbol.procedure laurelName _ _) => laurelName
+            | _ => funcName
+          return mkCall resolvedName
     | _ => throw (.unsupportedConstruct "Invalid call construct" (toString (repr f)))
   -- When ** is used at the call site and we have a known function signature,
   -- expand the dictionary into individual arguments using DictStrAny_get

--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -85,6 +85,14 @@ op intGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " >=_int " bound;
 op intLeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " <=_int " bound;
+op intAddExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(20)] left " +_int " right;
+op intSubExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(20)] left " -_int " right;
+op intMulExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(25)] left " *_int " right;
+op intEqExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(15)] left " ==_int " right;
 op floatExpr(value : Str) : SpecExprDecl => value;
 op floatGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " >=_float " bound;
@@ -251,6 +259,10 @@ protected def SpecExpr.toDDM (e : SpecExpr) : DDM.SpecExprDecl SourceRange :=
   | .intLit v loc => .intExpr loc (toDDMInt loc v)
   | .intGe subj bound loc => .intGeExpr loc subj.toDDM bound.toDDM
   | .intLe subj bound loc => .intLeExpr loc subj.toDDM bound.toDDM
+  | .intAdd left right loc => .intAddExpr loc left.toDDM right.toDDM
+  | .intSub left right loc => .intSubExpr loc left.toDDM right.toDDM
+  | .intMul left right loc => .intMulExpr loc left.toDDM right.toDDM
+  | .intEq left right loc => .intEqExpr loc left.toDDM right.toDDM
   | .floatLit v loc => .floatExpr loc ⟨loc, v⟩
   | .floatGe subj bound loc => .floatGeExpr loc subj.toDDM bound.toDDM
   | .floatLe subj bound loc => .floatLeExpr loc subj.toDDM bound.toDDM
@@ -391,6 +403,10 @@ private def DDM.SpecExprDecl.fromDDM (d : DDM.SpecExprDecl SourceRange) : Specs.
   | .intExpr loc i => .intLit i.ofDDM loc
   | .intGeExpr loc subj bound => .intGe subj.fromDDM bound.fromDDM loc
   | .intLeExpr loc subj bound => .intLe subj.fromDDM bound.fromDDM loc
+  | .intAddExpr loc left right => .intAdd left.fromDDM right.fromDDM loc
+  | .intSubExpr loc left right => .intSub left.fromDDM right.fromDDM loc
+  | .intMulExpr loc left right => .intMul left.fromDDM right.fromDDM loc
+  | .intEqExpr loc left right => .intEq left.fromDDM right.fromDDM loc
   | .floatExpr loc ⟨_, v⟩ => .floatLit v loc
   | .floatGeExpr loc subj bound => .floatGe subj.fromDDM bound.fromDDM loc
   | .floatLeExpr loc subj bound => .floatLe subj.fromDDM bound.fromDDM loc

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -324,6 +324,14 @@ inductive SpecExpr where
 | intLit (value : Int) (loc : SourceRange)
 | intGe (subject : SpecExpr) (bound : SpecExpr) (loc : SourceRange)
 | intLe (subject : SpecExpr) (bound : SpecExpr) (loc : SourceRange)
+/-- Integer addition: `intAdd a b` represents `a + b`. -/
+| intAdd (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
+/-- Integer subtraction: `intSub a b` represents `a - b`. -/
+| intSub (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
+/-- Integer multiplication: `intMul a b` represents `a * b`. -/
+| intMul (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
+/-- Integer equality: `intEq a b` represents `a == b`. -/
+| intEq (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
 /-- A floating-point literal, stored as a string to preserve precision. -/
 | floatLit (value : String) (loc : SourceRange)
 | floatGe (subject : SpecExpr) (bound : SpecExpr) (loc : SourceRange)

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -389,6 +389,41 @@ def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
       some (mkStmt (.PrimitiveOp .Leq
         [mkStmt (.StaticCall (mkId "Any..as_int!") [s]) md,
          mkStmt (.StaticCall (mkId "Any..as_int!") [b]) md]) md)
+  | .intAdd left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      let sum := mkStmt (.PrimitiveOp .Add [lInt, rInt]) md
+      some (mkStmt (.StaticCall (mkId "from_int") [sum]) md)
+  | .intSub left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      let diff := mkStmt (.PrimitiveOp .Sub [lInt, rInt]) md
+      some (mkStmt (.StaticCall (mkId "from_int") [diff]) md)
+  | .intMul left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      let prod := mkStmt (.PrimitiveOp .Mul [lInt, rInt]) md
+      some (mkStmt (.StaticCall (mkId "from_int") [prod]) md)
+  | .intEq left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      some (mkStmt (.PrimitiveOp .Eq [lInt, rInt]) md)
   | .floatGe subject bound loc => do
     let md ← nodeMd loc
     let s? ← specExprToLaurel subject md; let b? ← specExprToLaurel bound md

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -312,6 +312,7 @@ private def mkMdWithFileRange (loc : SourceRange) (msg : String := "")
   let mut md : Imperative.MetaData Core.Expression := #[⟨Imperative.MetaData.fileRange, .fileRange fr⟩]
   if !msg.isEmpty then
     md := md.withPropertySummary msg
+    md := md.push ⟨Imperative.MetaData.message, .msg msg⟩
   return md
 
 /-- Wrap a StmtExpr with metadata containing a file range and optional message. -/
@@ -394,6 +395,7 @@ def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
     let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
     return do
       let l ← l?; let r ← r?
+      -- Unwrap to int, add, re-wrap: from_int(as_int(l) + as_int(r))
       let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
       let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
       let sum := mkStmt (.PrimitiveOp .Add [lInt, rInt]) md
@@ -403,6 +405,7 @@ def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
     let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
     return do
       let l ← l?; let r ← r?
+      -- Unwrap to int, subtract, re-wrap: from_int(as_int(l) - as_int(r))
       let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
       let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
       let diff := mkStmt (.PrimitiveOp .Sub [lInt, rInt]) md
@@ -412,6 +415,7 @@ def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
     let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
     return do
       let l ← l?; let r ← r?
+      -- Unwrap to int, multiply, re-wrap: from_int(as_int(l) * as_int(r))
       let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
       let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
       let prod := mkStmt (.PrimitiveOp .Mul [lInt, rInt]) md
@@ -421,6 +425,7 @@ def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
     let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
     return do
       let l ← l?; let r ← r?
+      -- Unwrap to int, compare: as_int(l) == as_int(r)
       let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
       let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
       some (mkStmt (.PrimitiveOp .Eq [lInt, rInt]) md)
@@ -502,6 +507,20 @@ def SpecAssertMsg.render : SpecAssertMsg → String
   | .userAssertion text  => text
   | .unnamed index       => s!"precondition {index}"
 
+/-- Generate a human-readable message from a SpecExpr for postcondition labels. -/
+private def specExprToMessage : SpecExpr → String
+  | .var name _ => name
+  | .intLit v _ => toString v
+  | .intGe a b _ => s!"{specExprToMessage a} >= {specExprToMessage b}"
+  | .intLe a b _ => s!"{specExprToMessage a} <= {specExprToMessage b}"
+  | .intEq a b _ => s!"{specExprToMessage a} == {specExprToMessage b}"
+  | .intAdd a b _ => s!"{specExprToMessage a} + {specExprToMessage b}"
+  | .intSub a b _ => s!"{specExprToMessage a} - {specExprToMessage b}"
+  | .intMul a b _ => s!"{specExprToMessage a} * {specExprToMessage b}"
+  | .not e _ => s!"not ({specExprToMessage e})"
+  | .len e _ => s!"len({specExprToMessage e})"
+  | _ => "<expr>"
+
 /-- Build a procedure body that asserts preconditions.
     Outputs are already initialized non-deterministically. -/
 def buildSpecBody (preconditions : Array Assertion)
@@ -578,8 +597,54 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     [{ name := "result", type := match retType.val with
       | .TVoid => tyAny
       | _ => retType }]
-  if func.postconditions.size > 0 then
-    reportError func.loc "Postconditions not yet supported"
+  if func.postconditions.size > 0 then do
+    -- When postconditions exist, use TCore "Any" for all parameters and outputs
+    let anyTy : HighTypeMd := tyAny
+    let anyInputs := inputs.map fun p => { p with type := anyTy }
+    let anyOutputs := outputs.map fun p => { p with type := anyTy }
+    -- Build postcondition expressions
+    let fileMd ← mkFileMd
+    let postconds ← func.postconditions.toList.filterMapM fun postExpr => do
+      let msg := specExprToMessage postExpr
+      let postMd ← mkMdWithFileRange default msg
+      specExprToLaurel postExpr postMd
+    -- Add isfrom_int(result) so callers know the return value is an integer.
+    -- This is needed for PSub/PAdd to take the int-int branch.
+    let postconds := if !postconds.isEmpty then
+      let resultIntExpr := mkStmt (.StaticCall (mkId "Any..isfrom_int")
+        [mkStmt (.Identifier (mkId "result")) fileMd]) fileMd
+      postconds ++ [resultIntExpr]
+    else postconds
+    -- Build Laurel-level precondition expressions for the Procedure.preconditions
+    -- field. CallElim uses these to assert preconditions at call sites and
+    -- assume them in the body, enabling transitivity for internal calls.
+    let laurelPreconds ← func.preconditions.toList.filterMapM fun assertion => do
+      let msg := formatAssertionMessage assertion.message
+      let precondMd ← mkMdWithFileRange default msg
+      specExprToLaurel assertion.formula precondMd
+    -- Build body with precondition asserts
+    let impl ← if func.preconditions.size > 0 then do
+      let body ← buildSpecBody func.preconditions .empty
+        (requiredParams := allArgs.filterMap fun a =>
+          if a.default.isNone then some a.name else none)
+      pure (some body)
+    else do
+      let fileMd' ← mkFileMd
+      let body := mkStmt (.Block [] none) fileMd'
+      pure (some (Body.Transparent body))
+    let bodyVal : Body := match impl with
+      | some (.Transparent bodyExpr) => .Opaque postconds (some bodyExpr) []
+      | _ => .Opaque postconds none []
+    let md ← mkMdWithFileRange func.loc
+    return {
+      name := { text := procName, md := md }
+      inputs := anyInputs.toList
+      outputs := anyOutputs
+      preconditions := laurelPreconds
+      decreases := none
+      isFunctional := false
+      body := bodyVal
+    }
   -- When preconditions exist, use TCore "Any" for all parameters and outputs
   -- to match the Python→Laurel pipeline's Any-wrapping convention.
   let (inputs, outputs, body) ←

--- a/Strata/Transform/CoreTransform.lean
+++ b/Strata/Transform/CoreTransform.lean
@@ -259,11 +259,12 @@ def createAsserts
     : CoreTransformM (List Statement)
     := conds.mapM (fun (l, check) => do
           let newLabel ← genIdent l (fun s => s!"{labelPrefix}{s}")
-          -- Non-lifting: the replacement expressions must be closed (no dangling bvars).
-          -- Use the call site as the primary file range, preserving the requires
-          -- clause location as a related file range for richer diagnostics.
-          let assertMd := check.md.setCallSiteFileRange md
-          return Statement.assert newLabel.toPretty (Lambda.LExpr.substFvars check.expr subst) assertMd)
+          -- Merge propertySummary from the check metadata (e.g. precondition
+          -- description) into the call-site metadata so it appears in output.
+          let mergedMd := match check.md.getPropertySummary with
+            | some summary => md.withPropertySummary summary
+            | none => md
+          return Statement.assert newLabel.toPretty (Lambda.LExpr.substFvars check.expr subst) mergedMd)
 
 /-- turns a list of preconditions into assumes with substitution -/
 def createAssumes

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -590,6 +590,34 @@ def pyAnalyzeLaurelCommand : Command where
       let path := s!"{dir}/{baseName}.core"
       IO.FS.writeFile path (toString coreProgram)
 
+    -- Inline pyspec procedures so their precondition assertions are checked
+    -- at call sites with concrete arguments.
+    -- First, run CallElim on pyspec procedures to replace calls with
+    -- assert(preconditions) + havoc + assume(postconditions). This ensures
+    -- that when a decorated function calls another decorated function,
+    -- the caller's preconditions (assumed by CallElim) can satisfy the
+    -- callee's preconditions (asserted by CallElim).
+    let pyspecFiles := pflags.getRepeated "pyspec"
+    let coreProgram ←
+      if pyspecFiles.size > 0 then
+        -- CallElim: replace pyspec procedure calls with assert/havoc/assume
+        let coreProgram ← match Core.callElimUsingContract coreProgram with
+          | .error e => exitPyAnalyzeInternalError s!"CallElim failed: {e}"
+          | .ok prog => pure prog
+        -- Then inline remaining procedure bodies
+        match Core.inlineProcedures coreProgram
+              ⟨.some (fun name _ => name ≠ "__main__" && !_preludeNames.contains name)⟩ with
+        | .error e => exitPyAnalyzeInternalError s!"Inlining failed: {e}"
+        | .ok inlined => do
+          if verbose then
+            IO.println "\n==== Core Program (after inlining) ===="
+            IO.print inlined
+          if let some dir := keepDir then
+            let path := s!"{dir}/{baseName}.inlined.core"
+            IO.FS.writeFile path (toString inlined)
+          pure inlined
+      else pure coreProgram
+
     -- Verify using Core verifier
     -- --keep-all-files implies vc-directory if not explicitly set
     let baseVcDir := keepDir.map (fun dir => (s!"{dir}/{baseName}" : System.FilePath))
@@ -623,20 +651,52 @@ def pyAnalyzeLaurelCommand : Command where
 
     -- Print per-VC results by default, unless SARIF mode is used
     if !outputSarif then
+      let classifier : ResultClassifier := {}
       let mut s := ""
       for vcResult in vcResults do
-        let fileMap := mfm.map (·.2)
-        let location := match Imperative.getFileRange vcResult.obligation.metadata with
+        let propertySummaryOption := vcResult.obligation.metadata.getPropertySummary
+        let propertyDescription := match propertySummaryOption with
+          | some summary =>
+            let label := vcResult.obligation.label
+            -- Postcondition body checks (label contains ":postcondition") get a
+            -- "[procname]" prefix instead of a "(call site N)" suffix.
+            if (label.splitOn ":postcondition" |>.length) > 1 then
+              let procName := label.splitOn ":" |>.head!
+              s!"[{procName}] {summary}"
+            else
+              -- Extract call-site suffix from the label (e.g., "_7" from "func_assert(0)_7")
+              let suffix := match label.splitOn "_" |>.getLast? with
+                | some s => if s.toNat?.isSome then s!" (call site {s})" else ""
+                | none => ""
+              summary ++ suffix
+          | none => vcResult.obligation.label
+        let (locationPrefix, locationSuffix) := match Imperative.getFileRange vcResult.obligation.metadata with
           | some fr =>
-            if fr.range.isNone then ""
-            else s!"{fr.format fileMap (includeEnd? := false)}"
-          | none => ""
-        let messageSuffix := match vcResult.obligation.metadata.getPropertySummary with
-          | some msg => s!" - {msg}"
-          | none => s!" - {vcResult.obligation.label}"
+            if fr.range.isNone then ("", "")
+            else
+              match mfm with
+              | some (_, fm) =>
+                match fr.file with
+                | .file "" =>
+                  if classifier.isFailure vcResult then
+                    (s!"Assertion failed in prelude file: ", "")
+                  else
+                    ("", s!" (in prelude file)")
+                | .file _ =>
+                  let pos := fm.toPosition fr.range.start
+                  if classifier.isFailure vcResult then
+                    (s!"Assertion failed at line {pos.line}, col {pos.column}: ", "")
+                  else
+                    ("", s!" (at line {pos.line}, col {pos.column})")
+              | none =>
+                if classifier.isFailure vcResult then
+                  (s!"Assertion failed: ", "")
+                else
+                  ("", "")
+          | none => ("", "")
         let outcomeStr := vcResult.formatOutcome
-        let loc := if !location.isEmpty then s!"{location}: " else "unknown location: "
-        s := s ++ s!"{loc}{outcomeStr}{messageSuffix}\n"
+        s := s ++ s!"{locationPrefix}{propertyDescription}: \
+                      {outcomeStr}{locationSuffix}\n"
       IO.print s
     -- Output in SARIF format if requested
     if outputSarif then

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -606,7 +606,7 @@ def pyAnalyzeLaurelCommand : Command where
           | .ok prog => pure prog
         -- Then inline remaining procedure bodies
         match Core.inlineProcedures coreProgram
-              ⟨.some (fun name _ => name ≠ "__main__" && !_preludeNames.contains name)⟩ with
+              { doInline := fun name _ => name ≠ "__main__" && !_preludeNames.contains name } with
         | .error e => exitPyAnalyzeInternalError s!"Inlining failed: {e}"
         | .ok inlined => do
           if verbose then


### PR DESCRIPTION
> ⚠️ **Stacked PR** — This builds on https://github.com/strata-org/Strata/pull/863, which builds on https://github.com/strata-org/Strata/pull/859. Currently targeting `main` so the diff includes both prior PRs' changes. The diff will automatically clean up once https://github.com/strata-org/Strata/pull/863 merges into main.

### Summary

Runs `callElimUsingContract` before procedure inlining in `pyAnalyzeLaurel`, and replaces the default output format with human-readable verification results that distinguish call-site precondition checks from postcondition body checks.

### Changes

- `StrataMain.lean`
  - Inserts a `CallElim` pass before `inlineProcedures` when pyspec files are present. This replaces pyspec procedure calls with `assert(preconditions) + havoc + assume(postconditions)`, enabling inter-procedural verification.
  - Replaces the default per-VC output with structured output: postcondition body checks get `[procname]` prefixes, call-site checks get `(call site N)` suffixes, and `propertySummary` is used for human-readable assertion descriptions.
  - Fixes `InlineTransformOptions` constructor to use named fields (upstream struct gained a second field `maxIters`).

### Motivation

Without CallElim, when a decorated function calls another decorated function, the caller's preconditions can't satisfy the callee's preconditions because the call isn't expanded. The human-readable output makes it possible for downstream tools to map verification results back to source locations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
