### PR TITLE
Teach pySpecs to recognize @icontract.require and @icontract.ensure d…

### DIFF
--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -1218,14 +1218,34 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
                        (decorators : Array (expr SourceRange))
                        (returns : Option (expr SourceRange)) : PySpecM FunctionDecl := do
   let mut overload : Bool := false
+  -- Collect icontract preconditions and postconditions from decorators
+  let mut icontractRequires : Array (expr SourceRange) := #[]
+  let mut icontractEnsures : Array (expr SourceRange) := #[]
   for pyd in decorators do
-    let (success, d) ← runChecked <| pySpecValue pyd
-    if success then
-      match d with
-      | .typingOverload =>
-        overload := true
-      | _ =>
-        specError pyd.ann s!"Decorator {repr d} not supported."
+    -- Check for @icontract.require(lambda ...: cond) or @icontract.ensure(lambda ...: cond)
+    match pyd with
+    | .Call _ (.Attribute _ (.Name _ ⟨_, "icontract"⟩ (.Load _)) ⟨_, attr⟩ (.Load _)) args _ =>
+      if args.val.size ≥ 1 then
+        match args.val[0]! with
+        | .Lambda _ _lamArgs lamBody =>
+          if attr == "require" then
+            icontractRequires := icontractRequires.push lamBody
+          else if attr == "ensure" then
+            icontractEnsures := icontractEnsures.push lamBody
+          else
+            specWarning pyd.ann s!"Unknown icontract decorator: icontract.{attr}"
+        | _ =>
+          specWarning pyd.ann s!"icontract.{attr} expects a lambda argument"
+      else
+        specWarning pyd.ann s!"icontract.{attr} requires at least one argument"
+    | _ =>
+      let (success, d) ← runChecked <| pySpecValue pyd
+      if success then
+        match d with
+        | .typingOverload =>
+          overload := true
+        | _ =>
+          specError pyd.ann s!"Decorator {repr d} not supported."
 
   let .mk_arguments _ ⟨_, posonly⟩ ⟨_, posArgs⟩ ⟨_, vararg⟩ ⟨_, kwonly⟩ ⟨_, kw_defaults⟩ ⟨_, kwarg⟩ ⟨_, defaults⟩ := arguments
   assert! posonly.size = 0
@@ -1288,7 +1308,22 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
         match returns with
         | none => pure <| .ident fnLoc .typingAny
         | some tp => pySpecType tp
-  let as ← collectAssertions argDecls returnType <|
+  let as ← collectAssertions argDecls returnType <| do
+    -- Process icontract @require decorators as preconditions
+    for reqExpr in icontractRequires do
+      let formula ← transAssertExpr reqExpr
+      let msg := SpecExpr.toMessage formula
+      let message := #[MessagePart.str msg]
+      modify fun s => { s with
+        assertions := s.assertions.push { message, formula }
+      }
+    -- Process icontract @ensure decorators as postconditions
+    for ensExpr in icontractEnsures do
+      let formula ← transAssertExpr ensExpr
+      modify fun s => { s with
+        postconditions := s.postconditions.push formula
+      }
+    -- Process body assertions (assert statements)
     if overload then
       -- Overload stubs should have `...` as their only body statement.
       unless body.size = 1 &&

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -335,6 +335,29 @@ inductive SpecExpr where
 | forallDict (dict : SpecExpr) (keyVar : String) (valVar : String) (body : SpecExpr) (loc : SourceRange)
 deriving Inhabited
 
+/-- Generate a human-readable message from a SpecExpr.
+    Handles operator precedence to insert parentheses where needed.
+    Used for assertion failure messages and postcondition labels. -/
+def SpecExpr.toMessage : SpecExpr → String :=
+  go 0
+where
+  go (prec : Nat) : SpecExpr → String
+    | .var name _ => name
+    | .intLit v _ => toString v
+    | .floatLit v _ => v
+    | .getIndex s f _ => s!"{go 0 s}[{f}]"
+    | .len e _ => s!"len({go 0 e})"
+    | .not e _ => s!"not ({go 0 e})"
+    | .intGe a b _ => paren prec 10 s!"{go 11 a} >= {go 11 b}"
+    | .intLe a b _ => paren prec 10 s!"{go 11 a} <= {go 11 b}"
+    | .implies c b _ => paren prec 5 s!"{go 6 c} ==> {go 5 b}"
+    | .containsKey _ k _ => s!"\"{k}\" in <container>"
+    | .enumMember s vals _ => s!"{go 0 s} in {vals}"
+    | .regexMatch s p _ => s!"re.search(\"{p}\", {go 0 s})"
+    | _ => "<expr>"
+  paren (parentPrec opPrec : Nat) (s : String) : String :=
+    if parentPrec > opPrec then s!"({s})" else s
+
 inductive MessagePart where
 | str (s : String)
 | expr (e : SpecExpr)


### PR DESCRIPTION
### Summary

Extends `pySpecs` to extract preconditions and postconditions from [icontract](https://github.com/Parquery/icontract) decorators, in addition to the existing `assert`-based extraction.

### Changes

- `Strata/Languages/Python/Specs.lean` — The decorator loop in `pySpecFunctionArgs` now recognizes `@icontract.require(lambda ...: cond)` and `@icontract.ensure(lambda ...: cond)`, extracting the lambda body as a precondition or postcondition via `transAssertExpr`. Unknown icontract decorators produce a warning. Precondition messages use `SpecExpr.toMessage` for human-readable output (e.g. `len(x) >= 1`) instead of raw AST dumps.
- `Strata/Languages/Python/Specs/Decls.lean` — Adds `SpecExpr.toMessage`, a precedence-aware pretty-printer for `SpecExpr` that generates human-readable assertion messages with correct parenthesization.

### Motivation

icontract is a widely-used Python design-by-contract library. Supporting it in `pySpecs` means users can write specs as:

```python
@icontract.require(lambda balance: balance >= 0)
@icontract.require(lambda amount: amount >= 0)
@icontract.ensure(lambda result: result >= 0)
def withdraw(balance: int, amount: int) -> int:
    safe = cap(amount, balance)
    return balance - safe
```

Both icontract-decorated and assert-based formats now produce identical `.pyspec.st.ion` output through the same `pySpecs` command.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
