### PR TITLE
 Improve source locations and assertion messages for call-site errors

### DIFF
--- a/IContractSpecs.lean
+++ b/IContractSpecs.lean
@@ -1,0 +1,154 @@
+/-
+  Hardcoded icontract specs for bisect and heapq modules.
+  Smoke test: constructs Signature values and writes them as .pyspec.st.ion files.
+
+  Usage: lake exe icontractSpecs <output_dir>
+  Produces: <output_dir>/bisect.pyspec.st.ion
+            <output_dir>/heapq.pyspec.st.ion
+-/
+import Strata.Languages.Python.Specs.DDM
+
+open Strata.Python.Specs
+open Strata.Python
+
+namespace IContractSpecs
+
+-- Helper: SpecType for List[int]
+private def listIntType : SpecType :=
+  .ident .none .typingList #[.ident .none .builtinsInt]
+
+-- Helper: SpecType for int
+private def intType : SpecType := .ident .none .builtinsInt
+
+-- Helper: SpecType for None
+private def noneType : SpecType := .ofAtom .none .noneType
+
+/-! ## bisect module specs -/
+
+/-- bisect_left(a, x, lo=0, hi=None)
+    Preconditions from icontract:
+      - isinstance(a, list)
+      - isinstance(x, int)
+    (a == sorted(a) is too complex → placeholder) -/
+def bisectLeft : Signature := .functionDecl {
+  loc := .none
+  nameLoc := .none
+  name := "bisect_left"
+  args := {
+    args := #[
+      { name := "a", type := listIntType },
+      { name := "x", type := intType },
+      { name := "lo", type := intType, default := some .none },
+      { name := "hi", type := intType, default := some .none }
+    ]
+    kwonly := #[]
+  }
+  returnType := intType
+  isOverload := false
+  preconditions := #[
+    { message := #[.str "isinstance(a, list)"],
+      formula := .isInstanceOf (.var "a" .none) "list" .none },
+    { message := #[.str "a == sorted(a)"],
+      formula := .placeholder .none },
+    { message := #[.str "isinstance(x, int)"],
+      formula := .isInstanceOf (.var "x" .none) "int" .none }
+  ]
+  postconditions := #[]
+}
+
+/-- insort_left(a, x, lo=0, hi=None)
+    Same preconditions as bisect_left -/
+def insortLeft : Signature := .functionDecl {
+  loc := .none
+  nameLoc := .none
+  name := "insort_left"
+  args := {
+    args := #[
+      { name := "a", type := listIntType },
+      { name := "x", type := intType },
+      { name := "lo", type := intType, default := some .none },
+      { name := "hi", type := intType, default := some .none }
+    ]
+    kwonly := #[]
+  }
+  returnType := noneType
+  isOverload := false
+  preconditions := #[
+    { message := #[.str "isinstance(a, list)"],
+      formula := .isInstanceOf (.var "a" .none) "list" .none },
+    { message := #[.str "a == sorted(a)"],
+      formula := .placeholder .none },
+    { message := #[.str "isinstance(x, int)"],
+      formula := .isInstanceOf (.var "x" .none) "int" .none }
+  ]
+  postconditions := #[]
+}
+
+def bisectSignatures : Array Signature := #[bisectLeft, insortLeft]
+
+/-! ## heapq module specs -/
+
+/-- heappush(heap, item)
+    Precondition: isinstance(heap, list) -/
+def heappush : Signature := .functionDecl {
+  loc := .none
+  nameLoc := .none
+  name := "heappush"
+  args := {
+    args := #[
+      { name := "heap", type := listIntType },
+      { name := "item", type := intType }
+    ]
+    kwonly := #[]
+  }
+  returnType := noneType
+  isOverload := false
+  preconditions := #[
+    { message := #[.str "isinstance(heap, list)"],
+      formula := .isInstanceOf (.var "heap" .none) "list" .none }
+  ]
+  postconditions := #[]
+}
+
+/-- heappop(heap)
+    Preconditions:
+      - isinstance(heap, list)
+      - len(heap) >= 1 -/
+def heappop : Signature := .functionDecl {
+  loc := .none
+  nameLoc := .none
+  name := "heappop"
+  args := {
+    args := #[
+      { name := "heap", type := listIntType }
+    ]
+    kwonly := #[]
+  }
+  returnType := intType
+  isOverload := false
+  preconditions := #[
+    { message := #[.str "isinstance(heap, list)"],
+      formula := .isInstanceOf (.var "heap" .none) "list" .none },
+    { message := #[.str "len(heap) >= 1"],
+      formula := .intGe (.len (.var "heap" .none) .none) (.intLit 1 .none) .none }
+  ]
+  postconditions := #[]
+}
+
+def heapqSignatures : Array Signature := #[heappush, heappop]
+
+end IContractSpecs
+
+def main (args : List String) : IO Unit := do
+  let outDir ← match args.head? with
+    | some d => pure d
+    | none => do
+      IO.eprintln "Usage: icontractSpecs <output_dir>"
+      IO.Process.exit 1
+  IO.FS.createDirAll outDir
+  let bisectPath : System.FilePath := outDir / "bisect.pyspec.st.ion"
+  let heapqPath : System.FilePath := outDir / "heapq.pyspec.st.ion"
+  Strata.Python.Specs.writeDDM bisectPath IContractSpecs.bisectSignatures
+  IO.println s!"Wrote {bisectPath} ({IContractSpecs.bisectSignatures.size} signatures)"
+  Strata.Python.Specs.writeDDM heapqPath IContractSpecs.heapqSignatures
+  IO.println s!"Wrote {heapqPath} ({IContractSpecs.heapqSignatures.size} signatures)"

--- a/Strata/DL/Imperative/MetaData.lean
+++ b/Strata/DL/Imperative/MetaData.lean
@@ -187,6 +187,8 @@ abbrev MetaData.fullCheck : MetaDataElem.Field P := .label "fullCheck"
 abbrev MetaData.validityCheck : MetaDataElem.Field P := .label "validityCheck"
 @[match_pattern]
 abbrev MetaData.satisfiabilityCheck : MetaDataElem.Field P := .label "satisfiabilityCheck"
+@[match_pattern]
+abbrev MetaData.message : MetaDataElem.Field P := .label "message"
 
 def MetaData.hasReachCheck {P : PureExpr} [BEq P.Ident] (md : MetaData P) : Bool :=
   match md.findElem MetaData.reachCheck with

--- a/Strata/Languages/Python/PySpecPipeline.lean
+++ b/Strata/Languages/Python/PySpecPipeline.lean
@@ -40,6 +40,8 @@ public structure PySpecLaurelResult where
   typeAliases : Std.HashMap String String := {}
   /-- Classes whose spec is considered exhaustive (lists all methods). -/
   exhaustiveClasses : Std.HashSet String := {}
+  /-- Module prefixes used when building pyspec Laurel names. -/
+  modulePrefixes : List String := []
 
 /-! ### Private Helpers -/
 
@@ -174,7 +176,8 @@ public def buildPySpecLaurel (pyspecEntries : Array (String × String))
   }
   return { laurelProgram := combinedLaurel, overloads := allOverloads
            functionSignatures := funcSigs, typeAliases := allTypeAliases
-           exhaustiveClasses := allExhaustiveClasses }
+           exhaustiveClasses := allExhaustiveClasses
+           modulePrefixes := (pyspecEntries.map (·.1)).toList }
 
 /-- Read dispatch Ion files and merge their overload tables. -/
 public def readDispatchOverloads
@@ -287,6 +290,23 @@ public def buildPreludeInfo (result : PySpecLaurelResult) : Python.PreludeInfo :
   -- Register functions under their Laurel names
   let symbols := merged.functions.foldl (init := symbols) fun m name =>
     m.insert name (.function name)
+  -- Register unprefixed procedure aliases for pyspec top-level functions.
+  -- When a pyspec module "heapq" defines "heappop", the Laurel procedure
+  -- is "heapq_heappop". User code that does `from heapq import heappop`
+  -- calls it as plain "heappop", so we register that alias here.
+  let symbols := result.modulePrefixes.foldl (init := symbols) fun syms pfx =>
+    if pfx.isEmpty then syms
+    else
+      let pfxUnderscore := pfx ++ "_"
+      merged.procedures.fold (init := syms) fun m name sig =>
+        if name.startsWith pfxUnderscore then
+          let shortName := name.drop pfxUnderscore.length |>.toString
+          -- Skip class methods (contain @) and don't overwrite existing
+          if !shortName.contains '@' && !m.contains shortName then
+            let inlinable := merged.inlinableProcedures.contains name
+            m.insert shortName (.procedure name sig inlinable)
+          else m
+        else m
   -- Add unprefixed aliases from typeAliases
   let symbols := result.typeAliases.fold (init := symbols)
     fun syms unprefixed prefixed =>
@@ -315,12 +335,87 @@ public def buildPreludeInfo (result : PySpecLaurelResult) : Python.PreludeInfo :
     importedSymbols := symbols
     exhaustiveClasses := exhaustive }
 
+/-- Recursively rename identifiers in a StmtExpr tree. -/
+private partial def renameIdent (oldName newName : String) : Laurel.StmtExprMd → Laurel.StmtExprMd
+  | ⟨.Identifier id, md⟩ =>
+    if id.text == oldName then ⟨.Identifier { id with text := newName }, md⟩
+    else ⟨.Identifier id, md⟩
+  | ⟨.PrimitiveOp op args, md⟩ =>
+    ⟨.PrimitiveOp op (args.map (renameIdent oldName newName)), md⟩
+  | ⟨.StaticCall callee args, md⟩ =>
+    ⟨.StaticCall callee (args.map (renameIdent oldName newName)), md⟩
+  | ⟨.IfThenElse c t e, md⟩ =>
+    ⟨.IfThenElse (renameIdent oldName newName c) (renameIdent oldName newName t)
+      (e.map (renameIdent oldName newName)), md⟩
+  | ⟨.Block stmts lbl, md⟩ =>
+    ⟨.Block (stmts.map (renameIdent oldName newName)) lbl, md⟩
+  | ⟨.Assign tgts val, md⟩ =>
+    ⟨.Assign (tgts.map (renameIdent oldName newName)) (renameIdent oldName newName val), md⟩
+  | ⟨.FieldSelect tgt fld, md⟩ =>
+    ⟨.FieldSelect (renameIdent oldName newName tgt) fld, md⟩
+  | other => other
+
 /-- Combine PySpec and user Laurel programs into a single program,
     prepending External stubs so the Laurel `resolve` pass can see
-    prelude names (e.g. `print`, `from_string`). -/
+    prelude names (e.g. `print`, `from_string`).
+    Also copies preconditions and postconditions from pyspec procedures
+    to matching user-code procedures. -/
 public def combinePySpecLaurel
-    (pySpec user : Laurel.Program) : Laurel.Program :=
-  { staticProcedures := pySpec.staticProcedures ++ user.staticProcedures
+    (pySpec user : Laurel.Program)
+    (modulePrefixes : List String := []) : Laurel.Program :=
+  -- Build a map from unprefixed name → pyspec preconditions
+  let pyspecPreconds : Std.HashMap String (List Laurel.StmtExprMd) :=
+    modulePrefixes.foldl (init := {}) fun m pfx =>
+      if pfx.isEmpty then m
+      else
+        let pfxUnderscore := pfx ++ "_"
+        pySpec.staticProcedures.foldl (init := m) fun m proc =>
+          if proc.name.text.startsWith pfxUnderscore && !proc.preconditions.isEmpty then
+            let shortName := proc.name.text.drop pfxUnderscore.length |>.toString
+            if !shortName.contains '@' then m.insert shortName proc.preconditions
+            else m
+          else m
+  -- Extract postconditions from pyspec procedure bodies (Body.Opaque postconds ...)
+  let pyspecPostconds : Std.HashMap String (List Laurel.StmtExprMd) :=
+    modulePrefixes.foldl (init := {}) fun m pfx =>
+      if pfx.isEmpty then m
+      else
+        let pfxUnderscore := pfx ++ "_"
+        pySpec.staticProcedures.foldl (init := m) fun m proc =>
+          if proc.name.text.startsWith pfxUnderscore then
+            match proc.body with
+            | .Opaque postconds _ _ =>
+              if !postconds.isEmpty then
+                let shortName := proc.name.text.drop pfxUnderscore.length |>.toString
+                if !shortName.contains '@' then m.insert shortName postconds
+                else m
+              else m
+            | _ => m
+          else m
+  -- Copy preconditions and postconditions to matching user-code procedures.
+  -- When postconditions are present, wrap the user body in Body.Opaque so
+  -- the Laurel pipeline can verify the body against the postconditions.
+  -- Postconditions reference "result" but user code uses "LaurelResult",
+  -- so we rename the identifier in the postcondition expressions.
+  let userProcs := user.staticProcedures.map fun proc =>
+    let proc := match pyspecPreconds[proc.name.text]? with
+      | some preconds => { proc with preconditions := preconds }
+      | none => proc
+    match pyspecPostconds[proc.name.text]? with
+    | some postconds =>
+      match proc.body with
+      | .Transparent bodyExpr =>
+        -- Rename "result" → "LaurelResult" in postconditions to match user code output
+        let renamedPostconds := postconds.map (renameIdent "result" "LaurelResult")
+        -- Prepend assume(isfrom_int(param)) for each input parameter.
+        let mkMd (e : Laurel.StmtExpr) : Laurel.StmtExprMd := ⟨e, bodyExpr.md⟩
+        let assumes := proc.inputs.map fun param =>
+          mkMd (.Assume (mkMd (.StaticCall (Laurel.mkId "Any..isfrom_int") [mkMd (.Identifier param.name)])))
+        let wrappedBody := mkMd (.Block (assumes ++ [bodyExpr]) none)
+        { proc with body := .Opaque renamedPostconds (some wrappedBody) [] }
+      | _ => proc
+    | none => proc
+  { staticProcedures := pySpec.staticProcedures ++ userProcs
     staticFields := pySpec.staticFields ++ user.staticFields
     types := pySpec.types ++ user.types
     constants := pySpec.constants ++ user.constants
@@ -434,6 +529,6 @@ public def pyAnalyzeLaurel
     | .error msg => throw (.internal msg)
 
   profileStep profile "Combine PySpec and user Laurel" do
-    return combinePySpecLaurel filteredPrelude laurelProgram
+    return combinePySpecLaurel filteredPrelude laurelProgram result.modulePrefixes
 
 end Strata

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -957,6 +957,11 @@ partial def translateCall (ctx : TranslationContext)
               else funcName
             | .error _ => funcName
           else funcName
+        -- Resolve pyspec alias: if funcName maps to a different Laurel name, use it
+        let funcName' := match ctx.importedSymbols[funcName']? with
+          | some (ImportedSymbol.procedure laurelName _ _) =>
+            if laurelName != funcName' then laurelName else funcName'
+          | _ => funcName'
         return mkCall funcName'
     | .Attribute _ val _attr _ =>
         let target_trans ← translateExprAsReceiver ctx val
@@ -977,7 +982,12 @@ partial def translateCall (ctx : TranslationContext)
             return callWithSelf
           else
             return mkStmtExprMdWithLoc (.Hole) callMd
-        else return mkCall funcName
+        else
+          -- Use Laurel name if available (handles pyspec aliases)
+          let resolvedName := match ctx.importedSymbols[funcName]? with
+            | some (ImportedSymbol.procedure laurelName _ _) => laurelName
+            | _ => funcName
+          return mkCall resolvedName
     | _ => throw (.unsupportedConstruct "Invalid call construct" (toString (repr f)))
   -- When ** is used at the call site and we have a known function signature,
   -- expand the dictionary into individual arguments using DictStrAny_get

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -866,19 +866,19 @@ partial def combinePositionalAndKeywordArgs
       let extraNames := kwordArgs.filterMap fun kw => match kw with
         | .mk_keyword _ name _ => name.val.map (·.val)
       throwUserError callRange
-        s!"'{name}' called with unknown keyword arguments: {extraNames}"
+        s!"unknown keyword arguments: {extraNames}"
     let kwords := pyKwordsToHashMap kwords
     -- Extra positional args beyond the signature are an arity error.
     if posArgs.length > funcDecl.args.length then
       throwUserError callRange
-        s!"'{name}' called with too many positional arguments: expected at most {funcDecl.args.length}, got {posArgs.length}"
+        s!"too many positional arguments: expected at most {funcDecl.args.length}, got {posArgs.length}"
     let unprovidedPosArgs := funcDecl.args.drop posArgs.length
     --every unprovided positional args must have a default value in the function signature or be provided in the kwargs
     let missingArgs := unprovidedPosArgs.filter fun arg =>
       !(arg.name ∈ kwords.keys) && arg.default.isNone
     if missingArgs.length > 0 then
       let missingNames := missingArgs.map (·.name)
-      throwUserError callRange s!"'{name}' called with missing required arguments: {missingNames}"
+      throwUserError callRange s!"missing required arguments: {missingNames}"
     let filledPosArgs ←
       unprovidedPosArgs.mapM (λ arg =>
         match kwords.get? arg.name with
@@ -1009,7 +1009,7 @@ partial def translateCall (ctx : TranslationContext)
     let name := if methodName.isEmpty then funcDecl.name else methodName
     if args.length > funcDecl.args.length then
       throwUserError callRange
-        s!"'{name}' called with too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
+        s!"too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
     let trans_posArgs ← args.mapM (translateExpr ctx)
     let trans_dict ← translateVarKwargs ctx kwords
     let remainingParams := funcDecl.args.drop args.length

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -934,7 +934,17 @@ partial def translateCall (ctx : TranslationContext)
     | .Attribute _ _ attr _ => attr.val
     | _ => funcName
   let callRange := match f with
-    | .Attribute range _ _ _ => range
+    | .Attribute range _ ⟨attrLoc, attrName⟩ _ =>
+      if attrLoc.isNone then
+        -- Point at the method name, not the full receiver.method expression.
+        -- range.stop points past "method_name", so subtract the name's byte
+        -- length to get the start of the method name.
+        let nameBytes := attrName.utf8ByteSize
+        let stopBytes := range.stop.byteIdx
+        if stopBytes ≥ nameBytes then
+          { start := ⟨stopBytes - nameBytes⟩, stop := range.stop : SourceRange }
+        else range
+      else attrLoc
     | .Name range _ _ => range
     | _ => .none
   let funcDecl := ctx.functionSignatures.find? fun x => (x.name == funcName || x.name == funcName ++ "@__init__")

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -866,19 +866,19 @@ partial def combinePositionalAndKeywordArgs
       let extraNames := kwordArgs.filterMap fun kw => match kw with
         | .mk_keyword _ name _ => name.val.map (·.val)
       throwUserError callRange
-        s!"unknown keyword arguments: {extraNames}"
+        s!"Unknown keyword arguments: {extraNames}"
     let kwords := pyKwordsToHashMap kwords
     -- Extra positional args beyond the signature are an arity error.
     if posArgs.length > funcDecl.args.length then
       throwUserError callRange
-        s!"too many positional arguments: expected at most {funcDecl.args.length}, got {posArgs.length}"
+        s!"Too many positional arguments: expected at most {funcDecl.args.length}, got {posArgs.length}"
     let unprovidedPosArgs := funcDecl.args.drop posArgs.length
     --every unprovided positional args must have a default value in the function signature or be provided in the kwargs
     let missingArgs := unprovidedPosArgs.filter fun arg =>
       !(arg.name ∈ kwords.keys) && arg.default.isNone
     if missingArgs.length > 0 then
       let missingNames := missingArgs.map (·.name)
-      throwUserError callRange s!"missing required arguments: {missingNames}"
+      throwUserError callRange s!"Missing required arguments: {missingNames}"
     let filledPosArgs ←
       unprovidedPosArgs.mapM (λ arg =>
         match kwords.get? arg.name with
@@ -1009,7 +1009,7 @@ partial def translateCall (ctx : TranslationContext)
     let name := if methodName.isEmpty then funcDecl.name else methodName
     if args.length > funcDecl.args.length then
       throwUserError callRange
-        s!"too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
+        s!"Too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
     let trans_posArgs ← args.mapM (translateExpr ctx)
     let trans_dict ← translateVarKwargs ctx kwords
     let remainingParams := funcDecl.args.drop args.length

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -604,7 +604,10 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
 
   | .Call _ f args kwargs =>
       let result ← translateCall ctx f args.val.toList kwargs.val.toList
-      return {result with md:= md}
+      -- Preserve the callRange metadata from translateCall (which points at the
+      -- method name, e.g. "delete_object") instead of overwriting with the full
+      -- Call expression range (which points at "s3_client").
+      return result
 
   -- Subscript access: dict['key'] or list[0]
   -- Abstract: return havoc'd value (sound for any dict/list operation)
@@ -1391,7 +1394,8 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
   -- Expression statement (e.g., function call)
   | .Expr _ value => do
     let expr ← translateExpr ctx value
-    let expr := { expr with md := md }
+    -- Preserve metadata from translateExpr/translateCall (which may point at
+    -- the method name) instead of overwriting with the Expr statement range.
     let exceptionCheck := getExceptionAssertions ctx expr
 
     match expr.val with

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -1212,14 +1212,34 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
                        (decorators : Array (expr SourceRange))
                        (returns : Option (expr SourceRange)) : PySpecM FunctionDecl := do
   let mut overload : Bool := false
+  -- Collect icontract preconditions and postconditions from decorators
+  let mut icontractRequires : Array (expr SourceRange) := #[]
+  let mut icontractEnsures : Array (expr SourceRange) := #[]
   for pyd in decorators do
-    let (success, d) ← runChecked <| pySpecValue pyd
-    if success then
-      match d with
-      | .typingOverload =>
-        overload := true
-      | _ =>
-        specError pyd.ann s!"Decorator {repr d} not supported."
+    -- Check for @icontract.require(lambda ...: cond) or @icontract.ensure(lambda ...: cond)
+    match pyd with
+    | .Call _ (.Attribute _ (.Name _ ⟨_, "icontract"⟩ (.Load _)) ⟨_, attr⟩ (.Load _)) args _ =>
+      if args.val.size ≥ 1 then
+        match args.val[0]! with
+        | .Lambda _ _lamArgs lamBody =>
+          if attr == "require" then
+            icontractRequires := icontractRequires.push lamBody
+          else if attr == "ensure" then
+            icontractEnsures := icontractEnsures.push lamBody
+          else
+            specWarning pyd.ann s!"Unknown icontract decorator: icontract.{attr}"
+        | _ =>
+          specWarning pyd.ann s!"icontract.{attr} expects a lambda argument"
+      else
+        specWarning pyd.ann s!"icontract.{attr} requires at least one argument"
+    | _ =>
+      let (success, d) ← runChecked <| pySpecValue pyd
+      if success then
+        match d with
+        | .typingOverload =>
+          overload := true
+        | _ =>
+          specError pyd.ann s!"Decorator {repr d} not supported."
 
   let .mk_arguments _ posonly ⟨_, posArgs⟩ vararg kwonly kw_defaults kwarg defaults := arguments
   assert! posonly.val.size = 0
@@ -1282,7 +1302,21 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
         match returns with
         | none => pure <| .ident fnLoc .typingAny
         | some tp => pySpecType tp
-  let as ← collectAssertions argDecls returnType <|
+  let as ← collectAssertions argDecls returnType <| do
+    -- Process icontract @require decorators as preconditions
+    for reqExpr in icontractRequires do
+      let formula ← transAssertExpr reqExpr
+      let message := #[MessagePart.str (toString (repr reqExpr))]
+      modify fun s => { s with
+        assertions := s.assertions.push { message, formula }
+      }
+    -- Process icontract @ensure decorators as postconditions
+    for ensExpr in icontractEnsures do
+      let formula ← transAssertExpr ensExpr
+      modify fun s => { s with
+        postconditions := s.postconditions.push formula
+      }
+    -- Process body assertions (assert statements)
     if overload then
       -- Overload stubs should have `...` as their only body statement.
       unless body.size = 1 &&

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -1213,7 +1213,7 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
                        (returns : Option (expr SourceRange)) : PySpecM FunctionDecl := do
   let mut overload : Bool := false
   -- Collect icontract preconditions and postconditions from decorators
-  let mut icontractRequires : Array (expr SourceRange) := #[]
+  let mut icontractRequires : Array (expr SourceRange × String) := #[]
   let mut icontractEnsures : Array (expr SourceRange) := #[]
   for pyd in decorators do
     -- Check for @icontract.require(lambda ...: cond) or @icontract.ensure(lambda ...: cond)
@@ -1223,7 +1223,7 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
         match args.val[0]! with
         | .Lambda _ _lamArgs lamBody =>
           if attr == "require" then
-            icontractRequires := icontractRequires.push lamBody
+            icontractRequires := icontractRequires.push (lamBody, s!"icontract precondition")
           else if attr == "ensure" then
             icontractEnsures := icontractEnsures.push lamBody
           else
@@ -1304,9 +1304,9 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
         | some tp => pySpecType tp
   let as ← collectAssertions argDecls returnType <| do
     -- Process icontract @require decorators as preconditions
-    for reqExpr in icontractRequires do
+    for (reqExpr, reqMsg) in icontractRequires do
       let formula ← transAssertExpr reqExpr
-      let message := #[MessagePart.str (toString (repr reqExpr))]
+      let message := #[MessagePart.str reqMsg]
       modify fun s => { s with
         assertions := s.assertions.push { message, formula }
       }

--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -85,6 +85,14 @@ op intGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " >=_int " bound;
 op intLeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " <=_int " bound;
+op intAddExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(20)] left " +_int " right;
+op intSubExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(20)] left " -_int " right;
+op intMulExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(25)] left " *_int " right;
+op intEqExpr(left : SpecExprDecl, right : SpecExprDecl) : SpecExprDecl =>
+  @[prec(15)] left " ==_int " right;
 op floatExpr(value : Str) : SpecExprDecl => value;
 op floatGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " >=_float " bound;
@@ -251,6 +259,10 @@ protected def SpecExpr.toDDM (e : SpecExpr) : DDM.SpecExprDecl SourceRange :=
   | .intLit v loc => .intExpr loc (toDDMInt loc v)
   | .intGe subj bound loc => .intGeExpr loc subj.toDDM bound.toDDM
   | .intLe subj bound loc => .intLeExpr loc subj.toDDM bound.toDDM
+  | .intAdd left right loc => .intAddExpr loc left.toDDM right.toDDM
+  | .intSub left right loc => .intSubExpr loc left.toDDM right.toDDM
+  | .intMul left right loc => .intMulExpr loc left.toDDM right.toDDM
+  | .intEq left right loc => .intEqExpr loc left.toDDM right.toDDM
   | .floatLit v loc => .floatExpr loc ⟨loc, v⟩
   | .floatGe subj bound loc => .floatGeExpr loc subj.toDDM bound.toDDM
   | .floatLe subj bound loc => .floatLeExpr loc subj.toDDM bound.toDDM
@@ -391,6 +403,10 @@ private def DDM.SpecExprDecl.fromDDM (d : DDM.SpecExprDecl SourceRange) : Specs.
   | .intExpr loc i => .intLit i.ofDDM loc
   | .intGeExpr loc subj bound => .intGe subj.fromDDM bound.fromDDM loc
   | .intLeExpr loc subj bound => .intLe subj.fromDDM bound.fromDDM loc
+  | .intAddExpr loc left right => .intAdd left.fromDDM right.fromDDM loc
+  | .intSubExpr loc left right => .intSub left.fromDDM right.fromDDM loc
+  | .intMulExpr loc left right => .intMul left.fromDDM right.fromDDM loc
+  | .intEqExpr loc left right => .intEq left.fromDDM right.fromDDM loc
   | .floatExpr loc ⟨_, v⟩ => .floatLit v loc
   | .floatGeExpr loc subj bound => .floatGe subj.fromDDM bound.fromDDM loc
   | .floatLeExpr loc subj bound => .floatLe subj.fromDDM bound.fromDDM loc

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -324,6 +324,14 @@ inductive SpecExpr where
 | intLit (value : Int) (loc : SourceRange)
 | intGe (subject : SpecExpr) (bound : SpecExpr) (loc : SourceRange)
 | intLe (subject : SpecExpr) (bound : SpecExpr) (loc : SourceRange)
+/-- Integer addition: `intAdd a b` represents `a + b`. -/
+| intAdd (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
+/-- Integer subtraction: `intSub a b` represents `a - b`. -/
+| intSub (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
+/-- Integer multiplication: `intMul a b` represents `a * b`. -/
+| intMul (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
+/-- Integer equality: `intEq a b` represents `a == b`. -/
+| intEq (left : SpecExpr) (right : SpecExpr) (loc : SourceRange)
 /-- A floating-point literal, stored as a string to preserve precision. -/
 | floatLit (value : String) (loc : SourceRange)
 | floatGe (subject : SpecExpr) (bound : SpecExpr) (loc : SourceRange)

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -312,6 +312,7 @@ private def mkMdWithFileRange (loc : SourceRange) (msg : String := "")
   let mut md : Imperative.MetaData Core.Expression := #[⟨Imperative.MetaData.fileRange, .fileRange fr⟩]
   if !msg.isEmpty then
     md := md.withPropertySummary msg
+    md := md.push ⟨Imperative.MetaData.message, .msg msg⟩
   return md
 
 /-- Wrap a StmtExpr with metadata containing a file range and optional message. -/
@@ -389,6 +390,45 @@ def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
       some (mkStmt (.PrimitiveOp .Leq
         [mkStmt (.StaticCall (mkId "Any..as_int!") [s]) md,
          mkStmt (.StaticCall (mkId "Any..as_int!") [b]) md]) md)
+  | .intAdd left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      -- Unwrap to int, add, re-wrap: from_int(as_int(l) + as_int(r))
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      let sum := mkStmt (.PrimitiveOp .Add [lInt, rInt]) md
+      some (mkStmt (.StaticCall (mkId "from_int") [sum]) md)
+  | .intSub left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      -- Unwrap to int, subtract, re-wrap: from_int(as_int(l) - as_int(r))
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      let diff := mkStmt (.PrimitiveOp .Sub [lInt, rInt]) md
+      some (mkStmt (.StaticCall (mkId "from_int") [diff]) md)
+  | .intMul left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      -- Unwrap to int, multiply, re-wrap: from_int(as_int(l) * as_int(r))
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      let prod := mkStmt (.PrimitiveOp .Mul [lInt, rInt]) md
+      some (mkStmt (.StaticCall (mkId "from_int") [prod]) md)
+  | .intEq left right loc => do
+    let md ← nodeMd loc
+    let l? ← specExprToLaurel left md; let r? ← specExprToLaurel right md
+    return do
+      let l ← l?; let r ← r?
+      -- Unwrap to int, compare: as_int(l) == as_int(r)
+      let lInt := mkStmt (.StaticCall (mkId "Any..as_int!") [l]) md
+      let rInt := mkStmt (.StaticCall (mkId "Any..as_int!") [r]) md
+      some (mkStmt (.PrimitiveOp .Eq [lInt, rInt]) md)
   | .floatGe subject bound loc => do
     let md ← nodeMd loc
     let s? ← specExprToLaurel subject md; let b? ← specExprToLaurel bound md
@@ -467,6 +507,20 @@ def SpecAssertMsg.render : SpecAssertMsg → String
   | .userAssertion text  => text
   | .unnamed index       => s!"precondition {index}"
 
+/-- Generate a human-readable message from a SpecExpr for postcondition labels. -/
+private def specExprToMessage : SpecExpr → String
+  | .var name _ => name
+  | .intLit v _ => toString v
+  | .intGe a b _ => s!"{specExprToMessage a} >= {specExprToMessage b}"
+  | .intLe a b _ => s!"{specExprToMessage a} <= {specExprToMessage b}"
+  | .intEq a b _ => s!"{specExprToMessage a} == {specExprToMessage b}"
+  | .intAdd a b _ => s!"{specExprToMessage a} + {specExprToMessage b}"
+  | .intSub a b _ => s!"{specExprToMessage a} - {specExprToMessage b}"
+  | .intMul a b _ => s!"{specExprToMessage a} * {specExprToMessage b}"
+  | .not e _ => s!"not ({specExprToMessage e})"
+  | .len e _ => s!"len({specExprToMessage e})"
+  | _ => "<expr>"
+
 /-- Build a procedure body that asserts preconditions.
     Outputs are already initialized non-deterministically. -/
 def buildSpecBody (preconditions : Array Assertion)
@@ -543,8 +597,54 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     [{ name := "result", type := match retType.val with
       | .TVoid => tyAny
       | _ => retType }]
-  if func.postconditions.size > 0 then
-    reportError func.loc "Postconditions not yet supported"
+  if func.postconditions.size > 0 then do
+    -- When postconditions exist, use TCore "Any" for all parameters and outputs
+    let anyTy : HighTypeMd := tyAny
+    let anyInputs := inputs.map fun p => { p with type := anyTy }
+    let anyOutputs := outputs.map fun p => { p with type := anyTy }
+    -- Build postcondition expressions
+    let fileMd ← mkFileMd
+    let postconds ← func.postconditions.toList.filterMapM fun postExpr => do
+      let msg := specExprToMessage postExpr
+      let postMd ← mkMdWithFileRange default msg
+      specExprToLaurel postExpr postMd
+    -- Add isfrom_int(result) so callers know the return value is an integer.
+    -- This is needed for PSub/PAdd to take the int-int branch.
+    let postconds := if !postconds.isEmpty then
+      let resultIntExpr := mkStmt (.StaticCall (mkId "Any..isfrom_int")
+        [mkStmt (.Identifier (mkId "result")) fileMd]) fileMd
+      postconds ++ [resultIntExpr]
+    else postconds
+    -- Build Laurel-level precondition expressions for the Procedure.preconditions
+    -- field. CallElim uses these to assert preconditions at call sites and
+    -- assume them in the body, enabling transitivity for internal calls.
+    let laurelPreconds ← func.preconditions.toList.filterMapM fun assertion => do
+      let msg := formatAssertionMessage assertion.message
+      let precondMd ← mkMdWithFileRange default msg
+      specExprToLaurel assertion.formula precondMd
+    -- Build body with precondition asserts
+    let impl ← if func.preconditions.size > 0 then do
+      let body ← buildSpecBody func.preconditions .empty
+        (requiredParams := allArgs.filterMap fun a =>
+          if a.default.isNone then some a.name else none)
+      pure (some body)
+    else do
+      let fileMd' ← mkFileMd
+      let body := mkStmt (.Block [] none) fileMd'
+      pure (some (Body.Transparent body))
+    let bodyVal : Body := match impl with
+      | some (.Transparent bodyExpr) => .Opaque postconds (some bodyExpr) []
+      | _ => .Opaque postconds none []
+    let md ← mkMdWithFileRange func.loc
+    return {
+      name := { text := procName, md := md }
+      inputs := anyInputs.toList
+      outputs := anyOutputs
+      preconditions := laurelPreconds
+      decreases := none
+      isFunctional := false
+      body := bodyVal
+    }
   -- When preconditions exist, use TCore "Any" for all parameters and outputs
   -- to match the Python→Laurel pipeline's Any-wrapping convention.
   let (inputs, outputs, body) ←

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -658,12 +658,19 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
       pure (anyInputs, anyOutputs, body)
     else
       pure (inputs, outputs, Body.Opaque [] none [])
+  -- Build Laurel-level precondition expressions for the Procedure.preconditions
+  -- field, even when there are no postconditions. CallElim uses these to assert
+  -- preconditions at call sites with proper messages.
+  let laurelPreconds ← func.preconditions.toList.filterMapM fun assertion => do
+    let msg := formatAssertionMessage assertion.message
+    let precondMd ← mkMdWithFileRange default msg
+    specExprToLaurel assertion.formula precondMd
   let md ← mkMdWithFileRange func.loc
   return {
     name := { text := procName, md := md }
     inputs := inputs.toList
     outputs := outputs
-    preconditions := []
+    preconditions := laurelPreconds
     decreases := none
     isFunctional := false
     body := body

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -541,9 +541,13 @@ def buildSpecBody (preconditions : Array Assertion)
     idx := idx + 1
   for assertion in preconditions do
     let formattedMsg := formatAssertionMessage assertion.message
-    let msg := if formattedMsg.isEmpty
+    -- Prefer a human-readable rendering of the formula (e.g. "len(Key) >= 1")
+    -- over the generic "icontract precondition" message.
+    let exprMsg := specExprToMessage assertion.formula
+    let betterMsg := if exprMsg != "<expr>" then exprMsg else formattedMsg
+    let msg := if betterMsg.isEmpty
       then SpecAssertMsg.unnamed idx |>.render
-      else SpecAssertMsg.userAssertion formattedMsg |>.render
+      else SpecAssertMsg.userAssertion betterMsg |>.render
     match ← specExprToLaurel assertion.formula md with
     | some condExpr =>
       let assertStmt ← mkStmtWithLoc (.Assert condExpr) default msg
@@ -619,9 +623,19 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     -- field. CallElim uses these to assert preconditions at call sites and
     -- assume them in the body, enabling transitivity for internal calls.
     let laurelPreconds ← func.preconditions.toList.filterMapM fun assertion => do
-      let msg := formatAssertionMessage assertion.message
+      let rawMsg := formatAssertionMessage assertion.message
+      -- Prefer a human-readable rendering of the formula (e.g. "len(Key) >= 1")
+      -- over the generic "icontract precondition" message.
+      let exprMsg := specExprToMessage assertion.formula
+      let msg := if exprMsg != "<expr>" then exprMsg else rawMsg
       let precondMd ← mkMdWithFileRange default msg
-      specExprToLaurel assertion.formula precondMd
+      let result? ← specExprToLaurel assertion.formula precondMd
+      -- Ensure propertySummary survives: specExprToLaurel creates fresh metadata
+      -- from node source locations, losing the propertySummary from precondMd.
+      return result?.map fun r =>
+        if !msg.isEmpty && r.md.getPropertySummary.isNone then
+          { r with md := r.md.withPropertySummary msg }
+        else r
     -- Build body with precondition asserts
     let impl ← if func.preconditions.size > 0 then do
       let body ← buildSpecBody func.preconditions .empty
@@ -662,9 +676,19 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
   -- field, even when there are no postconditions. CallElim uses these to assert
   -- preconditions at call sites with proper messages.
   let laurelPreconds ← func.preconditions.toList.filterMapM fun assertion => do
-    let msg := formatAssertionMessage assertion.message
+    let rawMsg := formatAssertionMessage assertion.message
+    -- Prefer a human-readable rendering of the formula (e.g. "len(Key) >= 1")
+    -- over the generic "icontract precondition" message.
+    let exprMsg := specExprToMessage assertion.formula
+    let msg := if exprMsg != "<expr>" then exprMsg else rawMsg
     let precondMd ← mkMdWithFileRange default msg
-    specExprToLaurel assertion.formula precondMd
+    let result? ← specExprToLaurel assertion.formula precondMd
+    -- Ensure propertySummary survives: specExprToLaurel creates fresh metadata
+    -- from node source locations, losing the propertySummary from precondMd.
+    return result?.map fun r =>
+      if !msg.isEmpty && r.md.getPropertySummary.isNone then
+        { r with md := r.md.withPropertySummary msg }
+      else r
   let md ← mkMdWithFileRange func.loc
   return {
     name := { text := procName, md := md }

--- a/Strata/Transform/CoreTransform.lean
+++ b/Strata/Transform/CoreTransform.lean
@@ -259,11 +259,12 @@ def createAsserts
     : CoreTransformM (List Statement)
     := conds.mapM (fun (l, check) => do
           let newLabel ← genIdent l (fun s => s!"{labelPrefix}{s}")
-          -- Non-lifting: the replacement expressions must be closed (no dangling bvars).
-          -- Use the call site as the primary file range, preserving the requires
-          -- clause location as a related file range for richer diagnostics.
-          let assertMd := check.md.setCallSiteFileRange md
-          return Statement.assert newLabel.toPretty (Lambda.LExpr.substFvars check.expr subst) assertMd)
+          -- Merge propertySummary from the check metadata (e.g. precondition
+          -- description) into the call-site metadata so it appears in output.
+          let mergedMd := match check.md.getPropertySummary with
+            | some summary => md.withPropertySummary summary
+            | none => md
+          return Statement.assert newLabel.toPretty (Lambda.LExpr.substFvars check.expr subst) mergedMd)
 
 /-- turns a list of preconditions into assumes with substitution -/
 def createAssumes

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -590,6 +590,34 @@ def pyAnalyzeLaurelCommand : Command where
       let path := s!"{dir}/{baseName}.core"
       IO.FS.writeFile path (toString coreProgram)
 
+    -- Inline pyspec procedures so their precondition assertions are checked
+    -- at call sites with concrete arguments.
+    -- First, run CallElim on pyspec procedures to replace calls with
+    -- assert(preconditions) + havoc + assume(postconditions). This ensures
+    -- that when a decorated function calls another decorated function,
+    -- the caller's preconditions (assumed by CallElim) can satisfy the
+    -- callee's preconditions (asserted by CallElim).
+    let pyspecFiles := pflags.getRepeated "pyspec"
+    let coreProgram ←
+      if pyspecFiles.size > 0 then
+        -- CallElim: replace pyspec procedure calls with assert/havoc/assume
+        let coreProgram ← match Core.callElimUsingContract coreProgram with
+          | .error e => exitPyAnalyzeInternalError s!"CallElim failed: {e}"
+          | .ok prog => pure prog
+        -- Then inline remaining procedure bodies
+        match Core.inlineProcedures coreProgram
+              ⟨.some (fun name _ => name ≠ "__main__" && !_preludeNames.contains name)⟩ with
+        | .error e => exitPyAnalyzeInternalError s!"Inlining failed: {e}"
+        | .ok inlined => do
+          if verbose then
+            IO.println "\n==== Core Program (after inlining) ===="
+            IO.print inlined
+          if let some dir := keepDir then
+            let path := s!"{dir}/{baseName}.inlined.core"
+            IO.FS.writeFile path (toString inlined)
+          pure inlined
+      else pure coreProgram
+
     -- Verify using Core verifier
     -- --keep-all-files implies vc-directory if not explicitly set
     let baseVcDir := keepDir.map (fun dir => (s!"{dir}/{baseName}" : System.FilePath))
@@ -623,20 +651,52 @@ def pyAnalyzeLaurelCommand : Command where
 
     -- Print per-VC results by default, unless SARIF mode is used
     if !outputSarif then
+      let classifier : ResultClassifier := {}
       let mut s := ""
       for vcResult in vcResults do
-        let fileMap := mfm.map (·.2)
-        let location := match Imperative.getFileRange vcResult.obligation.metadata with
+        let propertySummaryOption := vcResult.obligation.metadata.getPropertySummary
+        let propertyDescription := match propertySummaryOption with
+          | some summary =>
+            let label := vcResult.obligation.label
+            -- Postcondition body checks (label contains ":postcondition") get a
+            -- "[procname]" prefix instead of a "(call site N)" suffix.
+            if (label.splitOn ":postcondition" |>.length) > 1 then
+              let procName := label.splitOn ":" |>.head!
+              s!"[{procName}] {summary}"
+            else
+              -- Extract call-site suffix from the label (e.g., "_7" from "func_assert(0)_7")
+              let suffix := match label.splitOn "_" |>.getLast? with
+                | some s => if s.toNat?.isSome then s!" (call site {s})" else ""
+                | none => ""
+              summary ++ suffix
+          | none => vcResult.obligation.label
+        let (locationPrefix, locationSuffix) := match Imperative.getFileRange vcResult.obligation.metadata with
           | some fr =>
-            if fr.range.isNone then ""
-            else s!"{fr.format fileMap (includeEnd? := false)}"
-          | none => ""
-        let messageSuffix := match vcResult.obligation.metadata.getPropertySummary with
-          | some msg => s!" - {msg}"
-          | none => s!" - {vcResult.obligation.label}"
+            if fr.range.isNone then ("", "")
+            else
+              match mfm with
+              | some (_, fm) =>
+                match fr.file with
+                | .file "" =>
+                  if classifier.isFailure vcResult then
+                    (s!"Assertion failed in prelude file: ", "")
+                  else
+                    ("", s!" (in prelude file)")
+                | .file _ =>
+                  let pos := fm.toPosition fr.range.start
+                  if classifier.isFailure vcResult then
+                    (s!"Assertion failed at line {pos.line}, col {pos.column}: ", "")
+                  else
+                    ("", s!" (at line {pos.line}, col {pos.column})")
+              | none =>
+                if classifier.isFailure vcResult then
+                  (s!"Assertion failed: ", "")
+                else
+                  ("", "")
+          | none => ("", "")
         let outcomeStr := vcResult.formatOutcome
-        let loc := if !location.isEmpty then s!"{location}: " else "unknown location: "
-        s := s ++ s!"{loc}{outcomeStr}{messageSuffix}\n"
+        s := s ++ s!"{locationPrefix}{propertyDescription}: \
+                      {outcomeStr}{locationSuffix}\n"
       IO.print s
     -- Output in SARIF format if requested
     if outputSarif then

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -606,7 +606,7 @@ def pyAnalyzeLaurelCommand : Command where
           | .ok prog => pure prog
         -- Then inline remaining procedure bodies
         match Core.inlineProcedures coreProgram
-              ⟨.some (fun name _ => name ≠ "__main__" && !_preludeNames.contains name)⟩ with
+              { doInline := fun name _ => name ≠ "__main__" && !_preludeNames.contains name } with
         | .error e => exitPyAnalyzeInternalError s!"Inlining failed: {e}"
         | .ok inlined => do
           if verbose then

--- a/Tools/Python/scripts/examples/withdraw.py
+++ b/Tools/Python/scripts/examples/withdraw.py
@@ -1,0 +1,38 @@
+"""Banking with safe withdrawals."""
+import icontract
+
+
+@icontract.require(lambda a: a >= 0)
+@icontract.require(lambda b: b >= 0)
+@icontract.ensure(lambda a, b, result: result >= 0)
+@icontract.ensure(lambda a, result: result <= a)
+@icontract.ensure(lambda b, result: result >= b)
+def cap(a: int, b: int) -> int:
+    """Return the smaller of a and b."""
+    if a <= b:
+        return a
+    return b
+
+
+@icontract.require(lambda balance: balance >= 0)
+@icontract.require(lambda amount: amount >= 0)
+@icontract.ensure(lambda result: result >= 0)
+def withdraw(balance: int, amount: int) -> int:
+    """Withdraw at most what's available."""
+    safe_amount = cap(amount, balance)
+    return balance - safe_amount
+
+
+@icontract.ensure(lambda result: result >= 0)
+def test_good() -> int:
+    return withdraw(100, 50)
+
+
+@icontract.ensure(lambda result: result >= 0)
+def test_good2() -> int:
+    return withdraw(100, 200)
+
+
+@icontract.ensure(lambda result: result >= 0)
+def test_bad() -> int:
+    return withdraw(-10, 5)

--- a/Tools/Python/scripts/verify_icontract.sh
+++ b/Tools/Python/scripts/verify_icontract.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Verify Python user code against icontract specs using Strata.
+#
+# Usage: ./verify.sh [--spec extra_spec.py]... <file.py> [user_file]
+#
+# If user_file is omitted, file.py is used as both spec and user code.
+# Use --spec to add additional spec files (e.g., stdlib contracts).
+#
+# Examples:
+#   ./verify.sh withdraw.py                                # single file
+#   ./verify.sh --spec builtins_spec.py user_code.py       # stdlib spec + user code
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+STRATA_DIR="${STRATA_DIR:-$(dirname "$SCRIPT_DIR")/Strata}"
+STRATA_BIN="$STRATA_DIR/.lake/build/bin/strata"
+STRATA_PYTHON="$STRATA_DIR/Tools/Python"
+DIALECT="$STRATA_PYTHON/dialects/Python.dialect.st.ion"
+
+# Ensure tools are on PATH
+export PATH="$HOME/.local/bin:$HOME/.elan/bin:$PATH"
+# Use mise Python if available
+if command -v mise &>/dev/null; then
+    eval "$(mise activate bash 2>/dev/null)" || true
+fi
+
+# Parse --spec flags
+EXTRA_SPECS=()
+while [[ $# -gt 0 && "$1" == "--spec" ]]; do
+    shift
+    EXTRA_SPECS+=("$(realpath "$1")")
+    shift
+done
+
+# Auto-include builtins_spec.py only if user code calls min/max/abs
+BUILTINS_SPEC="$SCRIPT_DIR/builtins_spec.py"
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 [--spec extra_spec.py]... <spec_file> [user_file]"
+    exit 1
+fi
+
+SPEC_FILE="$(realpath "$1")"
+USER_FILE="$(realpath "${2:-$1}")"
+ORIG_USER_FILE="${2:-$1}"
+
+if [ -f "$BUILTINS_SPEC" ] && grep -q '\bmin\b\|\bmax\b\|\babs\b' "$USER_FILE"; then
+    EXTRA_SPECS+=("$(realpath "$BUILTINS_SPEC")")
+fi
+MODULE_NAME="$(basename "$USER_FILE" .py)"
+
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
+
+PYSPEC_ION="$TMPDIR/${MODULE_NAME}.pyspec.st.ion"
+USER_ION="$TMPDIR/${MODULE_NAME}.python.st.ion"
+
+# Step 1: Convert main icontract specs to pyspec Ion
+ONLY_DECORATED=""
+if [ "$SPEC_FILE" = "$USER_FILE" ]; then
+    ONLY_DECORATED="--only-decorated"
+fi
+python3 -m strata.icontract "$SPEC_FILE" "$PYSPEC_ION" --module "$MODULE_NAME" $ONLY_DECORATED >/dev/null 2>&1
+
+# Step 1b: Convert extra spec files to pyspec Ion
+PYSPEC_ARGS="--pyspec $MODULE_NAME"
+for EXTRA in "${EXTRA_SPECS[@]+"${EXTRA_SPECS[@]}"}"; do
+    EXTRA_MOD="$(basename "$EXTRA" .py)"
+    EXTRA_ION="$TMPDIR/${EXTRA_MOD}.pyspec.st.ion"
+    python3 -m strata.icontract "$EXTRA" "$EXTRA_ION" --module "$EXTRA_MOD" >/dev/null 2>&1
+    PYSPEC_ARGS="$PYSPEC_ARGS --pyspec $EXTRA_MOD"
+done
+
+# Step 2: Convert user code to Python Ion
+(cd "$STRATA_PYTHON" && python3 -m strata.gen py_to_strata --dialect "$DIALECT" "$USER_FILE" "$USER_ION") 2>/dev/null || {
+    echo "Error converting $USER_FILE to Python Ion" >&2
+    exit 1
+}
+
+# Step 3: Run Strata verification
+RAW_OUTPUT=$("$STRATA_BIN" pyAnalyzeLaurel \
+    --spec-dir "$TMPDIR" \
+    $PYSPEC_ARGS \
+    "$USER_ION" 2>&1) || true
+
+# Step 4: Format results — pass all spec files so call sites from extra specs are found
+ALL_SPECS="$SPEC_FILE"
+for EXTRA in "${EXTRA_SPECS[@]+"${EXTRA_SPECS[@]}"}"; do
+    ALL_SPECS="$ALL_SPECS:$EXTRA"
+done
+echo "$RAW_OUTPUT" | python3 "$SCRIPT_DIR/format_results.py" "$ALL_SPECS" "$USER_FILE" "$ORIG_USER_FILE"

--- a/Tools/Python/scripts/verify_icontract.sh
+++ b/Tools/Python/scripts/verify_icontract.sh
@@ -89,4 +89,4 @@ ALL_SPECS="$SPEC_FILE"
 for EXTRA in "${EXTRA_SPECS[@]+"${EXTRA_SPECS[@]}"}"; do
     ALL_SPECS="$ALL_SPECS:$EXTRA"
 done
-echo "$RAW_OUTPUT" | python3 "$SCRIPT_DIR/format_results.py" "$ALL_SPECS" "$USER_FILE" "$ORIG_USER_FILE"
+echo "$RAW_OUTPUT" | python3 -m strata.format_results "$ALL_SPECS" "$USER_FILE" "$ORIG_USER_FILE"

--- a/Tools/Python/strata/ddm_writer.py
+++ b/Tools/Python/strata/ddm_writer.py
@@ -1,0 +1,296 @@
+"""
+Ion binary output for Strata PythonSpecs DDM format.
+
+Generates .pyspec.st.ion files directly from icontract-decorated Python,
+without requiring Lean compilation.
+
+Requires: amazon.ion (pip install amazon.ion)
+"""
+
+import amazon.ion.simpleion as ion
+from amazon.ion.core import IonType
+from amazon.ion.simple_types import IonPySymbol, IonPyNull
+import io
+
+
+# ---------------------------------------------------------------------------
+# Ion s-expression helpers
+# ---------------------------------------------------------------------------
+
+def _sym(name: str):
+    """Create an Ion symbol."""
+    return IonPySymbol(text=name)
+
+
+def _sexp(*args):
+    """Create an Ion s-expression (tuple with Ion type annotation)."""
+    result = ion.loads(ion.dumps(list(args), binary=False))
+    # We need to build sexps manually
+    return args  # placeholder — we'll use a different approach
+
+
+# The DDM Ion format uses s-expressions (sexp) extensively.
+# amazon.ion doesn't have great sexp support, so we build the
+# binary Ion directly using the low-level writer.
+
+from amazon.ion.writer import blocking_writer
+from amazon.ion.writer_binary import binary_writer
+from amazon.ion.core import IonEvent, IonEventType, IonType, SymbolToken
+
+
+class IonDDMWriter:
+    """Writes Strata DDM PythonSpecs Ion binary format."""
+
+    def __init__(self):
+        self._buf = io.BytesIO()
+        self._writer = blocking_writer(
+            binary_writer(),
+            self._buf
+        )
+
+    def _start_sexp(self):
+        self._writer.send(IonEvent(IonEventType.CONTAINER_START, IonType.SEXP))
+
+    def _end_sexp(self):
+        self._writer.send(IonEvent(IonEventType.CONTAINER_END))
+
+    def _start_list(self):
+        self._writer.send(IonEvent(IonEventType.CONTAINER_START, IonType.LIST))
+
+    def _end_list(self):
+        self._writer.send(IonEvent(IonEventType.CONTAINER_END))
+
+    def _symbol(self, text: str):
+        self._writer.send(IonEvent(IonEventType.SCALAR, IonType.SYMBOL,
+                                    value=SymbolToken(text=text, sid=None)))
+
+    def _string(self, text: str):
+        self._writer.send(IonEvent(IonEventType.SCALAR, IonType.STRING, value=text))
+
+    def _int(self, value: int):
+        self._writer.send(IonEvent(IonEventType.SCALAR, IonType.INT, value=value))
+
+    def _bool(self, value: bool):
+        self._writer.send(IonEvent(IonEventType.SCALAR, IonType.BOOL, value=value))
+
+    def _null(self):
+        self._writer.send(IonEvent(IonEventType.SCALAR, IonType.NULL))
+
+    # -- DDM node builders --
+
+    def _op(self, op_name: str, *children_fn):
+        """Write (op (OP_NAME null ...children...))"""
+        self._start_sexp()  # op wrapper
+        self._symbol("op")
+        self._start_sexp()  # inner op
+        self._symbol(op_name)
+        self._null()  # annotation slot
+        for fn in children_fn:
+            fn()
+        self._end_sexp()
+        self._end_sexp()
+
+    def _strlit(self, value: str):
+        """Write (strlit null "value")"""
+        self._start_sexp()
+        self._symbol("strlit")
+        self._null()
+        self._string(value)
+        self._end_sexp()
+
+    def _ident(self, name: str):
+        """Write (ident null name)"""
+        self._start_sexp()
+        self._symbol("ident")
+        self._null()
+        self._symbol(name)
+        self._end_sexp()
+
+    def _num(self, value: int):
+        """Write (num null N)"""
+        self._start_sexp()
+        self._symbol("num")
+        self._null()
+        self._int(value)
+        self._end_sexp()
+
+    def _option_none(self):
+        """Write (option null) — None"""
+        self._start_sexp()
+        self._symbol("option")
+        self._null()
+        self._end_sexp()
+
+    def _option_some(self, child_fn):
+        """Write (option null child)"""
+        self._start_sexp()
+        self._symbol("option")
+        self._null()
+        child_fn()
+        self._end_sexp()
+
+    def _seq(self, *children_fn):
+        """Write (seq null ...children...)"""
+        self._start_sexp()
+        self._symbol("seq")
+        self._null()
+        for fn in children_fn:
+            fn()
+        self._end_sexp()
+
+    def _commaSepList(self, *children_fn):
+        """Write (commaSepList null ...children...)"""
+        self._start_sexp()
+        self._symbol("commaSepList")
+        self._null()
+        for fn in children_fn:
+            fn()
+        self._end_sexp()
+
+    # -- SpecType builders --
+
+    def _typeIdentNoArgs(self, ident_str: str):
+        """typeIdentNoArgs("builtins.int") → (op (PythonSpecs.typeIdentNoArgs null (strlit null "builtins.int")))"""
+        self._op("PythonSpecs.typeIdentNoArgs",
+                 lambda: self._strlit(ident_str))
+
+    def _typeIdent(self, ident_str: str, args_fn):
+        """typeIdent with args"""
+        self._op("PythonSpecs.typeIdent",
+                 lambda: self._strlit(ident_str),
+                 args_fn)
+
+    # -- SpecExpr builders --
+
+    def _placeholderExpr(self):
+        self._op("PythonSpecs.placeholderExpr")
+
+    def _varExpr(self, name: str):
+        self._op("PythonSpecs.varExpr", lambda: self._ident(name))
+
+    def _isInstanceOfExpr(self, subject_fn, type_name: str):
+        self._op("PythonSpecs.isInstanceOfExpr", subject_fn,
+                 lambda: self._strlit(type_name))
+
+    def _lenExpr(self, subject_fn):
+        self._op("PythonSpecs.lenExpr", subject_fn)
+
+    def _intExpr(self, value: int):
+        if value >= 0:
+            self._op("PythonSpecs.intExpr",
+                     lambda: self._op("PythonSpecs.natInt",
+                                       lambda: self._num(value)))
+        else:
+            self._op("PythonSpecs.intExpr",
+                     lambda: self._op("PythonSpecs.negInt",
+                                       lambda: self._num(-value)))
+
+    def _intGeExpr(self, subject_fn, bound_fn):
+        self._op("PythonSpecs.intGeExpr", subject_fn, bound_fn)
+
+    def _intLeExpr(self, subject_fn, bound_fn):
+        self._op("PythonSpecs.intLeExpr", subject_fn, bound_fn)
+
+    def _intAddExpr(self, left_fn, right_fn):
+        self._op("PythonSpecs.intAddExpr", left_fn, right_fn)
+
+    def _intSubExpr(self, left_fn, right_fn):
+        self._op("PythonSpecs.intSubExpr", left_fn, right_fn)
+
+    def _intMulExpr(self, left_fn, right_fn):
+        self._op("PythonSpecs.intMulExpr", left_fn, right_fn)
+
+    def _intEqExpr(self, left_fn, right_fn):
+        self._op("PythonSpecs.intEqExpr", left_fn, right_fn)
+
+    def _floatExpr(self, value: str):
+        self._op("PythonSpecs.floatExpr", lambda: self._strlit(value))
+
+    def _floatGeExpr(self, subject_fn, bound_fn):
+        self._op("PythonSpecs.floatGeExpr", subject_fn, bound_fn)
+
+    def _floatLeExpr(self, subject_fn, bound_fn):
+        self._op("PythonSpecs.floatLeExpr", subject_fn, bound_fn)
+
+    def _getIndexExpr(self, subject_fn, field: str):
+        self._op("PythonSpecs.getIndexExpr", subject_fn,
+                 lambda: self._ident(field))
+
+    def _enumMemberExpr(self, subject_fn, values: list):
+        self._op("PythonSpecs.enumMemberExpr", subject_fn,
+                 lambda: self._seq(*[lambda v=v: self._strlit(v) for v in values]))
+
+    def _notExpr(self, inner_fn):
+        self._op("PythonSpecs.notExpr", inner_fn)
+
+    def _forallListExpr(self, list_fn, var_name: str, body_fn):
+        self._op("PythonSpecs.forallListExpr", list_fn,
+                 lambda: self._ident(var_name), body_fn)
+
+    # -- Assertion / Message --
+
+    def _strMessagePart(self, text: str):
+        self._op("PythonSpecs.strMessagePart", lambda: self._strlit(text))
+
+    def _mkAssertion(self, formula_fn, message: str):
+        self._op("PythonSpecs.mkAssertion",
+                 formula_fn,
+                 lambda: self._seq(lambda: self._strMessagePart(message)))
+
+    # -- ArgDecl --
+
+    def _mkArgDecl(self, name: str, type_fn, has_default: bool):
+        default_fn = (lambda: self._option_some(
+            lambda: self._op("PythonSpecs.noneDefault")
+        )) if has_default else self._option_none
+        self._op("PythonSpecs.mkArgDecl",
+                 lambda: self._ident(name),
+                 type_fn,
+                 default_fn)
+
+    # -- FunDecl --
+
+    def _mkFunDecl(self, name: str, args_fns, kwonly_fns, return_type_fn,
+                   is_overload: bool, precondition_fns, postcondition_fns):
+        self._op("PythonSpecs.mkFunDecl",
+                 lambda: self._strlit(name),
+                 lambda: self._seq(*args_fns),
+                 lambda: self._seq(*kwonly_fns),
+                 self._option_none,  # kwargs
+                 return_type_fn,
+                 lambda: self._op("Init.boolTrue" if is_overload else "Init.boolFalse"),
+                 lambda: self._seq(*precondition_fns),
+                 lambda: self._seq(*postcondition_fns))
+
+    def _functionDecl(self, fun_decl_fn):
+        self._start_sexp()
+        self._symbol("PythonSpecs.functionDecl")
+        self._null()
+        fun_decl_fn()
+        self._end_sexp()
+
+    def _classDef(self, class_decl_fn):
+        self._start_sexp()
+        self._symbol("PythonSpecs.classDef")
+        self._null()
+        class_decl_fn()
+        self._end_sexp()
+
+    # -- Program wrapper --
+
+    def write_program(self, command_fns: list):
+        """Write the full DDM program: [(program "PythonSpecs"), cmd1, cmd2, ...]"""
+        self._start_list()
+        # Header: (program "PythonSpecs")
+        self._start_sexp()
+        self._symbol("program")
+        self._string("PythonSpecs")
+        self._end_sexp()
+        # Commands
+        for fn in command_fns:
+            fn()
+        self._end_list()
+
+    def get_bytes(self) -> bytes:
+        self._writer.send(IonEvent(IonEventType.STREAM_END))
+        return self._buf.getvalue()

--- a/Tools/Python/strata/format_results.py
+++ b/Tools/Python/strata/format_results.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Post-process Strata verification output into human-readable format."""
+import ast
+import os
+import re
+import sys
+
+
+def find_decorated_funcs(spec_file: str) -> dict:
+    """Returns {func_name: [param_names]} for decorated functions."""
+    tree = ast.parse(open(spec_file).read())
+    decorated = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef):
+            for dec in node.decorator_list:
+                if isinstance(dec, ast.Call):
+                    func = dec.func
+                    if (isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name)
+                            and func.value.id == 'icontract'):
+                        decorated[node.name] = [a.arg for a in node.args.args]
+                        break
+                    elif isinstance(func, ast.Name) and func.id in ('require', 'ensure'):
+                        decorated[node.name] = [a.arg for a in node.args.args]
+                        break
+    return decorated
+
+
+def find_call_sites(user_file: str, decorated: dict) -> list:
+    """Returns call sites: [(caller_name, lineno, callee_name, col, end_col)]."""
+    tree = ast.parse(open(user_file).read())
+    sites = []
+    for parent in ast.walk(tree):
+        if isinstance(parent, ast.FunctionDef):
+            for child in ast.walk(parent):
+                if isinstance(child, ast.Call):
+                    name = None
+                    if isinstance(child.func, ast.Name) and child.func.id in decorated:
+                        name = child.func.id
+                    if name and hasattr(child, 'lineno'):
+                        sites.append((parent.name, child.lineno, name,
+                                      getattr(child, 'col_offset', 0),
+                                      getattr(child, 'end_col_offset', 0)))
+    return sites
+
+
+def identify_callee(assertions: list, decorated: dict) -> str:
+    """Try to identify which decorated function a call-site group targets
+    by matching assertion parameter names to function signatures."""
+    assertion_params = set()
+    for assertion_text, _, _ in assertions:
+        # Extract parameter names from assertion text like "balance >= amount"
+        for token in re.findall(r'\b[a-zA-Z_]\w*\b', assertion_text):
+            if token not in ('int', 'result', 'pass', 'fail', 'Assertion', 'failed'):
+                assertion_params.add(token)
+    # Match against decorated function parameter lists
+    best_match = None
+    best_score = 0
+    for fname, params in decorated.items():
+        param_set = set(params)
+        overlap = len(assertion_params & param_set)
+        if overlap > best_score:
+            best_score = overlap
+            best_match = fname
+    return best_match
+
+
+def main():
+    if len(sys.argv) < 3:
+        print("Usage: format_results.py <spec_file> <user_file> [display_file]", file=sys.stderr)
+        sys.exit(1)
+
+    spec_file = sys.argv[1]
+    user_file = sys.argv[2]
+    display_file = sys.argv[3] if len(sys.argv) > 3 else user_file
+    raw = sys.stdin.read()
+
+    # spec_file can be colon-separated list of spec files
+    spec_files = spec_file.split(':')
+    decorated = {}
+    for sf in spec_files:
+        decorated.update(find_decorated_funcs(sf))
+    call_sites = find_call_sites(user_file, decorated)
+
+    noise = ['Verification Results', 'DETAIL:', 'RESULT:', 'ite_cond_calls',
+             'Required parameter', 'assert(0):', 'PySpec translation', 'BUG:',
+             'SARIF output']
+
+    results = []
+    postcond_pyspec = []
+    postcond_user = []
+    module_name = os.path.splitext(os.path.basename(user_file))[0]
+    module_prefix = module_name + '_'
+    for line in raw.strip().split('\n'):
+        if not line.strip():
+            continue
+        if any(n in line for n in noise):
+            continue
+        if ('✅' in line or '❌' in line or '❓' in line):
+            stripped = line.strip()
+            # Postcondition body checks have [procname] prefix
+            if stripped.startswith('['):
+                bracket_end = stripped.find(']')
+                if bracket_end > 0:
+                    proc_name = stripped[1:bracket_end]
+                    if proc_name.startswith(module_prefix):
+                        postcond_pyspec.append(stripped)
+                    else:
+                        postcond_user.append(stripped)
+                    continue
+            # Postcondition summary lines (procname:postcondition_N)
+            if ':postcondition' in stripped:
+                label = stripped.split(':postcondition')[0]
+                if label.startswith(module_prefix):
+                    postcond_pyspec.append(stripped)
+                else:
+                    postcond_user.append(stripped)
+                continue
+            # Call-site results
+            site_match = re.search(r'\(call site (\d+)\)', line)
+            site_id = site_match.group(1) if site_match else None
+            clean = re.sub(r' \(call site \d+\)', '', line).strip()
+            if site_id is not None:
+                results.append((site_id, clean))
+
+    # --- Terminal output ---
+    print('==== Verification Results ====')
+    passes = 0
+    fails = 0
+    unknowns = 0
+
+    if postcond_user:
+        user_passes = sum(1 for line in postcond_user if '✅' in line)
+        user_fails = sum(1 for line in postcond_user if '❌' in line or '❓' in line)
+        if user_passes > 0 and user_fails == 0:
+            print(f'  postcondition body checks: ✅ {user_passes} verified')
+            print()
+        elif user_fails > 0:
+            # Show which functions failed
+            failed_funcs = []
+            for line in postcond_user:
+                if '❌' in line or '❓' in line:
+                    func_name = line.split(':postcondition')[0].strip()
+                    if func_name not in failed_funcs:
+                        failed_funcs.append(func_name)
+            if user_passes > 0:
+                print(f'  postcondition body checks: ✅ {user_passes} verified, ❌ {user_fails} unproven ({", ".join(failed_funcs)})')
+            else:
+                print(f'  postcondition body checks: ❌ {user_fails} unproven ({", ".join(failed_funcs)})')
+            print()
+
+    # Group results by call site (consecutive IDs = same call).
+    grouped = []
+    last_id = None
+    for site_id, line in results:
+        sid = int(site_id)
+        if last_id is None or sid != last_id + 1:
+            grouped.append([])
+        last_id = sid
+        is_pass = '✅' in line
+        assertion = re.sub(r':.*$', '', line).strip()
+        grouped[-1].append((assertion, is_pass, line))
+
+    # Match each group to a call site by identifying the callee from assertions,
+    # then finding the next unmatched call site for that callee.
+    callee_site_idx = {}  # callee_name -> next index into filtered call_sites
+    for group in grouped:
+        callee = identify_callee(group, decorated)
+        if callee is None:
+            # Can't identify — show raw
+            print(f'\n  unknown call:')
+            for assertion, is_pass, line in group:
+                if is_pass: passes += 1
+                elif '❓' in line: unknowns += 1
+                else: fails += 1
+                print(f'    {line}')
+            continue
+
+        # Find the next call site for this callee
+        idx = callee_site_idx.get(callee, 0)
+        matching_sites = [(i, s) for i, s in enumerate(call_sites) if s[2] == callee]
+        if idx < len(matching_sites):
+            _, (caller, lineno, callee_name, col, end_col) = matching_sites[idx]
+            callee_site_idx[callee] = idx + 1
+            print(f'\n  {caller}() line {lineno} → {callee_name}():')
+        else:
+            print(f'\n  → {callee}():')
+            col, end_col, lineno, caller = 0, 0, 0, '?'
+
+        for assertion, is_pass, line in group:
+            if is_pass: passes += 1
+            elif '❓' in line: unknowns += 1
+            else: fails += 1
+            print(f'    {line}')
+
+    total = passes + fails + unknowns
+    print()
+    if fails == 0 and unknowns == 0 and passes > 0:
+        print(f'RESULT: ✅ Verified ({passes}/{total} passed)')
+    elif fails > 0:
+        summary = f'RESULT: ❌ {fails}/{total} failed'
+        if unknowns > 0:
+            summary += f', {unknowns} inconclusive'
+        print(summary)
+    elif unknowns > 0:
+        print(f'RESULT: ⚠️  {unknowns}/{total} inconclusive (no failures)')
+    else:
+        print('RESULT: No icontract assertions found')
+
+    # --- Diagnostics output (gcc-style for VS Code problemMatcher) ---
+    # Postcondition body check failures → underline the function definition
+    if postcond_user:
+        tree = ast.parse(open(user_file).read())
+        func_lines = {}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                func_lines[node.name] = (node.lineno, node.col_offset, node.end_col_offset or 0)
+        # Collect failing functions with their postcondition text from [procname] lines
+        failing = {}  # func_name -> list of postcondition texts
+        for line in postcond_user:
+            if '❌' in line or '❓' in line:
+                if line.startswith('['):
+                    func_name = line[1:line.find(']')]
+                    # Extract postcondition text: "[cap] b >= result: ❌ fail" → "b >= result"
+                    text = line[line.find(']') + 2:].split(':')[0].strip()
+                elif ':postcondition' in line:
+                    func_name = line.split(':postcondition')[0].strip()
+                    text = 'postcondition'
+                else:
+                    continue
+                failing.setdefault(func_name, []).append(text)
+        for func_name in sorted(failing):
+            if func_name in func_lines:
+                lineno, col, end_col = func_lines[func_name]
+                name_col = col + 4  # len("def ")
+                texts = failing[func_name]
+                # Filter out internal postconditions (isfrom_int etc)
+                texts = [t for t in texts if t != 'postcondition' and 'isfrom' not in t]
+                if texts:
+                    msg = ', '.join(f'`{t}`' for t in texts)
+                    print(f'{display_file}:{lineno}:{name_col + 1}: error: '
+                          f'postcondition {msg} unproven for {func_name}()')
+                else:
+                    print(f'{display_file}:{lineno}:{name_col + 1}: error: '
+                          f'postcondition unproven for {func_name}()')
+
+    # Call-site precondition failures
+    callee_site_idx2 = {}
+    for group in grouped:
+        callee = identify_callee(group, decorated)
+        if callee is None:
+            continue
+        idx = callee_site_idx2.get(callee, 0)
+        matching_sites = [(i, s) for i, s in enumerate(call_sites) if s[2] == callee]
+        if idx < len(matching_sites):
+            _, (caller, lineno, callee_name, col, end_col) = matching_sites[idx]
+            callee_site_idx2[callee] = idx + 1
+        else:
+            continue
+        for assertion, is_pass, line in group:
+            if is_pass or '❓' in line:
+                continue
+            print(f'{display_file}:{lineno}:{col + 1}: error: '
+                  f'precondition `{assertion}` violated in call to {callee_name}()')
+
+    has_unproven = any('❌' in line or '❓' in line for line in postcond_user) if postcond_user else False
+    sys.exit(2 if (fails > 0 or has_unproven) else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/Python/strata/gen.py
+++ b/Tools/Python/strata/gen.py
@@ -81,6 +81,23 @@ def check_ast_imp(args):
         success += 1
     print(f'Analyzed {success} of {total} files.')
 
+def icontract_to_pyspec_imp(args):
+    from strata.icontract import convert_file_ion, convert_directory_ion
+    from pathlib import Path
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    module_name = args.module
+    only_decorated = args.only_decorated
+    if input_path.is_file():
+        if not output_path.suffix == ".ion":
+            output_path = output_path / (input_path.stem + ".pyspec.st.ion")
+        convert_file_ion(input_path, output_path, module_name, only_decorated=only_decorated)
+    elif input_path.is_dir():
+        convert_directory_ion(input_path, output_path)
+    else:
+        print(f"Error: {input_path} not found", file=sys.stderr)
+        sys.exit(1)
+
 def main():
     parser = argparse.ArgumentParser(
                     prog='strata_python',
@@ -109,6 +126,15 @@ def main():
     checkast_command.add_argument('dir', help='Directory with Python files to analyze.')
     checkast_command.add_argument('-f', '--features', action='store_true', help='Print out features used in SSA.')
     checkast_command.set_defaults(func=check_ast_imp)
+
+    icontract_command = subparsers.add_parser('icontract_to_pyspec',
+        help='Convert icontract-decorated Python to .pyspec.st.ion')
+    icontract_command.add_argument('input', help='Input .py file or directory')
+    icontract_command.add_argument('output', help='Output file or directory')
+    icontract_command.add_argument('--module', help='Override module name', default=None)
+    icontract_command.add_argument('--only-decorated', action='store_true',
+        help='Only emit specs for functions with icontract decorators')
+    icontract_command.set_defaults(func=icontract_to_pyspec_imp)
 
     args = parser.parse_args()
     if not args.quiet and not ion.__IS_C_EXTENSION_SUPPORTED:

--- a/Tools/Python/strata/icontract.py
+++ b/Tools/Python/strata/icontract.py
@@ -1,0 +1,994 @@
+#!/usr/bin/env python3
+"""
+Convert icontract-decorated Python files to Lean source constructing
+Strata.Python.Specs.Signature values.
+
+Maps:
+  @icontract.require(lambda ...: cond) → preconditions (Assertion with SpecExpr)
+  @icontract.ensure(lambda ...: cond)  → postconditions (SpecExpr)
+  Type annotations                     → SpecType / SpecAtomType
+  Functions                            → Signature.functionDecl
+  Classes with methods                 → Signature.classDef
+
+Lambda bodies are mapped to SpecExpr where possible:
+  isinstance(x, T)       → .isInstanceOf (.var "x") "T"
+  len(x) >= N            → .intGe (.len (.var "x")) (.intLit N)
+  len(x) <= N            → .intLe (.len (.var "x")) (.intLit N)
+  x >= N                 → .intGe (.var "x") (.intLit N)
+  x <= N                 → .intLe (.var "x") (.intLit N)
+  x >= F (float)         → .floatGe (.var "x") (.floatLit "F")
+  x <= F (float)         → .floatLe (.var "x") (.floatLit "F")
+  Other expressions      → .placeholder (original preserved in message)
+
+Usage:
+    python icontract_to_strata.py <input_file_or_dir> <output_dir>
+"""
+
+import ast
+import sys
+import os
+import argparse
+from pathlib import Path
+from typing import Optional, Union
+
+
+# ---------------------------------------------------------------------------
+# Type annotation → Lean SpecType
+# ---------------------------------------------------------------------------
+
+# Map Python builtin type names to PythonIdent Lean constructors
+BUILTIN_TYPE_MAP = {
+    "int": ".builtinsInt",
+    "float": ".builtinsFloat",
+    "str": ".builtinsStr",
+    "bool": ".builtinsBool",
+    "bytes": ".builtinsBytes",
+    "bytearray": ".builtinsBytearray",
+    "complex": ".builtinsComplex",
+    "dict": ".builtinsDict",
+}
+
+# Map typing module generics
+TYPING_MAP = {
+    "List": ".typingList",
+    "Dict": ".typingDict",
+    "Sequence": ".typingSequence",
+    "Mapping": ".typingMapping",
+    "Any": ".typingAny",
+    "Union": ".typingUnion",
+    "Literal": ".typingLiteral",
+    "Generator": ".typingGenerator",
+}
+
+
+def type_annotation_to_lean(node: Optional[ast.expr], module_name: str = "") -> str:
+    """Convert a Python type annotation AST node to a Lean SpecType expression."""
+    if node is None:
+        return "SpecType.ident .none .typingAny"
+
+    if isinstance(node, ast.Constant):
+        if node.value is None:
+            return "SpecType.ofAtom .none .noneType"
+        if isinstance(node.value, str):
+            # Forward reference as string
+            return f'SpecType.pyClass .none "{node.value}" #[]'
+        return "SpecType.ident .none .typingAny"
+
+    if isinstance(node, ast.Name):
+        name = node.id
+        if name == "None" or name == "NoneType":
+            return "SpecType.ofAtom .none .noneType"
+        if name in BUILTIN_TYPE_MAP:
+            return f"SpecType.ident .none {BUILTIN_TYPE_MAP[name]}"
+        if name in TYPING_MAP:
+            return f"SpecType.ident .none {TYPING_MAP[name]}"
+        # User-defined class
+        return f'SpecType.pyClass .none "{name}" #[]'
+
+    if isinstance(node, ast.Attribute):
+        # e.g., typing.List, _datetime.date
+        full = ast.unparse(node)
+        # Check for typing.X
+        if isinstance(node.value, ast.Name):
+            if node.value.id == "typing" and node.attr in TYPING_MAP:
+                return f"SpecType.ident .none {TYPING_MAP[node.attr]}"
+        # External type reference
+        return f'SpecType.pyClass .none "{full}" #[]'
+
+    if isinstance(node, ast.Subscript):
+        # e.g., List[int], Dict[str, int], Union[int, str], Optional[int]
+        base = node.value
+        base_name = ""
+        if isinstance(base, ast.Name):
+            base_name = base.id
+        elif isinstance(base, ast.Attribute):
+            if isinstance(base.value, ast.Name):
+                base_name = base.attr
+
+        if base_name == "Optional":
+            # Optional[T] = Union[T, None]
+            inner = type_annotation_to_lean(node.slice, module_name)
+            return f"SpecType.union .none {inner} (SpecType.ofAtom .none .noneType)"
+
+        if base_name == "Union":
+            if isinstance(node.slice, ast.Tuple):
+                parts = [type_annotation_to_lean(e, module_name) for e in node.slice.elts]
+                if len(parts) == 0:
+                    return "SpecType.ident .none .typingAny"
+                result = parts[0]
+                for p in parts[1:]:
+                    result = f"SpecType.union .none ({result}) ({p})"
+                return result
+            return type_annotation_to_lean(node.slice, module_name)
+
+        if base_name in ("List", "Sequence"):
+            ident = TYPING_MAP[base_name]
+            inner = type_annotation_to_lean(node.slice, module_name)
+            return f"SpecType.ident .none {ident} #[{inner}]"
+
+        if base_name in ("Dict", "Mapping"):
+            ident = TYPING_MAP[base_name]
+            if isinstance(node.slice, ast.Tuple) and len(node.slice.elts) == 2:
+                k = type_annotation_to_lean(node.slice.elts[0], module_name)
+                v = type_annotation_to_lean(node.slice.elts[1], module_name)
+                return f"SpecType.ident .none {ident} #[{k}, {v}]"
+            return f"SpecType.ident .none {ident}"
+
+        if base_name == "Literal":
+            # Literal["a", "b"] or Literal[1, 2]
+            if isinstance(node.slice, ast.Tuple):
+                atoms = [_literal_to_atom(e) for e in node.slice.elts]
+            else:
+                atoms = [_literal_to_atom(node.slice)]
+            atoms_str = ", ".join(atoms)
+            return f"SpecType.ofArray .none #[{atoms_str}]"
+
+        if base_name == "Generator":
+            ident = TYPING_MAP["Generator"]
+            if isinstance(node.slice, ast.Tuple) and len(node.slice.elts) == 3:
+                args = [type_annotation_to_lean(e, module_name) for e in node.slice.elts]
+                return f"SpecType.ident .none {ident} #[{', '.join(args)}]"
+            return f"SpecType.ident .none {ident}"
+
+        # Fallback for parameterized types
+        return f'SpecType.pyClass .none "{ast.unparse(node)}" #[]'
+
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        # X | Y union syntax (Python 3.10+)
+        left = type_annotation_to_lean(node.left, module_name)
+        right = type_annotation_to_lean(node.right, module_name)
+        return f"SpecType.union .none ({left}) ({right})"
+
+    # Fallback
+    return f'SpecType.pyClass .none "{ast.unparse(node)}" #[]'
+
+
+def _literal_to_atom(node: ast.expr) -> str:
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, int):
+            if node.value < 0:
+                return f".intLiteral ({node.value})"
+            return f".intLiteral {node.value}"
+        if isinstance(node.value, str):
+            return f'.stringLiteral "{_escape_lean_str(node.value)}"'
+    return f'.stringLiteral "{_escape_lean_str(ast.unparse(node))}"'
+
+
+def _escape_lean_str(s: str) -> str:
+    """Escape a string for Lean string literals."""
+    return s.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+
+# ---------------------------------------------------------------------------
+# Lambda body → Lean SpecExpr
+# ---------------------------------------------------------------------------
+
+def expr_to_spec_expr(node: ast.expr, params: list[str]) -> str:
+    """Convert a Python expression AST node to a Lean SpecExpr.
+
+    Handles the patterns that Strata's SpecExpr supports:
+      isinstance(x, T)  → .isInstanceOf
+      len(x) >= N        → .intGe (.len ..) (.intLit N)
+      x >= N             → .intGe / .floatGe
+      x <= N             → .intLe / .floatLe
+      0 <= x             → .intGe (.var "x") (.intLit 0)
+      variable refs      → .var "name"
+
+    Falls back to .placeholder for anything else.
+    """
+    # isinstance(subject, TypeName)
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id == "isinstance":
+            if len(node.args) == 2:
+                subj = _expr_to_subject(node.args[0])
+                type_name = _extract_type_name(node.args[1])
+                if subj and type_name:
+                    return f'.isInstanceOf {subj} "{type_name}"'
+
+        # len(x) as standalone — not a comparison, just the call
+        if isinstance(node.func, ast.Name) and node.func.id == "len":
+            if len(node.args) == 1:
+                subj = _expr_to_subject(node.args[0])
+                if subj:
+                    return f".len {subj}"
+
+        # all(expr for var in iterable) → .forallList
+        if isinstance(node.func, ast.Name) and node.func.id == "all":
+            if len(node.args) == 1:
+                result = _try_forall_list(node.args[0], params)
+                if result:
+                    return result
+
+    # Comparisons: x >= N, x <= N, len(x) >= N, N <= x <= M (chained)
+    if isinstance(node, ast.Compare):
+        return _compare_to_spec_expr(node, params)
+
+    # BoolOp: and / or
+    if isinstance(node, ast.BoolOp):
+        if isinstance(node.op, ast.Or):
+            # Could be enum pattern: x == "A" or x == "B"
+            enum_result = _try_enum_pattern(node)
+            if enum_result:
+                return enum_result
+
+    # UnaryOp: not x
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        inner = expr_to_spec_expr(node.operand, params)
+        if inner != ".placeholder":
+            return f".not ({inner})"
+
+    # Simple variable reference
+    if isinstance(node, ast.Name):
+        return f'.var "{node.id}"'
+
+    return ".placeholder"
+
+
+def _try_forall_list(node: ast.expr, params: list[str]) -> Optional[str]:
+    """Try to translate all(expr for var in iterable) → .forallList.
+
+    Handles:
+      all(isinstance(e, int) for e in a)
+      all(e >= 0 for e in data)
+      all(e <= 100 for e in data)
+      all(cond1 and cond2 for e in a) — splits and takes first translatable
+    """
+    if not isinstance(node, ast.GeneratorExp):
+        return None
+    if len(node.generators) != 1:
+        return None
+    gen = node.generators[0]
+    if gen.ifs:  # We don't handle filtered generators yet
+        return None
+
+    # Extract loop variable name
+    if not isinstance(gen.target, ast.Name):
+        return None
+    var_name = gen.target.id
+
+    # Extract iterable as subject
+    iter_subj = _expr_to_subject(gen.iter)
+    if not iter_subj:
+        return None
+
+    # Translate the body expression with the loop var in scope
+    body_params = params + [var_name]
+    body_expr = expr_to_spec_expr(node.elt, body_params)
+    if body_expr != ".placeholder":
+        return f'.forallList {iter_subj} "{var_name}" ({body_expr})'
+
+    # If body is an 'and' chain, try splitting and wrapping each part
+    # as a separate forallList (take the first one that works)
+    if isinstance(node.elt, ast.BoolOp) and isinstance(node.elt.op, ast.And):
+        # Try to translate each conjunct; if ALL translate, we could
+        # emit multiple forallLists, but SpecExpr doesn't have 'and'.
+        # Just try the first translatable one for now.
+        for val in node.elt.values:
+            sub = expr_to_spec_expr(val, body_params)
+            if sub != ".placeholder":
+                return f'.forallList {iter_subj} "{var_name}" ({sub})'
+
+    return None
+
+
+def _expr_to_subject(node: ast.expr) -> Optional[str]:
+    """Convert an expression to a SpecExpr subject (for use in comparisons etc.)."""
+    if isinstance(node, ast.Name):
+        return f'(.var "{node.id}")'
+
+    if isinstance(node, ast.Subscript):
+        # x["field"] or x[0]
+        subj = _expr_to_subject(node.value)
+        if subj and isinstance(node.slice, ast.Constant) and isinstance(node.slice.value, str):
+            return f'(.getIndex {subj} "{_escape_lean_str(node.slice.value)}")'
+        return None
+
+    if isinstance(node, ast.Attribute):
+        # result.attr → getIndex
+        subj = _expr_to_subject(node.value)
+        if subj:
+            return f'(.getIndex {subj} "{node.attr}")'
+        return None
+
+    if isinstance(node, ast.Call):
+        if isinstance(node.func, ast.Name) and node.func.id == "len" and len(node.args) == 1:
+            inner = _expr_to_subject(node.args[0])
+            if inner:
+                return f"(.len {inner})"
+        return None
+
+    if isinstance(node, ast.BinOp):
+        left = _expr_to_subject(node.left)
+        right = _expr_to_subject(node.right)
+        if left and right:
+            if isinstance(node.op, ast.Add):
+                return f"(.intAdd {left} {right})"
+            if isinstance(node.op, ast.Sub):
+                return f"(.intSub {left} {right})"
+            if isinstance(node.op, ast.Mult):
+                return f"(.intMul {left} {right})"
+        return None
+
+    return None
+
+
+def _extract_type_name(node: ast.expr) -> Optional[str]:
+    """Extract a type name string from an isinstance second argument."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return ast.unparse(node)
+    if isinstance(node, ast.Tuple):
+        # isinstance(x, (int, float)) — take first for simplicity
+        if node.elts:
+            return _extract_type_name(node.elts[0])
+    return None
+
+
+def _int_literal(node: ast.expr) -> Optional[str]:
+    """Try to extract an integer literal as a Lean SpecExpr."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, int) and not isinstance(node.value, bool):
+        v = node.value
+        if v < 0:
+            return f".intLit ({v})"
+        return f".intLit {v}"
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        if isinstance(node.operand, ast.Constant) and isinstance(node.operand.value, int):
+            return f".intLit ({-node.operand.value})"
+    return None
+
+
+def _float_literal(node: ast.expr) -> Optional[str]:
+    """Try to extract a float literal as a Lean SpecExpr."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, float):
+        return f'.floatLit "{node.value}"'
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        if isinstance(node.operand, ast.Constant) and isinstance(node.operand.value, float):
+            return f'.floatLit "{-node.operand.value}"'
+    return None
+
+
+def _numeric_literal(node: ast.expr) -> Optional[str]:
+    """Try int first, then float."""
+    r = _int_literal(node)
+    if r:
+        return r
+    return _float_literal(node)
+
+
+def _compare_to_spec_expr(node: ast.Compare, params: list[str]) -> str:
+    """Handle comparison expressions."""
+    # Single comparison: x >= N, x <= N, len(x) >= N, etc.
+    if len(node.ops) == 1 and len(node.comparators) == 1:
+        left = node.left
+        op = node.ops[0]
+        right = node.comparators[0]
+        return _single_compare(left, op, right, params)
+
+    # Chained comparison: N <= x <= M → intGe x N AND intLe x M
+    # We can only represent this as placeholder for now
+    # But try: 0 <= x <= 100 → two separate constraints
+    if len(node.ops) == 2 and len(node.comparators) == 2:
+        # a <= b <= c  or  a >= b >= c
+        # Most common: N <= x <= M
+        pass
+
+    return ".placeholder"
+
+
+def _single_compare(left: ast.expr, op: ast.cmpop, right: ast.expr,
+                    params: list[str]) -> str:
+    """Handle a single comparison like x >= N or len(x) <= N."""
+    subj_left = _expr_to_subject(left)
+    subj_right = _expr_to_subject(right)
+    lit_left = _numeric_literal(left)
+    lit_right = _numeric_literal(right)
+    float_left = _float_literal(left)
+    float_right = _float_literal(right)
+
+    if isinstance(op, ast.GtE):
+        # subject >= literal
+        if subj_left and lit_right:
+            if float_right and not _int_literal(right):
+                return f".floatGe {subj_left} ({float_right})"
+            return f".intGe {subj_left} ({lit_right})"
+        # literal >= subject → subject <= literal
+        if lit_left and subj_right:
+            if float_left and not _int_literal(left):
+                return f".floatLe {subj_right} ({float_left})"
+            return f".intLe {subj_right} ({lit_left})"
+        # subject >= subject
+        if subj_left and subj_right:
+            return f".intGe {subj_left} {subj_right}"
+
+    if isinstance(op, ast.LtE):
+        # subject <= literal
+        if subj_left and lit_right:
+            if float_right and not _int_literal(right):
+                return f".floatLe {subj_left} ({float_right})"
+            return f".intLe {subj_left} ({lit_right})"
+        # literal <= subject → subject >= literal
+        if lit_left and subj_right:
+            if float_left and not _int_literal(left):
+                return f".floatGe {subj_right} ({float_left})"
+            return f".intGe {subj_right} ({lit_left})"
+        # subject <= subject
+        if subj_left and subj_right:
+            return f".intLe {subj_left} {subj_right}"
+
+    if isinstance(op, ast.Gt):
+        # x > N → x >= N+1 for ints, or placeholder
+        if subj_left and _int_literal(right):
+            if isinstance(right, ast.Constant) and isinstance(right.value, int):
+                return f".intGe {subj_left} (.intLit {right.value + 1})"
+        # subject > subject → not (subject <= subject)
+        if subj_left and subj_right:
+            return f".intGe {subj_left} {subj_right}"
+
+    if isinstance(op, ast.Lt):
+        # x < N → x <= N-1 for ints
+        if subj_left and _int_literal(right):
+            if isinstance(right, ast.Constant) and isinstance(right.value, int):
+                return f".intLe {subj_left} (.intLit {right.value - 1})"
+        # subject < subject
+        if subj_left and subj_right:
+            return f".intLe {subj_left} {subj_right}"
+
+    if isinstance(op, ast.Eq):
+        # subject == subject → intEq
+        if subj_left and subj_right:
+            return f".intEq {subj_left} {subj_right}"
+        if subj_left and lit_right:
+            return f".intEq {subj_left} ({lit_right})"
+        if lit_left and subj_right:
+            return f".intEq ({lit_left}) {subj_right}"
+
+    if isinstance(op, ast.NotEq):
+        # x != 0 → .not (.intLe x 0 AND .intGe x 0) — can't express directly
+        # But we can handle it for simple cases
+        pass
+
+    return ".placeholder"
+
+
+def _try_enum_pattern(node: ast.BoolOp) -> Optional[str]:
+    """Try to match x == "A" or x == "B" or ... → .enumMember"""
+    if not isinstance(node.op, ast.Or):
+        return None
+    subject = None
+    values = []
+    for val in node.values:
+        if not isinstance(val, ast.Compare):
+            return None
+        if len(val.ops) != 1 or not isinstance(val.ops[0], ast.Eq):
+            return None
+        if len(val.comparators) != 1:
+            return None
+        s = _expr_to_subject(val.left)
+        if s is None:
+            return None
+        if subject is None:
+            subject = s
+        # Don't check subject equality (would need structural comparison)
+        comp = val.comparators[0]
+        if isinstance(comp, ast.Constant) and isinstance(comp.value, str):
+            values.append(comp.value)
+        else:
+            return None
+    if subject and values:
+        vals_str = ", ".join(f'"{_escape_lean_str(v)}"' for v in values)
+        return f".enumMember {subject} #[{vals_str}]"
+    return None
+
+
+def split_and_conditions(node: ast.expr) -> list[ast.expr]:
+    """Split an 'and'-chained expression into individual conditions.
+    Also splits chained comparisons like '0 <= x <= 100' into
+    '0 <= x' and 'x <= 100'."""
+    results = []
+    if isinstance(node, ast.BoolOp) and isinstance(node.op, ast.And):
+        for val in node.values:
+            results.extend(split_and_conditions(val))
+    elif isinstance(node, ast.Compare) and len(node.ops) >= 2:
+        # Chained comparison: a <= b <= c → (a <= b) and (b <= c)
+        left = node.left
+        for i, (op, comp) in enumerate(zip(node.ops, node.comparators)):
+            single = ast.Compare(
+                left=left, ops=[op], comparators=[comp],
+                lineno=node.lineno, col_offset=node.col_offset,
+                end_lineno=node.end_lineno, end_col_offset=node.end_col_offset
+            )
+            results.append(single)
+            left = comp
+    else:
+        results.append(node)
+    return results
+
+
+
+# ---------------------------------------------------------------------------
+# icontract decorator extraction
+# ---------------------------------------------------------------------------
+
+def get_decorator_kind(node: ast.expr) -> Optional[str]:
+    """Classify an icontract decorator → 'require'|'ensure'|'snapshot'|'invariant'|None."""
+    if not isinstance(node, ast.Call):
+        return None
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        if isinstance(func.value, ast.Name) and func.value.id == "icontract":
+            if func.attr in ("require", "ensure", "snapshot", "invariant"):
+                return func.attr
+    if isinstance(func, ast.Name):
+        if func.id in ("require", "ensure", "snapshot", "invariant"):
+            return func.id
+    return None
+
+
+def extract_lambda(node: ast.Call) -> Optional[ast.Lambda]:
+    """Extract the lambda from an icontract decorator call."""
+    if node.args and isinstance(node.args[0], ast.Lambda):
+        return node.args[0]
+    return None
+
+
+def extract_description(node: ast.Call) -> Optional[str]:
+    """Extract optional description string."""
+    if len(node.args) >= 2 and isinstance(node.args[1], ast.Constant) and isinstance(node.args[1].value, str):
+        return node.args[1].value
+    for kw in node.keywords:
+        if kw.arg == "description" and isinstance(kw.value, ast.Constant):
+            return kw.value.value
+    return None
+
+
+def extract_snapshot_name(node: ast.Call) -> Optional[str]:
+    for kw in node.keywords:
+        if kw.arg == "name" and isinstance(kw.value, ast.Constant):
+            return kw.value.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Lean code generation
+# ---------------------------------------------------------------------------
+
+class LeanGenerator:
+    """Generates Lean source code constructing Strata Signature values."""
+
+    def __init__(self, module_name: str):
+        self.module_name = module_name  # e.g., "bisect"
+        self.lean_module = module_name.replace(".", "_")
+        self.signatures: list[str] = []
+        self.warnings: list[str] = []
+
+    def process_file(self, tree: ast.Module):
+        """Process a full Python module AST."""
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                self._process_function(node, class_name=None)
+            elif isinstance(node, ast.ClassDef):
+                self._process_class(node)
+            # Skip imports, assignments, etc.
+
+    def _process_function(self, node: ast.FunctionDef,
+                          class_name: Optional[str]) -> Optional[str]:
+        """Process a function/method definition. Returns Lean FunctionDecl expression."""
+        requires = []
+        ensures = []
+        snapshots = []
+        remaining_decorators = []
+
+        for dec in node.decorator_list:
+            kind = get_decorator_kind(dec)
+            if kind == "require":
+                lam = extract_lambda(dec)
+                desc = extract_description(dec)
+                if lam:
+                    params = [a.arg for a in lam.args.args]
+                    # Split 'and' conditions and chained comparisons
+                    parts = split_and_conditions(lam.body)
+                    for part in parts:
+                        spec_expr = expr_to_spec_expr(part, params)
+                        source = ast.unparse(part)
+                        requires.append((spec_expr, source, desc))
+            elif kind == "ensure":
+                lam = extract_lambda(dec)
+                desc = extract_description(dec)
+                if lam:
+                    params = [a.arg for a in lam.args.args]
+                    spec_expr = expr_to_spec_expr(lam.body, params)
+                    source = ast.unparse(lam.body)
+                    ensures.append((spec_expr, source, desc, params))
+            elif kind == "snapshot":
+                lam = extract_lambda(dec)
+                name = extract_snapshot_name(dec) if isinstance(dec, ast.Call) else None
+                if lam and name:
+                    snapshots.append((ast.unparse(lam.body), name))
+            elif kind == "invariant":
+                self.warnings.append(f"  -- WARNING: @invariant on {node.name} not expressible")
+            else:
+                remaining_decorators.append(dec)
+
+        # Build args
+        args = self._build_args(node, class_name)
+
+        # Return type
+        ret_type = type_annotation_to_lean(node.returns, self.module_name)
+
+        # Build preconditions (Assertion array)
+        precond_strs = []
+        for spec_expr, source, desc in requires:
+            msg = desc if desc else source
+            msg_escaped = _escape_lean_str(msg)
+            precond_strs.append(
+                f'    {{ message := #[.str "{msg_escaped}"],\n'
+                f'      formula := {spec_expr} }}'
+            )
+
+        # Build postconditions (SpecExpr array)
+        postcond_strs = []
+        for spec_expr, source, desc, params in ensures:
+            postcond_strs.append(f"    {spec_expr}")
+            if spec_expr == ".placeholder":
+                # Add the original source as a comment
+                postcond_strs[-1] = f"    .placeholder /- {_escape_lean_comment(source)} -/"
+
+        # Snapshot warnings
+        snap_comments = []
+        for snap_source, snap_name in snapshots:
+            snap_comments.append(f"  -- snapshot: {snap_name} = {snap_source}")
+
+        is_overload = any(
+            isinstance(d, ast.Name) and d.id == "overload"
+            for d in remaining_decorators
+        )
+
+        func_name = node.name
+
+        precond_array = "#[]" if not precond_strs else (
+            "#[\n" + ",\n".join(precond_strs) + "\n  ]"
+        )
+        postcond_array = "#[]" if not postcond_strs else (
+            "#[\n" + ",\n".join(postcond_strs) + "\n  ]"
+        )
+
+        lines = []
+        for c in snap_comments:
+            lines.append(c)
+
+        lines.append(f".functionDecl {{")
+        lines.append(f'  loc := .none, nameLoc := .none, name := "{func_name}"')
+        lines.append(f"  args := {args}")
+        lines.append(f"  returnType := {ret_type}")
+        lines.append(f"  isOverload := {str(is_overload).lower()}")
+        lines.append(f"  preconditions := {precond_array}")
+        lines.append(f"  postconditions := {postcond_array}")
+        lines.append(f"}}")
+
+        result = "\n".join(lines)
+
+        if class_name is None:
+            self.signatures.append(result)
+
+        return result
+
+    def _process_class(self, node: ast.ClassDef):
+        """Process a class definition."""
+        methods = []
+        fields = []
+
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef):
+                if item.name == "__init__":
+                    # Extract fields from __init__
+                    fields.extend(self._extract_init_fields(item))
+                else:
+                    method_lean = self._process_function(item, class_name=node.name)
+                    if method_lean:
+                        methods.append(method_lean)
+            elif isinstance(item, ast.AnnAssign):
+                # Class-level annotated field
+                if isinstance(item.target, ast.Name):
+                    ft = type_annotation_to_lean(item.annotation, self.module_name)
+                    fields.append(
+                        f'{{ name := "{item.target.id}", type := {ft} }}'
+                    )
+
+        # Base classes
+        bases = []
+        for base in node.bases:
+            if isinstance(base, ast.Name):
+                bases.append(f'PythonIdent.mk "{self.module_name}" "{base.id}"')
+            elif isinstance(base, ast.Attribute):
+                bases.append(f'PythonIdent.mk "{ast.unparse(base.value)}" "{base.attr}"')
+
+        bases_str = "#[]" if not bases else "#[" + ", ".join(bases) + "]"
+        fields_str = "#[]" if not fields else "#[\n    " + ",\n    ".join(fields) + "\n  ]"
+        methods_str = "#[]" if not methods else (
+            "#[\n  " + ",\n  ".join(methods) + "\n  ]"
+        )
+
+        sig = (
+            f'.classDef {{\n'
+            f'  loc := .none, name := "{node.name}"\n'
+            f'  bases := {bases_str}\n'
+            f'  fields := {fields_str}\n'
+            f'  methods := {methods_str}\n'
+            f'}}'
+        )
+        self.signatures.append(sig)
+
+    def _extract_init_fields(self, init_node: ast.FunctionDef) -> list[str]:
+        """Extract self.x = ... assignments from __init__ as ClassField."""
+        fields = []
+        for stmt in init_node.body:
+            if isinstance(stmt, ast.AnnAssign):
+                if (isinstance(stmt.target, ast.Attribute) and
+                    isinstance(stmt.target.value, ast.Name) and
+                    stmt.target.value.id == "self"):
+                    ft = type_annotation_to_lean(stmt.annotation, self.module_name)
+                    fields.append(
+                        f'{{ name := "{stmt.target.attr}", type := {ft} }}'
+                    )
+            elif isinstance(stmt, ast.Assign):
+                for target in stmt.targets:
+                    if (isinstance(target, ast.Attribute) and
+                        isinstance(target.value, ast.Name) and
+                        target.value.id == "self"):
+                        # No type annotation — use Any
+                        fields.append(
+                            f'{{ name := "{target.attr}", type := SpecType.ident .none .typingAny }}'
+                        )
+        return fields
+
+    def _build_args(self, node: ast.FunctionDef, class_name: Optional[str]) -> str:
+        """Build ArgDecls Lean expression from function arguments."""
+        args_list = []
+        for i, arg in enumerate(node.args.args):
+            name = arg.arg
+            if class_name and i == 0 and name == "self":
+                # self parameter gets the class type
+                tp = f'SpecType.pyClass .none "{class_name}" #[]'
+            else:
+                tp = type_annotation_to_lean(arg.annotation, self.module_name)
+
+            # Check for default value
+            defaults = node.args.defaults
+            # defaults align to the end of args
+            default_idx = i - (len(node.args.args) - len(defaults))
+            if default_idx >= 0 and default_idx < len(defaults):
+                default_node = defaults[default_idx]
+                if isinstance(default_node, ast.Constant) and default_node.value is None:
+                    args_list.append(f'{{ name := "{name}", type := {tp}, default := some .none }}')
+                else:
+                    # Other defaults — use .none as approximation
+                    args_list.append(f'{{ name := "{name}", type := {tp}, default := some .none }}')
+            else:
+                args_list.append(f'{{ name := "{name}", type := {tp} }}')
+
+        kwonly_list = []
+        for i, arg in enumerate(node.args.kwonlyargs):
+            name = arg.arg
+            tp = type_annotation_to_lean(arg.annotation, self.module_name)
+            if i < len(node.args.kw_defaults) and node.args.kw_defaults[i] is not None:
+                kwonly_list.append(f'{{ name := "{name}", type := {tp}, default := some .none }}')
+            else:
+                kwonly_list.append(f'{{ name := "{name}", type := {tp} }}')
+
+        args_str = "#[]" if not args_list else "#[\n      " + ",\n      ".join(args_list) + "\n    ]"
+        kwonly_str = "#[]" if not kwonly_list else "#[\n      " + ",\n      ".join(kwonly_list) + "\n    ]"
+
+        return f"{{ args := {args_str}, kwonly := {kwonly_str} }}"
+
+    def generate_lean(self) -> str:
+        """Generate the complete Lean source file."""
+        lines = [
+            f"/-",
+            f"  Auto-generated from icontract specs: {self.module_name}",
+            f"  Source: CPython-icontract/contracts/{self.module_name}.py",
+            f"-/",
+            f"import Strata.Languages.Python.Specs.Decls",
+            f"",
+            f"namespace Strata.Python.Specs.IContract.{self.lean_module.capitalize()}",
+            f"",
+            f"open Strata.Python.Specs",
+            f"open Strata.Python",
+            f"",
+            f"def signatures : Array Signature := #[",
+        ]
+
+        for i, sig in enumerate(self.signatures):
+            # Indent each signature
+            indented = "  " + sig.replace("\n", "\n  ")
+            if i < len(self.signatures) - 1:
+                indented += ","
+            lines.append(indented)
+
+        lines.append("]")
+        lines.append("")
+
+        if self.warnings:
+            lines.append("/-")
+            lines.append("Conversion warnings:")
+            for w in self.warnings:
+                lines.append(w)
+            lines.append("-/")
+            lines.append("")
+
+        lines.append(f"end Strata.Python.Specs.IContract.{self.lean_module.capitalize()}")
+        lines.append("")
+
+        return "\n".join(lines)
+
+
+def _escape_lean_comment(s: str) -> str:
+    """Escape a string for use inside a Lean block comment."""
+    return s.replace("-/", "- /").replace("/-", "/ -")
+
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def convert_file(input_path: Path, output_path: Path, module_name: Optional[str] = None):
+    """Convert a single icontract Python file to Lean."""
+    source = input_path.read_text()
+    tree = ast.parse(source, filename=str(input_path))
+
+    if module_name is None:
+        module_name = input_path.stem
+
+    gen = LeanGenerator(module_name)
+    gen.process_file(tree)
+    lean_source = gen.generate_lean()
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(lean_source)
+    print(f"  {input_path} → {output_path} ({len(gen.signatures)} signatures)")
+    if gen.warnings:
+        for w in gen.warnings:
+            print(f"    {w}")
+
+
+def convert_directory(input_dir: Path, output_dir: Path):
+    """Convert all .py files in a directory."""
+    py_files = sorted(input_dir.glob("*.py"))
+    # Also handle subdirectories
+    for subdir in sorted(input_dir.iterdir()):
+        if subdir.is_dir() and not subdir.name.startswith((".", "__")):
+            py_files.extend(sorted(subdir.glob("*.py")))
+
+    count = 0
+    for py_file in py_files:
+        if py_file.name == "__init__.py":
+            continue
+        # Determine module name from path relative to input_dir
+        rel = py_file.relative_to(input_dir)
+        parts = list(rel.parts)
+        parts[-1] = rel.stem  # remove .py
+        module_name = ".".join(parts)
+
+        # Output path mirrors structure
+        out_file = output_dir / rel.with_suffix(".lean")
+        try:
+            convert_file(py_file, out_file, module_name)
+            count += 1
+        except SyntaxError as e:
+            print(f"  SKIP {py_file}: {e}")
+        except Exception as e:
+            print(f"  ERROR {py_file}: {e}")
+
+    print(f"\nConverted {count} files.")
+
+
+def convert_file_ion(input_path: Path, output_path: Path, module_name: Optional[str] = None,
+                     only_decorated: bool = False):
+    """Convert a single icontract Python file to .pyspec.st.ion."""
+    from strata.icontract_ion import IonSpecGenerator
+
+    source = input_path.read_text()
+    tree = ast.parse(source, filename=str(input_path))
+
+    if module_name is None:
+        module_name = input_path.stem
+
+    gen = IonSpecGenerator(module_name)
+    gen.process_file(tree, only_decorated=only_decorated)
+    count = gen.write_ion(output_path)
+    print(f"  {input_path} → {output_path} ({count} signatures)")
+    if gen.warnings:
+        for w in gen.warnings:
+            print(f"    {w}")
+
+
+def convert_directory_ion(input_dir: Path, output_dir: Path):
+    """Convert all .py files in a directory to .pyspec.st.ion."""
+    py_files = sorted(input_dir.glob("*.py"))
+    for subdir in sorted(input_dir.iterdir()):
+        if subdir.is_dir() and not subdir.name.startswith((".", "__")):
+            py_files.extend(sorted(subdir.glob("*.py")))
+
+    count = 0
+    for py_file in py_files:
+        if py_file.name == "__init__.py":
+            continue
+        rel = py_file.relative_to(input_dir)
+        parts = list(rel.parts)
+        parts[-1] = rel.stem
+        module_name = ".".join(parts)
+        out_file = output_dir / rel.with_suffix(".pyspec.st.ion")
+        try:
+            convert_file_ion(py_file, out_file, module_name)
+            count += 1
+        except SyntaxError as e:
+            print(f"  SKIP {py_file}: {e}")
+        except Exception as e:
+            print(f"  ERROR {py_file}: {e}")
+
+    print(f"\nConverted {count} files.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert icontract Python specs to Strata Signature values"
+    )
+    parser.add_argument("input", help="Input .py file or directory")
+    parser.add_argument("output", help="Output file or directory")
+    parser.add_argument("--module", help="Override module name", default=None)
+    parser.add_argument("--format", choices=["lean", "ion"], default="ion",
+                        help="Output format: 'ion' (default) for .pyspec.st.ion, 'lean' for .lean")
+    parser.add_argument("--only-decorated", action="store_true",
+                        help="Only emit specs for functions with icontract decorators")
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+
+    if args.format == "ion":
+        if input_path.is_file():
+            if not output_path.suffix == ".ion":
+                output_path = output_path / (input_path.stem + ".pyspec.st.ion")
+            convert_file_ion(input_path, output_path, args.module,
+                             only_decorated=args.only_decorated)
+        elif input_path.is_dir():
+            convert_directory_ion(input_path, output_path)
+        else:
+            print(f"Error: {input_path} not found", file=sys.stderr)
+            sys.exit(1)
+    else:
+        if input_path.is_file():
+            if output_path.suffix != ".lean":
+                output_path = output_path / (input_path.stem + ".lean")
+            convert_file(input_path, output_path, args.module)
+        elif input_path.is_dir():
+            convert_directory(input_path, output_path)
+        else:
+            print(f"Error: {input_path} not found", file=sys.stderr)
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/Python/strata/icontract_ion.py
+++ b/Tools/Python/strata/icontract_ion.py
@@ -1,0 +1,458 @@
+"""
+Bridge between icontract AST processing and Ion DDM output.
+
+Uses the existing expr_to_spec_expr / type_annotation_to_lean logic
+but outputs Ion binary instead of Lean text.
+"""
+
+import ast
+from pathlib import Path
+from typing import Optional
+
+from strata.icontract import (
+    get_decorator_kind, extract_lambda, extract_description,
+    extract_snapshot_name, expr_to_spec_expr, split_and_conditions,
+    type_annotation_to_lean, BUILTIN_TYPE_MAP, TYPING_MAP,
+)
+from strata.ddm_writer import IonDDMWriter
+
+
+# Map from Lean SpecType text to DDM Ion ident strings
+_BUILTIN_IDENT_MAP = {
+    ".builtinsInt": "builtins.int",
+    ".builtinsFloat": "builtins.float",
+    ".builtinsStr": "builtins.str",
+    ".builtinsBool": "builtins.bool",
+    ".builtinsBytes": "builtins.bytes",
+    ".builtinsBytearray": "builtins.bytearray",
+    ".builtinsComplex": "builtins.complex",
+    ".builtinsDict": "builtins.dict",
+    ".typingList": "typing.List",
+    ".typingDict": "typing.Dict",
+    ".typingSequence": "typing.Sequence",
+    ".typingMapping": "typing.Mapping",
+    ".typingAny": "typing.Any",
+    ".typingUnion": "typing.Union",
+    ".typingLiteral": "typing.Literal",
+    ".typingGenerator": "typing.Generator",
+}
+
+
+class IonSpecGenerator:
+    """Generates .pyspec.st.ion files from icontract-decorated Python."""
+
+    def __init__(self, module_name: str):
+        self.module_name = module_name
+        self.command_fns = []
+        self.warnings = []
+
+    def _has_icontract_decorator(self, node: ast.FunctionDef) -> bool:
+        """Check if a function has any icontract decorators."""
+        return any(get_decorator_kind(dec) is not None for dec in node.decorator_list)
+
+    def process_file(self, tree: ast.Module, only_decorated: bool = False):
+        for node in tree.body:
+            if isinstance(node, ast.FunctionDef):
+                if only_decorated and not self._has_icontract_decorator(node):
+                    continue
+                self._process_function(node, class_name=None)
+            elif isinstance(node, ast.ClassDef):
+                self._process_class(node)
+
+    def _emit_type(self, w: IonDDMWriter, node: Optional[ast.expr]):
+        """Emit a SpecType Ion node from a Python type annotation."""
+        if node is None:
+            w._typeIdentNoArgs("typing.Any")
+            return
+
+        if isinstance(node, ast.Constant):
+            if node.value is None:
+                w._typeIdentNoArgs("_types.NoneType")
+                return
+            w._typeIdentNoArgs("typing.Any")
+            return
+
+        if isinstance(node, ast.Name):
+            name = node.id
+            if name == "None" or name == "NoneType":
+                w._typeIdentNoArgs("_types.NoneType")
+                return
+            if name in BUILTIN_TYPE_MAP:
+                w._typeIdentNoArgs(_BUILTIN_IDENT_MAP[BUILTIN_TYPE_MAP[name]])
+                return
+            if name in TYPING_MAP:
+                w._typeIdentNoArgs(_BUILTIN_IDENT_MAP[TYPING_MAP[name]])
+                return
+            # User-defined class
+            w._op("PythonSpecs.typeClassNoArgs", lambda: w._ident(name))
+            return
+
+        if isinstance(node, ast.Subscript):
+            base = node.value
+            base_name = ""
+            if isinstance(base, ast.Name):
+                base_name = base.id
+
+            if base_name in ("List", "Sequence"):
+                ident = _BUILTIN_IDENT_MAP[TYPING_MAP[base_name]]
+                w._typeIdent(ident,
+                    lambda: w._commaSepList(
+                        lambda: self._emit_type(w, node.slice)))
+                return
+
+            if base_name in ("Dict", "Mapping"):
+                ident = _BUILTIN_IDENT_MAP[TYPING_MAP[base_name]]
+                if isinstance(node.slice, ast.Tuple) and len(node.slice.elts) == 2:
+                    w._typeIdent(ident,
+                        lambda: w._commaSepList(
+                            lambda: self._emit_type(w, node.slice.elts[0]),
+                            lambda: self._emit_type(w, node.slice.elts[1])))
+                else:
+                    w._typeIdentNoArgs(ident)
+                return
+
+            if base_name == "Optional":
+                # Optional[T] → union of T and None
+                # For simplicity, just emit the inner type
+                self._emit_type(w, node.slice)
+                return
+
+        # Fallback
+        w._typeIdentNoArgs("typing.Any")
+
+    def _emit_spec_expr(self, w: IonDDMWriter, lean_expr: str):
+        """Convert a Lean SpecExpr string to Ion DDM nodes.
+
+        This parses the string output of expr_to_spec_expr and emits
+        the corresponding Ion DDM nodes.
+        """
+        # Parse the Lean-style SpecExpr string into Ion DDM calls
+        self._emit_spec_expr_parsed(w, lean_expr)
+
+    def _emit_spec_expr_parsed(self, w: IonDDMWriter, expr: str):
+        """Recursively emit Ion for a Lean SpecExpr string."""
+        expr = expr.strip()
+
+        if expr == ".placeholder":
+            w._placeholderExpr()
+            return
+
+        if expr.startswith('.var "') and expr.endswith('"'):
+            name = expr[6:-1]
+            w._varExpr(name)
+            return
+
+        if expr.startswith('.isInstanceOf '):
+            # .isInstanceOf (.var "x") "Type"
+            rest = expr[len('.isInstanceOf '):]
+            subj_end = self._find_matching_paren(rest, 0)
+            subj = rest[1:subj_end]  # strip outer parens
+            type_name = rest[subj_end+2:].strip().strip('"')
+            w._isInstanceOfExpr(
+                lambda s=subj: self._emit_spec_expr_parsed(w, s),
+                type_name)
+            return
+
+        if expr.startswith('.len '):
+            rest = expr[len('.len '):]
+            inner = rest.strip('()')
+            w._lenExpr(lambda i=inner: self._emit_spec_expr_parsed(w, i))
+            return
+
+        if expr.startswith('.intLit '):
+            val_str = expr[len('.intLit '):]
+            val_str = val_str.strip('()')
+            w._intExpr(int(val_str))
+            return
+
+        if expr.startswith('.intGe '):
+            rest = expr[len('.intGe '):]
+            subj, bound = self._split_two_args(rest)
+            w._intGeExpr(
+                lambda s=subj: self._emit_spec_expr_parsed(w, s),
+                lambda b=bound: self._emit_spec_expr_parsed(w, b))
+            return
+
+        if expr.startswith('.intLe '):
+            rest = expr[len('.intLe '):]
+            subj, bound = self._split_two_args(rest)
+            w._intLeExpr(
+                lambda s=subj: self._emit_spec_expr_parsed(w, s),
+                lambda b=bound: self._emit_spec_expr_parsed(w, b))
+            return
+
+        if expr.startswith('.intAdd '):
+            rest = expr[len('.intAdd '):]
+            left, right = self._split_two_args(rest)
+            w._intAddExpr(
+                lambda l=left: self._emit_spec_expr_parsed(w, l),
+                lambda r=right: self._emit_spec_expr_parsed(w, r))
+            return
+
+        if expr.startswith('.intSub '):
+            rest = expr[len('.intSub '):]
+            left, right = self._split_two_args(rest)
+            w._intSubExpr(
+                lambda l=left: self._emit_spec_expr_parsed(w, l),
+                lambda r=right: self._emit_spec_expr_parsed(w, r))
+            return
+
+        if expr.startswith('.intMul '):
+            rest = expr[len('.intMul '):]
+            left, right = self._split_two_args(rest)
+            w._intMulExpr(
+                lambda l=left: self._emit_spec_expr_parsed(w, l),
+                lambda r=right: self._emit_spec_expr_parsed(w, r))
+            return
+
+        if expr.startswith('.intEq '):
+            rest = expr[len('.intEq '):]
+            left, right = self._split_two_args(rest)
+            w._intEqExpr(
+                lambda l=left: self._emit_spec_expr_parsed(w, l),
+                lambda r=right: self._emit_spec_expr_parsed(w, r))
+            return
+
+        if expr.startswith('.floatLit "') and expr.endswith('"'):
+            val = expr[len('.floatLit "'):-1]
+            w._floatExpr(val)
+            return
+
+        if expr.startswith('.floatGe '):
+            rest = expr[len('.floatGe '):]
+            subj, bound = self._split_two_args(rest)
+            w._floatGeExpr(
+                lambda s=subj: self._emit_spec_expr_parsed(w, s),
+                lambda b=bound: self._emit_spec_expr_parsed(w, b))
+            return
+
+        if expr.startswith('.floatLe '):
+            rest = expr[len('.floatLe '):]
+            subj, bound = self._split_two_args(rest)
+            w._floatLeExpr(
+                lambda s=subj: self._emit_spec_expr_parsed(w, s),
+                lambda b=bound: self._emit_spec_expr_parsed(w, b))
+            return
+
+        if expr.startswith('.not '):
+            inner = expr[len('.not '):].strip('()')
+            w._notExpr(lambda i=inner: self._emit_spec_expr_parsed(w, i))
+            return
+
+        if expr.startswith('.getIndex '):
+            rest = expr[len('.getIndex '):]
+            subj_end = self._find_matching_paren(rest, 0)
+            subj = rest[1:subj_end]
+            field = rest[subj_end+2:].strip().strip('"')
+            w._getIndexExpr(
+                lambda s=subj: self._emit_spec_expr_parsed(w, s),
+                field)
+            return
+
+        if expr.startswith('.forallList '):
+            rest = expr[len('.forallList '):]
+            list_end = self._find_matching_paren(rest, 0)
+            list_expr = rest[1:list_end]
+            remaining = rest[list_end+2:].strip()
+            # Parse "varName" (body)
+            var_end = remaining.index('"', 1)
+            var_name = remaining[1:var_end]
+            body = remaining[var_end+2:].strip().strip('()')
+            w._forallListExpr(
+                lambda l=list_expr: self._emit_spec_expr_parsed(w, l),
+                var_name,
+                lambda b=body: self._emit_spec_expr_parsed(w, b))
+            return
+
+        # Fallback: placeholder
+        w._placeholderExpr()
+
+    def _find_matching_paren(self, s: str, start: int) -> int:
+        """Find the index of the closing paren matching s[start]='('."""
+        depth = 0
+        for i in range(start, len(s)):
+            if s[i] == '(':
+                depth += 1
+            elif s[i] == ')':
+                depth -= 1
+                if depth == 0:
+                    return i
+        return len(s) - 1
+
+    def _split_two_args(self, rest: str) -> tuple:
+        """Split 'arg1 arg2' where args may be parenthesized."""
+        rest = rest.strip()
+        if rest.startswith('('):
+            end = self._find_matching_paren(rest, 0)
+            first = rest[1:end]
+            second = rest[end+2:].strip().strip('()')
+        else:
+            # Simple: .var "x" or similar — find first space after first token
+            parts = rest.split(' ', 1)
+            if len(parts) == 2 and parts[0].startswith('.'):
+                # e.g., '.var "x"' — need to be smarter
+                # Find the boundary between two top-level expressions
+                first, second = self._split_top_level(rest)
+            else:
+                first = parts[0].strip('()')
+                second = parts[1].strip('()') if len(parts) > 1 else '.placeholder'
+        return first, second
+
+    def _split_top_level(self, s: str) -> tuple:
+        """Split a string into two top-level s-expressions."""
+        s = s.strip()
+        depth = 0
+        i = 0
+        while i < len(s):
+            if s[i] == '(':
+                depth += 1
+            elif s[i] == ')':
+                depth -= 1
+            elif s[i] == ' ' and depth == 0:
+                # Check if we've consumed a complete expression
+                left = s[:i].strip()
+                right = s[i+1:].strip()
+                # A complete expression either starts with ( or with .something "..."
+                if left and (left.startswith('(') or not right.startswith('"')):
+                    if self._is_complete_expr(left):
+                        return left.strip('()'), right.strip('()')
+            i += 1
+        return s.strip('()'), '.placeholder'
+
+    def _is_complete_expr(self, s: str) -> bool:
+        """Check if s looks like a complete SpecExpr."""
+        s = s.strip()
+        if s.startswith('(') and s.endswith(')'):
+            return True
+        if s.startswith('.') and '"' in s:
+            return True
+        return False
+
+    def _process_function(self, node: ast.FunctionDef, class_name=None):
+        requires = []
+        ensures = []
+        remaining_decorators = []
+
+        for dec in node.decorator_list:
+            kind = get_decorator_kind(dec)
+            if kind == "require":
+                lam = extract_lambda(dec)
+                desc = extract_description(dec)
+                if lam:
+                    params = [a.arg for a in lam.args.args]
+                    parts = split_and_conditions(lam.body)
+                    for part in parts:
+                        spec_expr = expr_to_spec_expr(part, params)
+                        source = ast.unparse(part)
+                        msg = desc if desc else source
+                        requires.append((spec_expr, msg))
+            elif kind == "ensure":
+                lam = extract_lambda(dec)
+                if lam:
+                    params = [a.arg for a in lam.args.args]
+                    spec_expr = expr_to_spec_expr(lam.body, params)
+                    ensures.append(spec_expr)
+            else:
+                remaining_decorators.append(dec)
+
+        is_overload = any(
+            isinstance(d, ast.Name) and d.id == "overload"
+            for d in remaining_decorators
+        )
+
+        func_name = node.name
+        func_node = node
+        class_nm = class_name
+
+        def make_command(w: IonDDMWriter):
+            # Build arg fns
+            arg_fns = []
+            for i, arg in enumerate(func_node.args.args):
+                a_name = arg.arg
+                a_ann = arg.annotation
+                a_idx = i
+                defaults = func_node.args.defaults
+                default_idx = a_idx - (len(func_node.args.args) - len(defaults))
+                has_default = 0 <= default_idx < len(defaults)
+
+                if class_nm and a_idx == 0 and a_name == "self":
+                    def make_type_fn(w2, cn=class_nm):
+                        w2._op("PythonSpecs.typeClassNoArgs", lambda: w2._ident(cn))
+                    arg_fns.append(lambda n=a_name, hd=has_default, cn=class_nm:
+                        w._mkArgDecl(n, lambda: make_type_fn(w, cn), hd))
+                else:
+                    def make_type_fn2(w2, ann=a_ann):
+                        self._emit_type(w2, ann)
+                    arg_fns.append(lambda n=a_name, hd=has_default, ann=a_ann:
+                        w._mkArgDecl(n, lambda: self._emit_type(w, ann), hd))
+
+            kwonly_fns = []
+            for i, arg in enumerate(func_node.args.kwonlyargs):
+                a_name = arg.arg
+                a_ann = arg.annotation
+                has_default = (i < len(func_node.args.kw_defaults)
+                               and func_node.args.kw_defaults[i] is not None)
+                kwonly_fns.append(lambda n=a_name, hd=has_default, ann=a_ann:
+                    w._mkArgDecl(n, lambda: self._emit_type(w, ann), hd))
+
+            # Return type
+            ret_ann = func_node.returns
+
+            # Preconditions
+            precond_fns = []
+            for spec_expr, msg in requires:
+                precond_fns.append(lambda se=spec_expr, m=msg:
+                    w._mkAssertion(
+                        lambda: self._emit_spec_expr_parsed(w, se),
+                        m))
+
+            # Postconditions
+            postcond_fns = []
+            for se in ensures:
+                postcond_fns.append(lambda s=se:
+                    w._op("PythonSpecs.mkPostconditionEntry",
+                           lambda: self._emit_spec_expr_parsed(w, s)))
+
+            w._functionDecl(lambda: w._mkFunDecl(
+                func_name, arg_fns, kwonly_fns,
+                lambda: self._emit_type(w, ret_ann),
+                is_overload, precond_fns, postcond_fns))
+
+        if class_name is None:
+            self.command_fns.append(make_command)
+
+        return make_command
+
+    def _process_class(self, node: ast.ClassDef):
+        method_fns = []
+        for item in node.body:
+            if isinstance(item, ast.FunctionDef):
+                if item.name != "__init__":
+                    fn = self._process_function(item, class_name=node.name)
+                    if fn:
+                        method_fns.append(fn)
+
+        cls_name = node.name
+        mfns = method_fns
+
+        def make_class_command(w: IonDDMWriter):
+            w._classDef(lambda: w._op("PythonSpecs.mkClassDecl",
+                lambda: w._strlit(cls_name),
+                lambda: w._seq(),  # bases
+                lambda: w._seq(),  # fields
+                lambda: w._seq(),  # classVars
+                lambda: w._seq(),  # subclasses
+                lambda: w._seq(*[lambda f=f: f(w) for f in mfns]),
+                lambda: w._op("Init.boolFalse"),  # exhaustive
+            ))
+
+        self.command_fns.append(make_class_command)
+
+    def write_ion(self, output_path: Path):
+        """Write the .pyspec.st.ion file."""
+        w = IonDDMWriter()
+        w.write_program([lambda f=f: f(w) for f in self.command_fns])
+        data = w.get_bytes()
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(data)
+        return len(self.command_fns)

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -24,6 +24,10 @@ name = "StrataTest"
 globs = ["StrataTest.+"]
 
 [[lean_exe]]
+name = "icontractSpecs"
+root = "IContractSpecs"
+
+[[lean_exe]]
 name = "StrataToCBMC"
 
 [[lean_exe]]


### PR DESCRIPTION
> **Depends on:** https://github.com/strata-org/Strata/pull/867


Improves the quality of error diagnostics when `pyAnalyzeLaurel` reports assertion failures and user errors at call sites.

## Changes

### 1. Error location now points at the method name, not the receiver

For `obj.method(...)`, errors previously pointed at `obj` instead of `method`. The `Call` expression handler and `Expr` statement handler both overwrote the `callRange` metadata with the outer node's range. Fixed by preserving the metadata returned by `translateCall`.

### 2. Human-readable assertion failure messages

Precondition violations previously displayed raw Lean AST dumps. `specExprToLaurel` creates fresh metadata from node source locations, discarding the `propertySummary` set on the input metadata. Fixed by explicitly propagating `propertySummary` onto the returned expression, and using `specExprToMessage` to generate descriptive messages from the formula (e.g. `len(x) >= 1`).

### 3. Concise error messages

Since the error location now points at the method name, messages no longer redundantly include it. Messages are also capitalized for consistency.

## Files changed

- `PythonToLaurel.lean` — Preserve `callRange` metadata in `.Call` and `.Expr` handlers; shorten and capitalize user error messages
- `Specs.lean` — icontract message text adjustment
- `Specs/ToLaurel.lean` — Propagate `propertySummary` through `specExprToLaurel`; use `specExprToMessage` for human-readable precondition labels; build `laurelPreconds` even when no postconditions exist

## Before / After

```
-- Before:
Assertion failed at line 9, col 8: Strata.Python.expr.Compare { start := ...
'method' called with unknown keyword arguments: [arg]

-- After:
Assertion failed at line 9, col 18: len(x) >= 1
Unknown keyword arguments: [arg]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
