### PR TITLE
Fix extra parentheses around DeclList and MonoDeclList binders

### DIFF
--- a/Strata/Languages/Core/DDMTransform/Grammar.lean
+++ b/Strata/Languages/Core/DDMTransform/Grammar.lean
@@ -68,7 +68,7 @@ category DeclList;
 @[scope(b)]
 op declAtom (b : Bind) : DeclList => b;
 @[scope(b)]
-op declPush (dl : DeclList, @[scope(dl)] b : Bind) : DeclList => dl ", " b;
+op declPush (dl : DeclList, @[scope(dl)] b : Bind) : DeclList => dl:0 ", " b:0;
 
 category MonoBind;
 @[declare(v, tp)]
@@ -80,7 +80,7 @@ category MonoDeclList;
 op monoDeclAtom (b : MonoBind) : MonoDeclList => b;
 @[scope(b)]
 op monoDeclPush (dl : MonoDeclList, @[scope(dl)] b : MonoBind) : MonoDeclList =>
-  dl ", " b;
+  dl:0 ", " b:0;
 
 fn not (b : bool) : bool => "!" b;
 

--- a/StrataTest/Languages/Core/Examples/DDMAxiomsExtraction.lean
+++ b/StrataTest/Languages/Core/Examples/DDMAxiomsExtraction.lean
@@ -87,8 +87,8 @@ def extractAxiomsWithFreeTypeVars (pgm: Program) (typeArgs: List String): (List 
 info: program Core;
 type k;
 type v;
-axiom [updateSelect]: forall ((m : (Map v k)), (kk : k)), (vv : v) :: (m[kk:=vv])[kk] == vv;
-axiom [updatePreserves]: forall (((m : (Map v k)), (okk : k)), (kk : k)), (vv : v) :: (m[kk:=vv])[okk] == m[okk];
+axiom [updateSelect]: forall m : (Map v k), kk : k, vv : v :: (m[kk:=vv])[kk] == vv;
+axiom [updatePreserves]: forall m : (Map v k), okk : k, kk : k, vv : v :: (m[kk:=vv])[okk] == m[okk];
 -/
 #guard_msgs in
 #eval IO.println examplePgm


### PR DESCRIPTION
*Description of changes:*
- Remove extra parentheses around `DeclList` binders in formatted output (multi-binder `forall` / `exists`).
- Remove extra parentheses around `MonoDeclList` binders in formatted output (multi-binder `var` statements).

`DeclList` — before:
```
axiom [updateSelect]: forall ((m : (Map v k)), (kk : k)), (vv : v) :: (m[kk:=vv])[kk] == vv;
axiom [updatePreserves]: forall (((m : (Map v k)), (okk : k)), (kk : k)), (vv : v) :: (m[kk:=vv])[okk] == m[okk];
```
`DeclList` — after:
```
axiom [updateSelect]: forall m : (Map v k), kk : k, vv : v :: (m[kk:=vv])[kk] == vv;
axiom [updatePreserves]: forall m : (Map v k), okk : k, kk : k, vv : v :: (m[kk:=vv])[okk] == m[okk];
```

`MonoDeclList` — before:
```
procedure TestMultiVar () returns ()
{
  var ((x : int), (y : int)), (z : int);
};
```
`MonoDeclList` — after:
```
procedure TestMultiVar () returns ()
{
  var x : int, y : int, z : int;
};
```

Problem: 
Same root cause as #825: `SyntaxDefAtom.formatArgs` parenthesizes an argument when `prec > 0 ∧ innerPrec ≤ prec`. `declPush`'s output rule `dl ", " b` sets no precedence on either `dl` or `b`, so both positions default to `maxPrec` and both trigger the parenthesization. `dl` is a `DeclList`, so `declPush(declPush(declAtom(x), y), z)` formats as `((x : int), (y : int)), (z : int)`. `monoDeclPush` is analogous. The parser rejects this output (`unexpected token '('; expected Core.Bind or identifier`).

To reproduce, save the `MonoDeclList — after` snippet above (wrapped in `program Core;`) as `example.core.st`. Before this fix:

```
$ lake exe strata print example.core.st > out.core.st
# out.core.st now contains the `MonoDeclList — before` form
$ lake exe strata print out.core.st
Exception: 1 error(s) reading out.core.st:
  4:5: unexpected token '('; expected Core.Bind or identifier
```

With this PR, both runs succeed and produce the same text as `example.core.st`.

Fix: 
Same `:0` atom-prec pattern as #825, applied to both ident positions of `declPush` and `monoDeclPush`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
