### PR TITLE
Restore short-circuit ite encoding for AndThen/OrElse/Implies

### DIFF
--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -196,9 +196,9 @@ def translateExpr (expr : StmtExprMd)
     | .Neq => return .app () boolNotOp (.eq () re1 re2)
     | .And => return binOp boolAndOp
     | .Or => return binOp boolOrOp
-    | .AndThen => return binOp boolAndOp
-    | .OrElse => return binOp boolOrOp
-    | .Implies => return binOp boolImpliesOp
+    | .AndThen => return .ite () re1 re2 (.boolConst () false)
+    | .OrElse => return .ite () re1 (.boolConst () true) re2
+    | .Implies => return .ite () re1 re2 (.boolConst () true)
     | .Add => return binOp (if isReal then realAddOp else intAddOp)
     | .Sub => return binOp (if isReal then realSubOp else intSubOp)
     | .Mul => return binOp (if isReal then realMulOp else intMulOp)

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T15_ShortCircuit.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T15_ShortCircuit.lean
@@ -27,15 +27,11 @@ procedure mustNotCallProc(): int
 
 procedure testAndThenFunc() {
   var b: bool := false && mustNotCallFunc(0) > 0;
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion does not hold
-// TODO caused by a bug in Core: https://github.com/strata-org/Strata/issues/697
   assert !b
 };
 
 procedure testOrElseFunc() {
   var b: bool := true || mustNotCallFunc(0) > 0;
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion does not hold
-// TODO caused by a bug in Core: https://github.com/strata-org/Strata/issues/697
   assert b
 };
 
@@ -48,14 +44,10 @@ procedure testImpliesFunc() {
 
 procedure testAndThenDivByZero() {
   assert !(false && 1 / 0 > 0)
-//^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion does not hold
-// TODO caused by a bug in Core.
 };
 
 procedure testOrElseDivByZero() {
   assert true || 1 / 0 > 0
-//^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion does not hold
-// TODO caused by a bug in Core: https://github.com/strata-org/Strata/issues/697
 };
 
 procedure testImpliesDivByZero() {
@@ -80,7 +72,7 @@ procedure testImpliesProc() {
 };
 "
 
-#guard_msgs(drop info, error) in
+#guard_msgs(drop info) in
 #eval testInputWithOffset "ShortCircuit" shortCircuitProgram 15 processLaurelFile
 
 end Laurel


### PR DESCRIPTION
PR #638 changed the Laurel→Core translation of `AndThen`/`OrElse`/`Implies` from `ite` (if-then-else) encoding to eager `boolAndOp`/`boolOrOp`/`boolImpliesOp`. This broke short-circuit well-definedness: expressions like `y != 0 && x / y > 0` now evaluate the division even when `y == 0`.

The `ite` encoding is the correct semantics — it prevents evaluation of the second operand when the first operand short-circuits. The `DesugarShortCircuit` pass only handles imperative operands, not well-definedness concerns like division by zero or precondition violations on pure function calls.

This reverts the three translator lines and removes the error annotations added to `T15_ShortCircuit.lean` to accept the broken behavior.