### PR TITLE
Add type-safe Laurel expressions and structured warning kinds

### DIFF
--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -92,13 +92,13 @@ inductive Operation : Type where
   | DivT
   /-- Truncation modulus. -/
   | ModT
-  /-- Less than. Works on `Int` and `Float64`. -/
+  /-- Less than. Works on `Int` and `Real`. -/
   | Lt
-  /-- Less than or equal. Works on `Int` and `Float64`. -/
+  /-- Less than or equal. Works on `Int` and `Real`. -/
   | Leq
-  /-- Greater than. Works on `Int` and `Float64`. -/
+  /-- Greater than. Works on `Int` and `Real`. -/
   | Gt
-  /-- Greater than or equal. Works on `Int` and `Float64`. -/
+  /-- Greater than or equal. Works on `Int` and `Real`. -/
   | Geq
   /-- String concatenation. -/
   | StrConcat

--- a/Strata/Languages/Python/PySpecPipeline.lean
+++ b/Strata/Languages/Python/PySpecPipeline.lean
@@ -13,6 +13,7 @@ import Strata.Languages.Python.PythonLaurelCorePrelude
 import Strata.Languages.Python.PythonRuntimeLaurelPart
 import Strata.Languages.Python.Specs
 import Strata.Languages.Python.Specs.DDM
+public import Strata.Languages.Python.Specs.Error
 import Strata.Languages.Python.Specs.IdentifyOverloads
 import Strata.Languages.Python.Specs.ToLaurel
 import Strata.Util.DecideProp
@@ -40,6 +41,8 @@ public structure PySpecLaurelResult where
   typeAliases : Std.HashMap String String := {}
   /-- Classes whose spec is considered exhaustive (lists all methods). -/
   exhaustiveClasses : Std.HashSet String := {}
+  /-- Warnings collected during PySpec translation. -/
+  pyspecWarnings : Array Python.Specs.SpecError := #[]
 
 /-! ### Private Helpers -/
 
@@ -110,13 +113,14 @@ private def mergeOverloads (old new : OverloadTable) : OverloadTable :=
     to namespace all generated Laurel names (e.g., `"servicelib_Storage"` for
     module `servicelib.Storage`). -/
 public def buildPySpecLaurel (pyspecEntries : Array (String × String))
-    (overloads : OverloadTable) (quiet : Bool := false) : EIO String PySpecLaurelResult := do
+    (overloads : OverloadTable) : EIO String PySpecLaurelResult := do
   let mut combinedProcedures : Array (Laurel.Procedure × String) := #[]
   let mut combinedTypes : Array (Laurel.TypeDefinition × String) := #[]
   let mut allOverloads := overloads
   let mut funcSigs : List Python.PythonFunctionDecl := []
   let mut allTypeAliases : Std.HashMap String String := {}
   let mut allExhaustiveClasses : Std.HashSet String := {}
+  let mut allWarnings : Array Python.Specs.SpecError := #[]
   for (modulePrefix, ionPath) in pyspecEntries do
     let ionFile : System.FilePath := ionPath
     let sigs ←
@@ -125,11 +129,7 @@ public def buildPySpecLaurel (pyspecEntries : Array (String × String))
       | .error msg => throw s!"Could not read {ionFile}: {msg}"
     let { program, errors, overloads, typeAliases, exhaustiveClasses } :=
       Python.Specs.ToLaurel.signaturesToLaurel ionPath sigs modulePrefix
-    if errors.size > 0 && !quiet then
-      let _ ← IO.eprintln
-        s!"{errors.size} PySpec translation warning(s) for {ionPath}:" |>.toBaseIO
-      for err in errors do
-        let _ ← IO.eprintln s!"  {err.file}: {err.message}" |>.toBaseIO
+    allWarnings := allWarnings ++ errors
     allOverloads := mergeOverloads allOverloads overloads
     allTypeAliases := typeAliases.fold (init := allTypeAliases) fun m k v => m.insert k v
     allExhaustiveClasses := exhaustiveClasses.fold (init := allExhaustiveClasses) fun s name => s.insert name
@@ -168,14 +168,15 @@ public def buildPySpecLaurel (pyspecEntries : Array (String × String))
   }
   return { laurelProgram := combinedLaurel, overloads := allOverloads
            functionSignatures := funcSigs, typeAliases := allTypeAliases
-           exhaustiveClasses := allExhaustiveClasses }
+           exhaustiveClasses := allExhaustiveClasses
+           pyspecWarnings := allWarnings }
 
 /-- Read dispatch Ion files and merge their overload tables. -/
 public def readDispatchOverloads
     (dispatchPaths : Array String)
-    (quiet : Bool := false)
-    : EIO String OverloadTable := do
+    : EIO String (OverloadTable × Array Python.Specs.SpecError) := do
   let mut tbl : OverloadTable := {}
+  let mut allWarnings : Array Python.Specs.SpecError := #[]
   for dispatchPath in dispatchPaths do
     let ionFile : System.FilePath := dispatchPath
     let sigs ←
@@ -184,17 +185,13 @@ public def readDispatchOverloads
       | .error msg => throw s!"Could not read dispatch file {ionFile}: {msg}"
     let (overloads, errors) :=
       Python.Specs.ToLaurel.extractOverloads dispatchPath sigs
-    if errors.size > 0 && !quiet then
-      let _ ← IO.eprintln
-        s!"{errors.size} dispatch warning(s) for {ionFile}:" |>.toBaseIO
-      for err in errors do
-        let _ ← IO.eprintln s!"  {err.file}: {err.message}" |>.toBaseIO
+    allWarnings := allWarnings ++ errors
     for (funcName, fnOverloads) in overloads do
       let existing := tbl.getD funcName {}
       tbl := tbl.insert funcName
         (fnOverloads.fold (init := existing)
           fun acc k v => acc.insert k v)
-  return tbl
+  return (tbl, allWarnings)
 
 /-- Resolve a module name to a `(modulePrefix, ionPath)` pair for
     `buildPySpecLaurel`.  Returns `none` if the pyspec file is not found. -/
@@ -235,7 +232,7 @@ public def resolveAndBuildLaurelPrelude
     match ← resolveModuleEntry modName specDir (quiet := quiet) with
     | some (_, path) => dispatchPaths := dispatchPaths.push path
     | none => throw s!"Dispatch module '{modName}' not found in {specDir}"
-  let dispatchOverloads ← readDispatchOverloads dispatchPaths (quiet := quiet)
+  let (dispatchOverloads, dispatchWarnings) ← readDispatchOverloads dispatchPaths
   let resolveState :=
     Python.Specs.IdentifyOverloads.resolveOverloads dispatchOverloads stmts
   if !quiet then
@@ -259,7 +256,8 @@ public def resolveAndBuildLaurelPrelude
     | some entry => explicitEntries := explicitEntries.push entry
     | none => throw s!"PySpec module '{modName}' not found in {specDir}"
   let allSpecEntries := autoSpecEntries ++ explicitEntries
-  buildPySpecLaurel allSpecEntries dispatchOverloads (quiet := quiet)
+  let result ← buildPySpecLaurel allSpecEntries dispatchOverloads
+  return { result with pyspecWarnings := dispatchWarnings ++ result.pyspecWarnings }
 
 /-! ### Pipeline Steps -/
 
@@ -390,15 +388,18 @@ public instance : ToString PipelineError where
 /-- Run the pyAnalyzeLaurel pipeline: read a Python Ion program,
     resolve overloads from dispatch files, load PySpec declarations,
     translate Python to Laurel, and combine with PySpec Laurel.
-    Returns the combined Laurel program ready for
-    `translateCombinedLaurel`.
 
     `dispatchModules` and `pyspecModules` are dotted module names
     resolved against `specDir`.
 
     The optional `sourcePath` overrides the file path embedded in
     Laurel metadata (useful when the Ion file was generated from a
-    `.py` source and you want line numbers to refer to the original). -/
+    `.py` source and you want line numbers to refer to the original).
+
+    When `warningSummaryFile` is provided, writes a JSON summary of
+    PySpec translation warnings to that path. The summary is written
+    after pyspec resolution, before Python-to-Laurel translation, so
+    it is produced even when later pipeline stages fail. -/
 public def pythonAndSpecToLaurel
     (pythonIonPath : String)
     (dispatchModules : Array String := #[])
@@ -407,6 +408,7 @@ public def pythonAndSpecToLaurel
     (specDir : System.FilePath := ".")
     (profile : Bool := false)
     (quiet : Bool := false)
+    (warningSummaryFile : Option String := none)
     : EIO PipelineError Laurel.Program := do
   let stmts ← profileStep profile "Read Python Ion" do
     match ← Python.readPythonStrata pythonIonPath |>.toBaseIO with
@@ -417,6 +419,33 @@ public def pythonAndSpecToLaurel
     match ← resolveAndBuildLaurelPrelude dispatchModules pyspecModules stmts specDir (quiet := quiet) |>.toBaseIO with
     | .ok r => pure r
     | .error msg => throw (.internal msg)
+
+  -- Print and write PySpec warnings before later stages can fail
+  let pyspecWarnings := result.pyspecWarnings
+  if pyspecWarnings.size > 0 && !quiet then
+    let _ ← IO.eprintln
+      s!"{pyspecWarnings.size} PySpec translation warning(s):" |>.toBaseIO
+    for err in pyspecWarnings do
+      let _ ← IO.eprintln s!"  {err.file}: {err.kind.phase}.{err.kind.category}: {err.message}" |>.toBaseIO
+  if let some warnFile := warningSummaryFile then
+    let counts : Std.HashMap _ Nat := pyspecWarnings.foldl (init := {})
+      fun acc err => acc.alter err.kind fun mv => some (mv.getD 0 + 1)
+    let entries := counts.toArray.qsort fun ⟨a, _⟩ ⟨b, _⟩ => a < b
+    let jsonEntries : Array Lean.Json := entries.map fun (kind, count) =>
+      Lean.Json.mkObj [
+        ("phase", .str kind.phase),
+        ("category", .str kind.category),
+        ("count", .num count)
+      ]
+    let json := Lean.Json.mkObj [
+      ("pyspecWarningSummary", .arr jsonEntries),
+      ("totalWarnings", .num pyspecWarnings.size)
+    ]
+    match ← IO.FS.writeFile warnFile (json.compress ++ "\n") |>.toBaseIO with
+    | .ok () => pure ()
+    | .error e =>
+      let _ ← IO.eprintln s!"warning: failed to write warning summary to {warnFile}: {e}" |>.toBaseIO
+
   let preludeInfo := buildPreludeInfo result
 
   let metadataPath := sourcePath.getD pythonIonPath

--- a/Strata/Languages/Python/PythonLaurelTypedExpr.lean
+++ b/Strata/Languages/Python/PythonLaurelTypedExpr.lean
@@ -1,0 +1,168 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.Languages.Laurel.Laurel
+
+/-!
+# Typed Laurel Expression Builders for the Python Prelude
+
+Type-safe wrappers around the Python Laurel prelude's runtime functions
+(`from_int`, `Any..as_string!`, `DictStrAny_contains`, etc.).  These
+enforce correct `HighType` at construction time so that type mismatches
+are caught by the Lean type checker rather than surfacing as confusing
+errors later in the Laurel or Core pipeline.
+
+The wrapped functions correspond to declarations in
+`PythonRuntimeLaurelPart.lean` and `PythonLaurelCorePrelude.lean`.
+-/
+
+public section
+namespace Strata.Python.Laurel
+
+open Strata.Laurel (HighType HighTypeMd StmtExpr StmtExprMd mkId)
+
+abbrev Md := Imperative.MetaData Core.Expression
+
+abbrev tyAny : HighType := .UserDefined "Any"
+
+/--
+A Laurel `StmtExprMd` tagged with its `HighType`.
+
+The benefit is that composition of typed expressions is checked by the Lean type
+system, catching mismatches like passing an `Int` where a `Bool` is expected.
+
+The type parameter is not statically enforced; correctness depends on the helper
+functions in this namespace producing the right type tag.  After a translation
+error is reported, helpers may return a mistyped expression to allow continued
+translation and further error collection.
+-/
+structure TypedStmtExpr (tp : HighType) where
+  stmt : StmtExprMd
+
+namespace TypedStmtExpr
+
+def ofStmt {tp} (s : StmtExpr) (md : Md) (source : Option FileRange := none) : TypedStmtExpr tp :=
+  { stmt := { val := s, source := source, md := md } }
+
+def identifier (v : String) (tp : HighType) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr tp :=
+  .ofStmt (.Identifier (mkId v)) md source
+
+def literalBool (v : Bool) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr .TBool :=
+  .ofStmt (.LiteralBool v) md source
+
+def literalInt (v : Int) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr .TInt :=
+  .ofStmt (.LiteralInt v) md source
+
+def literalString (v : String) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr .TString :=
+  .ofStmt (.LiteralString v) md source
+
+def stringEq (x y : TypedStmtExpr .TString)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Eq [x.stmt, y.stmt]) md source
+
+def intGeq (x y : TypedStmtExpr .TInt)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Geq [x.stmt, y.stmt]) md source
+
+def intLeq (x y : TypedStmtExpr .TInt)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Leq [x.stmt, y.stmt]) md source
+
+def realGeq (x y : TypedStmtExpr .TReal)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Geq [x.stmt, y.stmt]) md source
+
+def realLeq (x y : TypedStmtExpr .TReal)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Leq [x.stmt, y.stmt]) md source
+
+def not (x : TypedStmtExpr .TBool)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Not [x.stmt]) md source
+
+def implies (x y : TypedStmtExpr .TBool)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Implies [x.stmt, y.stmt]) md source
+
+def or (x y : TypedStmtExpr .TBool)
+    (md : Md := x.stmt.md) (source : Option FileRange := x.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.PrimitiveOp .Or [x.stmt, y.stmt]) md source
+
+abbrev tyDictStrAny : HighType := .UserDefined "DictStrAny"
+
+def anyIsfromNone (v : TypedStmtExpr tyAny)
+    (md : Md := v.stmt.md) (source : Option FileRange := v.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.StaticCall (mkId "Any..isfrom_None") [v.stmt]) md source
+
+def fromInt (v : TypedStmtExpr .TInt)
+    (md : Md := v.stmt.md) (source : Option FileRange := v.stmt.source) : TypedStmtExpr tyAny :=
+  .ofStmt (.StaticCall (mkId "from_int") [v.stmt]) md source
+
+def anyAsInt (a : TypedStmtExpr tyAny)
+    (md : Md := a.stmt.md) (source : Option FileRange := a.stmt.source) : TypedStmtExpr .TInt :=
+  .ofStmt (.StaticCall (mkId "Any..as_int!") [a.stmt]) md source
+
+def fromStr (v : TypedStmtExpr .TString) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr tyAny :=
+  .ofStmt (.StaticCall (mkId "from_str") [v.stmt]) md source
+
+def anyAsString (a : TypedStmtExpr tyAny)
+    (md : Md := a.stmt.md) (source : Option FileRange := a.stmt.source) : TypedStmtExpr .TString :=
+  .ofStmt (.StaticCall (mkId "Any..as_string!") [a.stmt]) md source
+
+def anyAsFloat (a : TypedStmtExpr tyAny)
+    (md : Md := a.stmt.md) (source : Option FileRange := a.stmt.source) : TypedStmtExpr .TReal :=
+  .ofStmt (.StaticCall (mkId "Any..as_float!") [a.stmt]) md source
+
+def anyAsDict (a : TypedStmtExpr tyAny)
+    (md : Md := a.stmt.md) (source : Option FileRange := a.stmt.source) : TypedStmtExpr tyDictStrAny :=
+  .ofStmt (.StaticCall (mkId "Any..as_Dict!") [a.stmt]) md source
+
+def dictStrAnyContains (d : TypedStmtExpr tyDictStrAny) (k : TypedStmtExpr .TString)
+    (md : Md := d.stmt.md) (source : Option FileRange := d.stmt.source) : TypedStmtExpr .TBool :=
+  .ofStmt (.StaticCall (mkId "DictStrAny_contains") [d.stmt, k.stmt]) md source
+
+def anyGet (a i : TypedStmtExpr tyAny) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr tyAny :=
+  .ofStmt (.StaticCall (mkId "Any_get") [a.stmt, i.stmt]) md source
+
+def strLength (a : TypedStmtExpr .TString)
+    (md : Md := a.stmt.md) (source : Option FileRange := a.stmt.source) : TypedStmtExpr .TInt :=
+  .ofStmt (.StaticCall (mkId "Str.Length") [a.stmt]) md source
+
+def reSearchBool (pattern s : TypedStmtExpr .TString) (md : Md)
+    (source : Option FileRange := none) : TypedStmtExpr .TBool :=
+  .ofStmt (.StaticCall (mkId "re_search_bool") [pattern.stmt, s.stmt]) md source
+
+end TypedStmtExpr
+
+/--
+A dependent pair that bundles a `HighType` and a `TypedStmtExpr` of that type.
+
+This is used when the type is not statically known and must be checked at
+runtime.
+-/
+abbrev SomeTypedStmtExpr := Σ(tp : HighType), TypedStmtExpr tp
+
+namespace SomeTypedStmtExpr
+
+def mkSome {tp} (e : TypedStmtExpr tp) : SomeTypedStmtExpr := ⟨tp, e⟩
+
+instance : Inhabited SomeTypedStmtExpr where
+  default :=
+    let holeType : HighTypeMd := { val := tyAny, source := none }
+    let stmt : StmtExprMd := { val := .Hole true (.some holeType), source := none }
+    .mk tyAny { stmt := stmt }
+
+end SomeTypedStmtExpr
+
+end Strata.Python.Laurel
+end

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -352,7 +352,7 @@ def shouldSkip (name : String) : PySpecM Bool := do
   return nameIdent ∈ ctx.skipNames
 
 def specErrorAt (file : System.FilePath) (loc : SourceRange) (message : String) : PySpecM Unit := do
-  let e : SpecError := { file, loc, message }
+  let e : SpecError := { file, loc, kind := .pySpecParsingError, message }
   modify fun s => { s with errors := s.errors.push e }
 
 instance : PySpecMClass PySpecM where
@@ -360,7 +360,7 @@ instance : PySpecMClass PySpecM where
     specErrorAt (←read).pythonFile loc message
   specWarning loc message := do
     let file := (←read).pythonFile
-    let w : SpecError := { file, loc, message }
+    let w : SpecError := { file, loc, kind := .pySpecParsingWarning, message }
     modify fun s => { s with warnings := s.warnings.push w }
   runChecked act := do
     let cnt := (←get).errors.size
@@ -736,11 +736,11 @@ abbrev SpecAssertionM := ReaderT SpecAssertionContext (StateM SpecAssertionState
 instance : PySpecMClass SpecAssertionM where
   specError loc message := do
     let file := (←read) |>.filePath
-    let e : SpecError := { file, loc, message }
+    let e : SpecError := { file, loc, kind := .pySpecParsingError, message }
     modify fun s => { s with errors := s.errors.push e }
   specWarning loc message := do
     let file := (←read) |>.filePath
-    let w : SpecError := { file, loc, message }
+    let w : SpecError := { file, loc, kind := .pySpecParsingWarning, message }
     modify fun s => { s with warnings := s.warnings.push w }
   runChecked act := do
     let cnt := (←get).errors.size
@@ -770,8 +770,10 @@ def extractKwargsField (e : expr SourceRange)
 partial def extractSubject (e : expr SourceRange)
     : SpecAssertionM (Option SpecExpr) := do
   match ← extractKwargsField e with
-  | some (kn, fn) => return some (.getIndex (.var kn (loc := e.ann)) fn (loc := e.ann))
-  | none => pure ()
+  | some (kn, fn) =>
+    return some (.getIndex (.var kn (loc := e.ann)) fn (loc := e.ann))
+  | none =>
+    pure ()
   match e with
   | .Name _ ⟨_, name⟩ (.Load _) => return some (.var name (loc := e.ann))
   | .Subscript _ inner (.Constant _ (.ConString _ fieldName) _) (.Load _) =>

--- a/Strata/Languages/Python/Specs/Error.lean
+++ b/Strata/Languages/Python/Specs/Error.lean
@@ -10,10 +10,70 @@ public import Strata.DDM.Util.SourceRange
 public section
 namespace Strata.Python.Specs
 
+/-- A warning category for PySpec translation.
+    Uses an open vocabulary (string fields) so new categories can be added
+    without modifying an inductive type. -/
+structure WarningKind where
+  phase : String
+  category : String
+  deriving BEq, DecidableEq, Hashable, Ord, Repr
+
+instance : LT WarningKind where
+  lt a b := a.phase < b.phase ∨ (a.phase == b.phase ∧ a.category < b.category)
+
+instance (a b : WarningKind) : Decidable (a < b) :=
+  inferInstanceAs (Decidable (a.phase < b.phase ∨ (a.phase == b.phase ∧ a.category < b.category)))
+
+namespace WarningKind
+
+-- Type translation warnings
+def emptyType : WarningKind := { phase := "pySpecToLaurel", category := "emptyType" }
+def unsupportedUnion : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedUnion" }
+def unknownType : WarningKind := { phase := "pySpecToLaurel", category := "unknownType" }
+def unsupportedGenericClass : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedGenericClass" }
+def bytesToString : WarningKind := { phase := "pySpecToLaurel", category := "bytesToString" }
+def complexToReal : WarningKind := { phase := "pySpecToLaurel", category := "complexToReal" }
+
+-- Unsupported Optional patterns
+def unsupportedOptionalFloat : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedOptionalFloat" }
+def unsupportedOptionalList : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedOptionalList" }
+def unsupportedOptionalDict : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedOptionalDict" }
+def unsupportedOptionalAny : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedOptionalAny" }
+def unsupportedOptionalBytes : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedOptionalBytes" }
+
+-- Internal type errors
+def typeError : WarningKind := { phase := "pySpecToLaurel", category := "typeError" }
+
+-- Precondition warnings
+def placeholderExpr : WarningKind := { phase := "pySpecToLaurel", category := "placeholderExpr" }
+def floatLiteral : WarningKind := { phase := "pySpecToLaurel", category := "floatLiteral" }
+def isinstanceUnsupported : WarningKind := { phase := "pySpecToLaurel", category := "isinstanceUnsupported" }
+def forallListUnsupported : WarningKind := { phase := "pySpecToLaurel", category := "forallListUnsupported" }
+def forallDictUnsupported : WarningKind := { phase := "pySpecToLaurel", category := "forallDictUnsupported" }
+
+-- Declaration warnings
+def missingMethodSelf : WarningKind := { phase := "pySpecToLaurel", category := "missingMethodSelf" }
+def kwargsExpansionError : WarningKind := { phase := "pySpecToLaurel", category := "kwargsExpansionError" }
+def postconditionUnsupported : WarningKind := { phase := "pySpecToLaurel", category := "postconditionUnsupported" }
+
+-- Overload dispatch warnings
+def overloadNoArgs : WarningKind := { phase := "pySpecToLaurel", category := "overloadNoArgs" }
+def overloadArgArity : WarningKind := { phase := "pySpecToLaurel", category := "overloadArgArity" }
+def overloadArgNotStringLiteral : WarningKind := { phase := "pySpecToLaurel", category := "overloadArgNotStringLiteral" }
+def overloadReturnArity : WarningKind := { phase := "pySpecToLaurel", category := "overloadReturnArity" }
+def overloadReturnNotClass : WarningKind := { phase := "pySpecToLaurel", category := "overloadReturnNotClass" }
+
+-- PySpec parsing phase (generic — callers don't yet distinguish categories)
+def pySpecParsingError : WarningKind := { phase := "pySpecParsing", category := "error" }
+def pySpecParsingWarning : WarningKind := { phase := "pySpecParsing", category := "warning" }
+
+end WarningKind
+
 /-- An error encountered while processing a PySpec file. -/
 structure SpecError where
   file : System.FilePath
   loc : SourceRange
+  kind : WarningKind
   message : String
 
 end Strata.Python.Specs

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -7,6 +7,7 @@ module
 
 public import Strata.Languages.Laurel.Laurel
 import Strata.Languages.Python.OverloadTable
+import Strata.Languages.Python.PythonLaurelTypedExpr
 public import Strata.Languages.Python.Specs.Decls
 public import Strata.Languages.Python.Specs.Error
 import Strata.Languages.Python.Specs.DDM
@@ -50,6 +51,7 @@ end Strata.Python
 namespace Strata.Python.Specs.ToLaurel
 
 open Strata.Laurel
+open Strata.Python.Laurel
 open Strata.Python.Specs (SpecError)
 
 /-! ## ToLaurelM Monad -/
@@ -76,9 +78,15 @@ structure ToLaurelState where
 abbrev ToLaurelM := ReaderT ToLaurelContext (StateM ToLaurelState)
 
 /-- Report an error during translation. -/
-def reportError (loc : SourceRange) (message : String) : ToLaurelM Unit := do
-  let e : SpecError := ⟨(←read).filepath, loc, message⟩
+def reportError (kind : WarningKind) (loc : SourceRange) (message : String) : ToLaurelM Unit := do
+  let e : SpecError := ⟨(←read).filepath, loc, kind, message⟩
   modify fun s => { s with errors := s.errors.push e }
+
+def runChecked (act : ToLaurelM α) : ToLaurelM (α × Bool) := do
+  let old := (←get).errors.size
+  let r ← act
+  let new := (←get).errors.size
+  pure (r, old = new)
 
 /-- Add a Laurel procedure to the output. -/
 def pushProcedure (proc : Procedure) : ToLaurelM Unit :=
@@ -225,14 +233,19 @@ def detectOptionalType (ty : SpecType) : ToLaurelM (Option HighTypeMd) := do
       else if nm == PythonIdent.builtinsBool then return some tyBoolOrNone
       -- TODO: add CorePrelude types for these Optional patterns
       else if nm == PythonIdent.builtinsFloat then
+        reportError .unsupportedOptionalFloat default s!"Optional[float] mapped to TString"
         return some unsupportedType
       else if nm == PythonIdent.typingList then
+        reportError .unsupportedOptionalList default s!"Optional[List] mapped to TString"
         return some unsupportedType
       else if nm == PythonIdent.typingDict then
+        reportError .unsupportedOptionalDict default s!"Optional[Dict] mapped to TString"
         return some unsupportedType
       else if nm == PythonIdent.typingAny then
+        reportError .unsupportedOptionalAny default s!"Optional[Any] mapped to TString"
         return some unsupportedType
       else if nm == PythonIdent.builtinsBytes then
+        reportError .unsupportedOptionalBytes default s!"Optional[bytes] mapped to TString"
         return some unsupportedType
       else return none
     | .typedDict _ _ _ => return some tyDictStrAny
@@ -267,7 +280,7 @@ private def knownIdentTypes : Std.HashMap PythonIdent HighTypeMd :=
 def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
   match ty.atoms.size with
   | 0 =>
-    reportError default "Empty type (no atoms) encountered in Laurel conversion"
+    reportError .emptyType default "Empty type (no atoms) encountered in Laurel conversion"
     return tyString
   | _ =>
     -- Check for union types
@@ -286,22 +299,25 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
       | some laurelType => return laurelType
       | none =>
         let unionStr := formatUnionType ty.atoms
-        reportError default s!"Union type ({unionStr}) not yet supported in Laurel"
+        reportError .unsupportedUnion default s!"Union type ({unionStr}) not yet supported in Laurel"
         return tyString
     else
       pure ()
     -- Single atom type
     match ty.atoms[0]! with
-    | .ident nm args =>
-      if let some ty := knownIdentTypes[nm]? then return ty
-      if args.size > 0 then
-        reportError default
-          s!"Generic type '{nm}' with type args unsupported"
-      reportError default s!"Unknown type '{nm}' mapped to TString"
+    | .ident nm _args =>
+      -- Warn for lossy known-type approximations
+      if nm == .builtinsBytes || nm == .builtinsBytearray then
+        reportError .bytesToString default s!"'{nm}' mapped to TString (bytes have different semantics)"
+      if nm == .builtinsComplex then
+        reportError .complexToReal default s!"'{nm}' mapped to TReal (complex loses imaginary component)"
+      if let some ty := knownIdentTypes[nm]? then
+        return ty
+      reportError .unknownType default s!"Unknown type '{nm}' mapped to TString"
       return tyString
     | .pyClass name args =>
       if args.size > 0 then
-        reportError default
+        reportError .unsupportedGenericClass default
           s!"Generic class '{name}' with type args unsupported"
       let prefixed ← prefixName name
       return mkTy (.UserDefined { text := prefixed, md := .empty })
@@ -310,10 +326,6 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
     | .typedDict _ _ _ => return tyDictStrAny
 
 /-! ## SpecExpr to Laurel Translation -/
-
-/-- Wrap a StmtExpr with metadata. -/
-private def mkStmt (e : StmtExpr) (md : Imperative.MetaData Core.Expression) : StmtExprMd :=
-  { val := e, source := none, md := md }
 
 /-- Create file-level metadata from the current pyspec filepath.
     Uses a default (zero) source range; callers with a specific location
@@ -341,133 +353,154 @@ private def mkStmtWithLoc (e : StmtExpr) (loc : SourceRange) (msg : String := ""
   let md ← mkMdWithFileRange loc msg
   return { val := e, source := some fr, md := md }
 
-/-- Translate a SpecExpr to a Laurel StmtExpr.
-    All values are assumed to be Any-typed (the Python prelude's universal type).
-    Returns `none` for unsupported expressions (placeholders).
+/--
+Context for resolving identifiers.
+-/
+structure SpecExprContext where
+  procName : String
+  argTypes : Std.HashMap String HighType
+
+abbrev ToLaurelExprM := ReaderT SpecExprContext ToLaurelM
+
+private def asAny (loc : SourceRange) (act : ToLaurelExprM SomeTypedStmtExpr) : ToLaurelExprM (TypedStmtExpr Laurel.tyAny) := do
+  let ctx ← read
+  let (se, success) ← runChecked <| act ctx
+  if !success then
+    return ⟨se.2.stmt⟩
+  match se with
+  | ⟨.UserDefined "Any", e⟩ => pure e
+  | ⟨tp, e⟩ =>
+    let pn := (← read).procName
+    reportError .typeError loc s!"Expected Any-typed expression but got {repr tp} in '{pn}'"
+    pure ⟨e.stmt⟩
+
+private def asBool (loc : SourceRange) (act : ToLaurelExprM SomeTypedStmtExpr) : ToLaurelExprM (TypedStmtExpr .TBool) := do
+  let ctx ← read
+  let (se, success) ← runChecked <| act ctx
+  if !success then
+    return ⟨se.2.stmt⟩
+  match se with
+  | ⟨.TBool, e⟩ => pure e
+  | ⟨tp, e⟩ =>
+    let pn := (← read).procName
+    reportError .typeError loc s!"Expected Bool-typed expression but got {repr tp} in '{pn}'"
+    pure ⟨e.stmt⟩
+
+/-- Look up an identifier's type from the SpecExprContext and create a typed identifier.
+    Reports a typeError if the name is not found in argTypes. -/
+private def lookupIdentifier (name : String) (loc : SourceRange) (md : Md)
+    : ToLaurelExprM SomeTypedStmtExpr := do
+  match (← read).argTypes[name]? with
+  | some tp => return .mkSome <| .identifier name tp md
+  | none =>
+    let pn := (← read).procName
+    reportError .typeError loc s!"Unknown identifier '{name}' in '{pn}'"
+    return default
+
+/-- Translate a SpecExpr to a typed Laurel expression (`SomeTypedStmtExpr`).
+    Returns `default` (a `Hole`) for unsupported expressions; callers use
+    `runChecked` to detect whether errors were reported during translation.
     Uses Core prelude function names (Any_len, DictStrAny_contains, etc.)
     which are resolved after the Core prelude is prepended. -/
-def specExprToLaurel (e : SpecExpr) (md : Imperative.MetaData Core.Expression)
-  : ToLaurelM (Option StmtExprMd) :=
+def specExprToLaurel (e : SpecExpr) (md : Md)
+  : ToLaurelExprM SomeTypedStmtExpr :=
   -- Use per-node source range when available, falling back to the
   -- nearest ancestor's md for nodes with default (empty) locations.
   -- This is intentional: the parent's location is a closer approximation
   -- than the function-level metadata for nodes without their own location.
-  let nodeMd (loc : SourceRange) : ToLaurelM (Imperative.MetaData Core.Expression) := do
-    if loc == default then pure md
+  let nodeMd (loc : SourceRange) : ToLaurelM Md := do
+    if loc == default then
+      pure md
     else do
-      let ctx ← read
-      let fr : FileRange := { file := .file ctx.filepath.toString, range := loc }
+      let fr : FileRange := { file := .file (← read).filepath.toString, range := loc }
       pure #[⟨Imperative.MetaData.fileRange, .fileRange fr⟩]
   match e with
   | .placeholder loc => do
-    reportError loc "Placeholder expression not translatable"
-    return none
+    reportError .placeholderExpr loc "Placeholder expression not translatable"
+    return default
   | .var name loc => do
     let md ← nodeMd loc
-    return some (mkStmt (.Identifier (mkId name)) md)
+    lookupIdentifier name loc md
   | .intLit v loc => do
     let md ← nodeMd loc
-    return some (mkStmt (.StaticCall (mkId "from_int")
-      [mkStmt (.LiteralInt v) md]) md)
+    return .mkSome <| .fromInt (.literalInt v md)
   | .floatLit _ loc => do
-    reportError loc "Float literals not yet supported in preconditions"
-    return none
+    reportError .floatLiteral loc "Float literals not yet supported in preconditions"
+    return default
   | .getIndex subject field loc =>
     match subject with
     | .var "kwargs" .. => do
       let md ← nodeMd loc
-      return some (mkStmt (.Identifier (mkId field)) md)
+      lookupIdentifier field loc md
     | _ => do
       let md ← nodeMd loc
-      let s? ← specExprToLaurel subject md
-      return s?.map fun s =>
-        mkStmt (.StaticCall (mkId "Any_get")
-          [s, mkStmt (.StaticCall (mkId "from_str")
-            [mkStmt (.LiteralString field) md]) md]) md
+      let s ← asAny loc <| specExprToLaurel subject md
+      let from_str := .fromStr (.literalString field md) md
+      return .mkSome <| .anyGet s from_str md
   | .isInstanceOf _ typeName loc => do
-    reportError loc s!"isinstance check for '{typeName}' not yet supported in preconditions"
-    return none
+    reportError .isinstanceUnsupported loc s!"isinstance check for '{typeName}' not yet supported in preconditions"
+    return default
   | .len subject loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md
-    return s?.map fun s =>
-      let unwrapped := mkStmt (.StaticCall (mkId "Any..as_string!") [s]) md
-      mkStmt (.StaticCall (mkId "from_int")
-        [mkStmt (.StaticCall (mkId "Str.Length") [unwrapped]) md]) md
+    let s ← asAny loc <| specExprToLaurel subject md
+    return .mkSome <| .fromInt (.strLength (.anyAsString s md))
   | .intGe subject bound loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md; let b? ← specExprToLaurel bound md
-    return do
-      let s ← s?; let b ← b?
-      some (mkStmt (.PrimitiveOp .Geq
-        [mkStmt (.StaticCall (mkId "Any..as_int!") [s]) md,
-         mkStmt (.StaticCall (mkId "Any..as_int!") [b]) md]) md)
+    let s ← asAny loc <| specExprToLaurel subject md
+    let b ← asAny loc <| specExprToLaurel bound md
+    return .mkSome <| .intGeq (.anyAsInt s md) (.anyAsInt b md)
   | .intLe subject bound loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md; let b? ← specExprToLaurel bound md
-    return do
-      let s ← s?; let b ← b?
-      some (mkStmt (.PrimitiveOp .Leq
-        [mkStmt (.StaticCall (mkId "Any..as_int!") [s]) md,
-         mkStmt (.StaticCall (mkId "Any..as_int!") [b]) md]) md)
+    let s ← asAny loc <| specExprToLaurel subject md
+    let b ← asAny loc <| specExprToLaurel bound md
+    return .mkSome <| .intLeq (.anyAsInt s md) (.anyAsInt b md)
   | .floatGe subject bound loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md; let b? ← specExprToLaurel bound md
-    return do
-      let s ← s?; let b ← b?
-      let sF := mkStmt (.StaticCall (mkId "Any..as_float!") [s]) md
-      let bF := mkStmt (.StaticCall (mkId "Any..as_float!") [b]) md
-      some (mkStmt (.PrimitiveOp .Geq [sF, bF]) md)
+    let s ← asAny loc <| specExprToLaurel subject md
+    let b ← asAny loc <| specExprToLaurel bound md
+    return .mkSome <| .realGeq (.anyAsFloat s md) (.anyAsFloat b md)
   | .floatLe subject bound loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md; let b? ← specExprToLaurel bound md
-    return do
-      let s ← s?; let b ← b?
-      let sF := mkStmt (.StaticCall (mkId "Any..as_float!") [s]) md
-      let bF := mkStmt (.StaticCall (mkId "Any..as_float!") [b]) md
-      some (mkStmt (.PrimitiveOp .Leq [sF, bF]) md)
+    let s ← asAny loc <| specExprToLaurel subject md
+    let b ← asAny loc <| specExprToLaurel bound md
+    return .mkSome <| .realLeq (.anyAsFloat s md) (.anyAsFloat b md)
   | .not inner loc => do
     let md ← nodeMd loc
-    let i? ← specExprToLaurel inner md
-    return i?.map fun i => mkStmt (.PrimitiveOp .Not [i]) md
+    let i ← asBool loc <| specExprToLaurel inner md
+    return .mkSome <| .not i md
   | .implies cond body loc => do
     let md ← nodeMd loc
-    let c? ← specExprToLaurel cond md; let b? ← specExprToLaurel body md
-    return do let c ← c?; let b ← b?; some (mkStmt (.PrimitiveOp .Implies [c, b]) md)
+    let c ← asBool loc <| specExprToLaurel cond md
+    let b ← asBool loc <| specExprToLaurel body md
+    return .mkSome <| .implies c b md
   | .enumMember subject values loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md
-    return s?.map fun s =>
-      let sStr := mkStmt (.StaticCall (mkId "Any..as_string!") [s]) md
-      let eqs := values.toList.map fun v =>
-        mkStmt (.PrimitiveOp .Eq [sStr, mkStmt (.LiteralString v) md]) md
-      eqs.foldl (init := mkStmt (.LiteralBool false) md) fun acc eq =>
-        mkStmt (.PrimitiveOp .Or [acc, eq]) md
+    let s ← asAny loc <| specExprToLaurel subject md
+    let sStr := s.anyAsString md
+    return .mkSome <|
+      values.foldl (init := .literalBool false md) fun acc v =>
+        .or acc (.stringEq sStr (.literalString v md))
   | .containsKey container key loc => do
     let md ← nodeMd loc
     match container with
     | .var "kwargs" .. =>
-      return some (mkStmt (.PrimitiveOp .Not
-        [mkStmt (.StaticCall (mkId "Any..isfrom_None") [mkStmt (.Identifier (mkId key)) md]) md])
-        md)
+      -- FIXME: Check this.  We may want to move this up
+      let keyAny ← asAny loc <| lookupIdentifier key loc md
+      return .mkSome <| .not (.anyIsfromNone keyAny)
     | _ =>
-      let c? ← specExprToLaurel container md
-      return c?.map fun c =>
-        let unwrapped := mkStmt (.StaticCall (mkId "Any..as_Dict!") [c]) md
-        mkStmt (.StaticCall (mkId "DictStrAny_contains")
-          [unwrapped, mkStmt (.LiteralString key) md]) md
+      let c ← asAny loc <| specExprToLaurel container md
+      return .mkSome <| .dictStrAnyContains (c.anyAsDict md) (.literalString key md) md
   | .regexMatch subject pattern loc => do
     let md ← nodeMd loc
-    let s? ← specExprToLaurel subject md
-    return s?.map fun s =>
-      let sStr := mkStmt (.StaticCall (mkId "Any..as_string!") [s]) md
-      mkStmt (.StaticCall (mkId "re_search_bool") [mkStmt (.LiteralString pattern) md, sStr]) md
+    let s ← asAny loc <| specExprToLaurel subject md
+    let sStr := .anyAsString s md
+    return .mkSome <| .reSearchBool (.literalString pattern md) sStr md
   | .forallList _ _ _ loc => do
-    reportError loc "forallList quantifier not yet supported in preconditions"
-    return none
+    reportError .forallListUnsupported loc "forallList quantifier not yet supported in preconditions"
+    return default
   | .forallDict _ _ _ _ loc => do
-    reportError loc "forallDict quantifier not yet supported in preconditions"
-    return none
+    reportError .forallDictUnsupported loc "forallDict quantifier not yet supported in preconditions"
+    return default
 
 private def formatAssertionMessage (msg : Array MessagePart) : String :=
   let parts := msg.map fun
@@ -492,35 +525,38 @@ def SpecAssertMsg.render : SpecAssertMsg → String
     Outputs are already initialized non-deterministically. -/
 def buildSpecBody (preconditions : Array Assertion)
     (md : Imperative.MetaData Core.Expression)
+    (ctx : SpecExprContext)
     (requiredParams : Array String := #[])
     : ToLaurelM Body := do
   let fileMd ← mkFileMd
-  let mut stmts : List StmtExprMd := []
+  let mut stmts : Array StmtExprMd := #[]
   let mut idx := 0
   -- Assert that required parameters are provided (not None)
   for param in requiredParams do
-    let cond := mkStmt (.PrimitiveOp .Not
-      [mkStmt (.StaticCall (mkId "Any..isfrom_None")
-        [mkStmt (.Identifier (mkId param)) md]) md]) md
+    let cond : TypedStmtExpr _ := .not (.anyIsfromNone (.identifier param Laurel.tyAny md))
     let msg := SpecAssertMsg.requiredParam param |>.render
-    let assertStmt ← mkStmtWithLoc (.Assert cond) default msg
-    stmts := assertStmt :: stmts
+    let assertStmt ← mkStmtWithLoc (.Assert cond.stmt) default msg
+    stmts := stmts.push assertStmt
     idx := idx + 1
   for assertion in preconditions do
     let formattedMsg := formatAssertionMessage assertion.message
     let msg := if formattedMsg.isEmpty
       then SpecAssertMsg.unnamed idx |>.render
       else SpecAssertMsg.userAssertion formattedMsg |>.render
-    match ← specExprToLaurel assertion.formula md with
-    | some condExpr =>
-      let assertStmt ← mkStmtWithLoc (.Assert condExpr) default msg
-      stmts := assertStmt :: stmts
-    | none =>
-      reportError default s!"Untranslatable precondition (emitting nondeterministic assert): {msg}"
-      let assertStmt ← mkStmtWithLoc (.Assert (mkStmt .Hole md)) default msg
-      stmts := assertStmt :: stmts
+    let (⟨condType, condExpr⟩, success) ← runChecked <| specExprToLaurel assertion.formula md ctx
+    if success then
+      if let .TBool := condType then
+        let assertStmt ← mkStmtWithLoc (.Assert condExpr.stmt) default msg
+        stmts := stmts.push assertStmt
+      else
+        reportError .typeError default
+          s!"Precondition expression is not Bool in '{ctx.procName}' (skipping): {msg}"
     idx := idx + 1
-  let body := mkStmt (.Block stmts.reverse none) fileMd
+  let body := {
+      val := .Block stmts.toList none,
+      source := none,
+      md := fileMd
+  }
   return .Transparent body
 
 /-! ## Declaration Translation -/
@@ -550,13 +586,13 @@ public def expandKwargsArgs (kwargs : Option (String × SpecType))
 def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     (isMethod : Bool := false) : ToLaurelM Procedure := do
   if isMethod && func.args.args.size == 0 then
-    reportError default
+    reportError .missingMethodSelf default
       s!"Method '{func.name}' has no arguments (expected 'self' as first parameter)"
   let posArgs := if isMethod then func.args.args.extract 1 func.args.args.size
                  else func.args.args
   let kwargsArgs ← match expandKwargsArgs func.args.kwargs with
     | .ok args => pure args
-    | .error msg => do reportError default msg; pure #[]
+    | .error msg => do reportError .kwargsExpansionError default msg; pure #[]
   let allArgs := posArgs ++ func.args.kwonly ++ kwargsArgs
   let inputs ← allArgs.mapM argToParameter
   let retType ← specTypeToLaurelType func.returnType
@@ -565,7 +601,7 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
       | .TVoid => tyAny
       | _ => retType }]
   if func.postconditions.size > 0 then
-    reportError func.loc "Postconditions not yet supported"
+    reportError .postconditionUnsupported func.loc "Postconditions not yet supported"
   -- When preconditions exist, use TCore "Any" for all parameters and outputs
   -- to match the Python→Laurel pipeline's Any-wrapping convention.
   let (inputs, outputs, body) ←
@@ -573,7 +609,10 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
       let anyTy : HighTypeMd := tyAny
       let anyInputs := inputs.map fun p => { p with type := anyTy }
       let anyOutputs := outputs.map fun p => { p with type := anyTy }
-      let body ← buildSpecBody func.preconditions .empty
+      let argTypes := allArgs.foldl (init := {}) fun m a =>
+        m.insert a.name Laurel.tyAny
+      let specCtx : SpecExprContext := { procName, argTypes }
+      let body ← buildSpecBody func.preconditions .empty specCtx
         (requiredParams := allArgs.filterMap fun a =>
           if a.default.isNone then some a.name else none)
       pure (anyInputs, anyOutputs, body)
@@ -638,12 +677,12 @@ def typeDefToLaurel (td : TypeDef) : ToLaurelM Unit := do
 def extractOverloadEntry (func : FunctionDecl) : ToLaurelM Unit := do
   let args := func.args.args
   let .isTrue _ := decideProp (args.size > 0)
-    | reportError func.loc
+    | reportError .overloadNoArgs func.loc
         s!"Overloaded function '{func.name}' has no arguments"
       return
   let firstArgType := args[0].type
   let .isTrue _ := decideProp (firstArgType.atoms.size = 1)
-    | reportError func.loc
+    | reportError .overloadArgArity func.loc
         s!"Overloaded function '{func.name}': first argument \
           has {firstArgType.atoms.size} type atoms, expected 1"
       return
@@ -651,14 +690,14 @@ def extractOverloadEntry (func : FunctionDecl) : ToLaurelM Unit := do
         match firstArgType.atoms[0] with
         | .stringLiteral v => pure v
         | _ =>
-          reportError func.loc
+          reportError .overloadArgNotStringLiteral func.loc
             s!"Overloaded function '{func.name}': first argument \
               type '{specTypeToString firstArgType}' is not a \
               string literal (only string literal dispatch is \
               currently supported)"
           return
   let .isTrue _ := decideProp (func.returnType.atoms.size = 1)
-    | reportError func.loc
+    | reportError .overloadReturnArity func.loc
         s!"Overloaded function '{func.name}': return type \
         has {func.returnType.atoms.size} type atoms, expected 1"
       return
@@ -670,7 +709,7 @@ def extractOverloadEntry (func : FunctionDecl) : ToLaurelM Unit := do
           pure (PythonIdent.mk ctx.modulePrefix prefixed)
         | .ident nm _ => pure nm
         | _ =>
-          reportError func.loc
+          reportError .overloadReturnNotClass func.loc
             s!"Overloaded function '{func.name}': return type \
               '{specTypeToString func.returnType}' is not a \
               class type"

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -518,7 +518,10 @@ def pyAnalyzeLaurelCommand : Command where
               takesArg := .arg "dir" },
             { name := "entry-point",
               help := "Which procedures to verify: main (main fn only), roots (user procs with no user callers, default), or all (all user procs). Only valid in bugFinding mode.",
-              takesArg := .arg "mode" }]
+              takesArg := .arg "mode" },
+            { name := "warning-summary",
+              help := "Write PySpec warning summary as JSON to <file>.",
+              takesArg := .arg "file" }]
   help := "Verify a Python Ion program via the Laurel pipeline. Translates Python to Laurel to Core, then runs SMT verification."
   callback := fun v pflags => do
     let verbose := pflags.getBool "verbose"
@@ -542,10 +545,12 @@ def pyAnalyzeLaurelCommand : Command where
     let mfm : Option (String × Lean.FileMap) := match pySourceOpt with
       | some (pyPath, srcText) => some (pyPath, .ofString srcText)
       | none => none
+    let warningSummaryFile := pflags.getString "warning-summary"
     let combinedLaurel ←
       match ← Strata.pythonAndSpecToLaurel filePath dispatchModules pyspecModules sourcePath
                 (specDir := specDir) (profile := profile)
-                (quiet := quiet) |>.toBaseIO with
+                (quiet := quiet)
+                (warningSummaryFile := warningSummaryFile) |>.toBaseIO with
       | .ok r => pure r
       | .error (.userCode range msg) =>
         let location := if range.isNone then "" else
@@ -554,8 +559,6 @@ def pyAnalyzeLaurelCommand : Command where
             let pos := fm.toPosition range.start
             s!" at line {pos.line}, col {pos.column}"
           | none => ""
-        -- Emit structured set-info metadata before DETAIL/RESULT lines.
-        -- Also write the set-info metadata to user_errors.txt.
         let filePath' := sourcePath.getD filePath
         let mut lines := #[
           s!"(set-info :file {Strata.escapeSMTStringLit filePath'})"
@@ -856,7 +859,7 @@ def pyResolveOverloadsCommand : Command where
     -- Read dispatch overload table
     let overloads ←
       match ← readDispatchOverloads #[dispatchPath] |>.toBaseIO with
-      | .ok r => pure r
+      | .ok (r, _) => pure r
       | .error msg => exitFailure msg
     -- Convert .py to Python AST
     let stmts ←

--- a/StrataTest/Languages/Python/Specs/IdentifyOverloadsTest.lean
+++ b/StrataTest/Languages/Python/Specs/IdentifyOverloadsTest.lean
@@ -76,7 +76,7 @@ private meta def buildOverloadTable
     let some ionPath := pySpecOutputPath testDir outDir pyFile
       | throw <| .userError s!"Cannot derive output path for {pyFile}"
     match ← readDispatchOverloads #[ionPath.toString] |>.toBaseIO with
-    | .ok tbl => return tbl
+    | .ok (tbl, _) => return tbl
     | .error msg =>
       throw <| .userError s!"readDispatchOverloads failed: {msg}"
 

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -14,6 +14,10 @@ open Strata.Laurel
 
 /-! ## Test Infrastructure -/
 
+private def assertEq [BEq α] [ToString α] (actual expected : α) : IO Unit := do
+  unless actual == expected do
+    throw <| .userError s!"expected: {expected}\n  actual: {actual}"
+
 private def loc : SourceRange := default
 
 private def mkType (atom : SpecAtomType) : SpecType :=
@@ -95,6 +99,35 @@ private def runTestErrors (sigs : Array Signature) (modulePrefix : String := "")
   for err in result.errors do
     IO.println err.message
 
+/-- Run signaturesToLaurel and print warning kinds (phase.category: message). -/
+private def runTestWarningKinds (sigs : Array Signature) (modulePrefix : String := "") : IO Unit := do
+  let result := signaturesToLaurel "<test>" sigs modulePrefix
+  assert! result.errors.size > 0
+  for err in result.errors do
+    IO.println s!"{err.kind.phase}.{err.kind.category}: {err.message}"
+
+/-- Helper to make a function signature with preconditions. -/
+private def mkFuncSigWithPrecond (name : String) (returnType : SpecType)
+    (preconditions : Array Assertion) (args : Array Arg := #[]) : Signature :=
+  .functionDecl {
+    loc := loc, nameLoc := loc, name := name
+    args := { args := args, kwonly := #[] }
+    returnType := returnType
+    isOverload := false
+    preconditions := preconditions, postconditions := #[]
+  }
+
+/-- Helper to make a function signature with postconditions. -/
+private def mkFuncSigWithPostcond (name : String) (returnType : SpecType)
+    (postconditions : Array SpecExpr) : Signature :=
+  .functionDecl {
+    loc := loc, nameLoc := loc, name := name
+    args := { args := #[], kwonly := #[] }
+    returnType := returnType
+    isOverload := false
+    preconditions := #[], postconditions := postconditions
+  }
+
 private def noneAtom := SpecAtomType.noneType
 
 /-! ## Primitive and builtin types as args and return types -/
@@ -125,7 +158,6 @@ procedure with_kwonly(x:TInt, verbose:TBool) returns(result:TString)
 info: procedure takes_any(x:UserDefined(Any)) returns(result:TInt)
 procedure takes_list(items:UserDefined(ListStr)) returns(result:TBool)
 procedure returns_dict() returns(result:UserDefined(DictStrAny))
-procedure returns_bytes() returns(result:TString)
 procedure typed_list() returns(result:UserDefined(ListStr))
 procedure typed_dict() returns(result:UserDefined(DictStrAny))
 -/
@@ -136,7 +168,6 @@ procedure typed_dict() returns(result:UserDefined(DictStrAny))
   mkFuncSig "takes_list" (identType .builtinsBool)
     (args := #[mkArg "items" (identType .typingList)]),
   mkFuncSig "returns_dict" (identType .typingDict),
-  mkFuncSig "returns_bytes" (identType .builtinsBytes),
   mkFuncSig "typed_list"
     (mkType (.ident .typingList #[identType .builtinsStr])),
   mkFuncSig "typed_dict"
@@ -171,11 +202,6 @@ procedure str_enum() returns(result:TString)
 info: procedure opt_str() returns(result:UserDefined(StrOrNone))
 procedure opt_int() returns(result:UserDefined(IntOrNone))
 procedure opt_bool(x:UserDefined(StrOrNone)) returns(result:UserDefined(BoolOrNone))
-procedure opt_float() returns(result:TString)
-procedure opt_list() returns(result:TString)
-procedure opt_dict() returns(result:TString)
-procedure opt_any() returns(result:TString)
-procedure opt_bytes() returns(result:TString)
 procedure opt_typed_dict() returns(result:UserDefined(DictStrAny))
 procedure opt_str_enum() returns(result:UserDefined(StrOrNone))
 procedure opt_int_enum() returns(result:UserDefined(IntOrNone))
@@ -190,16 +216,6 @@ procedure opt_int_enum() returns(result:UserDefined(IntOrNone))
     (mkUnion #[noneAtom, identAtom .builtinsBool])
     (args := #[mkArg "x"
       (mkUnion #[noneAtom, identAtom .builtinsStr])]),
-  mkFuncSig "opt_float"
-    (mkUnion #[noneAtom, identAtom .builtinsFloat]),
-  mkFuncSig "opt_list"
-    (mkUnion #[noneAtom, identAtom .typingList]),
-  mkFuncSig "opt_dict"
-    (mkUnion #[noneAtom, identAtom .typingDict]),
-  mkFuncSig "opt_any"
-    (mkUnion #[noneAtom, identAtom .typingAny]),
-  mkFuncSig "opt_bytes"
-    (mkUnion #[noneAtom, identAtom .builtinsBytes]),
   mkFuncSig "opt_typed_dict"
     (mkUnion #[noneAtom,
       .typedDict #["x"] #[identType .builtinsStr] #[true]]),
@@ -210,37 +226,37 @@ procedure opt_int_enum() returns(result:UserDefined(IntOrNone))
     (mkUnion #[noneAtom, .intLiteral 1, .intLiteral 2])
 ]
 
-/-! ## Error cases -/
+/-! ## Error cases (updated to verify WarningKind) -/
 
 /--
-info: Unknown type 'foo.Bar' mapped to TString
+info: pySpecToLaurel.unknownType: Unknown type 'foo.Bar' mapped to TString
 -/
 #guard_msgs in
-#eval runTestErrors
+#eval runTestWarningKinds
   #[mkFuncSig "f"
     (identType (PythonIdent.mk "foo" "Bar"))]
 
 /--
-info: Empty type (no atoms) encountered in Laurel conversion
+info: pySpecToLaurel.emptyType: Empty type (no atoms) encountered in Laurel conversion
 -/
 #guard_msgs in
-#eval runTestErrors
+#eval runTestWarningKinds
   #[mkFuncSig "f" { atoms := #[], loc := default }]
 
 /--
-info: Union type (builtins.str | builtins.int) not yet supported in Laurel
+info: pySpecToLaurel.unsupportedUnion: Union type (builtins.str | builtins.int) not yet supported in Laurel
 -/
 #guard_msgs in
-#eval runTestErrors
+#eval runTestWarningKinds
   #[mkFuncSig "f"
     (mkUnion #[identAtom .builtinsStr,
                identAtom .builtinsInt])]
 
 /--
-info: Union type (None | foo.Bar) not yet supported in Laurel
+info: pySpecToLaurel.unsupportedUnion: Union type (None | foo.Bar) not yet supported in Laurel
 -/
 #guard_msgs in
-#eval runTestErrors
+#eval runTestWarningKinds
   #[mkFuncSig "f"
     (mkUnion #[noneAtom,
       identAtom (PythonIdent.mk "foo" "Bar")])]
@@ -483,5 +499,318 @@ body contains FieldSelect: false
     IO.println s!"body contains Any_get: {bodyStr.contains "Any_get"}"
     IO.println s!"body contains FieldSelect: {bodyStr.contains "#"}"
   | [] => IO.println "no procedures"
+
+/-! ## Warning kind tests -/
+
+-- Type translation: unsupportedGenericClass
+/--
+info: pySpecToLaurel.unsupportedGenericClass: Generic class 'Foo' with type args unsupported
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (mkType (.pyClass "Foo" #[identType .builtinsInt]))]
+
+-- Type translation: bytesToString
+/--
+info: pySpecToLaurel.bytesToString: 'builtins.bytes' mapped to TString (bytes have different semantics)
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (identType .builtinsBytes)]
+
+-- Type translation: bytesToString (bytearray variant)
+/--
+info: pySpecToLaurel.bytesToString: 'builtins.bytearray' mapped to TString (bytes have different semantics)
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (identType .builtinsBytearray)]
+
+-- Type translation: complexToReal
+/--
+info: pySpecToLaurel.complexToReal: 'builtins.complex' mapped to TReal (complex loses imaginary component)
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (identType .builtinsComplex)]
+
+-- Unsupported Optional patterns
+/--
+info: pySpecToLaurel.unsupportedOptionalFloat: Optional[float] mapped to TString
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (mkUnion #[noneAtom, identAtom .builtinsFloat])]
+
+/--
+info: pySpecToLaurel.unsupportedOptionalList: Optional[List] mapped to TString
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (mkUnion #[noneAtom, identAtom .typingList])]
+
+/--
+info: pySpecToLaurel.unsupportedOptionalDict: Optional[Dict] mapped to TString
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (mkUnion #[noneAtom, identAtom .typingDict])]
+
+/--
+info: pySpecToLaurel.unsupportedOptionalAny: Optional[Any] mapped to TString
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (mkUnion #[noneAtom, identAtom .typingAny])]
+
+/--
+info: pySpecToLaurel.unsupportedOptionalBytes: Optional[bytes] mapped to TString
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSig "f" (mkUnion #[noneAtom, identAtom .builtinsBytes])]
+
+-- Precondition: placeholderExpr
+/--
+info: pySpecToLaurel.placeholderExpr: Placeholder expression not translatable
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSigWithPrecond "f" (identType .builtinsStr)
+    #[{ message := #[], formula := .placeholder loc }]]
+
+-- Precondition: floatLiteral
+/--
+info: pySpecToLaurel.floatLiteral: Float literals not yet supported in preconditions
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSigWithPrecond "f" (identType .builtinsStr)
+    #[{ message := #[], formula := .floatLit "3.14" loc }]]
+
+-- Precondition: isinstanceUnsupported
+/--
+info: pySpecToLaurel.isinstanceUnsupported: isinstance check for 'MyType' not yet supported in preconditions
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSigWithPrecond "f" (identType .builtinsStr)
+    #[{ message := #[], formula := .isInstanceOf (.var "x" loc) "MyType" loc }]]
+
+-- Precondition: forallListUnsupported
+/--
+info: pySpecToLaurel.forallListUnsupported: forallList quantifier not yet supported in preconditions
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSigWithPrecond "f" (identType .builtinsStr)
+    #[{ message := #[], formula := .forallList (.var "xs" loc) "x" (.var "x" loc) loc }]]
+
+-- Precondition: forallDictUnsupported
+/--
+info: pySpecToLaurel.forallDictUnsupported: forallDict quantifier not yet supported in preconditions
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSigWithPrecond "f" (identType .builtinsStr)
+    #[{ message := #[], formula := .forallDict (.var "d" loc) "k" "v" (.var "k" loc) loc }]]
+
+-- Declaration: missingMethodSelf
+/--
+info: pySpecToLaurel.missingMethodSelf: Method 'bad_method' has no arguments (expected 'self' as first parameter)
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[.classDef {
+    loc := loc, name := "C"
+    methods := #[
+      { loc := loc, nameLoc := loc, name := "bad_method"
+        args := { args := #[], kwonly := #[] }
+        returnType := identType .builtinsStr
+        isOverload := false
+        preconditions := #[], postconditions := #[] }
+    ]
+  }]
+
+-- Declaration: kwargsExpansionError
+/--
+info: pySpecToLaurel.kwargsExpansionError: **kw has non-TypedDict type; kwargs not expanded
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[.functionDecl {
+    loc := loc, nameLoc := loc, name := "f"
+    args := { args := #[], kwonly := #[],
+              kwargs := some ("kw", identType .builtinsStr) }
+    returnType := identType .builtinsStr
+    isOverload := false
+    preconditions := #[], postconditions := #[]
+  }]
+
+-- Declaration: postconditionUnsupported
+/--
+info: pySpecToLaurel.postconditionUnsupported: Postconditions not yet supported
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkFuncSigWithPostcond "f" (identType .builtinsStr)
+    #[.intGe (.var "result" loc) (.intLit 0 loc) loc]]
+
+-- Overload: overloadNoArgs
+/--
+info: pySpecToLaurel.overloadNoArgs: Overloaded function 'bad' has no arguments
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkOverload "bad" (identType .builtinsStr)]
+
+-- Overload: overloadArgArity
+/--
+info: pySpecToLaurel.overloadArgArity: Overloaded function 'bad': first argument has 2 type atoms, expected 1
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkOverload "bad" (identType .builtinsStr)
+    (args := #[mkArg "x" (mkUnion #[.stringLiteral "a", .stringLiteral "b"])])]
+
+-- Overload: overloadArgNotStringLiteral
+/--
+info: pySpecToLaurel.overloadArgNotStringLiteral: Overloaded function 'bad': first argument type 'builtins.str' is not a string literal (only string literal dispatch is currently supported)
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkOverload "bad" (identType .builtinsStr)
+    (args := #[mkArg "x" (identType .builtinsStr)])]
+
+-- Overload: overloadReturnArity
+/--
+info: pySpecToLaurel.overloadReturnArity: Overloaded function 'bad': return type has 2 type atoms, expected 1
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkOverload "bad"
+    (mkUnion #[identAtom .builtinsStr, identAtom .builtinsInt])
+    (args := #[mkArg "x" (mkType (.stringLiteral "a"))])]
+
+-- Overload: overloadReturnNotClass
+/--
+info: pySpecToLaurel.overloadReturnNotClass: Overloaded function 'bad': return type 'Literal["hello"]' is not a class type
+-/
+#guard_msgs in
+#eval runTestWarningKinds
+  #[mkOverload "bad"
+    (mkType (.stringLiteral "hello"))
+    (args := #[mkArg "x" (mkType (.stringLiteral "a"))])]
+
+/-! ## Precondition integration tests
+
+End-to-end tests that precondition formulas translate to the expected Laurel
+operations.  Each test runs `signaturesToLaurel` with a precondition and
+checks that the formatted procedure body contains the correct operation
+names (concrete Laurel syntax).  These catch bugs where `TypedStmtExpr`
+wrappers emit wrong operations or wrong return types that cause assertions
+to be silently dropped. -/
+
+/-- Extract formatted body text from the first procedure in a translation result.
+    Returns `none` if there are no procedures or the body is opaque/empty. -/
+private def getBody (result : TranslationResult) : Option String :=
+  match result.program.staticProcedures with
+  | proc :: _ => match proc.body with
+    | .Transparent body => some (toString (Strata.Laurel.formatStmtExpr body))
+    | .Opaque _ (some body) _ => some (toString (Strata.Laurel.formatStmtExpr body))
+    | _ => none
+  | [] => none
+
+/-- Translate a single function with preconditions. -/
+private def translatePrecondResult (preconditions : Array Assertion)
+    (args : Array Arg := #[]) : TranslationResult :=
+  let strTy := identType .builtinsStr
+  signaturesToLaurel "<test>" #[
+    .functionDecl {
+      loc := loc, nameLoc := loc, name := "f"
+      args := { args := args, kwonly := #[] }
+      returnType := strTy, isOverload := false
+      preconditions, postconditions := #[]
+    }] ""
+
+/-- Translate a single function with preconditions and return
+    `(bodyString, errorCount)`. -/
+private def translatePrecond (preconditions : Array Assertion)
+    (args : Array Arg := #[]) : String × Nat :=
+  let result := translatePrecondResult preconditions args
+  (getBody result |>.getD "", result.errors.size)
+
+-- enumMember: or and eq via `|` and `==` infix syntax
+#eval do
+  let (body, errs) := translatePrecond
+    #[{ message := #[], formula :=
+          .enumMember (.var "x" loc) #["a", "b"] loc }]
+    (args := #[mkArg "x" (identType .builtinsStr)])
+  assert! errs == 0
+  -- `or` renders as `|`, `eq` as `==`; would have been `<=` before fix #1
+  assert! body.contains " | "
+  assert! body.contains "=="
+  assert! !body.contains "<="
+
+-- implies: `==>` infix syntax
+#eval do
+  let (body, errs) := translatePrecond
+    #[{ message := #[], formula :=
+          .implies
+            (.intGe (.var "x" loc) (.intLit 0 loc) loc)
+            (.intGe (.var "y" loc) (.intLit 0 loc) loc)
+            loc }]
+    (args := #[mkArg "x" (identType .builtinsStr),
+               mkArg "y" (identType .builtinsStr)])
+  assert! errs == 0
+  -- `implies` renders as `==>`; would have been `<=` before fix #1
+  assert! body.contains "==>"
+
+-- not via containsKey on kwargs: `!` prefix syntax
+#eval do
+  let strTy := identType .builtinsStr
+  let kwargsTy := SpecType.ofAtom loc
+    (.typedDict #["key"] #[strTy] #[false])
+  let result := signaturesToLaurel "<test>" #[
+    .functionDecl {
+      loc := loc, nameLoc := loc, name := "f"
+      args := { args := #[], kwonly := #[],
+                kwargs := some ("kw", kwargsTy) }
+      returnType := strTy, isOverload := false
+      preconditions := #[{
+        message := #[], formula :=
+          .containsKey (.var "kwargs" loc) "key" loc }]
+      postconditions := #[] }] ""
+  let body := getBody result |>.getD ""
+  assertEq result.errors.size 0
+  assertEq body "{ assert !Any..isfrom_None(key) }"
+
+-- containsKey on a non-kwargs dict: DictStrAny_contains in an assert
+-- (would have been silently dropped before fix #2)
+#eval do
+  let (body, errs) := translatePrecond
+    #[{ message := #[], formula :=
+          .containsKey (.var "d" loc) "mykey" loc }]
+    (args := #[mkArg "d" (identType .builtinsStr)])
+  assert! errs == 0
+  assert! body.contains "DictStrAny_contains"
+
+
+/-! ## typeError warning coverage -/
+
+private def hasTypeError (result : TranslationResult) : Bool :=
+  result.errors.any fun e => e.kind == .typeError
+
+-- Unknown identifier triggers typeError
+#eval do
+  let result := translatePrecondResult
+    #[{ message := #[], formula := .var "unknown_name" loc }]
+  assert! hasTypeError result
+
+-- Non-Bool precondition formula (intLit returns Any, not Bool) triggers typeError
+#eval do
+  let result := translatePrecondResult
+    #[{ message := #[], formula := .intLit 42 loc }]
+  assert! hasTypeError result
 
 end Strata.Python.Specs.ToLaurel.Tests


### PR DESCRIPTION
## Summary

The PySpec-to-Laurel translation built Laurel expressions as untyped
`StmtExpr` values, making it easy to silently produce ill-typed Laurel
(e.g., passing an int where a bool was expected). Warnings were plain
strings with no machine-readable category, so downstream tooling could
not filter or summarize them.

- Introduce `TypedStmtExpr tp` / `SomeTypedStmtExpr` so the Lean type
  checker catches type mismatches at translation time rather than
  surfacing them as confusing Laurel or Core errors later in the
  pipeline.
- Refactor `specExprToLaurel` to return `SomeTypedStmtExpr` instead of
  `Option StmtExprMd`. Callers use `runChecked` to detect whether errors
  were reported, replacing the old `some`/`none` pattern. When
  translation fails or produces a non-Bool type, a specific warning is
  emitted (the old code emitted a nondeterministic `.Assert .Hole`).
- Add `SpecExprContext.argTypes` so identifier references are resolved
  against the function's actual parameter types instead of being
  unconditionally assumed `Any`. Unknown identifiers now produce a clear
  `.typeError` warning.
- Add structured `WarningKind` (`phase` + `category`) to `SpecError` so
  warnings can be counted, filtered, and triaged programmatically. ~25
  specific warning kinds covering type translation, precondition issues,
  declaration problems, and overload dispatch.
- Surface `pyspecWarnings` through `PySpecLaurelResult` and centralize
  stderr printing in `pythonAndSpecToLaurel` (including `WarningKind`
  info in output). Remove unused `quiet` parameter from
  `buildPySpecLaurel` and `readDispatchOverloads`.
- Add `--warning-summary` CLI flag that writes a JSON file with per-kind
  warning counts, for CI and benchmark scripts. Report write errors to
  stderr instead of silently ignoring them.
- Fix comparison operation docstrings (`Lt`, `Leq`, `Gt`, `Geq`) to say
  `Int` and `Real` -- `Float64` is not supported in the Core translation.

## Test changes

- Add precondition integration tests that run `signaturesToLaurel` and
  check the formatted Laurel body for correct operations (`|` for or,
  `==>` for implies, `!` for not, `DictStrAny_contains` for dict
  containsKey). These would have caught the bugs fixed in an earlier version
  of this PR where `TypedStmtExpr` wrappers emitted wrong `PrimitiveOp`
  constructors or wrong return types.
- Add `typeError` warning coverage tests (unknown identifier, non-Bool
  precondition formula).
- Add `runTestWarningKinds` helper and tests for every `WarningKind`
  using the `phase.category: message` format.
- Update existing `#guard_msgs` expected output for the new structured
  warning format.
- Update `IdentifyOverloadsTest.lean` for the new `SpecError` constructor
  (adding `WarningKind` field).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.