### PR TITLE
Replace SpecAtomType.pyClass with .ident, add BinaryIO, and align type mappings

### DIFF
--- a/Strata/DDM/Util/SourceRange.lean
+++ b/Strata/DDM/Util/SourceRange.lean
@@ -40,12 +40,15 @@ instance : Std.ToFormat SourceRange where
     Renders location information in a format VSCode understands.
     Returns "path:line:col-col" if on same line, otherwise "path:line:col". -/
 def format (loc : SourceRange) (path : System.FilePath) (fm : Lean.FileMap) : String :=
-  let spos := fm.toPosition loc.start
-  let epos := fm.toPosition loc.stop
-  if spos.line == epos.line then
-    s!"{path}:{spos.line}:{spos.column+1}-{epos.column+1}"
+  if loc.isNone then
+    s!"{path}:unknown"
   else
-    s!"{path}:{spos.line}:{spos.column+1}"
+    let spos := fm.toPosition loc.start
+    let epos := fm.toPosition loc.stop
+    if spos.line == epos.line then
+      s!"{path}:{spos.line}:{spos.column+1}-{epos.column+1}"
+    else
+      s!"{path}:{spos.line}:{spos.column+1}"
 
 end Strata.SourceRange
 end

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -410,6 +410,10 @@ def checkEq {α : Type} (loc : SourceRange) (name : String) (as : Array α) (n :
     pure none
 
 def valueAsType (loc : SourceRange) (v : SpecValue) : PySpecM SpecType := do
+  let loc := if loc.isNone then
+                @panic _ ⟨loc⟩ s!"Empty location"
+              else
+                loc
   match v with
   | .typeValue itp =>
     pure itp
@@ -423,6 +427,7 @@ def valueAsType (loc : SourceRange) (v : SpecValue) : PySpecM SpecType := do
     | some (.typeValue tp) =>
       return tp
     | _ =>
+      specError loc s!"Unknown type in valueAsType {repr val}."
       recordTypeRef loc val
       return .ofAtom loc (.pyClass val #[])
   | _ =>
@@ -525,7 +530,7 @@ def translateCall (loc : SourceRange) (func : SpecValue)
     specError loc s!"Unknown call {repr func}."
     return default
 
-def translateConstant (value : constant SourceRange) : PySpecM SpecValue := do
+def translateConstant (loc : SourceRange) (value : constant SourceRange) : PySpecM SpecValue := do
   match value with
   | .ConFalse .. =>
     return .boolConst false
@@ -533,14 +538,14 @@ def translateConstant (value : constant SourceRange) : PySpecM SpecValue := do
     return .boolConst true
   | .ConNone _ =>
     return .noneConst
-  | .ConPos _ n =>
-    return .intConst n.ann (Int.ofNat n.val)
-  | .ConNeg _ n =>
-    return .intConst n.ann (Int.negOfNat n.val)
-  | .ConString _ name =>
-    return .stringConst name.ann name.val
+  | .ConPos _ ⟨_, n⟩ =>
+    return .intConst loc (Int.ofNat n)
+  | .ConNeg _ ⟨_, n⟩ =>
+    return .intConst loc (Int.negOfNat n)
+  | .ConString _ ⟨_, name⟩ =>
+    return .stringConst loc name
   | _ =>
-    specError value.ann s!"Could not interpret constant {value}"
+    specError loc s!"Could not interpret constant {value}"
     return default
 
 def translateSubscript (paramLoc : SourceRange) (paramType : String)
@@ -579,8 +584,8 @@ def translateDictKey (loc : SourceRange) (mk : opt_expr SourceRange) : PySpecM S
   let .some_expr _ k := mk
     | specError loc s!"Dict key missing"; return default
   match k with
-  | .Constant _ (.ConString _ key) _ =>
-    pure key.val
+  | .Constant _ (.ConString _ ⟨_, key⟩) _ =>
+    pure key
   | _ =>
     specError loc s!"Dict key value mismatch"
     return default
@@ -589,9 +594,9 @@ mutual
 
 def pyKeywordValue (k : keyword SourceRange) : PySpecM (Option String × SpecValue) := do
   let arg : Option String :=
-        match k.arg.val with
-        | none => none
-        | some e => e.val
+        match k.arg with
+        | ⟨_, none⟩ => none
+        | ⟨_, some ⟨_, e⟩⟩ => some e
   pure (arg, ← pySpecValue k.value)
 termination_by 2 * sizeOf k
 decreasing_by
@@ -617,9 +622,9 @@ def pySpecValue (expr : expr SourceRange) : PySpecM SpecValue := do
       translateCall loc func args kwargs
     else
       return default
-  | .Constant _ value kind =>
-    assert! kind.val.isNone
-    translateConstant value
+  | .Constant constLoc value ⟨_, kind⟩ =>
+    assert! kind.isNone
+    translateConstant constLoc value
   | .Dict loc ⟨_, keys⟩ ⟨_, values⟩ =>
     let .isTrue size_eq := inferInstanceAs (Decidable (keys.size = values.size))
       | specError loc s!"Dict key value mismatch"; return default
@@ -628,9 +633,9 @@ def pySpecValue (expr : expr SourceRange) : PySpecM SpecValue := do
       let v ← pySpecValue values[i]
       pure ⟨key, v⟩
     return .dictValue m
-  | .Name _ ident (.Load _) =>
-    let some v := ←getNameValue? ident.val
-      | specError expr.ann s!"Unknown identifier {ident.val}."; return default
+  | .Name _ ⟨_, ident⟩ (.Load _) =>
+    let some v := ←getNameValue? ident
+      | specError expr.ann s!"Unknown identifier {ident}."; return default
     pure v
   | .Attribute _ (.Name _ ⟨_, modName⟩ (.Load _)) ⟨_, attrName⟩ (.Load _) =>
     let qualName := s!"{modName}.{attrName}"
@@ -686,9 +691,9 @@ def pySpecArg (usedNames : Std.HashSet String)
               (selfType : Option String)
               (arg : Strata.Python.arg Strata.SourceRange)
               (de : Option (expr SourceRange)) : PySpecM Arg := do
-  let .mk_arg loc name ⟨_typeLoc, type⟩ comment := arg
-  if name.val ∈ usedNames then
-    specError name.ann s!"Argument {name.val} already declared."
+  let .mk_arg loc ⟨_, name⟩ ⟨_typeLoc, type⟩ ⟨_, comment⟩ := arg
+  if name ∈ usedNames then
+    specError loc s!"Argument {name} already declared."
   assert! !loc.isNone
   assert! _typeLoc.isNone
   let tp ←
@@ -696,14 +701,14 @@ def pySpecArg (usedNames : Std.HashSet String)
     | none =>
       match type with
       | none =>
-        specError loc s!"Missing argument to {name.val}"
+        specError loc s!"Missing argument to {name}"
         pure default
       | some tp => pySpecType tp
     | some cl =>
       if type.isSome then
-        specError loc s!"Unexpected argument to {name.val}"
+        specError loc s!"Unexpected argument to {name}"
       pure <| .pyClass loc cl #[]
-  assert! comment.val.isNone
+  assert! comment.isNone
   let argDefault ←
     match de with
     | none => pure none
@@ -711,7 +716,7 @@ def pySpecArg (usedNames : Std.HashSet String)
       pyDefaultValue d tp
       pure (some .none)
   return {
-    name := name.val
+    name := name
     type := tp
     default := argDefault
   }
@@ -753,11 +758,11 @@ instance : PySpecMClass SpecAssertionM where
 def extractKwargsField (e : expr SourceRange)
     : SpecAssertionM (Option (String × String)) := do
   match e with
-  | .Subscript _ (.Name _ paramName (.Load _))
-      (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+  | .Subscript _ (.Name _ ⟨_, paramName⟩ (.Load _))
+      (.Constant _ (.ConString _ ⟨_, fieldName⟩) _) (.Load _) =>
     match (←read).kwargsParamName with
     | some kn =>
-      if paramName.val == kn then return some (kn, fieldName.val)
+      if paramName == kn then return some (kn, fieldName)
       else return none
     | none => return none
   | _ => return none
@@ -776,9 +781,9 @@ partial def extractSubject (e : expr SourceRange)
     pure ()
   match e with
   | .Name _ ⟨_, name⟩ (.Load _) => return some (.var name (loc := e.ann))
-  | .Subscript _ inner (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+  | .Subscript _ inner (.Constant _ (.ConString _ ⟨_, fieldName⟩) _) (.Load _) =>
     match ← extractSubject inner with
-    | some subj => return some (.getIndex subj fieldName.val (loc := e.ann))
+    | some subj => return some (.getIndex subj fieldName (loc := e.ann))
     | none => return none
   | _ => return none
 
@@ -786,13 +791,13 @@ partial def extractSubject (e : expr SourceRange)
     Currently recognizes `"key" in container` patterns. -/
 def transCondition (e : expr SourceRange) : SpecAssertionM (Option SpecExpr) := do
   match e with
-  | .Compare _ (.Constant _ (.ConString _ key) _) ops comparators =>
-    if h₁ : ops.val.size = 1 then
-      if h₂ : comparators.val.size = 1 then
-        match ops.val[0] with
+  | .Compare _ (.Constant _ (.ConString _ ⟨_, key⟩) _) ⟨_, ops⟩ ⟨_, comparators⟩ =>
+    if h₁ : ops.size = 1 then
+      if h₂ : comparators.size = 1 then
+        match ops[0] with
         | .In _ =>
-          match ← extractSubject comparators.val[0] with
-          | some subj => return some (.containsKey subj key.val (loc := e.ann))
+          match ← extractSubject comparators[0] with
+          | some subj => return some (.containsKey subj key (loc := e.ann))
           | none => pure ()
         | _ => pure ()
     pure ()
@@ -825,9 +830,9 @@ def transMessageExpr (e : expr SourceRange)
   | some subj => return subj
   | none => pure ()
   match e with
-  | .Call _ (.Name _ funcName (.Load _)) args _ =>
-    if funcName.val == "len" && args.val.size == 1 then
-      match ← extractSubject args.val[0]! with
+  | .Call _ (.Name _ ⟨_, funcName⟩ (.Load _)) ⟨_, args⟩ _ =>
+    if funcName == "len" && args.size == 1 then
+      match ← extractSubject args[0]! with
       | some subj => return .len subj (loc := e.ann)
       | none => return .placeholder (loc := e.ann)
     else return .placeholder (loc := e.ann)
@@ -849,19 +854,19 @@ partial def inferExprType (e : expr SourceRange) : SpecAssertionM (Option SpecTy
   match e with
   | .Name _ ⟨_, name⟩ (.Load _) =>
     return (←read).localTypes[name]?
-  | .Subscript _ (.Name _ paramName (.Load _))
-      (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+  | .Subscript _ (.Name _ ⟨_, paramName⟩ (.Load _))
+      (.Constant _ (.ConString _ ⟨_, fieldName⟩) _) (.Load _) =>
     match (←read).kwargsParamName with
     | some kn =>
-      if paramName.val == kn then
+      if paramName == kn then
         match (←read).kwargsType with
-        | some kwTp => return lookupTypedDictField kwTp fieldName.val
+        | some kwTp => return lookupTypedDictField kwTp fieldName
         | none => return none
       else return none
     | none => return none
-  | .Subscript _ inner (.Constant _ (.ConString _ fieldName) _) (.Load _) =>
+  | .Subscript _ inner (.Constant _ (.ConString _ ⟨_, fieldName⟩) _) (.Load _) =>
     match ← inferExprType inner with
-    | some innerTp => return lookupTypedDictField innerTp fieldName.val
+    | some innerTp => return lookupTypedDictField innerTp fieldName
     | none => return none
   | _ => return none
 
@@ -893,9 +898,9 @@ def extractDictKeyValueTypes (tp : SpecType) : Option (SpecType × SpecType) := 
 partial def collectEnumValues (e : expr SourceRange)
     : SpecAssertionM (Option (SpecExpr × Array String)) := do
   match e with
-  | .BoolOp _ (.Or _) values =>
+  | .BoolOp _ (.Or _) ⟨_, values⟩ =>
     let mut result : Option (SpecExpr × Array String) := none
-    for val in values.val do
+    for val in values do
       match ← collectEnumValues val with
       | some (subj, vals) =>
         match result with
@@ -905,18 +910,18 @@ partial def collectEnumValues (e : expr SourceRange)
           result := some (subj, acc ++ vals)
       | none => return none
     return result
-  | .Compare _ lhs ops comparators =>
-    let .isTrue _ := decideProp (ops.val.size = 1)
+  | .Compare _ lhs ⟨_, ops⟩ ⟨_, comparators⟩ =>
+    let .isTrue _ := decideProp (ops.size = 1)
       | return none
-    match ops.val[0] with
+    match ops[0] with
     | .Eq _ =>
-      let .isTrue _ := decideProp (comparators.val.size = 1)
+      let .isTrue _ := decideProp (comparators.size = 1)
         | return none
       match ← extractSubject lhs with
       | some subj =>
-        match comparators.val[0] with
-        | .Constant _ (.ConString _ strVal) _ =>
-          return some (subj, #[strVal.val])
+        match comparators[0] with
+        | .Constant _ (.ConString _ ⟨_, strVal⟩) _ =>
+          return some (subj, #[strVal])
         | _ => return none
       | none => return none
     | _ => return none
@@ -927,10 +932,10 @@ partial def collectEnumValues (e : expr SourceRange)
     and `UnaryOp(USub, Constant(ConPos n))` (i.e., `-n`). -/
 def extractIntBound (e : expr SourceRange) : Option Int :=
   match e with
-  | .Constant _ (.ConPos _ n) _ => some (Int.ofNat n.val)
-  | .Constant _ (.ConNeg _ n) _ => some (Int.negOfNat n.val)
-  | .UnaryOp _ (.USub _) (.Constant _ (.ConPos _ n) _) =>
-    some (Int.negOfNat n.val)
+  | .Constant _ (.ConPos _ ⟨_, n⟩) _ => some (Int.ofNat n)
+  | .Constant _ (.ConNeg _ ⟨_, n⟩) _ => some (Int.negOfNat n)
+  | .UnaryOp _ (.USub _) (.Constant _ (.ConPos _ ⟨_, n⟩) _) =>
+    some (Int.negOfNat n)
   | _ => none
 
 /-- Extract a float literal string from a Python expression.
@@ -975,51 +980,51 @@ def transAssertExpr (e : expr SourceRange)
   let loc := e.ann
   -- isinstance(subject, T)
   match e with
-  | .Call _ (.Name _ funcName (.Load _)) args _ =>
-    if funcName.val == "isinstance" then
-      if h : args.val.size = 2 then
-        match ← extractSubject args.val[0] with
+  | .Call _ (.Name _ ⟨_, funcName⟩ (.Load _)) ⟨_, args⟩ _ =>
+    if funcName == "isinstance" then
+      if h : args.size = 2 then
+        match ← extractSubject args[0] with
         | some subj =>
-          match args.val[1] with
-          | .Name _ typeName (.Load _) =>
-            return .isInstanceOf subj typeName.val (loc := loc)
+          match args[1] with
+          | .Name _ ⟨_, typeName⟩ (.Load _) =>
+            return .isInstanceOf subj typeName (loc := loc)
           | _ =>
             specWarning e.ann s!"isinstance: unsupported type argument"
             return .placeholder (loc := loc)
         | none => pure () -- fall through
-    if funcName.val == "len" && args.val.size == 1 then
+    if funcName == "len" && args.size == 1 then
       -- This is just len(x), not a comparison; fall through
       pure ()
   | _ => pure ()
   -- len(subject) >= N / len(subject) <= N
   match e with
-  | .Compare _ (.Call _ (.Name _ funcName (.Load _)) callArgs _)
-      ops comparators =>
-    if funcName.val == "len" then
-      if h₁ : callArgs.val.size = 1 then
-        if h₂ : ops.val.size = 1 then
-          if h₃ : comparators.val.size = 1 then
-            match ← extractSubject callArgs.val[0] with
+  | .Compare _ (.Call _ (.Name _ ⟨_, funcName⟩ (.Load _)) ⟨_, callArgs⟩ _)
+      ⟨_, ops⟩ ⟨_, comparators⟩ =>
+    if funcName == "len" then
+      if h₁ : callArgs.size = 1 then
+        if h₂ : ops.size = 1 then
+          if h₃ : comparators.size = 1 then
+            match ← extractSubject callArgs[0] with
             | some subj =>
-              match ops.val[0], extractIntBound comparators.val[0] with
-              | .GtE _, some n => return .intGe (.len subj (loc := loc)) (.intLit n (loc := comparators.val[0].ann)) (loc := loc)
-              | .LtE _, some n => return .intLe (.len subj (loc := loc)) (.intLit n (loc := comparators.val[0].ann)) (loc := loc)
+              match ops[0], extractIntBound comparators[0] with
+              | .GtE _, some n => return .intGe (.len subj (loc := loc)) (.intLit n (loc := comparators[0].ann)) (loc := loc)
+              | .LtE _, some n => return .intLe (.len subj (loc := loc)) (.intLit n (loc := comparators[0].ann)) (loc := loc)
               | _, _ => pure ()
             | none => pure ()
   | _ => pure ()
   -- subject >= N / subject <= N (type-checked: int or float)
   match e with
-  | .Compare _ lhs ops comparators =>
-    if h₁ : ops.val.size = 1 then
-      if h₂ : comparators.val.size = 1 then
+  | .Compare _ lhs ⟨_, ops⟩ ⟨_, comparators⟩ =>
+    if h₁ : ops.size = 1 then
+      if h₂ : comparators.size = 1 then
         match ← extractSubject lhs with
         | some subj =>
           let subjType ← inferExprType lhs
           let isFloat := subjType.any isFloatType
           let isInt := subjType.any isIntType
-          let cmp ← match ops.val[0] with
-          | .GtE _ => makeComparison (.floatGe · · (loc := loc)) (.intGe · · (loc := loc)) isFloat isInt subj comparators.val[0]
-          | .LtE _ => makeComparison (.floatLe · · (loc := loc)) (.intLe · · (loc := loc)) isFloat isInt subj comparators.val[0]
+          let cmp ← match ops[0] with
+          | .GtE _ => makeComparison (.floatGe · · (loc := loc)) (.intGe · · (loc := loc)) isFloat isInt subj comparators[0]
+          | .LtE _ => makeComparison (.floatLe · · (loc := loc)) (.intLe · · (loc := loc)) isFloat isInt subj comparators[0]
           | _ => pure none
           match cmp with
           | some expr => return expr
@@ -1034,21 +1039,21 @@ def transAssertExpr (e : expr SourceRange)
   -- compile("pattern").search(subject) is not None
   match e with
   | .Compare _
-      (.Call _ (.Attribute _ (.Call _ (.Name _ compileName (.Load _)) compileArgs _)
-        searchAttr (.Load _)) searchArgs _)
-      ops comparators =>
-    if compileName.val == "compile" && searchAttr.val == "search" then
-      if h₁ : compileArgs.val.size = 1 then
-        if h₂ : searchArgs.val.size = 1 then
-          if h₃ : ops.val.size = 1 then
-            if h₄ : comparators.val.size = 1 then
-              match compileArgs.val[0] with
-              | .Constant _ (.ConString _ pattern) _ =>
-                match ← extractSubject searchArgs.val[0] with
+      (.Call _ (.Attribute _ (.Call _ (.Name _ ⟨_, compileName⟩ (.Load _)) ⟨_, compileArgs⟩ _)
+        ⟨_, searchAttr⟩ (.Load _)) ⟨_, searchArgs⟩ _)
+      ⟨_, ops⟩ ⟨_, comparators⟩ =>
+    if compileName == "compile" && searchAttr == "search" then
+      if h₁ : compileArgs.size = 1 then
+        if h₂ : searchArgs.size = 1 then
+          if h₃ : ops.size = 1 then
+            if h₄ : comparators.size = 1 then
+              match compileArgs[0] with
+              | .Constant _ (.ConString _ ⟨_, pattern⟩) _ =>
+                match ← extractSubject searchArgs[0] with
                 | some subj =>
-                  match ops.val[0], comparators.val[0] with
+                  match ops[0], comparators[0] with
                   | .IsNot _, .Constant _ (.ConNone _) _ =>
-                    return .regexMatch subj pattern.val (loc := loc)
+                    return .regexMatch subj pattern (loc := loc)
                   | _, _ => pure ()
                 | none => pure ()
               | _ => pure ()
@@ -1071,19 +1076,19 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
     specWarning s.ann "skipped Expr in function body"
   | .Assert _ test msg =>
     let formula ← transAssertExpr test
-    let message ← match msg.val with
-      | some (.Constant _ (.ConString _ str) _) => pure #[MessagePart.str str.val]
-      | some (.JoinedStr _ values) =>
-        values.val.attach.mapM fun ⟨v, _⟩ =>
+    let message ← match msg with
+      | ⟨_, some (.Constant _ (.ConString _ ⟨_, str⟩) _)⟩ => pure #[MessagePart.str str]
+      | ⟨_, some (.JoinedStr _ ⟨_, values⟩)⟩ =>
+        values.attach.mapM fun ⟨v, _⟩ =>
           match v with
-          | .Constant _ (.ConString _ str) _ => pure (MessagePart.str str.val)
+          | .Constant _ (.ConString _ ⟨_, str⟩) _ => pure (MessagePart.str str)
           | .FormattedValue _ value _ _ =>
             MessagePart.expr <$> transMessageExpr value
           | other => do
             specWarning other.ann "unsupported f-string part"
             pure (MessagePart.str "")
-      | none => pure #[]
-      | some e =>
+      | ⟨_, none⟩ => pure #[]
+      | ⟨_, some e⟩ =>
         specWarning e.ann "assert message is not a string literal"
         pure #[]
     modify fun s => { s with
@@ -1095,10 +1100,10 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
     specWarning s.ann "skipped Raise in function body"
   | .ClassDef .. =>
     specError s.ann s!"Inner classes are not supported."
-  | .For _ target iter body orelse type_comment =>
-    if type_comment.val.isSome then
+  | .For _ target iter ⟨_, body⟩ ⟨_, orelse⟩ ⟨_, type_comment⟩ =>
+    if type_comment.isSome then
       specWarning s.ann "For: type_comment not supported"
-    if orelse.val.size > 0 then
+    if orelse.size > 0 then
       specWarning s.ann "For: else clause not supported"
     match target, iter with
     -- for varName in iterable:
@@ -1114,7 +1119,7 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
         withReader (fun ctx => match elemTp with
           | some tp => { ctx with localTypes := ctx.localTypes.insert varName tp }
           | none => ctx) <|
-          blockStmts body.val
+          blockStmts body
         let bodyAssertions := (←get).assertions
         let wrapped := bodyAssertions.map fun a =>
           { a with formula := .forallList listExpr varName a.formula s.ann }
@@ -1122,14 +1127,14 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
       | none =>
         specWarning s.ann s!"For: cannot extract iterable expression"
     -- for keyVar, valVar in dictExpr.items():
-    | .Tuple _ elts (.Store _),
-      .Call _ (.Attribute _ dictExpr ⟨_, "items"⟩ (.Load _)) args _ =>
-      if elts.val.size != 2 then
+    | .Tuple _ ⟨_, elts⟩ (.Store _),
+      .Call _ (.Attribute _ dictExpr ⟨_, "items"⟩ (.Load _)) ⟨_, args⟩ _ =>
+      if elts.size != 2 then
         specWarning s.ann "For: dict unpacking requires exactly 2 variables"
-      else if args.val.size != 0 then
+      else if args.size != 0 then
         specWarning s.ann "For: .items() call should have no arguments"
       else
-        match elts.val[0]!, elts.val[1]! with
+        match elts[0]!, elts[1]! with
         | .Name _ ⟨_, keyVar⟩ (.Store _), .Name _ ⟨_, valVar⟩ (.Store _) =>
           match ← extractSubject dictExpr with
           | some dictSubj =>
@@ -1155,7 +1160,7 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
                     |>.insert keyVar kTp
                     |>.insert valVar vTp }
               | none => ctx) <|
-              blockStmts body.val
+              blockStmts body
             let bodyAssertions := (←get).assertions
             let wrapped := bodyAssertions.map fun a =>
               { a with formula := .forallDict dictSubj keyVar valVar a.formula s.ann }
@@ -1166,13 +1171,13 @@ def blockStmt (s : stmt SourceRange) : SpecAssertionM Unit := do
           specWarning s.ann "For: dict unpacking requires Name targets"
     | _, _ =>
       specWarning s.ann "For: unsupported target pattern"
-  | .If _ pred t f =>
+  | .If _ pred ⟨_, t⟩ ⟨_, f⟩ =>
     let cond ← transCondition pred
     if cond.isNone then
       specWarning pred.ann s!"if: unrecognized condition pattern: {eformat pred.toAst}"
-    assumeCondition cond pred.ann <| blockStmts t.val
-    if f.val.size > 0 then
-      assumeCondition (cond.map (.not · pred.ann)) pred.ann <| blockStmts f.val
+    assumeCondition cond pred.ann <| blockStmts t
+    if f.size > 0 then
+      assumeCondition (cond.map (.not · pred.ann)) pred.ann <| blockStmts f
   | .Pass _ =>
     pure ()
   | _ => specError s.ann s!"Unsupported statement: {eformat s.toAst}"
@@ -1223,20 +1228,20 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
       | _ =>
         specError pyd.ann s!"Decorator {repr d} not supported."
 
-  let .mk_arguments _ posonly ⟨_, posArgs⟩ vararg kwonly kw_defaults kwarg defaults := arguments
-  assert! posonly.val.size = 0
+  let .mk_arguments _ ⟨_, posonly⟩ ⟨_, posArgs⟩ ⟨_, vararg⟩ ⟨_, kwonly⟩ ⟨_, kw_defaults⟩ ⟨_, kwarg⟩ ⟨_, defaults⟩ := arguments
+  assert! posonly.size = 0
   let argc := posArgs.size
 
   let .up defaults_bnd ←
-    if h : defaults.val.size ≤ posArgs.size then
+    if h : defaults.size ≤ posArgs.size then
       pure <| PULift.up.{1, 0} h
     else
       specError fnLoc s!"internal: bad index"; return default
 
-  let .isTrue kw_bnd := inferInstanceAs (Decidable (kwonly.val.size = kw_defaults.val.size))
+  let .isTrue kw_bnd := inferInstanceAs (Decidable (kwonly.size = kw_defaults.size))
     | specError fnLoc s!"Keyword only arguments must have defaults."; return default
-  assert! vararg.val.isNone
-  let min_default := argc - defaults.val.size
+  assert! vararg.isNone
+  let min_default := argc - defaults.size
   let isMethod := className.isSome
   if isMethod ∧ argc = 0 then
     specError fnLoc "Method expecting self argument"
@@ -1247,7 +1252,7 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
     -- Arguments with defaults occur at end
     let d : Option _ :=
       if p : i ≥ min_default then
-        some defaults.val[i - min_default]
+        some defaults[i - min_default]
       else
         none
     let self_type :=
@@ -1257,12 +1262,12 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
     let ba ← pySpecArg usedNames self_type a d
     usedNames := usedNames.insert ba.name
     specArgs := specArgs.push ba
-  let mut kwSpecArgs : Array Arg := .emptyWithCapacity kwonly.val.size
-  for ⟨i, ib⟩ in Fin.range kwonly.val.size do
-    let a := kwonly.val[i]
+  let mut kwSpecArgs : Array Arg := .emptyWithCapacity kwonly.size
+  for ⟨i, ib⟩ in Fin.range kwonly.size do
+    let a := kwonly[i]
     -- Arguments with defaults occur at end
     let d : Option _ :=
-        match kw_defaults.val[i] with
+        match kw_defaults[i] with
         | .some_expr _ v => some v
         | .missing_expr _ => none
     let ba ← pySpecArg usedNames none a d
@@ -1270,14 +1275,14 @@ def pySpecFunctionArgs (fnLoc : SourceRange)
     kwSpecArgs := kwSpecArgs.push ba
   -- Handle **kwargs: store parameter name and type
   let mut kwargsOpt : Option (String × SpecType) := none
-  match kwarg.val with
+  match kwarg with
   | none => pure ()
   | some kwargArg =>
-    let .mk_arg kwargLoc kwargParamName ⟨_, kwargType⟩ _ := kwargArg
+    let .mk_arg kwargLoc ⟨_, kwargParamName⟩ ⟨_, kwargType⟩ _ := kwargArg
     match kwargType with
     | some typeExpr =>
       let tp ← pySpecType typeExpr
-      kwargsOpt := some (kwargParamName.val, tp)
+      kwargsOpt := some (kwargParamName, tp)
     | none => specError kwargLoc s!"**kwargs requires type annotation"
   let argDecls : ArgDecls := { args := specArgs, kwonly := kwSpecArgs, kwargs := kwargsOpt }
   let returnType : SpecType ←
@@ -1347,11 +1352,11 @@ partial def pySpecClassBody (loc : SourceRange) (className : String)
         let fieldType ← pySpecType annotation
         fields := fields.push { name := fieldName, type := fieldType }
       | _ => specError stmt.ann s!"Unsupported field target"
-    | .ClassDef innerLoc ⟨_, innerClassName⟩ innerBases _keywords innerStmts
+    | .ClassDef innerLoc ⟨_, innerClassName⟩ ⟨_, innerBases⟩ _keywords ⟨_, innerStmts⟩
                 _decorators _typeParams =>
-      let innerBaseIdents ← resolveBaseClasses innerBases.val
+      let innerBaseIdents ← resolveBaseClasses innerBases
       let innerDef ← pySpecClassBody innerLoc innerClassName
-        innerBaseIdents innerStmts.val
+        innerBaseIdents innerStmts
       subclasses := subclasses.push innerDef
     | .Assign _ ⟨_, targets⟩ value _typeAnn =>
       if h : targets.size = 1 then
@@ -1701,27 +1706,27 @@ partial def translate (body : Array (stmt Strata.SourceRange)) : PySpecM Unit :=
       assert! typeParams.size = 0
       let d ← pySpecFunctionArgs (className := none) loc funName args body decorators returns
       pushSignature (.functionDecl d)
-    | .Import loc names =>
-      translateImport loc names.val
+    | .Import loc ⟨_, names⟩ =>
+      translateImport loc names
     | .ImportFrom loc ⟨_, pyModule⟩ ⟨_, names⟩ ⟨_, level⟩ =>
       translateImportFromStmt loc pyModule names level
-    | .ClassDef loc ⟨_classNameLoc, className⟩ bases keywords stmts decorators typeParams =>
+    | .ClassDef loc ⟨_classNameLoc, className⟩ ⟨_, bases⟩ ⟨_, keywords⟩ ⟨_, stmts⟩ ⟨_, decorators⟩ ⟨_, typeParams⟩ =>
       if ←shouldSkip className then
         logEvent "skip" s!"Skipping class {className}"
         continue
       assert! _classNameLoc.isNone
-      assert! keywords.val.size = 0
-      let isExhaustive := decorators.val.any fun d =>
+      assert! keywords.size = 0
+      let isExhaustive := decorators.any fun d =>
         match d with
         | .Name _ ⟨_, "exhaustive"⟩ _ => true
         | _ => false
-      assert! decorators.val.size = 0 || (decorators.val.size = 1 && isExhaustive)
-      assert! typeParams.val.size = 0
-      let baseIdents ← resolveBaseClasses bases.val
+      assert! decorators.size = 0 || (decorators.size = 1 && isExhaustive)
+      assert! typeParams.size = 0
+      let baseIdents ← resolveBaseClasses bases
       let (success, _) ← runChecked <| recordTypeDef loc className
       -- Add the class to nameMap so it can be used in forward references
       setNameValue className (.typeValue (.pyClass loc className #[]))
-      let d ← pySpecClassBody loc className baseIdents stmts.val
+      let d ← pySpecClassBody loc className baseIdents stmts
       let d := { d with exhaustive := isExhaustive }
       if success then
         pushSignature (.classDef d)

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -241,6 +241,7 @@ def preludeSig :=
     .mk .noneType (typeIdent .noneType),
 
     .mk .typingAny (typeIdent .typingAny),
+    .mk .typingBinaryIO (typeIdent .typingBinaryIO),
     .mk .typingDict (.metaType .typingDict),
     .mk .typingGenerator (.metaType .typingGenerator),
     .mk .typingList (.metaType .typingList),

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -411,10 +411,6 @@ def checkEq {α : Type} (loc : SourceRange) (name : String) (as : Array α) (n :
     pure none
 
 def valueAsType (loc : SourceRange) (v : SpecValue) : PySpecM SpecType := do
-  let loc := if loc.isNone then
-                @panic _ ⟨loc⟩ s!"Empty location"
-              else
-                loc
   match v with
   | .typeValue itp =>
     pure itp

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -427,9 +427,10 @@ def valueAsType (loc : SourceRange) (v : SpecValue) : PySpecM SpecType := do
     | some (.typeValue tp) =>
       return tp
     | _ =>
-      specError loc s!"Unknown type in valueAsType {repr val}."
       recordTypeRef loc val
-      return .ofAtom loc (.pyClass val #[])
+      let mod := toString (← read).currentModule
+      let pyIdent : PythonIdent := { pythonModule := mod, name := val }
+      return .ofAtom loc (.ident pyIdent #[])
   | _ =>
     specError loc s!"Expected type instead of {repr v}."
     return default
@@ -707,7 +708,8 @@ def pySpecArg (usedNames : Std.HashSet String)
     | some cl =>
       if type.isSome then
         specError loc s!"Unexpected argument to {name}"
-      pure <| .pyClass loc cl #[]
+      let mod := toString (← read).currentModule
+      pure <| .ident loc { pythonModule := mod, name := cl } #[]
   assert! comment.isNone
   let argDefault ←
     match de with
@@ -1324,9 +1326,6 @@ private def resolveBaseClasses (bases : Array (expr SourceRange))
           match tp.asSingleton with
           | some (.ident pyIdent _) =>
             result := result.push pyIdent
-          | some (.pyClass clsName _) =>
-            let mod := toString (← read).currentModule
-            result := result.push { pythonModule := mod, name := clsName }
           | _ =>
             specError base.ann s!"Unknown base class '{name}'"
         | _ =>
@@ -1385,9 +1384,11 @@ partial def pySpecClassBody (loc : SourceRange) (className : String)
                 match value with
                 | .Call _ (.Attribute _ (.Name _ ⟨_, "self"⟩ (.Load _))
                     ⟨_, innerClsName⟩ (.Load _)) _ _ =>
+                  let mod := toString (← read).currentModule
+                  let pyIdent : PythonIdent := { pythonModule := mod, name := innerClsName }
                   let f : ClassField := {
                     name := fieldName,
-                    type := SpecType.pyClass loc innerClsName #[],
+                    type := .ident loc pyIdent #[],
                     constValue := some s!"{innerClsName}()" }
                   fields := fields.push f
                 | _ =>
@@ -1725,7 +1726,8 @@ partial def translate (body : Array (stmt Strata.SourceRange)) : PySpecM Unit :=
       let baseIdents ← resolveBaseClasses bases
       let (success, _) ← runChecked <| recordTypeDef loc className
       -- Add the class to nameMap so it can be used in forward references
-      setNameValue className (.typeValue (.pyClass loc className #[]))
+      let mod := toString (← read).currentModule
+      setNameValue className (.typeValue (.ident loc { pythonModule := mod, name := className } #[]))
       let d ← pySpecClassBody loc className baseIdents stmts
       let d := { d with exhaustive := isExhaustive }
       if success then

--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -205,11 +205,6 @@ private def SpecAtomType.toDDM (d : SpecAtomType)
       .typeIdentNoArgs loc nm.toDDM
     else
       .typeIdent loc nm.toDDM ⟨.none, args.map (·.toDDM)⟩
-  | .pyClass name args =>
-    if args.isEmpty then
-      .typeClassNoArgs loc ⟨.none, name⟩
-    else
-      .typeClass loc ⟨.none, name⟩ ⟨.none, args.map (·.toDDM)⟩
   | .intLiteral i => .typeIntLiteral loc (toDDMInt .none i)
   | .stringLiteral v => .typeStringLiteral loc ⟨.none, v⟩
   | .typedDict fields types fieldRequired =>
@@ -331,10 +326,10 @@ private def Signature.toDDM (sig : Signature) : DDM.Signature SourceRange :=
 private def DDM.SpecType.fromDDM (d : DDM.SpecType SourceRange) : Specs.SpecType :=
   match d with
   | .typeClassNoArgs loc ⟨_, cl⟩ =>
-    .ofAtom loc <| .pyClass cl #[]
+    .ident loc { pythonModule := "", name := cl } #[]
   | .typeClass loc ⟨_, cl⟩ ⟨_, args⟩ =>
     let a := args.map (·.fromDDM)
-    .ofAtom loc <| .pyClass cl a
+    .ident loc { pythonModule := "", name := cl } a
   | .typeIdentNoArgs loc ⟨_, ident⟩ =>
     if let some pyIdent := PythonIdent.ofString ident then
       .ident loc pyIdent #[]

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -77,7 +77,6 @@ An atomic type in the PySpec language
 -/
 inductive SpecAtomType where
 | ident (nm : PythonIdent) (args : Array SpecType)
-| pyClass (name : String) (args : Array SpecType)
 /- An integer literal -/
 | intLiteral (value : Int)
 /-- A string literal -/
@@ -127,7 +126,7 @@ termination_by a₁.size - i
 mutual
 
 /-- Compare two atom types by structure, ignoring `loc` in nested `SpecType`
-    values. Variants are ordered: ident < pyClass < intLiteral < stringLiteral
+    values. Variants are ordered: ident < intLiteral < stringLiteral
     < typedDict. -/
 protected def SpecAtomType.compare (x y : SpecAtomType) : Ordering :=
   match x, y with
@@ -136,12 +135,6 @@ protected def SpecAtomType.compare (x y : SpecAtomType) : Ordering :=
       compareHLex (fun ⟨xe, _⟩ ye => xe.compare ye) xargs.attach yargs
   | .ident .., _ => .lt
   | _, .ident .. => .gt
-
-  | .pyClass xname xargs, .pyClass yname yargs =>
-    compare xname yname |>.then $
-      compareHLex (fun ⟨xe, _⟩ ye => xe.compare ye) xargs.attach yargs
-  | .pyClass .., _ => .lt
-  | _, .pyClass .. => .gt
 
   | .intLiteral xval, .intLiteral yval => compare xval yval
   | .intLiteral .., _ => .lt
@@ -261,9 +254,6 @@ protected def ofArray (loc : SourceRange) (atoms : Array SpecAtomType) : SpecTyp
 
 def ident (loc : SourceRange) (i : PythonIdent) (args : Array SpecType := #[]) : SpecType :=
   ofAtom loc (.ident i args)
-
-def pyClass (loc : SourceRange) (name : String) (params : Array SpecType) : SpecType :=
-  ofAtom loc (.pyClass name params)
 
 def asSingleton (tp : SpecType) : Option SpecAtomType := do
   if tp.atoms.size = 1 then

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -25,6 +25,7 @@ def builtinsStr := mk "builtins" "str"
 def noneType := mk "_types" "NoneType"
 
 def typingAny := mk "typing" "Any"
+def typingBinaryIO := mk "typing" "BinaryIO"
 def typingDict := mk "typing" "Dict"
 def typingGenerator := mk "typing" "Generator"
 def typingList := mk "typing" "List"

--- a/Strata/Languages/Python/Specs/Error.lean
+++ b/Strata/Languages/Python/Specs/Error.lean
@@ -29,10 +29,6 @@ namespace WarningKind
 -- Type translation warnings
 def emptyType : WarningKind := { phase := "pySpecToLaurel", category := "emptyType" }
 def unsupportedUnion : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedUnion" }
-def unknownType : WarningKind := { phase := "pySpecToLaurel", category := "unknownType" }
-def unsupportedGenericClass : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedGenericClass" }
-def bytesToString : WarningKind := { phase := "pySpecToLaurel", category := "bytesToString" }
-def complexToReal : WarningKind := { phase := "pySpecToLaurel", category := "complexToReal" }
 
 -- Unsupported Optional patterns
 def unsupportedOptionalFloat : WarningKind := { phase := "pySpecToLaurel", category := "unsupportedOptionalFloat" }

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -158,11 +158,6 @@ def atomTypeToString (a : SpecAtomType) : String :=
     else
       let argStrs := args.map specTypeToString
       s!"{nm}[{String.intercalate ", " argStrs.toList}]"
-  | .pyClass name args =>
-    if args.isEmpty then name
-    else
-      let argStrs := args.map specTypeToString
-      s!"{name}[{String.intercalate ", " argStrs.toList}]"
   | .intLiteral v => s!"Literal[{v}]"
   | .stringLiteral v => s!"Literal[\"{v}\"]"
   | .typedDict _ _ _ => "TypedDict"
@@ -313,13 +308,7 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
         reportError .complexToReal default s!"'{nm}' mapped to TReal (complex loses imaginary component)"
       if let some ty := knownIdentTypes[nm]? then
         return ty
-      reportError .unknownType default s!"Unknown type '{nm}' mapped to TString"
-      return tyString
-    | .pyClass name args =>
-      if args.size > 0 then
-        reportError .unsupportedGenericClass default
-          s!"Generic class '{name}' with type args unsupported"
-      let prefixed ← prefixName name
+      let prefixed ← prefixName nm.name
       return mkTy (.UserDefined { text := prefixed, md := .empty })
     | .intLiteral _ => return tyInt
     | .stringLiteral _ => return tyString
@@ -671,9 +660,8 @@ def typeDefToLaurel (td : TypeDef) : ToLaurelM Unit := do
   })
 
 /-- Extract an overload dispatch entry from an `@overload` function declaration.
-    Looks for a `stringLiteral` in the first argument's type and a class
-    return type (either `.pyClass` for locally-defined classes or `.ident`
-    for externally imported classes), and records them in the dispatch table. -/
+    Looks for a `stringLiteral` in the first argument's type and an `.ident`
+    return type, and records them in the dispatch table. -/
 def extractOverloadEntry (func : FunctionDecl) : ToLaurelM Unit := do
   let args := func.args.args
   let .isTrue _ := decideProp (args.size > 0)
@@ -703,10 +691,6 @@ def extractOverloadEntry (func : FunctionDecl) : ToLaurelM Unit := do
       return
   let retType ←
         match func.returnType.atoms[0] with
-        | .pyClass name _ => do
-          let ctx ← read
-          let prefixed ← prefixName name
-          pure (PythonIdent.mk ctx.modulePrefix prefixed)
         | .ident nm _ => pure nm
         | _ =>
           reportError .overloadReturnNotClass func.loc

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -300,11 +300,6 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
     -- Single atom type
     match ty.atoms[0]! with
     | .ident nm _args =>
-      -- Warn for lossy known-type approximations
-      if nm == .builtinsBytes || nm == .builtinsBytearray then
-        reportError .bytesToString default s!"'{nm}' mapped to TString (bytes have different semantics)"
-      if nm == .builtinsComplex then
-        reportError .complexToReal default s!"'{nm}' mapped to TReal (complex loses imaginary component)"
       if let some ty := knownIdentTypes[nm]? then
         return ty
       let prefixed ← prefixName nm.name

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -250,25 +250,24 @@ def detectOptionalType (ty : SpecType) : ToLaurelM (Option HighTypeMd) := do
     return none
 
 /-- Known PythonIdent → Laurel type mappings for single-atom ident types.
-    - `bytes`/`bytearray` → TString (closest string-like approximation)
-    - `complex` → TReal (no complex type in SMT; real is the closest numeric type)
-    - `Exception` → UserDefined "Error" (matches CorePrelude's Error datatype)
-    - `typing.Any` → UserDefined "Any" (datatype in Laurel prelude) -/
+    Matches PythonToLaurel's type mapping: only int, str, bool, float get
+    concrete Laurel types; everything else maps to Any. -/
 private def knownIdentTypes : Std.HashMap PythonIdent HighTypeMd :=
   .ofList [
     (.builtinsBool,      tyBool),
-    (.builtinsBytearray, tyString),
-    (.builtinsBytes,     tyString),
-    (.builtinsComplex,   tyReal),
-    (.builtinsDict,      tyDictStrAny),
-    (.builtinsException, tyError),
+    (.builtinsBytearray, tyAny),
+    (.builtinsBytes,     tyAny),
+    (.builtinsComplex,   tyAny),
+    (.builtinsDict,      tyAny),
+    (.builtinsException, tyAny),
     (.builtinsFloat,     tyReal),
     (.builtinsInt,       tyInt),
     (.builtinsStr,       tyString),
     (.noneType,          tyVoid),
     (.typingAny,         tyAny),
-    (.typingDict,        tyDictStrAny),
-    (.typingList,        tyListStr),
+    (.typingBinaryIO,    tyAny),
+    (.typingDict,        tyAny),
+    (.typingList,        tyAny),
   ]
 
 /-- Convert a SpecType to a Laurel HighTypeMd. -/

--- a/StrataTest/Languages/Python/Specs/DeclsTest.lean
+++ b/StrataTest/Languages/Python/Specs/DeclsTest.lean
@@ -12,9 +12,8 @@ namespace DeclsTest
 private abbrev mk1 (a : SpecAtomType) : SpecType := ⟨#[a], ⟨0, 0⟩⟩
 private abbrev mk2 (a : SpecAtomType) : SpecType := ⟨#[a], ⟨⟨1⟩, ⟨2⟩⟩⟩
 
--- Atom ordering: ident < pyClass < intLiteral < stringLiteral < typedDict
-#guard compare (SpecAtomType.ident .builtinsInt #[]) (.pyClass "Foo" #[]) == .lt
-#guard compare (SpecAtomType.pyClass "Foo" #[]) (.intLiteral 0) == .lt
+-- Atom ordering: ident < intLiteral < stringLiteral < typedDict
+#guard compare (SpecAtomType.ident .builtinsInt #[]) (.intLiteral 0) == .lt
 #guard compare (SpecAtomType.intLiteral 0) (.stringLiteral "a") == .lt
 
 -- Same variant compares by fields

--- a/StrataTest/Languages/Python/SpecsTest.lean
+++ b/StrataTest/Languages/Python/SpecsTest.lean
@@ -79,7 +79,7 @@ class "MainClass" {
   exhaustive: false
   function "main_method"{
     args: [
-      self : class(MainClass) [default: ]
+      self : ident("main.MainClass") [default: ]
       x : ident("basetypes.BaseClass") [default: ]
     ]
     kwonly: [
@@ -94,7 +94,7 @@ class "MainClass" {
 }
 function "main_function"{
   args: [
-    x : class(MainClass) [default: ]
+    x : ident("main.MainClass") [default: ]
   ]
   kwonly: [
   ]
@@ -186,7 +186,7 @@ class "InnerHelper" {
 class "ClassWithInit" {
   bases: []
   fields: [
-    helper : class(_InnerHelper) "_InnerHelper()"
+    helper : ident("main._InnerHelper") "_InnerHelper()"
   ]
   classVars: []
   subclasses: [
@@ -198,7 +198,7 @@ class "ClassWithInit" {
       exhaustive: false
       function "do_work"{
         args: [
-          self : class(_InnerHelper) [default: ]
+          self : ident("main._InnerHelper") [default: ]
         ]
         kwonly: [
         ]

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -156,10 +156,10 @@ procedure with_kwonly(x:TInt, verbose:TBool) returns(result:TString)
 
 /--
 info: procedure takes_any(x:UserDefined(Any)) returns(result:TInt)
-procedure takes_list(items:UserDefined(ListStr)) returns(result:TBool)
-procedure returns_dict() returns(result:UserDefined(DictStrAny))
-procedure typed_list() returns(result:UserDefined(ListStr))
-procedure typed_dict() returns(result:UserDefined(DictStrAny))
+procedure takes_list(items:UserDefined(Any)) returns(result:TBool)
+procedure returns_dict() returns(result:UserDefined(Any))
+procedure typed_list() returns(result:UserDefined(Any))
+procedure typed_dict() returns(result:UserDefined(Any))
 -/
 #guard_msgs in
 #eval runTest #[
@@ -229,10 +229,10 @@ procedure opt_int_enum() returns(result:UserDefined(IntOrNone))
 /-! ## Error cases (updated to verify WarningKind) -/
 
 /--
-info: pySpecToLaurel.unknownType: Unknown type 'foo.Bar' mapped to TString
+info: procedure f() returns(result:UserDefined(Bar))
 -/
 #guard_msgs in
-#eval runTestWarningKinds
+#eval runTest
   #[mkFuncSig "f"
     (identType (PythonIdent.mk "foo" "Bar"))]
 
@@ -317,8 +317,8 @@ procedure uses_class(x:UserDefined(Foo)) returns(result:UserDefined(Foo))
     loc := loc, name := "Foo"
     methods := #[]
   },
-  mkFuncSig "uses_class" (.pyClass loc "Foo" #[])
-    (args := #[mkArg "x" (.pyClass loc "Foo" #[])])
+  mkFuncSig "uses_class" (mkType (.ident (PythonIdent.mk "" "Foo") #[]))
+    (args := #[mkArg "x" (mkType (.ident (PythonIdent.mk "" "Foo") #[]))])
 ]
 
 /-! ## Empty input -/
@@ -407,7 +407,7 @@ dispatch create_client:
   mkFuncSig "helper" (identType .builtinsBool)
 ]
 
--- Overloads with locally-defined class return types (.pyClass).
+-- Overloads with locally-defined class return types.
 /--
 info: type Alpha
 type Beta
@@ -419,9 +419,9 @@ dispatch make:
 #eval runFullTest #[
   .classDef { loc := loc, name := "Alpha", methods := #[] },
   .classDef { loc := loc, name := "Beta", methods := #[] },
-  mkOverload "make" (.pyClass loc "Alpha" #[])
+  mkOverload "make" (mkType (.ident (PythonIdent.mk "" "Alpha") #[]))
     (args := #[mkArg "kind" (mkType (.stringLiteral "a"))]),
-  mkOverload "make" (.pyClass loc "Beta" #[])
+  mkOverload "make" (mkType (.ident (PythonIdent.mk "" "Beta") #[]))
     (args := #[mkArg "kind" (mkType (.stringLiteral "b"))])
 ]
 
@@ -502,36 +502,26 @@ body contains FieldSelect: false
 
 /-! ## Warning kind tests -/
 
--- Type translation: unsupportedGenericClass
+-- bytes, bytearray, complex now map to Any (matching PythonToLaurel)
 /--
-info: pySpecToLaurel.unsupportedGenericClass: Generic class 'Foo' with type args unsupported
+info: procedure f() returns(result:UserDefined(Any))
 -/
 #guard_msgs in
-#eval runTestWarningKinds
-  #[mkFuncSig "f" (mkType (.pyClass "Foo" #[identType .builtinsInt]))]
-
--- Type translation: bytesToString
-/--
-info: pySpecToLaurel.bytesToString: 'builtins.bytes' mapped to TString (bytes have different semantics)
--/
-#guard_msgs in
-#eval runTestWarningKinds
+#eval runTest
   #[mkFuncSig "f" (identType .builtinsBytes)]
 
--- Type translation: bytesToString (bytearray variant)
 /--
-info: pySpecToLaurel.bytesToString: 'builtins.bytearray' mapped to TString (bytes have different semantics)
+info: procedure f() returns(result:UserDefined(Any))
 -/
 #guard_msgs in
-#eval runTestWarningKinds
+#eval runTest
   #[mkFuncSig "f" (identType .builtinsBytearray)]
 
--- Type translation: complexToReal
 /--
-info: pySpecToLaurel.complexToReal: 'builtins.complex' mapped to TReal (complex loses imaginary component)
+info: procedure f() returns(result:UserDefined(Any))
 -/
 #guard_msgs in
-#eval runTestWarningKinds
+#eval runTest
   #[mkFuncSig "f" (identType .builtinsComplex)]
 
 -- Unsupported Optional patterns


### PR DESCRIPTION
Replace the `SpecAtomType.pyClass` variant with `.ident` using qualified `PythonIdent`, add `typing.BinaryIO` support, and align PySpec→Laurel type mappings with PythonToLaurel so non-primitive builtins map to `Any` instead of lossy approximations.

## Changes

### 1. Fix missing source locations in PySpec translation errors (`SourceRange.lean`, `Specs.lean`)

`SourceRange.format` crashed when called with a `none` range because it unconditionally called `fm.toPosition` on zero offsets. Now it guards on `isNone` and renders `"path:unknown"` instead. Several pattern matches in `Specs.lean` were extracting annotated values via `name.val`/`name.ann` but discarding the source location — these now destructure as `⟨_, name⟩` at the binding site and pass the parent `loc` to error reporters, ensuring translation errors always have usable locations.

### 2. Remove `SpecAtomType.pyClass` variant (`Decls.lean`, `DDM.lean`, `Specs.lean`, `ToLaurel.lean`)

`pyClass` stored an unqualified class name string, which was ambiguous across modules. All construction sites now use `.ident` with a fully qualified `PythonIdent` (module + name). DDM deserialization of legacy `typeClass`/`typeClassNoArgs` Ion payloads produces `.ident` with empty `pythonModule` for backward compatibility. All match arms and comparison logic for `.pyClass` are removed.

### 3. Add `typing.BinaryIO` support (`Decls.lean`, `Specs.lean`, `ToLaurel.lean`)

`BinaryIO` appears in boto3 stubs (e.g., `lambda_/client.py`'s `invoke` returns `StreamingBody` typed as `BinaryIO`). Without this, pySpecs throws "BinaryIO is not defined in module typing". Added `PythonIdent.typingBinaryIO`, registered it in `preludeSig`, and mapped it to `Any` in `knownIdentTypes`.

### 4. Align `knownIdentTypes` with PythonToLaurel (`ToLaurel.lean`)

Previously, PySpec→Laurel mapped types more aggressively than PythonToLaurel: `bytes`/`bytearray`→`TString`, `complex`→`TReal`, `dict`→`DictStrAny`, `Exception`→`Error`, `typing.List`→`ListStr`, `typing.Dict`→`DictStrAny`. PythonToLaurel maps all of these to `Any`. The mismatch meant pyspec-dispatched analysis could generate spurious preconditions (e.g., string-length bounds on `bytes` parameters). Now both paths agree: only `int`, `str`, `bool`, `float`, and `None` get concrete Laurel types; everything else is `Any`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.