### PR TITLE
Add auto-labeling workflows for PR areas and review status

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,52 @@
+Python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Strata/Languages/Python/**'
+          - 'StrataTest/Languages/Python/**'
+          - 'Tools/Python/**'
+
+Laurel:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Strata/Languages/Laurel/**'
+          - 'StrataTest/Languages/Laurel/**'
+
+Core:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Strata/Languages/Core/**'
+          - 'StrataTest/Languages/Core/**'
+
+SMT:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Strata/DL/SMT/**'
+          - 'StrataTest/DL/SMT/**'
+
+GOTO:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Strata/Backends/CBMC/GOTO/**'
+          - 'StrataTest/Backends/CBMC/GOTO/**'
+
+Java:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'Strata/DDM/Integration/Java/**'
+          - 'Strata/DDM/Integration/Java.lean'
+          - 'StrataTest/DDM/Integration/Java/**'
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'lake-manifest.json'
+          - 'lakefile.toml'
+          - 'lean-toolchain'
+          - 'Tools/Python/pyproject.toml'
+          - 'Tools/BoogieToStrata/**/*.csproj'
+          - 'Tools/BoogieToStrata/**/*.sln'
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/**'

--- a/.github/workflows/label-areas.yml
+++ b/.github/workflows/label-areas.yml
@@ -1,0 +1,18 @@
+name: Label PR areas
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-areas:
+    runs-on: ubuntu-slim
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/label-review-status.yml
+++ b/.github/workflows/label-review-status.yml
@@ -7,6 +7,7 @@ on:
     types: [submitted]
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/label-review-status.yml
+++ b/.github/workflows/label-review-status.yml
@@ -1,0 +1,56 @@
+name: Label review status
+
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, synchronize, converted_to_draft]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  update-review-labels:
+    runs-on: ubuntu-slim
+    steps:
+      - name: Update review status labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          PR_JSON=$(gh pr view "$PR_NUMBER" --json isDraft,reviews)
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.isDraft')
+
+          APPROVALS=$(echo "$PR_JSON" | jq '
+            [.reviews
+             | map(select(.author.login != null))
+             | group_by(.author.login)
+             | .[]
+             | sort_by(.submittedAt)
+             | last
+             | select(.state == "APPROVED")]
+            | length')
+
+          echo "is_draft=$IS_DRAFT approvals=$APPROVALS"
+
+          add_label() {
+            gh pr edit "$PR_NUMBER" --add-label "$1" 2>/dev/null || true
+          }
+          remove_label() {
+            gh pr edit "$PR_NUMBER" --remove-label "$1" 2>/dev/null || true
+          }
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            remove_label "Waiting-For-Review"
+            remove_label "Has 1 approval"
+          elif [ "$APPROVALS" -eq 0 ]; then
+            add_label "Waiting-For-Review"
+            remove_label "Has 1 approval"
+          elif [ "$APPROVALS" -eq 1 ]; then
+            remove_label "Waiting-For-Review"
+            add_label "Has 1 approval"
+          else
+            remove_label "Waiting-For-Review"
+            remove_label "Has 1 approval"
+          fi


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows that automatically label PRs:

- **Area labels** (Python, Laurel, Core, SMT, GOTO, Java, dependencies, github_actions) based on which files are changed, using `actions/labeler@v5`
- **Review status labels** (`Waiting-For-Review`, `Has 1 approval`) based on the current review state

All 10 labels already exist in the repo — no manual label creation needed.

## What's handled

### Area labeling (`label-areas.yml` + `labeler.yml`)
- Labels applied on PR open and each push, based on changed file paths
- A PR touching multiple areas gets multiple labels (e.g., Python + Laurel)
- Labels auto-removed when files change and no longer match (`sync-labels: true`)
- Only manages labels defined in `labeler.yml` — manually applied labels (bug, CSLib, etc.) are never touched

### Review status labeling (`label-review-status.yml`)
- `Waiting-For-Review` added when a non-draft PR has 0 approvals
- `Has 1 approval` added when PR has exactly 1 approval
- Both labels removed when PR has 2+ approvals
- Both labels removed when PR is converted to draft
- Re-evaluated on every push, review submission, and draft toggle
- Counts only the latest review per reviewer (handles approve → request changes correctly)
- Null/deleted reviewer authors filtered out defensively

### Existing workflow compatibility
- `Git conflicts` label continues to be managed by the existing `label-conflicts.yml` — unchanged
- No overlap between the three labeling workflows

## What's NOT handled

- **Regular issue comments** (non-review comments) don't trigger label changes — only formal review submissions do. A PR with comments but no approval keeps `Waiting-For-Review`, which is the intended behavior.
- **`Spec` area** — no label exists for it yet and no `Spec/` top-level directory in the current repo structure. Can be added to `labeler.yml` if needed.
- **CSLib label** — not auto-applied; this is a community tag that should remain manually managed.
- **Files outside all area paths** (e.g., `docs/`, `editors/`, root-level `.lean` files, `Strata/Transform/`, `Strata/Util/`) don't trigger any area label. These can be added to `labeler.yml` as new labels are created.

## Important: how area label sync works

Area labels (Python, Laurel, Core, etc.) are kept in sync with the actual files changed in the PR. If a label no longer matches any changed file after a push, it is **automatically removed**. This means:

- **Manually applying an area label will not stick** if the PR's files don't match that area's patterns in `labeler.yml`. The next push will remove it.
- This only affects the 8 area labels listed in `labeler.yml`. All other labels (bug, CSLib, help wanted, etc.) are never touched.
- Existing open PRs won't be relabeled until their next event (push, review, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)