### PR TITLE
Apply mergeByAssertion in Core.verify to deduplicate VCResults

### DIFF
--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -1088,7 +1088,8 @@ def verify (program : Program)
   let allStats := VCss.foldl (fun acc (_, s) => acc.merge s) allStats
   if profile then
     let _ ← (IO.println allStats.format |>.toBaseIO)
-  .ok (VCss.map (·.fst)).toArray.flatten
+  let results : VCResults := (VCss.map (·.fst)).toArray.flatten
+  .ok results.mergeByAssertion
 
 end -- public section
 end Core

--- a/Strata/Util/Statistics.lean
+++ b/Strata/Util/Statistics.lean
@@ -44,6 +44,10 @@ def format (stats : Statistics) : String :=
   let lines := sorted.map fun (k, v) => s!"[statistics] {k}: {v}"
   "\n".intercalate lines.toList
 
+/-- Look up a counter value, returning 0 if absent. -/
+def get (stats : Statistics) (key : String) : Int :=
+  stats.data.getD key 0
+
 end Statistics
 
 /-! ## Derive `ToString` for enum-like stat key inductives

--- a/StrataTest/Languages/Core/Tests/VCGPathTests.lean
+++ b/StrataTest/Languages/Core/Tests/VCGPathTests.lean
@@ -9,8 +9,8 @@ import Strata.Languages.Core.Verifier
 ---------------------------------------------------------------------
 namespace Strata
 
--- `second`'s obligation is checked once. However, `first`'s `post` is checked
--- twice because we don't (yet) do within-procedure path merging.
+-- `second`'s obligation is checked once. `first`'s `post` is checked on two
+-- paths but mergeByAssertion deduplicates the results.
 def issue419TestPgm :=
 #strata
 program Core;
@@ -30,10 +30,6 @@ procedure second() returns () { assert [a]: true; };
 
 /--
 info:
-Obligation: post
-Property: assert
-Result: ✅ pass
-
 Obligation: post
 Property: assert
 Result: ✅ pass
@@ -67,14 +63,6 @@ info:
 Obligation: wrong_ensures_0
 Property: assert
 Result: ❌ fail
-
-Obligation: wrong_ensures_0
-Property: assert
-Result: ✅ pass
-
-Obligation: wrong_ensures_0
-Property: assert
-Result: ✅ pass
 -/
 #guard_msgs in
 #eval verify sequentialExitPgm (options := .quiet)
@@ -279,10 +267,6 @@ Result: ✅ pass
 Obligation: else_path
 Property: assert
 Result: ✅ pass
-
-Obligation: post
-Property: assert
-Result: ✅ pass
 -/
 #guard_msgs in
 #eval verify noDupConcreteTrue (options := .quiet)
@@ -327,10 +311,6 @@ Property: assert
 Result: ✅ pass
 
 Obligation: else_path
-Property: assert
-Result: ✅ pass
-
-Obligation: post
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataTest/Languages/Core/Tests/VCGPathTests.lean
+++ b/StrataTest/Languages/Core/Tests/VCGPathTests.lean
@@ -316,3 +316,44 @@ Result: ✅ pass
 -/
 #guard_msgs in
 #eval verify noDupConcreteFalse (options := .quiet)
+
+---------------------------------------------------------------------
+-- Evaluator statistics tests
+--
+-- These verify that path splitting is observable in the evaluator stats
+-- (diverged count, obligation count) independently of mergeByAssertion
+-- which only deduplicates at the outcome/display level.
+---------------------------------------------------------------------
+
+/-- Extract evaluator statistics from a program without running the solver. -/
+private def getEvalStats (program : Strata.Program) : IO (Statistics × Nat) := do
+  let (coreProgram, _) := Core.getProgram program
+  match Core.typeCheckAndEval .quiet coreProgram with
+  | .error _ => return ({}, 0)
+  | .ok (envs, stats) =>
+    let numObligations := envs.foldl (fun acc e => acc + e.deferred.size) 0
+    return (stats, numObligations)
+
+-- issue419TestPgm: the evaluator produces 2 paths (1 diverged ITE) and
+-- 3 obligations (2 for `post`, 1 for `a`). mergeByAssertion collapses
+-- the 2 `post` results into 1 displayed result, but the evaluator still
+-- explored both paths.
+/--
+info: diverged=1 obligations=3
+-/
+#guard_msgs in
+#eval do
+  let (stats, numObs) ← getEvalStats issue419TestPgm
+  let key := s!"{Core.Evaluator.Stats.processIteBranches_diverged}"
+  IO.println s!"diverged={stats.get key} obligations={numObs}"
+
+-- sequentialExitPgm: 2 diverged ITEs, 3 paths, 3 obligations for
+-- `wrong_ensures_0`. mergeByAssertion collapses to 1 displayed result.
+/--
+info: diverged=2 obligations=3
+-/
+#guard_msgs in
+#eval do
+  let (stats, numObs) ← getEvalStats sequentialExitPgm
+  let key := s!"{Core.Evaluator.Stats.processIteBranches_diverged}"
+  IO.println s!"diverged={stats.get key} obligations={numObs}"

--- a/Tools/BoogieToStrata/Tests/Bubble.expect
+++ b/Tools/BoogieToStrata/Tests/Bubble.expect
@@ -29,8 +29,4 @@ Bubble.core.st(46, 0) [arbitrary_iter_maintain_invariant_1_1]: ✅ pass
 Bubble.core.st(46, 0) [arbitrary_iter_maintain_invariant_1_2]: ✅ pass
 Bubble.core.st(46, 0) [arbitrary_iter_maintain_invariant_1_3]: ✅ pass
 Bubble.core.st(46, 0) [arbitrary_iter_maintain_invariant_1_4]: ✅ pass
-Bubble.core.st(20, 2) [BubbleSort_ensures_1]: ✅ pass
-Bubble.core.st(21, 2) [BubbleSort_ensures_2]: ✅ pass
-Bubble.core.st(22, 2) [BubbleSort_ensures_3]: ✅ pass
-Bubble.core.st(23, 2) [BubbleSort_ensures_4]: ✅ pass
-All 34 goals passed.
+All 30 goals passed.

--- a/Tools/BoogieToStrata/Tests/CrossNestingExit.expect
+++ b/Tools/BoogieToStrata/Tests/CrossNestingExit.expect
@@ -1,8 +1,5 @@
 Successfully parsed.
 CrossNestingExit.core.st(45, 6) [assert_0]: ✅ pass
-CrossNestingExit.core.st(45, 6) [assert_0]: ✅ pass
-CrossNestingExit.core.st(85, 6) [assert_1]: ❌ fail
-CrossNestingExit.core.st(85, 6) [assert_1]: ✅ pass
-CrossNestingExit.core.st(125, 6) [assert_2]: ❌ fail
-CrossNestingExit.core.st(125, 6) [assert_2]: ✅ pass
-Finished with 4 goals passed, 2 failed.
+CrossNestingExit.core.st(85, 6) [assert_1]: ❌ fail (fail on 1 path, pass on 1 path)
+CrossNestingExit.core.st(125, 6) [assert_2]: ❌ fail (fail on 1 path, pass on 1 path)
+Finished with 1 goals passed, 2 failed.


### PR DESCRIPTION
## Summary

- Closes #980. PR #833 added `VCResults.mergeByAssertion` to deduplicate path-split assertions, but only wired it into the Laurel and Python pipelines. This applies it in `Core.verify` so the Core verify path and `strata verify` CLI also deduplicate.
- Updates 4 `#guard_msgs` tests in `VCGPathTests.lean` where duplicate obligations are now merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.