### PR TITLE
Convert remaining Lean files under /Strata to modules

### DIFF
--- a/Strata.lean
+++ b/Strata.lean
@@ -6,7 +6,7 @@
 
 -- This module serves as the root of the `Strata` library.
 -- In each category, imports are sorted by alphabetical order.
-
+module
 /- DDM -/
 import Strata.DDM.Integration.Lean
 import Strata.DDM.Ion

--- a/Strata/Backends/CBMC/CProver.lean
+++ b/Strata/Backends/CBMC/CProver.lean
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 -------------------------------------------------------------------------------
 
-import Strata.Backends.CBMC.GOTO.Program
-import Strata.Backends.CBMC.GOTO.InstToJson
+public import Strata.Backends.CBMC.GOTO.Program
+public import Strata.Backends.CBMC.GOTO.InstToJson

--- a/Strata/Backends/CBMC/CollectSymbols.lean
+++ b/Strata/Backends/CBMC/CollectSymbols.lean
@@ -3,14 +3,17 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Backends.CBMC.GOTO.InstToJson
-import Strata.Backends.CBMC.GOTO.LambdaToCProverGOTO
+public import Strata.Backends.CBMC.GOTO.InstToJson
+public import Strata.Backends.CBMC.GOTO.LambdaToCProverGOTO
 import Strata.DL.Lambda.TypeConstructor
 import Strata.DL.Lambda.TypeFactory
-import Strata.Languages.Core.Program
+public import Strata.Languages.Core.Program
 
 namespace Strata
+
+public section
 
 private def datatypeToSymbolEntry (dt : Lambda.LDatatype Unit)
     (mutualNames : List String := [dt.name]) :
@@ -152,5 +155,6 @@ def collectExtraSymbols (pgm : Core.Program) :
   let globalSyms ← collectGlobalSymbols pgm
   return typeSyms ++ globalSyms
 
+end -- public section
 
 end Strata

--- a/Strata/Backends/CBMC/Common.lean
+++ b/Strata/Backends/CBMC/Common.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Lean.Data.Json
-import Strata.DL.Util.Map
+public import Lean.Data.Json
+public import Strata.DL.Util.Map
+
+public section
 
 -------------------------------------------------------------------------------
 

--- a/Strata/Backends/CBMC/CoreToCBMC.lean
+++ b/Strata/Backends/CBMC/CoreToCBMC.lean
@@ -3,22 +3,28 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
+
+public import Strata.Backends.CBMC.Common
+public import Strata.Languages.Core.Procedure
 
 import Lean.Data.Json
+import Strata.DDM.Integration.Lean.HashCommands
 import Strata.Languages.Core.Env
 import Strata.Languages.Core.DDMTransform.Grammar
 import Strata.Languages.Core.DDMTransform.Translate
 import Strata.DL.Util.Map
 import Strata.Languages.Core.Core
-import Strata.Backends.CBMC.Common
 import Strata.Util.Tactics
+
+public section
 
 open Lean
 open Strata.CBMC
 
 namespace Core
 -- Our test program
-def SimpleTestEnv :=
+private def SimpleTestEnv :=
 #strata
 program Core;
 
@@ -36,9 +42,9 @@ spec {
 #end
 
 open Core in
-def SimpleTestEnvAST := Strata.TransM.run Inhabited.default (Strata.translateProgram (SimpleTestEnv))
+private def SimpleTestEnvAST := Strata.TransM.run Inhabited.default (Strata.translateProgram (SimpleTestEnv))
 
-def myProc : Except String Core.Procedure := do
+private def myProc : Except String Core.Procedure := do
   match SimpleTestEnvAST.fst.decls.head!.getProc? with
   | .some p => return p
   | .none => throw "Expected procedure"

--- a/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
@@ -3,12 +3,15 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Core.Verifier
-import Strata.Backends.CBMC.GOTO.InstToJson
-import Strata.Backends.CBMC.GOTO.DefaultSymbols
-import Strata.Backends.CBMC.GOTO.LambdaToCProverGOTO
-import Strata.DL.Imperative.ToCProverGOTO
+public import Strata.Backends.CBMC.GOTO.InstToJson
+public import Strata.Backends.CBMC.GOTO.DefaultSymbols
+public import Strata.Backends.CBMC.GOTO.LambdaToCProverGOTO
+public import Strata.DL.Imperative.ToCProverGOTO
+public import Strata.Languages.Core.Verifier
+
+public section
 
 open Std (ToFormat Format format)
 
@@ -37,7 +40,7 @@ abbrev Core.ExprStr : Imperative.PureExpr :=
 
 namespace CoreToGOTO
 
-private def lookupType (T : Core.Expression.TyEnv) (i : Core.Expression.Ident) :
+def lookupType (T : Core.Expression.TyEnv) (i : Core.Expression.Ident) :
     Except Format CProverGOTO.Ty :=
   match T.context.types.find? i with
   | none => throw f!"Cannot find {i} in the type context!"
@@ -47,7 +50,7 @@ private def lookupType (T : Core.Expression.TyEnv) (i : Core.Expression.Ident) :
       ty.toGotoType
     else throw f!"Poly-type unexpected in the context for {i}: {ty}"
 
-private def updateType (T : Core.Expression.TyEnv) (i : Core.Expression.Ident)
+def updateType (T : Core.Expression.TyEnv) (i : Core.Expression.Ident)
     (ty : Core.Expression.Ty) : Core.Expression.TyEnv :=
   @Lambda.TEnv.addInNewestContext ⟨Core.ExpressionMetadata, Unit⟩ T [(i, ty)]
 
@@ -58,7 +61,7 @@ instance : Imperative.ToGoto Core.Expression where
   toGotoType := (fun ty => Lambda.LMonoTy.toGotoType ty.toMonoTypeUnsafe)
   toGotoExpr := Lambda.LExpr.toGotoExpr
 
-private def lookupTypeStr (T : Core.ExprStr.TyEnv) (i : Core.ExprStr.Ident) :
+def lookupTypeStr (T : Core.ExprStr.TyEnv) (i : Core.ExprStr.Ident) :
     Except Format CProverGOTO.Ty :=
   match T.context.types.find? i with
   | none => throw f!"Cannot find {i} in the type context!"
@@ -68,7 +71,7 @@ private def lookupTypeStr (T : Core.ExprStr.TyEnv) (i : Core.ExprStr.Ident) :
       ty.toGotoType
     else throw f!"Poly-type unexpected in the context for {i}: {ty}"
 
-private def updateTypeStr (T : Core.ExprStr.TyEnv) (i : Core.ExprStr.Ident)
+def updateTypeStr (T : Core.ExprStr.TyEnv) (i : Core.ExprStr.Ident)
     (ty : Core.ExprStr.Ty) : Core.ExprStr.TyEnv :=
   T.addInNewestContext [(i, ty)]
 
@@ -98,7 +101,7 @@ def substVarNames {Metadata IDMeta: Type} [DecidableEq IDMeta]
 /-- Convert metadata from `Core.Expression` to `Core.ExprStr`, preserving
     label-keyed elements (fileRange, propertySummary, etc.) and dropping
     variable-keyed elements whose identifier type changes. -/
-private def convertMetaData (md : Imperative.MetaData Core.Expression)
+def convertMetaData (md : Imperative.MetaData Core.Expression)
     : Imperative.MetaData Core.ExprStr :=
   md.filterMap fun elem =>
     match elem.fld with

--- a/Strata/Backends/CBMC/GOTO/CoreToGOTOPipeline.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToGOTOPipeline.lean
@@ -3,9 +3,10 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Backends.CBMC.CollectSymbols
-import Strata.Backends.CBMC.GOTO.CoreToCProverGOTO
+public import Strata.Backends.CBMC.CollectSymbols
+public import Strata.Backends.CBMC.GOTO.CoreToCProverGOTO
 import Strata.Transform.ProcedureInlining
 
 /-! ## Core-to-GOTO translation pipeline
@@ -40,6 +41,8 @@ The following are not yet handled:
 -/
 
 namespace Strata
+
+public section
 
 private def renameIdent (rn : Std.HashMap String String) (id : Core.CoreIdent) : Core.CoreIdent :=
   match rn[id.name]? with
@@ -514,5 +517,7 @@ public def inlineCoreToGotoFiles (program : Core.Program)
     | .ok r => pure r
     | .error msg => throw msg
   coreToGotoFiles tcPgm Env baseName sourceText entryPoints
+
+end -- public section
 
 end Strata

--- a/Strata/Backends/CBMC/GOTO/DefaultSymbols.lean
+++ b/Strata/Backends/CBMC/GOTO/DefaultSymbols.lean
@@ -3,8 +3,9 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Backends.CBMC.GOTO.InstToJson
+public import Strata.Backends.CBMC.GOTO.InstToJson
 
 /-!
 # CBMC Default Symbol Table
@@ -23,6 +24,8 @@ The symbols fall into three groups:
 -/
 
 namespace CProverGOTO
+
+public section
 
 /-- Target architecture configuration.
 
@@ -559,5 +562,7 @@ def wrapSymtab (symtabObj : Std.TreeMap.Raw String Lean.Json)
   let obj := (defaultSymbols cfg moduleName).foldl
     (fun acc (k, v) => acc.insert k (Lean.toJson v)) symtabObj
   Lean.Json.mkObj [("symbolTable", Lean.Json.obj obj)]
+
+end -- public section
 
 end CProverGOTO

--- a/Strata/Backends/CBMC/GOTO/InstToJson.lean
+++ b/Strata/Backends/CBMC/GOTO/InstToJson.lean
@@ -3,11 +3,15 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Backends.CBMC.GOTO.Program
-import Strata.Backends.CBMC.Common
+public import Strata.Backends.CBMC.Common
+public import Strata.Util.Json
+public import Strata.Backends.CBMC.GOTO.Program
+
 import Strata.Util.Tactics
-import Strata.Util.Json
+
+public section
 
 namespace CProverGOTO
 open Lean

--- a/Strata/Backends/CBMC/GOTO/LambdaToCProverGOTO.lean
+++ b/Strata/Backends/CBMC/GOTO/LambdaToCProverGOTO.lean
@@ -3,10 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DL.Lambda.Lambda
-import Strata.Backends.CBMC.GOTO.Expr
+public import Strata.DL.Lambda.Lambda
+public import Strata.Backends.CBMC.GOTO.Expr
 import Strata.Languages.Core.CoreOp
+
+public section
 namespace Lambda
 
 /-! # Lambda-to-GOTO expression and type translation

--- a/Strata/Backends/CBMC/GOTO/SourceLocation.lean
+++ b/Strata/Backends/CBMC/GOTO/SourceLocation.lean
@@ -22,6 +22,7 @@ structure SourceLocation where
   comment : String
 deriving Repr, DecidableEq, Inhabited, Lean.ToJson, Lean.FromJson
 
+@[expose]
 def SourceLocation.nil : SourceLocation :=
   { file := "", line := 0, column := 0, function := "", workingDir := "", comment := "" }
 

--- a/Strata/Backends/CBMC/StrataToCBMC.lean
+++ b/Strata/Backends/CBMC/StrataToCBMC.lean
@@ -3,18 +3,21 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 import Lean.Data.Json
 import Strata.DL.Util.Map
-import Strata.Languages.C_Simp.C_Simp
-import Strata.Languages.C_Simp.Verify
-import Strata.Backends.CBMC.Common
+public import Strata.Languages.C_Simp.C_Simp
+public import Strata.Languages.C_Simp.Verify
+public import Strata.Backends.CBMC.Common
 import Strata.Util.Tactics
 
 open Lean
 open Strata.CBMC
 
 namespace CSimp
+
+public section
 
 -- Our test program
 def SimpleTestEnv :=
@@ -399,5 +402,7 @@ def testSymbols (myFunc: Strata.C_Simp.Function) : Except String String := do
   m := m.insert s!"{myFunc.name}::1::z" zSymbol
 
   return toString (toJson m)
+
+end -- public section
 
 end CSimp

--- a/Strata/DL/Imperative/BasicBlock.lean
+++ b/Strata/DL/Imperative/BasicBlock.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DL.Imperative.MetaData
-import Strata.DL.Imperative.PureExpr
+public import Strata.DL.Imperative.MetaData
+public import Strata.DL.Imperative.PureExpr
+
+public section
 
 namespace Imperative
 
@@ -61,12 +64,12 @@ structure BasicBlock (TransferCmd Cmd : Type) where
 
 /-- A deterministic basic block is a basic block parameterized by deterministic
 commands. -/
-def DetBlock (Label Cmd : Type) (P : PureExpr) :=
+@[expose] def DetBlock (Label Cmd : Type) (P : PureExpr) :=
   BasicBlock (DetTransferCmd Label P) Cmd
 
 /-- A non-deterministic basic block is a basic block parameterized by
 non-deterministic commands. -/
-def NondetBlock (Label Cmd : Type) (P : PureExpr) :=
+@[expose] def NondetBlock (Label Cmd : Type) (P : PureExpr) :=
   BasicBlock (NondetTransferCmd Label P) Cmd
 
 /-- A control flow graph is a list of blocks paired with a label indicating

--- a/Strata/DL/Imperative/CFGSemantics.lean
+++ b/Strata/DL/Imperative/CFGSemantics.lean
@@ -3,11 +3,15 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
-import Strata.DL.Imperative.BasicBlock
-import Strata.DL.Imperative.Cmd
-import Strata.DL.Imperative.CmdSemantics
-import Strata.DL.Imperative.StmtSemantics
-import Strata.DL.Util.Relations
+module
+
+public import Strata.DL.Imperative.BasicBlock
+public import Strata.DL.Imperative.Cmd
+public import Strata.DL.Imperative.CmdSemantics
+public import Strata.DL.Imperative.StmtSemantics
+public import Strata.DL.Util.Relations
+
+public section
 
 ---------------------------------------------------------------------
 

--- a/Strata/DL/Imperative/CFGToCProverGOTO.lean
+++ b/Strata/DL/Imperative/CFGToCProverGOTO.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DL.Imperative.BasicBlock
-import Strata.DL.Imperative.ToCProverGOTO
+public import Strata.DL.Imperative.BasicBlock
+public import Strata.DL.Imperative.ToCProverGOTO
+
+public section
 
 /-! # CFG to CProverGOTO Translation
 

--- a/Strata/DL/Imperative/CmdSemantics.lean
+++ b/Strata/DL/Imperative/CmdSemantics.lean
@@ -236,7 +236,7 @@ def WellFormedSemanticEvalVal {P : PureExpr} [HasVal P]
   -- evaluator is identity on values
     (∀ v' σ, HasVal.value v' → δ σ v' = some v')
 
-def WellFormedSemanticEvalVar {P : PureExpr} [HasFvar P] (δ : SemanticEval P)
+@[expose] def WellFormedSemanticEvalVar {P : PureExpr} [HasFvar P] (δ : SemanticEval P)
     : Prop := (∀ e v σ, HasFvar.getFvar e = some v → δ σ e = σ v)
 
 def WellFormedSemanticEvalExprCongr {P : PureExpr} [HasVarsPure P P.Expr] (δ : SemanticEval P)

--- a/Strata/DL/Lambda/TestGen.lean
+++ b/Strata/DL/Lambda/TestGen.lean
@@ -3,19 +3,21 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DL.Lambda.LExpr
-import Strata.DL.Lambda.LExprTypeSpec
-import Strata.DL.Lambda.LExprTypeEnv
-import Strata.DL.Lambda.LExprWF
-import Strata.DL.Lambda.LExprT
-import Strata.DL.Lambda.LExprEval
+import Plausible.Arbitrary
+public import Plausible.ArbitraryFueled
+import Plausible.Gen
+
+public meta import Strata.DL.Lambda.Factory
+public meta import Strata.DL.Lambda.Identifiers
 import Strata.DL.Lambda.IntBoolFactory
-import Plausible.Sampleable
-import Plausible.DeriveArbitrary
-import Plausible.Attr
-import Strata.DL.Lambda.PlausibleHelpers
-import Strata.Util.Random
+public meta import Strata.DL.Lambda.LExpr
+import Strata.DL.Lambda.LExprT
+public meta import Strata.DL.Lambda.LExprTypeEnv
+public meta import Strata.DL.Lambda.LExprWF
+public meta import Strata.DL.Lambda.MetaData
+public import Strata.DL.Lambda.PlausibleHelpers
 
 -- -- Add these if depending on Chamelean for instance generation.
 -- import Plausible.Chamelean.ArbitrarySizedSuchThat
@@ -32,6 +34,9 @@ import Strata.Util.Random
 
 open Plausible
 
+public section
+
+meta section
 deriving instance Arbitrary for Lambda.Identifier
 deriving instance Arbitrary for Lambda.Info
 deriving instance Arbitrary for Lambda.QuantifierKind
@@ -142,6 +147,7 @@ def instArbitraryLExpr.arbitrary {T}
   fun fuel => aux_arb fuel
 
 instance {T} [Arbitrary T.base.Metadata] [Arbitrary T.base.IDMeta] [Arbitrary T.TypeType] : Plausible.ArbitraryFueled (@Lambda.LExpr T) := ⟨instArbitraryLExpr.arbitrary⟩
+end
 
 -- -- Prints a few examples of random expressions.
 -- #eval Gen.printSamples (Arbitrary.arbitrary : Gen <| Lambda.LExpr ⟨⟨String, String⟩, String⟩)
@@ -197,10 +203,10 @@ inductive MapsInsert : Maps α β → α → β → Maps α β → Prop where
 | empty : MapsInsert [] x y [[(x, y)]]
 
 -- -- We hand write this to avoid guessing and checking for strings.
-instance instStringSuchThatIsInt : ArbitrarySizedSuchThat String (fun s => s.isInt) where
+private meta instance instStringSuchThatIsInt : ArbitrarySizedSuchThat String (fun s => s.isInt) where
   arbitrarySizedST _ := toString <$> (Arbitrary.arbitrary : Gen Int)
 
-instance instArrayFindSuchThat {α} {a : Array α} : ArbitrarySizedSuchThat α (fun x => x ∈ a) where
+meta instance instArrayFindSuchThat {α} {a : Array α} : ArbitrarySizedSuchThat α (fun x => x ∈ a) where
   arbitrarySizedST _ := do
   if h:a.size = 0 then throw <| GenError.genError "Gen: cannot generate elements of empty array" else
   let i ← Gen.chooseNatLt 0 a.size (by omega)
@@ -215,8 +221,9 @@ inductive IsBinaryArg : LTy → (LTy × LTy) → LTy → Prop where
 -- Compare `LExpr.HasType` in `LExprTypeSpec.lean`
 
 -- Parameters for terms without metadata
-abbrev TrivialParams : LExprParams := ⟨Unit, Unit⟩
+public abbrev TrivialParams : LExprParams := ⟨Unit, Unit⟩
 
+public
 def varClose (k : Nat) (x : IdentT LMonoTy TrivialParams.IDMeta) (e : LExpr TrivialParams.mono) : LExpr TrivialParams.mono :=
   match e with
   | .const m c => .const m c
@@ -230,6 +237,7 @@ def varClose (k : Nat) (x : IdentT LMonoTy TrivialParams.IDMeta) (e : LExpr Triv
   | .ite m c t e => .ite m (varClose k x c) (varClose k x t) (varClose k x e)
   | .eq m e1 e2 => .eq m (varClose k x e1) (varClose k x e2)
 
+meta section
 def LFunc.type! (f : (LFunc T)) : LTy :=
   let input_tys := f.inputs.values
   let output_tys := Lambda.LMonoTy.destructArrow f.output
@@ -237,11 +245,12 @@ def LFunc.type! (f : (LFunc T)) : LTy :=
   | [] => .forAll f.typeArgs f.output
   | ity :: irest =>
     .forAll f.typeArgs (Lambda.LMonoTy.mkArrow ity (irest ++ output_tys))
+end
 
 -- We massage the `HasType` definition to be more amenable to generation. The main differences are that
 -- polymorphism is not supported, and we tend to move function applications in the "output" position to the conclusion.
 -- This avoids an additional costly check in the hypothesis.
-inductive HasType {T: LExprParams} [DecidableEq T.IDMeta] (C : LContext T) : (TContext T.IDMeta) → LExpr T.mono → LTy → Prop where
+public inductive HasType {T: LExprParams} [DecidableEq T.IDMeta] (C : LContext T) : (TContext T.IDMeta) → LExpr T.mono → LTy → Prop where
   | tbool_const : ∀ Γ m b,
             C.knownTypes.containsName "bool" →
             HasType C Γ (.boolConst m b) (.forAll [] .bool)
@@ -303,6 +312,7 @@ inductive HasType {T: LExprParams} [DecidableEq T.IDMeta] (C : LContext T) : (TC
   -- -- We only generate monomorphic types for now
 
 -- -- We hand write this instance to control the base type names.
+meta section
 instance : Arbitrary LMonoTy where
   arbitrary :=
     let rec aux (n : Nat) : Gen LMonoTy :=
@@ -749,7 +759,6 @@ instance : ArbitrarySizedSuchThat LTy (fun ty₁_1 => @IsUnaryArg ty_1 ty₁_1 t
             ])
     fun size => aux_arb size size ty_1 ty₂_1
 
-
 -- -- This works
 -- derive_generator fun ty ty₂ => ∃ ty₁, IsUnaryArg ty ty₁ ty₂
 
@@ -1041,8 +1050,9 @@ instance {T : LExprParams}
         ])
     fun size => aux_arb size size ctx_1 ty_1
 
+end
 
-abbrev example_lctx : LContext TrivialParams :=
+private abbrev example_lctx : LContext TrivialParams :=
 { LContext.empty with knownTypes := KnownTypes.default
                       functions := Lambda.IntBoolFactory
 }
@@ -1051,11 +1061,13 @@ abbrev example_ctx : TContext Unit := ⟨[[]], []⟩
 -- abbrev example_ty : LTy := .forAll [] <| .tcons "bool" []
 abbrev example_ty : LTy := .forAll [] <| .tcons "arrow" [.tcons "bool" [], .tcons "bool" []]
 
-def example_lstate :=
+private def example_lstate :=
   { LState.init (T := TrivialParams) with config :=
     { LState.init.config (T := TrivialParams) with
       factory := Lambda.IntBoolFactory (T := TrivialParams)}
   }
+
+meta section
 
 /-- `Monad` instance for List.
     Note that:
@@ -1066,8 +1078,7 @@ private instance : Monad List where
   pure x := [x]
   bind xs f := xs.flatMap f
 
-instance [Inhabited T.base.IDMeta] : Shrinkable (LExpr T) where
-  shrink t :=
+def shrinkLExpr {T} [Inhabited T.base.IDMeta] (t : LExpr T) : List (LExpr T) :=
   let rec aux (t : LExpr T) : List (LExpr T) :=
   match t with
     | .fvar _ _ _
@@ -1082,6 +1093,11 @@ instance [Inhabited T.base.IDMeta] : Shrinkable (LExpr T) where
     | .ite m cond t u => cond :: t :: u :: (.ite m <$> aux cond <*> aux t <*> aux u)
     | .quant m k name ty tr t => (LExpr.varOpen 0 ⟨⟨"x", default⟩, ty⟩ t) :: (.quant m k name ty tr <$> aux t)
   aux t
+
+instance [Inhabited T.base.IDMeta] : Shrinkable (LExpr T) where
+  shrink := shrinkLExpr
+
+end
 
 -- Shrinks an element of `α` recursively.
 partial def shrinkFunAux [Shrinkable α] (f : α → Bool) (x : α) : Option α := do
@@ -1112,3 +1128,5 @@ match t with
 def reduces (t : LExpr TrivialParams.mono) : Bool :=
   let t' := t.eval 1000 example_lstate
   isIntConst t'
+
+end

--- a/Strata/DL/SMT/Denote.lean
+++ b/Strata/DL/SMT/Denote.lean
@@ -3,8 +3,11 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Core.SMTEncoder
+public import Strata.Languages.Core.SMTEncoder
+
+public section
 
 /-!
 # Denotation of SMT terms for the Strata DSL
@@ -24,7 +27,7 @@ theorem List.getElem_of_findIdx?_eq_some {xs : List α} {mkTypeFunType : α → 
   have ⟨h1, h2⟩ := List.findIdx?_eq_some_iff_getElem.mp h
   exact h2.1
 
-def mkTypeFunType (n : Nat) : Type 1 := n.repeat (Type → ·) Type
+@[expose] def mkTypeFunType (n : Nat) : Type 1 := n.repeat (Type → ·) Type
 
 def applyTypeArg {n : Nat} (tf : mkTypeFunType (n + 1)) (α : Type) : mkTypeFunType n :=
   tf α
@@ -380,7 +383,7 @@ Check that denoted argument types match declared variable types.
 
 If lengths differ, this returns `false`.
 -/
-@[simp]
+@[simp, expose]
 noncomputable def argTypesAlign (as : List (TermDenoteResult ctx)) (vs : List TermVar) : Bool :=
   match as, vs with
   | [], [] => true
@@ -410,13 +413,13 @@ theorem argTypesAlign_length_eq (h : argTypesAlign as vs) : as.length = vs.lengt
     have h' : as.length = vs.length := argTypesAlign_length_eq (Bool.and_eq_true_iff.mp h).right
     simpa using congrArg Nat.succ h'
 
-theorem argTypesAlign_true (h : argTypesAlign as vs) :
-  ∀ i, (hi : i < as.length) → as[i].ty = (vs[i]'(argTypesAlign_length_eq h ▸ hi)).ty := by
-  exact argTypesAlign_true_with_len h (argTypesAlign_length_eq h)
+theorem argTypesAlign_true {as : List (TermDenoteResult ctx)} {vs : List TermVar} (h : argTypesAlign as vs) :
+  ∀ i, (hi : i < as.length) → as[i].ty = (vs[i]'(argTypesAlign_length_eq h ▸ hi)).ty :=
+  argTypesAlign_true_with_len h (argTypesAlign_length_eq h)
 
-theorem argTypesAlign_arg_types (h : argTypesAlign as vs) :
-  ∀ i, (hi : i < as.length) → as[i].ty = (vs[i]'(argTypesAlign_length_eq h ▸ hi)).ty := by
-  exact argTypesAlign_true h
+theorem argTypesAlign_arg_types {as : List (TermDenoteResult ctx)} {vs : List TermVar} (h : argTypesAlign as vs) :
+  ∀ i, (hi : i < as.length) → as[i].ty = (vs[i]'(argTypesAlign_length_eq h ▸ hi)).ty :=
+  argTypesAlign_true h
 
 -- Note: `noncomputable` because of a compiler error
 /--

--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -3,10 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Lean.Expr
-import Lean.ToExpr
-import Strata.Languages.Core.SMTEncoder
+public import Lean.Expr
+public import Lean.ToExpr
+public import Strata.Languages.Core.SMTEncoder
+
+public section
 
 open Lean
 open Strata hiding Expr

--- a/Strata/DL/Util/ListUtils.lean
+++ b/Strata/DL/Util/ListUtils.lean
@@ -101,7 +101,7 @@ def List.replaceAll [BEq α] : List α → α → α → List α
 /-- `Disjoint l₁ l₂` means that `l₁` and `l₂` have no elements in common.
 Taken from https://github.com/leanprover-community/batteries/blob/3613427d66262c4e25e19b40a6a49242e94ba072/Batteries/Data/List/Basic.lean#L512-L514
 -/
-def List.Disjoint (l₁ l₂ : List α) : Prop :=
+@[expose] def List.Disjoint (l₁ l₂ : List α) : Prop :=
   ∀ ⦃a⦄, a ∈ l₁ → a ∈ l₂ → False
 
 end -- public section

--- a/Strata/Languages/B3/DDMTransform/Conversion.lean
+++ b/Strata/Languages/B3/DDMTransform/Conversion.lean
@@ -3,10 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.DDMTransform.ParseCST
-import Strata.Languages.B3.DDMTransform.DefinitionAST
+public import Strata.Languages.B3.DDMTransform.ParseCST
+public import Strata.Languages.B3.DDMTransform.DefinitionAST
 import Strata.Util.Tactics
+
+public section
 
 /-!
 # B3 ↔ DDM Bidirectional Conversion

--- a/Strata/Languages/B3/DDMTransform/DefinitionAST.lean
+++ b/Strata/Languages/B3/DDMTransform/DefinitionAST.lean
@@ -3,10 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DDM.Integration.Lean
-import Strata.DDM.Util.Format
+public import Strata.DDM.Integration.Lean
+public import Strata.DDM.Util.Format
 import Strata.Util.Tactics
+
+public section
 
 ---------------------------------------------------------------------
 

--- a/Strata/Languages/B3/DDMTransform/ParseCST.lean
+++ b/Strata/Languages/B3/DDMTransform/ParseCST.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DDM.Integration.Lean
-import Strata.DDM.Util.Format
+public import Strata.DDM.Integration.Lean
+public import Strata.DDM.Util.Format
+
+public section
 
 ---------------------------------------------------------------------
 

--- a/Strata/Languages/B3/Transform/FunctionToAxiom.lean
+++ b/Strata/Languages/B3/Transform/FunctionToAxiom.lean
@@ -3,8 +3,11 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.DDMTransform.DefinitionAST
+public import Strata.Languages.B3.DDMTransform.DefinitionAST
+
+public section
 
 /-!
 # Function-to-Axiom Transformation

--- a/Strata/Languages/B3/Verifier.lean
+++ b/Strata/Languages/B3/Verifier.lean
@@ -3,12 +3,16 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.Verifier.Expression
-import Strata.Languages.B3.Verifier.Formatter
-import Strata.Languages.B3.Verifier.State
-import Strata.Languages.B3.Verifier.Program
-import Strata.Languages.B3.Verifier.Diagnosis
+public import Strata.Languages.B3.Verifier.Expression
+public import Strata.Languages.B3.Verifier.Formatter
+public import Strata.Languages.B3.Verifier.State
+public import Strata.Languages.B3.Verifier.Program
+public import Strata.Languages.B3.Verifier.Diagnosis
+meta import Strata.Languages.B3.DDMTransform.ParseCST
+meta import Strata.Languages.B3.Verifier.Statements
+meta import Strata.Languages.B3.Verifier.Program
 
 open Strata
 open Strata.B3.Verifier
@@ -57,7 +61,7 @@ Use `programToSMTWithoutDiagnosis` for faster verification without diagnosis - r
 
 -- Example: Verify a simple B3 program (meta to avoid including in production)
 -- This is not a test, it only demonstrates the end-to-end API
-meta def exampleVerification : IO Unit := do
+public meta def exampleVerification : IO Unit := do
   -- Parse B3 program using DDM syntax
   let ddmProgram : Strata.Program := #strata program B3CST;
     function f(x : int) : int { x + 1 }

--- a/Strata/Languages/B3/Verifier/Diagnosis.lean
+++ b/Strata/Languages/B3/Verifier/Diagnosis.lean
@@ -3,10 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.Verifier.State
-import Strata.Languages.B3.Verifier.Expression
-import Strata.Languages.B3.Verifier.Statements
+public import Strata.Languages.B3.Verifier.State
+public import Strata.Languages.B3.Verifier.Expression
+public import Strata.Languages.B3.Verifier.Statements
+
+public section
 
 /-!
 # Verification Diagnosis Strategies

--- a/Strata/Languages/B3/Verifier/Expression.lean
+++ b/Strata/Languages/B3/Verifier/Expression.lean
@@ -3,12 +3,15 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.DDMTransform.DefinitionAST
-import Strata.DL.SMT.SMT
-import Strata.DL.SMT.Factory
-import Strata.Languages.B3.DDMTransform.Conversion
+public import Strata.Languages.B3.DDMTransform.DefinitionAST
+public import Strata.DL.SMT.SMT
+public import Strata.DL.SMT.Factory
+public import Strata.Languages.B3.DDMTransform.Conversion
 import Strata.Util.Tactics
+
+public section
 
 /-!
 # B3 AST to SMT Term Conversion

--- a/Strata/Languages/B3/Verifier/Formatter.lean
+++ b/Strata/Languages/B3/Verifier/Formatter.lean
@@ -3,8 +3,11 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DL.SMT.DDMTransform.Translate
+public import Strata.DL.SMT.DDMTransform.Translate
+
+public section
 
 /-!
 # SMT Term Formatting

--- a/Strata/Languages/B3/Verifier/Program.lean
+++ b/Strata/Languages/B3/Verifier/Program.lean
@@ -3,14 +3,17 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
+public import Strata.Languages.B3.Verifier.Diagnosis
 import Strata.Languages.B3.Verifier.State
 import Strata.Languages.B3.Verifier.Expression
 import Strata.Languages.B3.Verifier.Formatter
 import Strata.Languages.B3.Verifier.Statements
-import Strata.Languages.B3.Verifier.Diagnosis
 import Strata.Languages.B3.Transform.FunctionToAxiom
 import Strata.Languages.B3.DDMTransform.Conversion
+
+public section
 
 /-!
 # B3 Program Verification

--- a/Strata/Languages/B3/Verifier/State.lean
+++ b/Strata/Languages/B3/Verifier/State.lean
@@ -3,11 +3,14 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.Verifier.Expression
-import Strata.Languages.B3.DDMTransform.DefinitionAST
-import Strata.DL.SMT.Solver
+public import Strata.Languages.B3.Verifier.Expression
+public import Strata.Languages.B3.DDMTransform.DefinitionAST
+public import Strata.DL.SMT.Solver
 import Strata.DL.SMT.Factory
+
+public section
 
 /-!
 # B3 Verification State

--- a/Strata/Languages/B3/Verifier/Statements.lean
+++ b/Strata/Languages/B3/Verifier/Statements.lean
@@ -3,11 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.B3.Verifier.Expression
-import Strata.Languages.B3.Verifier.State
-import Strata.Languages.B3.DDMTransform.ParseCST
-import Strata.Languages.B3.DDMTransform.Conversion
+public import Strata.Languages.B3.Verifier.Expression
+public import Strata.Languages.B3.Verifier.State
+public import Strata.Languages.B3.DDMTransform.ParseCST
+public import Strata.Languages.B3.DDMTransform.Conversion
 import Strata.DDM.Integration.Lean
 import Strata.DDM.Util.Format
 import Strata.Util.Tactics
@@ -30,6 +31,8 @@ Key advantage: O(n) not O(n²), solver accumulates lemmas.
 -/
 
 namespace Strata.B3.Verifier
+
+public section
 
 open Strata
 open Strata.SMT
@@ -113,5 +116,7 @@ def formatStatement (prog : Program) (stmt : B3AST.Statement SourceRange) (ctx: 
   let fmtCtx := FormatContext.ofDialects prog.dialects prog.globalContext {}
   let fmtState : FormatState := { openDialects := prog.dialects.toList.foldl (init := {}) fun a (dialect : Dialect) => a.insert dialect.name }
   (mformat (ArgF.op cstStmt.toAst) fmtCtx fmtState).format.pretty.trimAscii.toString
+
+end -- public section
 
 end Strata.B3.Verifier

--- a/Strata/Languages/Boole/Boole.lean
+++ b/Strata/Languages/Boole/Boole.lean
@@ -3,8 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Boole.Grammar
+public import Strata.Languages.Boole.Grammar
+meta import Strata.DDM.Integration.Lean
+
+public section
 
 namespace Strata.BooleDDM
 

--- a/Strata/Languages/Boole/Grammar.lean
+++ b/Strata/Languages/Boole/Grammar.lean
@@ -3,8 +3,10 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Core.DDMTransform.Grammar
+public import Strata.Languages.Core.DDMTransform.Grammar
+meta import Strata.DDM.Integration.Lean
 
 ---------------------------------------------------------------------
 

--- a/Strata/Languages/Boole/Verify.lean
+++ b/Strata/Languages/Boole/Verify.lean
@@ -3,14 +3,17 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Boole.Boole
-import Strata.Languages.Core.Program
-import Strata.Languages.Core.Statement
-import Strata.Languages.Core.Verifier
-import Strata.DL.Lambda.LExpr
+public import Strata.Languages.Boole.Boole
+public import Strata.Languages.Core.Program
+public import Strata.Languages.Core.Statement
+public import Strata.Languages.Core.Verifier
+public import Strata.DL.Lambda.LExpr
 import Strata.DL.Lambda.LExprWF
-import Strata.DL.Imperative.Stmt
+public import Strata.DL.Imperative.Stmt
+
+public section
 
 namespace Strata.Boole
 

--- a/Strata/Languages/C_Simp/C_Simp.lean
+++ b/Strata/Languages/C_Simp/C_Simp.lean
@@ -3,13 +3,16 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.C_Simp.DDMTransform.Parse
-import Strata.DL.Imperative.Stmt
-import Strata.DL.Lambda.Lambda
-import Strata.DL.Lambda.LExpr
-import Strata.DL.Lambda.LTy
-import Strata.DL.Lambda.Identifiers
+public import Strata.Languages.C_Simp.DDMTransform.Parse
+public import Strata.DL.Imperative.Stmt
+public import Strata.DL.Lambda.Lambda
+public import Strata.DL.Lambda.LExpr
+public import Strata.DL.Lambda.LTy
+public import Strata.DL.Lambda.Identifiers
+
+public section
 
 -- We define the AST for our language here.
 

--- a/Strata/Languages/C_Simp/DDMTransform/Parse.lean
+++ b/Strata/Languages/C_Simp/DDMTransform/Parse.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DDM.Integration.Lean
+public import Strata.DDM.Integration.Lean
 import Strata.DDM.Util.Format
+
+public section
 
 #dialect
 dialect C_Simp;

--- a/Strata/Languages/C_Simp/DDMTransform/Translate.lean
+++ b/Strata/Languages/C_Simp/DDMTransform/Translate.lean
@@ -3,11 +3,14 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.C_Simp.DDMTransform.Parse
-import Strata.Languages.C_Simp.C_Simp
+public import Strata.Languages.C_Simp.DDMTransform.Parse
+public import Strata.Languages.C_Simp.C_Simp
 import Strata.DDM.AST
-import Strata.Languages.Core.CoreOp
+public import Strata.Languages.Core.CoreOp
+
+public section
 
 ---------------------------------------------------------------------
 namespace Strata
@@ -31,7 +34,7 @@ structure TransState where
   inputCtx : InputContext
   errors : Array String
 
-def TransM := StateM TransState
+@[expose] def TransM := StateM TransState
   deriving Monad
 
 def TransM.run (ictx : InputContext) (m : TransM α) : (α × Array String) :=

--- a/Strata/Languages/C_Simp/Verify.lean
+++ b/Strata/Languages/C_Simp/Verify.lean
@@ -3,13 +3,16 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.C_Simp.C_Simp
-import Strata.Languages.C_Simp.DDMTransform.Translate
-import Strata.Languages.Core.Options
-import Strata.Languages.Core.Verifier
+public import Strata.Languages.C_Simp.C_Simp
+public import Strata.Languages.C_Simp.DDMTransform.Translate
+public import Strata.Languages.Core.Options
+public import Strata.Languages.Core.Verifier
 import Strata.Languages.Core.CoreOp
 import Strata.DL.Imperative.Stmt
+
+public section
 
 open Core
 

--- a/Strata/Languages/Core/SarifOutput.lean
+++ b/Strata/Languages/Core/SarifOutput.lean
@@ -3,9 +3,14 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Core.Verifier
-import Strata.Util.Sarif
+public import Strata.Util.Sarif
+public import Strata.Languages.Core.Verifier
+
+
+
+public section
 
 /-!
 # Core SARIF Output

--- a/Strata/Languages/Core/SeqModel.lean
+++ b/Strata/Languages/Core/SeqModel.lean
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 /-!
 # Sequence Axiom Model

--- a/Strata/Languages/Core/StatementSemantics.lean
+++ b/Strata/Languages/Core/StatementSemantics.lean
@@ -367,7 +367,7 @@ def withOldBindings
     Core commands have type `Command = CmdExt Expression`, so an assert
     command appears as `.cmd (CmdExt.cmd (Cmd.assert l e md))`.
     Call commands (`.cmd (CmdExt.call ...)`) never trigger assert detection. -/
-def coreIsAtAssert : CoreConfig → Imperative.AssertId Expression → Prop
+@[expose] def coreIsAtAssert : CoreConfig → Imperative.AssertId Expression → Prop
   | .stmt (.cmd (.cmd (.assert label expr _))) _, aid =>
     aid.label = label ∧ aid.expr = expr
   | .stmts ((.cmd (.cmd (.assert label expr _))) :: _) _, aid =>

--- a/Strata/Languages/Core/VerifierProofs.lean
+++ b/Strata/Languages/Core/VerifierProofs.lean
@@ -3,8 +3,8 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
-
-import Strata.Languages.Core.Verifier
+module
+import all Strata.Languages.Core.Verifier
 
 /-!
 # Proofs about `SMT.Result.merge`

--- a/Strata/Languages/Dyn/DDMTransform/Parse.lean
+++ b/Strata/Languages/Dyn/DDMTransform/Parse.lean
@@ -3,9 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.DDM.Integration.Lean
-import Strata.DDM.Util.Format
+public import Strata.DDM.Integration.Lean
+public import Strata.DDM.Util.Format
+
+public section
 
 namespace Strata
 

--- a/Strata/Languages/Dyn/DDMTransform/Translate.lean
+++ b/Strata/Languages/Dyn/DDMTransform/Translate.lean
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 -- TODO: Translation from concrete syntax to abstract syntax
 

--- a/Strata/Languages/Dyn/Dyn.lean
+++ b/Strata/Languages/Dyn/Dyn.lean
@@ -3,12 +3,15 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 -- Main Dyn dialect definition
 -- TODO: Implement AST structure for dynamic Python-like language
 
-import Strata.Languages.Dyn.DDMTransform.Parse
-import Strata.Languages.Dyn.DDMTransform.Translate
+public import Strata.Languages.Dyn.DDMTransform.Parse
+public import Strata.Languages.Dyn.DDMTransform.Translate
+
+public section
 
 namespace Strata
 namespace Dyn

--- a/Strata/Languages/Dyn/Verify.lean
+++ b/Strata/Languages/Dyn/Verify.lean
@@ -3,10 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 -- TODO: Verification integration for Dyn language
 
-import Strata.Languages.Dyn.Dyn
+public import Strata.Languages.Dyn.Dyn
+
+public section
 
 namespace Strata
 namespace Dyn

--- a/Strata/MetaVerifier.lean
+++ b/Strata/MetaVerifier.lean
@@ -3,19 +3,22 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 import Lean.Meta
 import Lean.Elab.Tactic
 
 import Strata.Languages.Core.Verifier
 import Strata.Transform.LoopElim
-import Strata.Languages.C_Simp.Verify
-import Strata.Languages.Boole.Verify
+public import Strata.Languages.C_Simp.Verify
+public import Strata.Languages.Boole.Verify
 import Strata.DL.Imperative.SMTUtils
-import Strata.DL.SMT.Denote
-import Strata.DL.SMT.Translate
+public import Strata.DL.SMT.Denote
+public import Strata.DL.SMT.Translate
 
 open Lean hiding Options
+
+public section
 
 namespace Strata.SMT
 
@@ -249,6 +252,14 @@ def createGoal : SMTVC → MetaM MVarId := fun (label, ctx, ts, t) => do
 
 end SMT
 
+end Strata
+
+end -- public section
+
+namespace Strata
+
+public section
+
 namespace Meta
 
 def andN (ps : List Lean.Expr) : Lean.Expr :=
@@ -289,7 +300,7 @@ where
     addAndCompile decl
     pure auxName
 
-unsafe def genSMTVCs (mv : MVarId) : MetaM (List MVarId) := do
+private unsafe def genSMTVCsUnsafe (mv : MVarId) : MetaM (List MVarId) := do
   let type ← mv.getType
   let some program := type.app1? ``Strata.smtVCsCorrect | throwError "Expected a Strata.smtVCsCorrect goal"
   trace[debug] m!"Generating SMT VCs for {program}"
@@ -311,7 +322,14 @@ unsafe def genSMTVCs (mv : MVarId) : MetaM (List MVarId) := do
   mv.assign hP
   return mvs
 
+@[implemented_by genSMTVCsUnsafe]
+meta opaque genSMTVCs (mv : MVarId) : MetaM (List MVarId)
+
 end Meta
+
+end -- public section
+
+public section
 
 namespace Tactic
 
@@ -322,7 +340,7 @@ Generate one Lean goal per SMT verification condition in a goal of the form
 syntax (name := genSMTVCs) "gen_smt_vcs" : tactic
 
 open Lean Elab Tactic in
-@[tactic genSMTVCs] unsafe def evalGenSMTVCs : Tactic := fun stx => do
+@[tactic genSMTVCs] meta def evalGenSMTVCs : Tactic := fun stx => do
   match stx with
   | `(tactic| gen_smt_vcs) =>
     let mvs ← Meta.genSMTVCs (← Tactic.getMainGoal)
@@ -330,5 +348,7 @@ open Lean Elab Tactic in
   | _ => throwUnsupportedSyntax
 
 end Tactic
+
+end -- public section
 
 end Strata

--- a/Strata/Transform/CoreSpecification.lean
+++ b/Strata/Transform/CoreSpecification.lean
@@ -3,10 +3,14 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
-import Strata.Languages.Core.StatementSemantics
-import Strata.Languages.Core.StatementSemanticsProps
-import Strata.Transform.Specification
-import Strata.Languages.Core.WF
+module
+
+public import Strata.Languages.Core.StatementSemantics
+public import Strata.Languages.Core.StatementSemanticsProps
+public import Strata.Transform.Specification
+public import Strata.Languages.Core.WF
+
+public section
 
 /-! # Core-Level Specification
 
@@ -28,7 +32,7 @@ open Core Imperative
 /-! ## Core `Lang` bundle -/
 
 /-- The `Lang Expression` bundle for Core small-step semantics. -/
-def Lang.core
+@[expose] def Lang.core
     (π : String → Option Procedure)
     (φ : CoreEval → PureFunc Expression → CoreEval) :
     Imperative.Specification.Lang Expression :=
@@ -42,7 +46,7 @@ def Lang.core
     outputs are included because the body refers to the output variables without
     initialization.
     This does not include the old variables. -/
-def procVerifyInitIdents (proc : Procedure) : List Expression.Ident :=
+@[expose] def procVerifyInitIdents (proc : Procedure) : List Expression.Ident :=
   ListMap.keys proc.header.inputs ++
   ListMap.keys proc.header.outputs ++
   proc.spec.modifies
@@ -71,7 +75,7 @@ variable (φ : CoreEval → PureFunc Expression → CoreEval)
 
 /-- A specific assertion `a` in procedure `proc` is valid
     for initial program states satisfying the preconditions (`ProcEnvWF`). -/
-def AssertValidInProcedure
+@[expose] def AssertValidInProcedure
     (proc : Procedure)
     (a : Imperative.AssertId Expression) : Prop :=
   Imperative.Specification.AssertValidWhen (Specification.Lang.core π φ)

--- a/Strata/Transform/ProcBodyVerify.lean
+++ b/Strata/Transform/ProcBodyVerify.lean
@@ -3,11 +3,14 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Languages.Core.Procedure
-import Strata.Languages.Core.Statement
-import Strata.Languages.Core.Identifiers
-import Strata.Transform.CoreTransform
+public import Strata.Languages.Core.Procedure
+public import Strata.Languages.Core.Statement
+public import Strata.Languages.Core.Identifiers
+public import Strata.Transform.CoreTransform
+
+public section
 
 /-! # Procedure Body Verification Transformation
 
@@ -51,19 +54,19 @@ namespace Core.ProcBodyVerify
 open Core Imperative Transform
 
 /-- Convert preconditions to assume statements -/
-def requiresToAssumes (preconditions : ListMap CoreLabel Procedure.Check) : List Statement :=
+@[expose] def requiresToAssumes (preconditions : ListMap CoreLabel Procedure.Check) : List Statement :=
   preconditions.toList.map fun (label, check) =>
     Statement.assume label check.expr check.md
 
 /-- Convert postconditions to assert statements -/
-def ensuresToAsserts (postconditions : ListMap CoreLabel Procedure.Check) : List Statement :=
+@[expose] def ensuresToAsserts (postconditions : ListMap CoreLabel Procedure.Check) : List Statement :=
   postconditions.toList.filterMap fun (label, check) =>
     match check.attr with
     | .Free => none
     | .Default => some (Statement.assert label check.expr check.md)
 
 /-- Main transformation: convert a procedure to a verification statement -/
-def procToVerifyStmt (proc : Procedure) (p : Program) : CoreTransformM Statement := do
+@[expose] def procToVerifyStmt (proc : Procedure) (p : Program) : CoreTransformM Statement := do
   let procName := proc.header.name.name
   let bodyLabel := s!"body_{procName}"
   let verifyLabel := s!"verify_{procName}"

--- a/Strata/Transform/ProcBodyVerifyCorrect.lean
+++ b/Strata/Transform/ProcBodyVerifyCorrect.lean
@@ -3,12 +3,15 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
-import Strata.Transform.ProcBodyVerify
-import Strata.Transform.CoreSpecification
-import Strata.Languages.Core.WF
+public import Strata.Transform.ProcBodyVerify
+public import Strata.Transform.CoreSpecification
+public import Strata.Languages.Core.WF
 import Strata.DL.Util.ListMap
 import Strata.DL.Util.List
+
+public section
 
 /-! # Procedure Body Verification Correctness Proof -/
 

--- a/Strata/Transform/Specification.lean
+++ b/Strata/Transform/Specification.lean
@@ -125,7 +125,7 @@ on the initial environment.  `AssertValid` is `AssertValidWhen (fun _ => True)`.
 /-- Assert `a` is *valid* in statement `s` when `Pre` holds on the initial
     environment.  This is the general form; `AssertValid` is the special case
     with `Pre = fun _ => True`. -/
-def AssertValidWhen (Pre : Env P → Prop) (s : L.StmtT) (a : AssertId P) : Prop :=
+@[expose] def AssertValidWhen (Pre : Env P → Prop) (s : L.StmtT) (a : AssertId P) : Prop :=
   ∀ (ρ₀ : Env P) (cfg : L.CfgT),
     Pre ρ₀ →
     L.star (L.stmtCfg s ρ₀) cfg →
@@ -137,11 +137,11 @@ def AllAssertsValidWhen (Pre : Env P → Prop) (s : L.StmtT) : Prop :=
   ∀ (a : AssertId P), AssertValidWhen L Pre s a
 
 /-- Assert `a` is *valid* in statement `s` (for all initial environments). -/
-def AssertValid (s : L.StmtT) (a : AssertId P) : Prop :=
+@[expose] def AssertValid (s : L.StmtT) (a : AssertId P) : Prop :=
   AssertValidWhen L (fun _ => True) s a
 
 /-- All asserts are valid in statement `s`. -/
-def AllAssertsValid (s : L.StmtT) : Prop :=
+@[expose] def AllAssertsValid (s : L.StmtT) : Prop :=
   ∀ (a : AssertId P), AssertValid L s a
 
 

--- a/Strata/Transform/StructuredToUnstructured.lean
+++ b/Strata/Transform/StructuredToUnstructured.lean
@@ -3,14 +3,17 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 import Strata.DL.Imperative.PureExpr
-import Strata.DL.Imperative.BasicBlock
-import Strata.DL.Imperative.CFGSemantics
+public import Strata.DL.Imperative.BasicBlock
+public import Strata.DL.Imperative.CFGSemantics
 import Strata.DL.Imperative.Cmd
-import Strata.DL.Imperative.Stmt
+public import Strata.DL.Imperative.Stmt
 import Strata.DL.Lambda.LExpr
-import Strata.DL.Util.LabelGen
+public import Strata.DL.Util.LabelGen
+
+public section
 
 namespace Imperative
 

--- a/Strata/Util/Json.lean
+++ b/Strata/Util/Json.lean
@@ -3,8 +3,12 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
+public import Lean.Data.Json.Basic
 import Lean.Data.Json.Printer
+
+public section
 
 /-! Streaming JSON writer that avoids stack overflow on large values. -/
 

--- a/Strata/Util/Sarif.lean
+++ b/Strata/Util/Sarif.lean
@@ -3,8 +3,13 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
+public import Lean.Data.Json.Basic
+public import Lean.Data.Json.FromToJson
 import Lean.Data.Json
+
+public section
 
 /-!
 # SARIF Output

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -3,6 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
+module
 
 -- Executable with utilities for working with Strata files.
 import Strata.Backends.CBMC.CollectSymbols
@@ -25,6 +26,12 @@ import Strata.Util.IO
 import Strata.SimpleAPI
 import Strata.Util.Profile
 import Strata.Util.Json
+import Strata.DDM.BuiltinDialects
+import Strata.DDM.Util.String
+import Strata.Languages.Python.PyFactory
+import Strata.Languages.Python.Specs
+import Strata.Languages.Python.Specs.DDM
+import Strata.Languages.Python.ReadPython
 
 open Strata
 
@@ -1368,6 +1375,7 @@ private def parseArgs (cmdName : String)
   | [] =>
     pure (acc, pflags)
 
+public
 def main (args : List String) : IO Unit := do
   try do
     match args with

--- a/StrataTest/DL/Lambda/TestGenTests.lean
+++ b/StrataTest/DL/Lambda/TestGenTests.lean
@@ -5,6 +5,7 @@
 -/
 
 import Strata.DL.Lambda.TestGen
+import Strata.Util.Random
 
 /-! ## Tests for TestGen -/
 


### PR DESCRIPTION
## Summary

Convert 49 of the 50 remaining non-module `.lean` files to use the Lean `module` keyword,
making `StrataMain` and nearly all files under `Strata/` proper Lean modules.

## Changes

- **Added `module` keyword** to 49 files across all subsystems (CBMC, B3, Boole, C_Simp,
  Core, Dyn, DL, Transform, Util, MetaVerifier, StrataMain).

- **Added `public section` blocks** for files that export types or functions used by
  downstream consumers. Used `public import` with minimal scope (e.g.
  `public import Lean.Data.Json.Basic` rather than `public import Lean.Data.Json`) to
  keep transitive exports narrow.

- **Added `@[expose]` annotations** to a handful of upstream definitions
  (`ListUtils.lean`, `CmdSemantics.lean`, `StatementSemantics.lean`, `ProcBodyVerify.lean`,
  `CoreSpecification.lean`, `Specification.lean`) where proof files needed to unfold
  definitions across module boundaries.

- **MetaVerifier**: Moved `meta` tactic registration outside the main `public section`
  into its own `public section` to satisfy the requirement that tactic elaboration
  attributes are public.

- **StrataMain**: Added explicit imports for modules that were previously accessible
  transitively but became inaccessible once StrataMain became a module.

## Not converted

- `Strata.Languages.C_Simp.StrataToCBMC` — has pre-existing build errors (references
  non-existent `CProverJson` namespace). Nothing imports this file.

## Files changed by subsystem

| Subsystem | Files converted |
|-----------|----------------|
| `Strata.Backends.CBMC` | 10 |
| `Strata.DL.Imperative` | 3 |
| `Strata.DL.Lambda` | 1 |
| `Strata.DL.SMT` | 2 |
| `Strata.Languages.B3` | 10 |
| `Strata.Languages.Boole` | 3 |
| `Strata.Languages.C_Simp` | 4 |
| `Strata.Languages.Core` | 3 |
| `Strata.Languages.Dyn` | 4 |
| `Strata.MetaVerifier` | 1 |
| `Strata.Transform` | 4 |
| `Strata.Util` | 2 |
| `StrataMain` | 1 |
| **Total** | **49** |

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.