### PR TITLE
Add Core-to-Core function inlining transforms

### DIFF
--- a/Strata/Transform/FunctionInlining.lean
+++ b/Strata/Transform/FunctionInlining.lean
@@ -1,0 +1,114 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.Languages.Core.Program
+public import Strata.Languages.Core.Statement
+public import Strata.Languages.Core.Expressions
+
+namespace Strata
+
+/-! ## Function Inlining
+
+Core-to-Core transforms that replace function calls with their bodies.
+-/
+
+public section
+
+/--
+Inline function bodies in an expression. For each fully-applied call `f(a₁, ..., aₙ)`
+where `f` has a known body, replace it with `body[a₁/x₁, ..., aₙ/xₙ]`.
+This avoids emitting uninterpreted `mathematical_function` symbols in GOTO.
+-/
+partial def inlineFuncDefs
+    (defs : List (String × List Core.CoreIdent × Lambda.LExpr Core.CoreLParams.mono))
+    (postProcess : Lambda.LExpr Core.CoreLParams.mono → Lambda.LExpr Core.CoreLParams.mono := id)
+    (e : Lambda.LExpr Core.CoreLParams.mono) : Lambda.LExpr Core.CoreLParams.mono :=
+  let rec go (e : Lambda.LExpr Core.CoreLParams.mono) : Lambda.LExpr Core.CoreLParams.mono :=
+    let (head, args) := collectApp e
+    match head with
+    | .op _ o _ =>
+      let args' := args.map go
+      match defs.find? (fun (n, _, _) => n == (Lambda.Identifier.name o)) with
+      | some (_, formals, body) =>
+        if args'.length == formals.length then
+          go (postProcess (Lambda.LExpr.substFvars body (formals.zip args')))
+        else rebuildApp head args'
+      | none => postProcess (rebuildApp head args')
+    | _ =>
+      match e with
+      | .const .. | .op .. | .bvar .. | .fvar .. => e
+      | .abs m n ty b => .abs m n ty (go b)
+      | .quant m k n ty tr b => .quant m k n ty (go tr) (go b)
+      | .app m f a => .app m (go f) (go a)
+      | .ite m c t el => .ite m (go c) (go t) (go el)
+      | .eq m l r => .eq m (go l) (go r)
+  go e
+where
+  collectApp (e : Lambda.LExpr Core.CoreLParams.mono)
+      : Lambda.LExpr Core.CoreLParams.mono × List (Lambda.LExpr Core.CoreLParams.mono) :=
+    match e with
+    | .app _ f a => let (h, as) := collectApp f; (h, as ++ [a])
+    | other => (other, [])
+  rebuildApp (head : Lambda.LExpr Core.CoreLParams.mono)
+      (args : List (Lambda.LExpr Core.CoreLParams.mono))
+      : Lambda.LExpr Core.CoreLParams.mono :=
+    args.foldl (fun acc arg => .app default acc arg) head
+
+/-- Build the function definition map from a program's declarations. -/
+def collectFuncDefs (pgm : Core.Program)
+    : List (String × List Core.CoreIdent × Lambda.LExpr Core.CoreLParams.mono) :=
+  pgm.decls.filterMap fun d => do
+    let f ← d.getFunc?
+    let body ← f.body
+    guard (!f.isRecursive)
+    guard (f.typeArgs.toArray.isEmpty)
+    some (f.name.name, f.inputs.keys, body)
+
+/-- Inline recursive function calls with bounded unrolling.
+    At depth 0, recursive calls are left as-is (uninterpreted). -/
+partial def inlineRecFuncDefs
+    (recDefs : List (String × List Core.CoreIdent × Lambda.LExpr Core.CoreLParams.mono))
+    (maxDepth : Nat)
+    (e : Lambda.LExpr Core.CoreLParams.mono) : Lambda.LExpr Core.CoreLParams.mono :=
+  go maxDepth e
+where
+  go (depth : Nat) (e : Lambda.LExpr Core.CoreLParams.mono)
+      : Lambda.LExpr Core.CoreLParams.mono :=
+    if depth == 0 then e
+    else
+      let (head, args) := collectApp e
+      match head with
+      | .op _ o _ =>
+        let args' := args.map (go depth)
+        match recDefs.find? (fun (n, _, _) => n == (Lambda.Identifier.name o)) with
+        | some (_, formals, body) =>
+          if args'.length == formals.length then
+            go (depth - 1) (Lambda.LExpr.substFvars body (formals.zip args'))
+          else rebuildApp head args'
+        | none => rebuildApp head args'
+      | _ =>
+        match e with
+        | .const .. | .op .. | .bvar .. | .fvar .. => e
+        | .abs m n ty b => .abs m n ty (go depth b)
+        | .quant m k n ty tr b => .quant m k n ty (go depth tr) (go depth b)
+        | .app m f a => .app m (go depth f) (go depth a)
+        | .ite m c t el => .ite m (go depth c) (go depth t) (go depth el)
+        | .eq m l r => .eq m (go depth l) (go depth r)
+  collectApp (e : Lambda.LExpr Core.CoreLParams.mono)
+      : Lambda.LExpr Core.CoreLParams.mono × List (Lambda.LExpr Core.CoreLParams.mono) :=
+    match e with
+    | .app _ f a => let (h, as) := collectApp f; (h, as ++ [a])
+    | other => (other, [])
+  rebuildApp (head : Lambda.LExpr Core.CoreLParams.mono)
+      (args : List (Lambda.LExpr Core.CoreLParams.mono))
+      : Lambda.LExpr Core.CoreLParams.mono :=
+    args.foldl (fun acc arg => .app default acc arg) head
+
+
+end -- public section
+
+end Strata

--- a/Strata/Transform/FunctionInlining.lean
+++ b/Strata/Transform/FunctionInlining.lean
@@ -8,70 +8,72 @@ module
 public import Strata.Languages.Core.Program
 public import Strata.Languages.Core.Statement
 public import Strata.Languages.Core.Expressions
+import Strata.DL.Lambda.LExprWF
 
 namespace Strata
 
 /-! ## Function Inlining
 
 Core-to-Core transforms that replace function calls with their bodies.
+
+Uses the same inlining logic as `LExprEval.eval`: `Factory.callOfLFunc`
+to decompose applications, `LFunc.computeTypeSubst` + `LExpr.applySubst`
+for polymorphic type instantiation, and `substFvarsLifting` for
+capture-safe substitution under binders.
 -/
 
 public section
 
+/-- Try to inline a single function call. Returns `some result` if the
+    function has a body and is fully applied; `none` otherwise.
+    Handles polymorphic functions via type substitution, matching
+    the inlining path in `LExprEval.eval`. -/
+private def tryInlineCall
+    (factory : Lambda.Factory Core.CoreLParams)
+    (e : Lambda.LExpr Core.CoreLParams.mono)
+    : Option (Lambda.LExpr Core.CoreLParams.mono) :=
+  match factory.callOfLFunc e with
+  | some (op_expr, args, lfunc) =>
+    match lfunc.body with
+    | none => none
+    | some body =>
+      match Lambda.LFunc.computeTypeSubst lfunc op_expr args with
+      | some tySubst =>
+        let body := body.applySubst tySubst
+        let input_map := lfunc.inputs.keys.zip args
+        some (Lambda.LExpr.substFvarsLifting body input_map)
+      | none => none
+  | none => none
+
 /--
-Inline function bodies in an expression. For each fully-applied call `f(a₁, ..., aₙ)`
-where `f` has a known body, replace it with `body[a₁/x₁, ..., aₙ/xₙ]`.
-This avoids emitting uninterpreted `mathematical_function` symbols in GOTO.
+Inline non-recursive function bodies in an expression. For each fully-applied
+call `f(a₁, ..., aₙ)` where `f` has a known body in the factory, replace it
+with `body[a₁/x₁, ..., aₙ/xₙ]` (with polymorphic type instantiation).
 -/
 partial def inlineFuncDefs
-    (defs : List (String × List Core.CoreIdent × Lambda.LExpr Core.CoreLParams.mono))
+    (factory : Lambda.Factory Core.CoreLParams)
     (postProcess : Lambda.LExpr Core.CoreLParams.mono → Lambda.LExpr Core.CoreLParams.mono := id)
     (e : Lambda.LExpr Core.CoreLParams.mono) : Lambda.LExpr Core.CoreLParams.mono :=
   let rec go (e : Lambda.LExpr Core.CoreLParams.mono) : Lambda.LExpr Core.CoreLParams.mono :=
-    let (head, args) := collectApp e
-    match head with
-    | .op _ o _ =>
-      let args' := args.map go
-      match defs.find? (fun (n, _, _) => n == (Lambda.Identifier.name o)) with
-      | some (_, formals, body) =>
-        if args'.length == formals.length then
-          go (postProcess (Lambda.LExpr.substFvars body (formals.zip args')))
-        else rebuildApp head args'
-      | none => postProcess (rebuildApp head args')
-    | _ =>
-      match e with
-      | .const .. | .op .. | .bvar .. | .fvar .. => e
-      | .abs m n ty b => .abs m n ty (go b)
-      | .quant m k n ty tr b => .quant m k n ty (go tr) (go b)
+    -- First recurse into subexpressions
+    let e' := match e with
       | .app m f a => .app m (go f) (go a)
       | .ite m c t el => .ite m (go c) (go t) (go el)
+      | .abs m n ty b => .abs m n ty (go b)
+      | .quant m k n ty tr b => .quant m k n ty (go tr) (go b)
       | .eq m l r => .eq m (go l) (go r)
+      | other => other
+    -- Then try to inline the (possibly rebuilt) application
+    match tryInlineCall factory e' with
+    | some inlined => go (postProcess inlined)
+    | none => postProcess e'
   go e
-where
-  collectApp (e : Lambda.LExpr Core.CoreLParams.mono)
-      : Lambda.LExpr Core.CoreLParams.mono × List (Lambda.LExpr Core.CoreLParams.mono) :=
-    match e with
-    | .app _ f a => let (h, as) := collectApp f; (h, as ++ [a])
-    | other => (other, [])
-  rebuildApp (head : Lambda.LExpr Core.CoreLParams.mono)
-      (args : List (Lambda.LExpr Core.CoreLParams.mono))
-      : Lambda.LExpr Core.CoreLParams.mono :=
-    args.foldl (fun acc arg => .app default acc arg) head
-
-/-- Build the function definition map from a program's declarations. -/
-def collectFuncDefs (pgm : Core.Program)
-    : List (String × List Core.CoreIdent × Lambda.LExpr Core.CoreLParams.mono) :=
-  pgm.decls.filterMap fun d => do
-    let f ← d.getFunc?
-    let body ← f.body
-    guard (!f.isRecursive)
-    guard (f.typeArgs.toArray.isEmpty)
-    some (f.name.name, f.inputs.keys, body)
 
 /-- Inline recursive function calls with bounded unrolling.
-    At depth 0, recursive calls are left as-is (uninterpreted). -/
+    At depth 0, recursive calls are left as-is (uninterpreted).
+    Uses the factory for function lookup and type substitution. -/
 partial def inlineRecFuncDefs
-    (recDefs : List (String × List Core.CoreIdent × Lambda.LExpr Core.CoreLParams.mono))
+    (factory : Lambda.Factory Core.CoreLParams)
     (maxDepth : Nat)
     (e : Lambda.LExpr Core.CoreLParams.mono) : Lambda.LExpr Core.CoreLParams.mono :=
   go maxDepth e
@@ -80,34 +82,16 @@ where
       : Lambda.LExpr Core.CoreLParams.mono :=
     if depth == 0 then e
     else
-      let (head, args) := collectApp e
-      match head with
-      | .op _ o _ =>
-        let args' := args.map (go depth)
-        match recDefs.find? (fun (n, _, _) => n == (Lambda.Identifier.name o)) with
-        | some (_, formals, body) =>
-          if args'.length == formals.length then
-            go (depth - 1) (Lambda.LExpr.substFvars body (formals.zip args'))
-          else rebuildApp head args'
-        | none => rebuildApp head args'
-      | _ =>
-        match e with
-        | .const .. | .op .. | .bvar .. | .fvar .. => e
-        | .abs m n ty b => .abs m n ty (go depth b)
-        | .quant m k n ty tr b => .quant m k n ty (go depth tr) (go depth b)
+      let e' := match e with
         | .app m f a => .app m (go depth f) (go depth a)
         | .ite m c t el => .ite m (go depth c) (go depth t) (go depth el)
+        | .abs m n ty b => .abs m n ty (go depth b)
+        | .quant m k n ty tr b => .quant m k n ty (go depth tr) (go depth b)
         | .eq m l r => .eq m (go depth l) (go depth r)
-  collectApp (e : Lambda.LExpr Core.CoreLParams.mono)
-      : Lambda.LExpr Core.CoreLParams.mono × List (Lambda.LExpr Core.CoreLParams.mono) :=
-    match e with
-    | .app _ f a => let (h, as) := collectApp f; (h, as ++ [a])
-    | other => (other, [])
-  rebuildApp (head : Lambda.LExpr Core.CoreLParams.mono)
-      (args : List (Lambda.LExpr Core.CoreLParams.mono))
-      : Lambda.LExpr Core.CoreLParams.mono :=
-    args.foldl (fun acc arg => .app default acc arg) head
-
+        | other => other
+      match tryInlineCall factory e' with
+      | some inlined => go (depth - 1) inlined
+      | none => e'
 
 end -- public section
 

--- a/StrataTest/Transform/FunctionInlining.lean
+++ b/StrataTest/Transform/FunctionInlining.lean
@@ -1,0 +1,51 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.DDM.Integration.Lean
+import Strata.Languages.Core.Core
+import Strata.Languages.Core.DDMTransform.Translate
+import Strata.Transform.FunctionInlining
+
+open Core
+open Strata
+
+/-! ## FunctionInlining Tests -/
+
+section FunctionInliningTests
+
+def translate (t : Strata.Program) : Core.Program :=
+  (TransM.run Inhabited.default (translateProgram t)).fst
+
+/-! ### Test: inlineFuncDefs on a literal is identity -/
+
+#guard_msgs in
+#eval do
+  let m : Core.ExpressionMetadata := default
+  let lit : Lambda.LExpr Core.CoreLParams.mono := .const m (.intConst 42)
+  let result := inlineFuncDefs Core.Factory id lit
+  assert! result matches .const _ (.intConst 42)
+
+/-! ### Test: inlineRecFuncDefs at depth 0 is identity -/
+
+#guard_msgs in
+#eval do
+  let m : Core.ExpressionMetadata := default
+  let lit : Lambda.LExpr Core.CoreLParams.mono := .const m (.intConst 42)
+  let result := inlineRecFuncDefs Core.Factory 0 lit
+  assert! result matches .const _ (.intConst 42)
+
+/-! ### Test: inlineFuncDefs leaves primitives (no body) unchanged -/
+
+#guard_msgs in
+#eval do
+  let m : Core.ExpressionMetadata := default
+  let negOp := Lambda.LExpr.op m ⟨"Int.Neg", ()⟩ none
+  let call := Lambda.LExpr.app m negOp (.const m (.intConst 5))
+  let result := inlineFuncDefs Core.Factory id call
+  -- Int.Neg is a primitive (no body) — should NOT be inlined
+  assert! result matches .app _ _ _
+
+end FunctionInliningTests


### PR DESCRIPTION
Add function inlining transforms in Strata/Transform/FunctionInlining.lean:
- inlineFuncDefs: replace non-recursive function calls with their bodies, with optional postProcess hook for composing with other transforms
- collectFuncDefs: collect non-recursive function definitions
- inlineRecFuncDefs: bounded unrolling of recursive function calls

These operate at the expression level (pure function applications), complementing the existing ProcedureInlining which operates at the statement level (imperative procedure calls).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
