### PR TITLE
Ensure Strata.lean imports all modules and add import stats

### DIFF
--- a/Scripts/CheckImports.lean
+++ b/Scripts/CheckImports.lean
@@ -1,0 +1,75 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+import Strata
+import Lean
+
+open Lean System
+
+/-- Recursively find all `.lean` files under `dir` and return their module names
+    relative to the workspace root. E.g., `Strata/Foo/Bar.lean` → `Strata.Foo.Bar`. -/
+partial def findLeanModules (root dir : FilePath) : IO (Array Name) := do
+  let mut modules := #[]
+  for entry in ← dir.readDir do
+    if ← entry.path.isDir then
+      modules := modules ++ (← findLeanModules root entry.path)
+    else if entry.path.extension == some "lean" then
+      let relPath := entry.path.toString.dropPrefix root.toString |>.toString
+        |>.dropPrefix "/"
+      let modStr := relPath.dropSuffix ".lean" |>.replace "/" "."
+      modules := modules.push modStr.toName
+  return modules
+
+/-- Parse `-- noimport: Strata.Foo.Bar` lines from a file. -/
+def parseNoimportComments (path : FilePath) : IO (Array Name) := do
+  let contents ← IO.FS.readFile path
+  let mut allowlist := #[]
+  for line in contents.splitOn "\n" do
+    let trimmed := line.trimAscii
+    if trimmed.startsWith "-- noimport:" then
+      let modStr := trimmed.dropPrefix "-- noimport:" |>.toString |>.trimAscii
+      let modName := modStr.takeWhile (· ≠ ' ') |>.takeWhile (· ≠ '-')
+        |>.trimAsciiEnd
+      if !modName.isEmpty then
+        allowlist := allowlist.push modName.toName
+  return allowlist
+
+def main : IO UInt32 := do
+  initSearchPath (← findSysroot)
+  let env ← do
+    let opts := Options.empty
+    let imports := #[{ module := `Strata : Import }]
+    let trustLevel := 0
+    Lean.importModules imports opts trustLevel
+
+  let importedModules : Std.HashSet Name :=
+    env.allImportedModuleNames.foldl (init := {}) fun s n =>
+      if n.getRoot == `Strata then s.insert n else s
+
+  let strataDir : FilePath := "Strata"
+  let onDiskModules ← findLeanModules "." strataDir
+
+  let allowlist ← parseNoimportComments "Strata.lean"
+  let allowlistSet : Std.HashSet Name :=
+    allowlist.foldl (init := {}) fun s n => s.insert n
+
+  let mut missing := #[]
+  for m in onDiskModules do
+    if !importedModules.contains m && !allowlistSet.contains m then
+      missing := missing.push m
+
+  missing := missing.qsort (·.toString < ·.toString)
+
+  if missing.isEmpty then
+    IO.println s!"✓ All {onDiskModules.size} Strata modules are transitively imported."
+    return 0
+  else
+    IO.eprintln s!"✗ {missing.size} Strata module(s) not transitively imported by Strata.lean:"
+    for m in missing do
+      IO.eprintln s!"  {m}"
+    IO.eprintln ""
+    IO.eprintln "To fix: add an import for each module (directly or transitively),"
+    IO.eprintln "or add '-- noimport: <module>' to Strata.lean to exclude it."
+    return 1

--- a/Scripts/CheckImports.lean
+++ b/Scripts/CheckImports.lean
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 import Strata
-import Lean
+import Lean.Environment
+import Lean.Util.Path
 
 open Lean System
 

--- a/Scripts/ImportStats.lean
+++ b/Scripts/ImportStats.lean
@@ -1,0 +1,116 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+import Strata
+import Lean
+
+open Lean System
+
+def main : IO UInt32 := do
+  initSearchPath (← findSysroot)
+  let env ← do
+    let imports := #[{ module := `Strata : Import }]
+    Lean.importModules imports {} 0
+
+  let header := env.header
+  let moduleNames := header.moduleNames
+  let moduleData := header.moduleData
+
+  -- Build name → index map and Strata membership set
+  let mut name2idx : Std.HashMap Name Nat := {}
+  let mut isStrata : Std.HashSet Nat := {}
+  for h : i in [:moduleNames.size] do
+    name2idx := name2idx.insert moduleNames[i] i
+    if moduleNames[i].getRoot == `Strata then
+      isStrata := isStrata.insert i
+
+  -- Build direct-import adjacency lists (index → indices)
+  let mut directImports : Array (Array Nat) := .replicate moduleNames.size #[]
+  for h : i in [:moduleData.size] do
+    let md := moduleData[i]
+    let mut deps : Array Nat := #[]
+    for imp in md.imports do
+      if let some j := name2idx[imp.module]? then
+        deps := deps.push j
+    directImports := directImports.set! i deps
+
+  -- Compute transitive closure via BFS for each module
+  -- Track both total and Strata-only transitive import counts
+  let mut totalTransCounts : Array Nat := .replicate moduleNames.size 0
+  let mut strataTransCounts : Array Nat := .replicate moduleNames.size 0
+  for h : i in [:moduleNames.size] do
+    let mut visited : Std.HashSet Nat := {}
+    let mut queue : Array Nat := directImports[i]!
+    for j in directImports[i]! do
+      visited := visited.insert j
+    while queue.size > 0 do
+      let cur := queue.back!
+      queue := queue.pop
+      for next in directImports[cur]! do
+        if !visited.contains next then
+          visited := visited.insert next
+          queue := queue.push next
+    totalTransCounts := totalTransCounts.set! i visited.size
+    let strataCount := visited.fold (init := 0) fun acc idx =>
+      if isStrata.contains idx then acc + 1 else acc
+    strataTransCounts := strataTransCounts.set! i strataCount
+
+  -- Filter to Strata modules only
+  let mut strataModules : Array (Name × Nat × Nat) := #[]
+  for h : i in [:moduleNames.size] do
+    let n := moduleNames[i]
+    if isStrata.contains i then
+      strataModules := strataModules.push (n, totalTransCounts[i]!, strataTransCounts[i]!)
+
+  -- Compute and print stats for both total and Strata-only
+  for (label, getCount) in [
+    ("all (including Lean/Std)", fun (x : Name × Nat × Nat) => x.2.1),
+    ("Strata-only",             fun (x : Name × Nat × Nat) => x.2.2)
+  ] do
+    let sorted := strataModules.qsort (fun a b => getCount a > getCount b)
+    let total := strataModules.foldl (init := 0) fun acc m => acc + getCount m
+    let count := strataModules.size
+    let avg : Float := if count > 0 then total.toFloat / count.toFloat else 0.0
+    let max := strataModules.foldl (init := 0) fun acc m => Nat.max acc (getCount m)
+    let min := strataModules.foldl (init := total) fun acc m => Nat.min acc (getCount m)
+    let median := if sorted.size > 0 then getCount sorted[sorted.size / 2]! else 0
+
+    IO.println s!"=== Transitive imports ({label}) for {count} Strata modules ==="
+    IO.println s!"  Average: {Float.toString avg}"
+    IO.println s!"  Median:  {median}"
+    IO.println s!"  Min:     {min}"
+    IO.println s!"  Max:     {max}"
+    IO.println s!"  Total:   {total}"
+    IO.println ""
+    IO.println "  Top 20:"
+    for i in [:Nat.min 20 sorted.size] do
+      let m := sorted[i]!
+      IO.println s!"    {getCount m}\t{m.1}"
+    IO.println ""
+    IO.println "  Bottom 10:"
+    let start := if sorted.size > 10 then sorted.size - 10 else 0
+    for i in [start:sorted.size] do
+      let m := sorted[i]!
+      IO.println s!"    {getCount m}\t{m.1}"
+
+    IO.println ""
+    IO.println "  Histogram (bucket size = 10):"
+    let bucketSize := 10
+    let numBuckets := max / bucketSize + 1
+    let mut buckets : Array Nat := .replicate numBuckets 0
+    for m in strataModules do
+      let b := getCount m / bucketSize
+      buckets := buckets.set! b (buckets[b]! + 1)
+    for b in [:numBuckets] do
+      let lo := b * bucketSize
+      let hi := lo + bucketSize - 1
+      let cnt := buckets[b]!
+      if cnt > 0 then
+        let bar := String.ofList (List.replicate (Nat.min cnt 60) '█')
+        let suffix := if cnt > 60 then "…" else ""
+        IO.println s!"    {lo}-{hi}\t{cnt}\t{bar}{suffix}"
+    IO.println ""
+
+  return 0

--- a/Scripts/ImportStats.lean
+++ b/Scripts/ImportStats.lean
@@ -4,7 +4,8 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 import Strata
-import Lean
+import Lean.Environment
+import Lean.Util.Path
 
 open Lean System
 

--- a/Strata.lean
+++ b/Strata.lean
@@ -33,8 +33,37 @@ import Strata.Transform.DetToKleeneCorrect
 import Strata.Transform.ProcBodyVerifyCorrect
 import Strata.Transform.Specification
 
+/- Strata Languages — additional -/
+import Strata.Languages.B3
+import Strata.Languages.Boole.Boole
+import Strata.Languages.Boole.Verify
+import Strata.Languages.C_Simp.C_Simp
+import Strata.Languages.C_Simp.Verify
+import Strata.Languages.Core.EntryPoint
+import Strata.Languages.Core.VerifierProofs
+import Strata.Languages.Dyn.Dyn
+import Strata.Languages.Dyn.Verify
+import Strata.Languages.Python.Python
+
+/- DDM -/
+import Strata.DDM
+
 /- Backends -/
-import Strata.Backends.CBMC.CProver
+import Strata.Backends.CBMC
+
+/- Dialect Library — additional (can't go in aggregates due to cycles) -/
+import Strata.DL.Imperative.CFGToCProverGOTO
+import Strata.DL.Imperative.ToCProverGOTO
+import Strata.DL.SMT.Denote
+import Strata.DL.SMT.Translate
+
+/- Code Transforms — additional -/
+import Strata.Transform.StructuredToUnstructured
+
+/- Other -/
+import Strata.MetaVerifier
 
 /- Simple API -/
 import Strata.SimpleAPI
+
+-- noimport: Strata.Util.Random -- deletion candidate: nothing imports this module

--- a/Strata/Backends/CBMC.lean
+++ b/Strata/Backends/CBMC.lean
@@ -1,0 +1,12 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+import Strata.Backends.CBMC.CProver
+import Strata.Backends.CBMC.CollectSymbols
+import Strata.Backends.CBMC.CoreToCBMC
+import Strata.Backends.CBMC.GOTO
+import Strata.Backends.CBMC.StrataToCBMC

--- a/Strata/Backends/CBMC/GOTO.lean
+++ b/Strata/Backends/CBMC/GOTO.lean
@@ -1,0 +1,11 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+import Strata.Backends.CBMC.GOTO.CoreToCProverGOTO
+import Strata.Backends.CBMC.GOTO.CoreToGOTOPipeline
+import Strata.Backends.CBMC.GOTO.DefaultSymbols
+import Strata.Backends.CBMC.GOTO.LambdaToCProverGOTO

--- a/Strata/DDM.lean
+++ b/Strata/DDM.lean
@@ -1,0 +1,9 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+import Strata.DDM.AST.Lemmas
+import Strata.DDM.Integration.Java

--- a/Strata/DL/Imperative/Imperative.lean
+++ b/Strata/DL/Imperative/Imperative.lean
@@ -20,3 +20,6 @@ public import Strata.DL.Imperative.KleeneStmtSemantics
 public import Strata.DL.Imperative.SemanticsProps
 
 public import Strata.DL.Imperative.SMTUtils
+
+import Strata.DL.Imperative.BasicBlock
+import Strata.DL.Imperative.CFGSemantics

--- a/Strata/DL/Lambda/Lambda.lean
+++ b/Strata/DL/Lambda/Lambda.lean
@@ -13,6 +13,9 @@ public import Strata.DL.Lambda.Denote.LExprSemanticsConsistent
 public import Strata.DL.Lambda.TypeFactory
 public import Strata.DL.Lambda.Reflect
 
+import Strata.DL.Lambda.PlausibleHelpers
+import Strata.DL.Lambda.TestGen
+
 namespace Lambda
 open Strata
 open Std (ToFormat Format format)

--- a/Strata/Languages/B3.lean
+++ b/Strata/Languages/B3.lean
@@ -1,0 +1,12 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+import Strata.Languages.B3.DDMTransform.Conversion
+import Strata.Languages.B3.DDMTransform.DefinitionAST
+import Strata.Languages.B3.DDMTransform.ParseCST
+import Strata.Languages.B3.Transform.FunctionToAxiom
+import Strata.Languages.B3.Verifier

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -35,4 +35,8 @@ name = "CheckImports"
 root = "Scripts.CheckImports"
 
 [[lean_exe]]
+name = "ImportStats"
+root = "Scripts.ImportStats"
+
+[[lean_exe]]
 name = "DiffTestCore"

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -2,6 +2,7 @@ name = "Strata"
 version = "0.1.0"
 defaultTargets = ["Strata", "strata", "StrataMain", "StrataToCBMC", "StrataCoreToGoto"]
 testDriver = "StrataTest"
+lintDriver = "CheckImports"
 
 [[require]]
 name = "plausible"
@@ -28,6 +29,10 @@ name = "StrataToCBMC"
 
 [[lean_exe]]
 name = "StrataCoreToGoto"
+
+[[lean_exe]]
+name = "CheckImports"
+root = "Scripts.CheckImports"
 
 [[lean_exe]]
 name = "DiffTestCore"


### PR DESCRIPTION
## Summary

Add CI linting to ensure `Strata.lean` transitively imports every Strata module,
and add a statistics script for measuring the import graph.

## Changes

- **Import lint driver (`Scripts/CheckImports.lean`)**: Verifies that all `.lean`
  files under `Strata/` are transitively imported by `Strata.lean`. Registered as
  `lintDriver` in `lakefile.toml` so `lake lint` runs it automatically. Supports
  `-- noimport: Strata.Foo` comments in `Strata.lean` to allowlist intentionally
  excluded modules.

- **`Strata.lean` updated** to transitively import all 293 modules. Added
  aggregator modules (`CBMC.lean`, `GOTO.lean`, `B3.lean`, `DDM.lean`) that
  re-export submodules.

- **Import statistics script (`Scripts/ImportStats.lean`)**: Computes per-module
  transitive import counts (both total and Strata-only), reporting average,
  median, min, max, top/bottom lists, and histograms. Run via `lake exe ImportStats`.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.