### PR TITLE
Improve verifier profiling accuracy; add PAdd perf test

### DIFF
--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -888,7 +888,7 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
           (label := obligation.label))
   let tDone ← IO.monoNanosNow
   if profile then
-    let _ ← (IO.println s!"[profile]         getVars: {nsToMs (tDischarge - tGetVars)}ms, discharge: {nsToMs (tDone - tDischarge)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]         getVars: {nsToMs (tDischarge - tGetVars)}ms, serialize/write/solve: {nsToMs (tDone - tDischarge)}ms" |>.toBaseIO)
   match ans with
   | .error e =>
     dbg_trace f!"\n\nObligation {obligation.label}: SMT Solver Invocation Error!\

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -862,10 +862,13 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
     (tempDir : System.FilePath) (satisfiabilityCheck validityCheck : Bool)
     (phases : List AbstractedPhase)
     : EIO DiagnosticModel VCResult := do
-  let prog := f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
+  let profile := options.profile
+  let debugProg : Unit → Format := fun _ =>
+    f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
   let counterVal ← counter.get
   counter.set (counterVal + 1)
   let filename := tempDir / s!"{Core.SMT.sanitizeFilename obligation.label}_{counterVal}.smt2"
+  let tGetVars ← IO.monoNanosNow
   let varsInObligation := ProofObligation.getVars obligation
   -- All variables in ProofObligation must have been typed.
   let typedVarsInObligation ← varsInObligation.mapM
@@ -873,6 +876,7 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
       match ty with
       | .some ty => return (v,LTy.forAll [] ty)
       | .none => throw (DiagnosticModel.fromMessage s!"{v} untyped"))
+  let tDischarge ← IO.monoNanosNow
   let ans ←
       IO.toEIO
         (fun e => DiagnosticModel.fromFormat f!"{e}")
@@ -882,11 +886,14 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
             filename.toString
           assumptionTerms obligationTerm ctx satisfiabilityCheck validityCheck
           (label := obligation.label))
+  let tDone ← IO.monoNanosNow
+  if profile then
+    let _ ← (IO.println s!"[profile]         getVars: {nsToMs (tDischarge - tGetVars)}ms, discharge: {nsToMs (tDone - tDischarge)}ms" |>.toBaseIO)
   match ans with
   | .error e =>
     dbg_trace f!"\n\nObligation {obligation.label}: SMT Solver Invocation Error!\
                  \n\nError: {e}\
-                 {if options.verbose >= .debug then prog else ""}"
+                 {if options.verbose >= .debug then debugProg () else ""}"
     .error <| DiagnosticModel.fromFormat e
   | .ok (satResult, validityResult, estate) =>
     -- Convert unvalidated sat results to unknown when phases require validation
@@ -935,7 +942,9 @@ def verifySingleEnv (E : Env) (options : VerifyOptions)
     let mut smtEncodeNs : Nat := 0
     let mut solverNs : Nat := 0
     let mut peResolvedCount : Nat := 0
+    let mut obligationIdx : Nat := 0
     for obligation in E.deferred do
+      let tOblStart ← IO.monoNanosNow
       -- Determine which checks to perform based on metadata or check mode/amount
       let (satisfiabilityCheck, validityCheck) :=
         if Imperative.MetaData.hasFullCheck obligation.metadata then
@@ -973,15 +982,16 @@ def verifySingleEnv (E : Env) (options : VerifyOptions)
               let prog := f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
               dbg_trace f!"\n\nResult: {result}\n{prog}"
             if options.stopOnFirstError then break
+          if profile then
+            let tOblEnd ← IO.monoNanosNow
+            let _ ← (IO.println s!"[profile]       obligation[{obligationIdx}] {obligation.label}: {nsToMs (tOblEnd - tOblStart)}ms (PE resolved)" |>.toBaseIO)
+          obligationIdx := obligationIdx + 1
           continue
       -- Need the solver for at least one check
       let needSatCheck := satisfiabilityCheck && peSatResult?.isNone
       let needValCheck := validityCheck && peValResult?.isNone
       let t2 ← IO.monoNanosNow
-      let maybeTerms := ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory
-      let t3 ← IO.monoNanosNow
-      smtEncodeNs := smtEncodeNs + (t3 - t2)
-      match maybeTerms with
+      match ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory with
       | .error err =>
         let err := f!"SMT Encoding Error! " ++ err
         let result := { obligation,
@@ -996,6 +1006,8 @@ def verifySingleEnv (E : Env) (options : VerifyOptions)
         results := results.push result
         if options.stopOnFirstError then break
       | .ok (assumptionTerms, obligationTerm, ctx, encStats) =>
+        let t3 ← IO.monoNanosNow
+        smtEncodeNs := smtEncodeNs + (t3 - t2)
         stats := stats.merge encStats
         let t4 ← IO.monoNanosNow
         let result ← getObligationResult assumptionTerms obligationTerm ctx obligation p options
@@ -1017,6 +1029,10 @@ def verifySingleEnv (E : Env) (options : VerifyOptions)
             let prog := f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
             dbg_trace f!"\n\nResult: {result}\n{prog}"
           if options.stopOnFirstError then break
+      if profile then
+        let tOblEnd ← IO.monoNanosNow
+        let _ ← (IO.println s!"[profile]       obligation[{obligationIdx}] {obligation.label}: {nsToMs (tOblEnd - tOblStart)}ms" |>.toBaseIO)
+      obligationIdx := obligationIdx + 1
     if profile then
       let _ ← (IO.println s!"[profile]     Preprocess obligations: {nsToMs preprocessNs}ms" |>.toBaseIO)
       let _ ← (IO.println s!"[profile]     SMT encoding: {nsToMs smtEncodeNs}ms" |>.toBaseIO)

--- a/StrataTest/Languages/Python/tests/pending/test_add6.py
+++ b/StrataTest/Languages/Python/tests/pending/test_add6.py
@@ -1,0 +1,7 @@
+def add6(a: int, b: int, c: int, d: int, e: int, f_: int) -> int:
+    return a + b + c + d + e + f_
+
+def test():
+    r: int = add6(1, 2, 3, 4, 5, 6)
+    assert r == 21, "sum of 6"
+test()


### PR DESCRIPTION
## Summary

- **Fix eager `formatProgram`**: `getObligationResult` was computing `Core.formatProgram p` unconditionally for every obligation (only used in debug traces). Deferred behind a thunk.

- **Fix `toSMTTerms` timing**: The existing profiling bound `toSMTTerms` with a pure `let`, so its cost was deferred and misattributed to "Solver/file writing". Inlined the `match` so SMT encoding time is correctly reported.

- **Add per-obligation profiling**: When `--profile` is set, print per-obligation timing and `getVars`/`serialize/write/solve` breakdown inside `getObligationResult`.

- **Add `test_add6.py`**: Pending Python test with 6 `int` parameters whose nested `PAdd` calls trigger exponential expression blowup in VC processing.

## Profiling results on `test_add6.py`

To reproduce:
```
source StrataTest/Languages/Python/venv/bin/activate
python3 Tools/Python/strata/gen.py py_to_strata \
  --dialect "Tools/Python/dialects/Python.dialect.st.ion" \
  StrataTest/Languages/Python/tests/pending/test_add6.py \
  /tmp/test_add6.python.st.ion

lake exe strata pyAnalyzeLaurel --no-solve --vc-directory /tmp/add6_vcs \
  --profile /tmp/test_add6.python.st.ion
```

Before this PR, `--profile` reported SMT encoding as 0ms. After:

```
obligation[0] assert(77):      53,939ms
  getVars: 3,900ms, serialize/write/solve: 8,910ms
obligation[1] postcondition:   57,232ms
  getVars: 4,423ms, serialize/write/solve: 8,784ms
obligation[2..9]:              < 1ms each

Preprocess obligations: 18,545ms   (getOps tree walk for axiom pruning)
SMT encoding:           66,609ms   (toSMTTerms tree walk — was 0ms before)
Solver/file writing:    26,021ms   (serialize + write + solve)
```

Only 2 of 10 obligations are slow — those containing the deeply nested `PAdd` ITE expression. All four components (preprocess, SMT encoding, getVars, file writing) suffer from the same root cause: DAG-as-tree traversal of shared sub-expressions.

## Test plan

- [ ] `lake build strata:exe` succeeds
- [ ] Run `test_add6.py` through `pyAnalyzeLaurel --profile` and verify the new profiling output shows per-obligation timing and correct SMT encoding attribution

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.