### PR TITLE
Fix #1038 quantifier bvar order bug

### DIFF
--- a/Strata/Languages/Core/DDMTransform/Translate.lean
+++ b/Strata/Languages/Core/DDMTransform/Translate.lean
@@ -694,8 +694,8 @@ def translateQuantifier
   (bindings : TransBindings) (xsa : Arg) (triggersa: Option Arg) (bodya: Arg) :
   TransM Core.Expression.Expr := do
     let xsArray ← translateDeclList bindings xsa
-    -- Note: the indices in the following are placeholders
-    let newBoundVars := List.toArray (xsArray.mapIdx (fun i _ => LExpr.bvar () i))
+    let n := xsArray.size
+    let newBoundVars := List.toArray (xsArray.mapIdx (fun i _ => LExpr.bvar () (n - 1 - i)))
     let boundVars' := bindings.boundVars ++ newBoundVars
     let xbindings := { bindings with boundVars := boundVars' }
     let b ← translateExpr p xbindings bodya

--- a/StrataTest/Languages/Core/Tests/QuantifierBvarIndexTest.lean
+++ b/StrataTest/Languages/Core/Tests/QuantifierBvarIndexTest.lean
@@ -1,0 +1,80 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Core.Core
+import Strata.Languages.Core.DDMTransform.Translate
+
+open Core
+open Strata
+
+def translate (t : Strata.Program) : Core.Program :=
+  (TransM.run Inhabited.default (translateProgram t)).fst
+
+/-! ## Regression test for #1038 (https://github.com/strata-org/Strata/issues/1038)
+
+`translateQuantifier` assigned placeholder bvar indices left-to-right via
+`mapIdx` (0, 1, …), but `foldr` nests quantifiers right-to-left, so the de
+Bruijn indices ended up reversed.
+-/
+
+-- Axiom-level quantifier with bound variable application
+def axiomApplyBoundVar :=
+#strata
+program Core;
+
+function apply(f : int -> int, x : int) : int;
+axiom forall f : int -> int, x : int :: apply(f, x) == f(x);
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+---
+info: ok: program Core;
+
+function apply (f : int -> int, x : int) : int;
+axiom [axiom_0]: forall __q0 : int -> int :: forall __q1 : int :: apply(__q0, __q1) == __q0(__q1);
+-/
+#guard_msgs in
+#eval (Std.format ((Core.typeCheck .default (translate axiomApplyBoundVar).stripMetaData)))
+
+-- Expression-level quantifier with bound variable application (no axiom needed)
+def quantifierApplyBoundVar :=
+#strata
+program Core;
+
+function apply(f : int -> int, x : int) : int
+{
+  f(x)
+}
+
+procedure Check(out result: bool)
+spec {
+  ensures result == (forall f : int -> int, x : int :: apply(f, x) == f(x));
+}
+{
+  result := true;
+};
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+---
+info: ok: program Core;
+
+function apply (f : int -> int, x : int) : int {
+  f(x)
+}
+procedure Check (out result : bool)
+spec {
+  ensures [Check_ensures_0]: result == forall __q0 : int -> int :: forall __q1 : int :: apply(__q0, __q1) == __q0(__q1);
+  } {
+  result := true;
+};
+-/
+#guard_msgs in
+#eval (Std.format ((Core.typeCheck .default (translate quantifierApplyBoundVar).stripMetaData)))


### PR DESCRIPTION
*Issue #, if available:* #1038

*Description of changes:* Fixes bug where quantifier `bvars` were reversed leading to typechecker error. Includes regression tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
