### PR TITLE
Minimize DDM imports via lake shake

### DIFF
--- a/Strata/Backends/CBMC/CoreToCBMC.lean
+++ b/Strata/Backends/CBMC/CoreToCBMC.lean
@@ -9,6 +9,7 @@ public import Strata.Backends.CBMC.Common
 public import Strata.Languages.Core.Procedure
 
 import Lean.Data.Json
+import Lean.Parser.Types
 import Strata.DDM.Integration.Lean.HashCommands
 import Strata.Languages.Core.Env
 import Strata.Languages.Core.DDMTransform.Grammar

--- a/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
@@ -10,6 +10,7 @@ public import Strata.Backends.CBMC.GOTO.DefaultSymbols
 public import Strata.Backends.CBMC.GOTO.LambdaToCProverGOTO
 public import Strata.DL.Imperative.ToCProverGOTO
 public import Strata.Languages.Core.Verifier
+import Lean.Parser.Types
 
 public section
 

--- a/Strata/Backends/CBMC/StrataToCBMC.lean
+++ b/Strata/Backends/CBMC/StrataToCBMC.lean
@@ -6,6 +6,7 @@
 module
 
 import Lean.Data.Json
+import Lean.Parser.Types
 import Strata.DL.Util.Map
 public import Strata.Languages.C_Simp.C_Simp
 public import Strata.Languages.C_Simp.Verify

--- a/Strata/DDM.lean
+++ b/Strata/DDM.lean
@@ -5,5 +5,6 @@
 -/
 module
 
-import Strata.DDM.AST.Lemmas
-import Strata.DDM.Integration.Java
+-- Aggregator: re-exports DDM submodules
+import Strata.DDM.AST.Lemmas -- shake: keep
+import Strata.DDM.Integration.Java -- shake: keep

--- a/Strata/DDM/AST.lean
+++ b/Strata/DDM/AST.lean
@@ -5,16 +5,15 @@
 -/
 module
 
-public import Std.Data.HashMap.Basic
+import Std.Data.HashMap.Lemmas
+
 public import Strata.DDM.AST.Datatype
+import all Strata.DDM.Util.Array
 public import Strata.DDM.Util.ByteArray
+import all Strata.DDM.Util.ByteArray
 public import Strata.DDM.Util.Decimal
 public import Strata.DDM.Util.SourceRange
-
-import Std.Data.HashMap
-import all Strata.DDM.Util.Array
 import Strata.Util.DecideProp
-import all Strata.DDM.Util.ByteArray
 
 set_option autoImplicit false
 

--- a/Strata/DDM/BuiltinDialects/BuiltinM.lean
+++ b/Strata/DDM/BuiltinDialects/BuiltinM.lean
@@ -6,8 +6,6 @@
 module
 
 public import Strata.DDM.Elab.DeclM
-public import Lean.Parser.Types
-public import Strata.DDM.Elab.LoadedDialects
 
 
 public section

--- a/Strata/DDM/Elab.lean
+++ b/Strata/DDM/Elab.lean
@@ -4,15 +4,18 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 module
-public import Strata.DDM.Elab.DeclM
-public import Strata.DDM.Ion
 
-import Strata.DDM.Elab.DialectM
 import Strata.DDM.BuiltinDialects
+public import Strata.DDM.Elab.DeclM
+public import Strata.DDM.Elab.DialectM
+public import Strata.DDM.Ion
 import Strata.DDM.Util.Ion.Serialize
 
 import all Strata.DDM.Util.ByteArray
 import all Strata.DDM.Util.Lean
+public import Strata.DDM.BuiltinDialects.Init
+public import Strata.DDM.BuiltinDialects.StrataDDL
+public import Strata.DDM.Util.Lean
 
 open Lean (Message)
 open Strata.Parser (InputContext)

--- a/Strata/DDM/Elab/Core.lean
+++ b/Strata/DDM/Elab/Core.lean
@@ -11,6 +11,7 @@ import Strata.DDM.HNF
 import all Strata.DDM.Util.Array
 import all Strata.DDM.Util.Fin
 import all Strata.DDM.Util.Lean
+import Strata.DDM.Util.Fin
 import Strata.Util.DecideProp
 
 open Lean (

--- a/Strata/DDM/Elab/DeclM.lean
+++ b/Strata/DDM/Elab/DeclM.lean
@@ -5,11 +5,8 @@
 -/
 module
 
-public import Lean.Parser.Types
 
-public import Strata.DDM.AST
 public import Strata.DDM.Elab.LoadedDialects
-public import Strata.DDM.Parser
 import all Strata.DDM.Util.Lean
 import all Strata.DDM.Util.PrattParsingTables
 

--- a/Strata/DDM/Elab/DialectM.lean
+++ b/Strata/DDM/Elab/DialectM.lean
@@ -5,13 +5,13 @@
 -/
 module
 
-public import Strata.DDM.AST
+import Std.Data.HashMap.Lemmas
+
 public import Strata.DDM.Elab.Core
 
-import Std.Data.HashMap
-import Strata.Util.DecideProp
 import all Strata.DDM.Util.Array
 import all Strata.DDM.Util.Fin
+import Strata.Util.DecideProp
 
 set_option autoImplicit false
 

--- a/Strata/DDM/Elab/Env.lean
+++ b/Strata/DDM/Elab/Env.lean
@@ -7,7 +7,6 @@ module
 
 public import Strata.DDM.AST
 public import Lean.Parser.Basic
-public import Lean.Environment
 
 namespace Strata
 

--- a/Strata/DDM/Elab/LoadedDialects.lean
+++ b/Strata/DDM/Elab/LoadedDialects.lean
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 module
-public import Std.Data.HashMap.Basic
 public import Strata.DDM.Parser
 public import Strata.DDM.Elab.SyntaxElab
 

--- a/Strata/DDM/Elab/SyntaxElab.lean
+++ b/Strata/DDM/Elab/SyntaxElab.lean
@@ -5,10 +5,7 @@
 -/
 module
 public import Strata.DDM.AST
-public import Std.Data.HashMap.Basic
 
-import Strata.DDM.Parser
-import Strata.DDM.Util.Lean
 import Strata.Util.DecideProp
 
 public section

--- a/Strata/DDM/Elab/Tree.lean
+++ b/Strata/DDM/Elab/Tree.lean
@@ -5,7 +5,6 @@
 -/
 module
 
-public import Strata.DDM.AST
 public import Strata.DDM.Format
 set_option autoImplicit false
 

--- a/Strata/DDM/Format.lean
+++ b/Strata/DDM/Format.lean
@@ -5,7 +5,6 @@
 -/
 module
 
-import Std.Data.HashSet
 public import Strata.DDM.AST
 import all Strata.DDM.Util.Format
 import all Strata.DDM.Util.Nat

--- a/Strata/DDM/Integration/Lean.lean
+++ b/Strata/DDM/Integration/Lean.lean
@@ -5,9 +5,9 @@
 -/
 module
 
-public import Strata.DDM.Format  -- FormatOptions used by test files
 public import Strata.DDM.Integration.Lean.Gen
 public import Strata.DDM.Integration.Lean.HashCommands
+public import Strata.DDM.Integration.Lean.GenTrace
 
 /-!
 Umbrella module that re-exports all imports needed to work with

--- a/Strata/DDM/Integration/Lean/Env.lean
+++ b/Strata/DDM/Integration/Lean/Env.lean
@@ -4,7 +4,6 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 module
-public import Lean.Environment
 public import Strata.DDM.Elab.LoadedDialects
 import Strata.DDM.BuiltinDialects
 

--- a/Strata/DDM/Integration/Lean/Gen.lean
+++ b/Strata/DDM/Integration/Lean/Gen.lean
@@ -6,20 +6,20 @@
 module
 
 public meta import Lean.Elab.Command
-public meta import Strata.DDM.AST
--- `public import` provides object-level access for generated code at call sites.
--- `public meta import` provides meta-level access for #strata_gen elaboration.
-public import      Strata.DDM.BuiltinDialects.Init  -- Generated code uses Init types
-public import      Strata.DDM.HNF  -- Generated ofAst uses ExprF.hnf
-public meta import Strata.DDM.BuiltinDialects.Init
+import Lean.Parser.Command
+
+public import      Strata.DDM.BuiltinDialects.Init -- shake: keep (Generated code uses Init types)
+public meta import Strata.DDM.BuiltinDialects.Init -- shake: keep
 meta import        Strata.DDM.BuiltinDialects.StrataDDL
-public meta import Strata.DDM.Integration.Categories
+public import      Strata.DDM.HNF  -- shake: keep (Generated ofAst uses ExprF.hnf)
+public meta import Strata.DDM.Integration.Categories --shake: keep (shake bug)
 public meta import Strata.DDM.Integration.Lean.Env
-public meta import Strata.DDM.Integration.Lean.GenTrace  -- trace option
-public import      Strata.DDM.Integration.Lean.OfAstM  -- Generated ofAst combinators
-public meta import Strata.DDM.Integration.Lean.OfAstM
-public meta import Strata.DDM.Util.Graph.Tarjan
-meta import        Strata.Util.DecideProp
+public meta import Strata.DDM.Integration.Lean.GenTrace  -- shake: keep (trace option)
+public import      Strata.DDM.Integration.Lean.OfAstM -- shake: keep (Generated ofAst combinators)
+public meta import Strata.DDM.Integration.Lean.OfAstM -- shake: keep
+public meta import Strata.DDM.Util.Graph.Tarjan -- shake: keep (shake bug)
+import Strata.DDM.Util.Graph.Tarjan
+meta import Strata.Util.DecideProp
 
 /-!
 Implements the `#strata_gen` command, which reads a dialect definition and

--- a/Strata/DDM/Integration/Lean/Gen.lean
+++ b/Strata/DDM/Integration/Lean/Gen.lean
@@ -12,7 +12,7 @@ public import      Strata.DDM.BuiltinDialects.Init -- shake: keep (Generated cod
 public meta import Strata.DDM.BuiltinDialects.Init -- shake: keep
 meta import        Strata.DDM.BuiltinDialects.StrataDDL
 public import      Strata.DDM.HNF  -- shake: keep (Generated ofAst uses ExprF.hnf)
-public meta import Strata.DDM.Integration.Categories --shake: keep (shake bug)
+public meta import Strata.DDM.Integration.Categories -- shake: keep (shake bug)
 public meta import Strata.DDM.Integration.Lean.Env
 public meta import Strata.DDM.Integration.Lean.GenTrace  -- shake: keep (trace option)
 public import      Strata.DDM.Integration.Lean.OfAstM -- shake: keep (Generated ofAst combinators)

--- a/Strata/DDM/Integration/Lean/HashCommands.lean
+++ b/Strata/DDM/Integration/Lean/HashCommands.lean
@@ -5,13 +5,15 @@
 -/
 module
 
-public import Lean.Elab.Command
-public import Lean.Parser.Types
+import Lean.Elab.Command
 public meta import Strata.DDM.Elab
 public meta import Strata.DDM.Integration.Lean.Env
 public meta import Strata.DDM.Integration.Lean.ToExpr
 public meta import Strata.DDM.TaggedRegions
-public meta import Strata.DDM.Util.Lean
+import Strata.DDM.Elab.DeclM
+import Strata.DDM.Integration.Lean.Env
+import Strata.DDM.Integration.Lean.ToExpr
+import Strata.DDM.TaggedRegions
 
 open Lean
 open Lean.Elab (throwUnsupportedSyntax)
@@ -19,9 +21,8 @@ open Lean.Elab.Command (CommandElab CommandElabM liftCoreM)
 open Lean.Elab.Term (TermElab)
 open Lean.Parser (InputContext)
 open System (FilePath)
-open Strata.Lean
+open Strata.Lean (arrayToExpr listToExpr)
 
-public meta section
 namespace Strata
 
 class HasInputContext (m : Type → Type _) [Functor m] where
@@ -29,7 +30,9 @@ class HasInputContext (m : Type → Type _) [Functor m] where
   getFileName : m FilePath :=
     (fun ctx => FilePath.mk ctx.fileName) <$> getInputContext
 
-private instance : HasInputContext CommandElabM where
+meta section
+
+instance : HasInputContext CommandElabM where
   getInputContext := do
     let ctx ← read
     pure {
@@ -39,7 +42,7 @@ private instance : HasInputContext CommandElabM where
     }
   getFileName := return (← read).fileName
 
-private instance : HasInputContext CoreM where
+instance : HasInputContext CoreM where
   getInputContext := do
     let ctx ← read
     pure {
@@ -49,7 +52,7 @@ private instance : HasInputContext CoreM where
     }
   getFileName := return (← read).fileName
 
-private def mkScopedName {m} [Monad m] [MonadError m] [MonadEnv m] [MonadResolveName m] (name : Name) : m Name := do
+def mkScopedName {m} [Monad m] [MonadError m] [MonadEnv m] [MonadResolveName m] (name : Name) : m Name := do
   let scope ← getCurrNamespace
   let fullName := scope ++ name
   let env ← getEnv
@@ -57,13 +60,13 @@ private def mkScopedName {m} [Monad m] [MonadError m] [MonadEnv m] [MonadResolve
     throwError s!"Cannot define {name}: {fullName} already exists."
   return fullName
 
-private def offsetPos (base : String.Pos.Raw) (pos : String.Pos.Raw) : String.Pos.Raw :=
+def offsetPos (base : String.Pos.Raw) (pos : String.Pos.Raw) : String.Pos.Raw :=
   ⟨base.byteIdx + pos.byteIdx⟩
 
-private def offsetSourceRange (base : String.Pos.Raw) (sr : SourceRange) : SourceRange :=
+def offsetSourceRange (base : String.Pos.Raw) (sr : SourceRange) : SourceRange :=
   { start := offsetPos base sr.start, stop := offsetPos base sr.stop }
 
-private def offsetMessage
+def offsetMessage
     (fullCtx snippetCtx : InputContext)
     (base : String.Pos.Raw)
     (msg : Lean.Message) : Lean.Message :=
@@ -75,7 +78,7 @@ private def offsetMessage
 /--
 Add a definition to environment and compile it.
 -/
-private def addDefn (name : Lean.Name)
+def addDefn (name : Lean.Name)
             (type : Lean.Expr)
             (value : Lean.Expr)
             (levelParams : List Name := [])
@@ -91,6 +94,8 @@ private def addDefn (name : Lean.Name)
     safety := safety
     all := all
   }
+
+public section
 
 /--
 Declare dialect and add to environment.
@@ -181,7 +186,7 @@ meta def strataProgramImpl : TermElab := fun stx tp => do
 
 syntax (name := loadDialectCommand) "#load_dialect" str : command
 
-def resolveLeanRelPath {m} [Monad m] [HasInputContext m] [MonadError m] (path : FilePath) : m FilePath := do
+private def resolveLeanRelPath {m} [Monad m] [HasInputContext m] [MonadError m] (path : FilePath) : m FilePath := do
   if path.isAbsolute then
     pure path
   else
@@ -191,7 +196,7 @@ def resolveLeanRelPath {m} [Monad m] [HasInputContext m] [MonadError m] (path : 
     pure <| leanDir / path
 
 @[command_elab loadDialectCommand]
-def loadDialectImpl: CommandElab := fun (stx : Syntax) => do
+def loadDialectImpl : CommandElab := fun (stx : Syntax) => do
   match stx with
   | `(command|#load_dialect $pathStx) =>
     let dialectPath : FilePath := pathStx.getString
@@ -211,5 +216,7 @@ def loadDialectImpl: CommandElab := fun (stx : Syntax) => do
   | _ =>
     throwUnsupportedSyntax
 
-end Strata
 end
+end
+
+end Strata

--- a/Strata/DDM/Integration/Lean/ToExpr.lean
+++ b/Strata/DDM/Integration/Lean/ToExpr.lean
@@ -8,12 +8,10 @@ module
 This module provides ToExpr instances and other methods
 for converting DDM types into Lean expressions.
 -/
-public import Lean.Elab.Term
-meta import Lean.Elab.Term.TermElabM
 public import Strata.DDM.AST
-import Strata.DDM.Util.ByteArray
-import Strata.DDM.Util.Decimal
 import Strata.DDM.Util.Lean
+public meta import Lean.Elab.Term.TermElabM
+import Lean.Exception
 
 
 open Lean

--- a/Strata/DDM/Ion.lean
+++ b/Strata/DDM/Ion.lean
@@ -6,11 +6,10 @@
 module
 
 public import Strata.DDM.AST
-public import Strata.DDM.Util.Ion
 
-import Strata.DDM.Util.Array
 import Strata.DDM.Util.Ion.Lean
 import Strata.Util.DecideProp
+public import Strata.DDM.Util.Ion.SymbolTable
 
 open Lean
 open Lean.Elab

--- a/Strata/DDM/Parser.lean
+++ b/Strata/DDM/Parser.lean
@@ -7,7 +7,6 @@ module
 
 public import Strata.DDM.Elab.Env
 public import Strata.DDM.Format
-import Strata.DDM.Util.ByteArray
 import Strata.Util.DecideProp
 
 open Lean

--- a/Strata/DDM/TaggedRegions.lean
+++ b/Strata/DDM/TaggedRegions.lean
@@ -5,11 +5,11 @@
 -/
 module
 
-import Lean.PrettyPrinter.Formatter
-import Lean.PrettyPrinter.Parenthesizer
 import all Strata.DDM.Util.String
 
-public meta import Lean.Elab.Syntax
+public import Lean.PrettyPrinter.Formatter
+public import Lean.PrettyPrinter.Parenthesizer
+public meta import Lean.Elab.Syntax -- shake: keep (needed for public meta command)
 
 open Lean (SourceInfo Syntax SyntaxNodeKind Name format)
 open Lean.Elab.Command (CommandElab CommandElabM liftTermElabM elabCommand)

--- a/Strata/DDM/Util/ByteArray.lean
+++ b/Strata/DDM/Util/ByteArray.lean
@@ -8,7 +8,6 @@ module
 /-
 Functions for ByteArray that could potentially be upstreamed to Lean.
 -/
-import Std.Data.HashMap
 public import Lean.ToExpr
 
 namespace ByteArray

--- a/Strata/DDM/Util/Decimal.lean
+++ b/Strata/DDM/Util/Decimal.lean
@@ -7,7 +7,6 @@ module
 
 public import Lean.ToExpr
 
-import Lean.ToExpr
 import all Strata.DDM.Util.Lean
 import all Strata.DDM.Util.String
 

--- a/Strata/DDM/Util/DecimalRat.lean
+++ b/Strata/DDM/Util/DecimalRat.lean
@@ -5,7 +5,6 @@
 -/
 module
 public import Strata.DDM.Util.Decimal
-meta import Strata.DDM.Util.Decimal
 
 public section
 namespace Strata.Decimal

--- a/Strata/DDM/Util/Ion.lean
+++ b/Strata/DDM/Util/Ion.lean
@@ -12,7 +12,6 @@ public import Strata.DDM.Util.Ion.SymbolTable
 
 import all Strata.DDM.Util.ByteArray
 import all Strata.DDM.Util.Fin
-import Strata.DDM.Util.Ion.Deserialize
 import Strata.DDM.Util.Ion.JSON
 
 public section

--- a/Strata/DDM/Util/Ion/Deserialize.lean
+++ b/Strata/DDM/Util/Ion/Deserialize.lean
@@ -7,7 +7,6 @@ module
 
 public import Strata.DDM.Util.Ion.AST
 
-import Strata.DDM.Util.ByteArray
 import Strata.Util.DecideProp
 
 open Strata (decideProp)

--- a/Strata/DDM/Util/Ion/JSON.lean
+++ b/Strata/DDM/Util/Ion/JSON.lean
@@ -7,7 +7,6 @@ module
 
 import Lean.Data.Json.Basic
 
-import Strata.DDM.Util.Array
 import Strata.DDM.Util.Ion.AST
 
 

--- a/Strata/DDM/Util/Ion/Lean.lean
+++ b/Strata/DDM/Util/Ion/Lean.lean
@@ -10,13 +10,14 @@ extension to create high performance Ion serialization and deserialization.
 -/
 module
 
-public import Lean.Elab.Command
-public import Lean.Elab.Term.TermElabM
 public import Strata.DDM.Util.Ion
 
 public meta import Strata.DDM.Util.Ion.Env
 public meta import Strata.DDM.Util.Ion.SymbolTable
 public meta import Lean.Meta.Eval
+public meta import Lean.Elab.Command
+import Lean.Util.Trace
+import Strata.DDM.Util.Ion.Env
 
 open Lean
 open Lean.Elab

--- a/Strata/DDM/Util/Ion/SymbolTable.lean
+++ b/Strata/DDM/Util/Ion/SymbolTable.lean
@@ -5,7 +5,7 @@
 -/
 module
 
-import Lean.Elab.Command
+import Lean.Elab.Command -- shake: keep
 public import Strata.DDM.Util.Ion.AST
 import all Strata.DDM.Util.Lean
 
@@ -73,8 +73,8 @@ def systemSymbolId! (sym : String) : SymbolId := SymbolTable.system |>.symbolId!
 
 -- Use metaprogramming to declare `{sym}SymbolId : SymbolId` for each system symbol.
 section
-open Lean
-open Elab.Command
+open Lean (TSyntax)
+open Lean.Elab.Command (elabCommand)
 
 -- Declare all system symbol ids as constants
 run_cmd do

--- a/Strata/DDM/Util/Lean.lean
+++ b/Strata/DDM/Util/Lean.lean
@@ -7,7 +7,6 @@ module
 
 public import Lean.Expr
 import Lean.Parser.Types
-import Lean.ResolveName
 
 open Lean Parser
 

--- a/Strata/DDM/Util/PrattParsingTables.lean
+++ b/Strata/DDM/Util/PrattParsingTables.lean
@@ -5,7 +5,7 @@
 -/
 module
 
-public import Lean.Parser.Basic
+import Lean.Parser.Basic
 
 namespace Lean.Parser.PrattParsingTables
 

--- a/Strata/DL/SMT/Solver.lean
+++ b/Strata/DL/SMT/Solver.lean
@@ -9,6 +9,7 @@ public import Strata.DL.SMT.DDMTransform.Translate
 public import Strata.DL.SMT.Term
 public import Strata.DL.SMT.TermType
 public import Strata.Languages.Core.Options
+import Strata.DDM.Format
 import Std.Data.HashMap
 
 /-!

--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -5,8 +5,8 @@
 -/
 module
 
-public import Lean.Expr
-public import Lean.ToExpr
+import Lean.Meta.Basic
+
 public import Strata.Languages.Core.SMTEncoder
 
 public section

--- a/Strata/Languages/B3/Verifier/Expression.lean
+++ b/Strata/Languages/B3/Verifier/Expression.lean
@@ -9,6 +9,7 @@ public import Strata.Languages.B3.DDMTransform.DefinitionAST
 public import Strata.DL.SMT.SMT
 public import Strata.DL.SMT.Factory
 public import Strata.Languages.B3.DDMTransform.Conversion
+import Strata.DDM.Format
 import Strata.Util.Tactics
 
 public section

--- a/Strata/Languages/B3/Verifier/Statements.lean
+++ b/Strata/Languages/B3/Verifier/Statements.lean
@@ -9,6 +9,7 @@ public import Strata.Languages.B3.Verifier.Expression
 public import Strata.Languages.B3.Verifier.State
 public import Strata.Languages.B3.DDMTransform.ParseCST
 public import Strata.Languages.B3.DDMTransform.Conversion
+import Strata.DDM.Format
 import Strata.DDM.Integration.Lean
 import Strata.DDM.Util.Format
 import Strata.Util.Tactics

--- a/Strata/Languages/C_Simp/Verify.lean
+++ b/Strata/Languages/C_Simp/Verify.lean
@@ -9,6 +9,7 @@ public import Strata.Languages.C_Simp.C_Simp
 public import Strata.Languages.C_Simp.DDMTransform.Translate
 public import Strata.Languages.Core.Options
 public import Strata.Languages.Core.Verifier
+import Lean.Parser.Types
 import Strata.Languages.Core.CoreOp
 import Strata.DL.Imperative.Stmt
 

--- a/Strata/Languages/Python/ReadPython.lean
+++ b/Strata/Languages/Python/ReadPython.lean
@@ -6,6 +6,7 @@
 module
 
 import Strata.DDM.Ion
+import Strata.DDM.Util.Ion
 public import Strata.Languages.Python.PythonDialect
 
 public section

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -6,6 +6,7 @@
 module
 
 public import Strata.Languages.Laurel.Laurel
+import Strata.DDM.Format
 import Strata.Languages.Python.OverloadTable
 import Strata.Languages.Python.PythonLaurelTypedExpr
 public import Strata.Languages.Python.Specs.Decls

--- a/Strata/Util/IO.lean
+++ b/Strata/Util/IO.lean
@@ -9,7 +9,7 @@ import Strata.DDM.Elab
 import Strata.DDM.Ion
 import Strata.DDM.BuiltinDialects
 public import Strata.DDM.Elab.LoadedDialects
-import Strata.DDM.Util.Ion.Serialize
+import Strata.DDM.Util.Ion
 import Strata.DDM.Util.ByteArray
 import Strata.DDM.Util.Lean
 

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -6,6 +6,7 @@
 module
 
 -- Executable with utilities for working with Strata files.
+import Lean.Parser.Extension
 import Strata.Backends.CBMC.CollectSymbols
 import Strata.Backends.CBMC.GOTO.CoreToGOTOPipeline
 import Strata.DDM.Integration.Java.Gen

--- a/StrataTest/DDM/Prec.lean
+++ b/StrataTest/DDM/Prec.lean
@@ -6,6 +6,7 @@
 module
 
 import Strata.DDM.Integration.Lean
+import Strata.DDM.Format
 
 #dialect
 dialect TestPrec;


### PR DESCRIPTION
## Summary

Run `lake shake` on DDM modules to minimize their import graph. This is the
DDM-only subset of #1020, split out to reduce merge conflict surface.

## Changes

- **DDM import minimization**: Applied `lake shake --fix` across 30
  `Strata/DDM/` files, removing unnecessary imports and demoting `public
  import` to `import` where re-export was not needed by downstream consumers.

- **`HashCommands.lean` visibility fixes**: Reorganized `meta section` /
  `public section` boundaries and removed unnecessary `private` qualifiers
  to maintain correct elaboration-time visibility after import changes.

- **Downstream import fixes**: 13 non-DDM files that lost transitive access
  to DDM symbols received explicit imports (`Strata.DDM.Format`,
  `Strata.DDM.Util.Ion`, `Lean.Parser.Types`, `Lean.Parser.Extension`).
  Two unnecessary `public import Lean.Expr` / `public import Lean.ToExpr`
  were removed from `Translate.lean`.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.