### PR TITLE
Add backwards compatibility for pyspec #1048 change

### DIFF
--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -78,8 +78,10 @@ op getIndexExpr(subject : SpecExprDecl, field : Ident) : SpecExprDecl =>
   @[prec(50)] subject "[" field "]";
 op isInstanceOfExpr(subject : SpecExprDecl, typeName : Str) : SpecExprDecl =>
   "isinstance" "(" subject ", " typeName ")";
-op stringLenExpr(subject : SpecExprDecl) : SpecExprDecl =>
+op lenExpr(subject : SpecExprDecl) : SpecExprDecl =>
   "len" "(" subject ")";
+op stringLenExpr(subject : SpecExprDecl) : SpecExprDecl =>
+  "stringLen" "(" subject ")";
 op intExpr(value : Int) : SpecExprDecl => value;
 op intGeExpr(subject : SpecExprDecl, bound : SpecExprDecl) : SpecExprDecl =>
   @[prec(15)] subject " >=_int " bound;
@@ -409,6 +411,7 @@ private def DDM.SpecExprDecl.fromDDM (d : DDM.SpecExprDecl SourceRange) : Specs.
   | .varExpr loc ⟨_, name⟩ => .var name loc
   | .getIndexExpr loc subj ⟨_, field⟩ => .getIndex subj.fromDDM field loc
   | .isInstanceOfExpr loc subj ⟨_, tn⟩ => .isInstanceOf subj.fromDDM tn loc
+  | .lenExpr loc subj => .stringLen subj.fromDDM loc
   | .stringLenExpr loc subj => .stringLen subj.fromDDM loc
   | .intExpr loc i => .intLit i.ofDDM loc
   | .intGeExpr loc subj bound => .intGe subj.fromDDM bound.fromDDM loc

--- a/StrataTestExtra/Languages/Python/SpecsTest.lean
+++ b/StrataTestExtra/Languages/Python/SpecsTest.lean
@@ -138,12 +138,12 @@ function "fstring_and_regex"{
   return: ident("_types.NoneType")
   overload: false
   preconditions: [
-    ensure(len(params[Name]) >=_int 1, "Expected len(params[\"Name\"]) >= 1, got "{len(params[Name])})
-    ensure(len(params[Name]) <=_int 100, "Expected len(params[\"Name\"]) <= 100, got "{len(params[Name])})
+    ensure(stringLen(params[Name]) >=_int 1, "Expected len(params[\"Name\"]) >= 1, got "{stringLen(params[Name])})
+    ensure(stringLen(params[Name]) <=_int 100, "Expected len(params[\"Name\"]) <= 100, got "{stringLen(params[Name])})
     ensure(regex(params[Name], "^[a-zA-Z]+$"), "params[\"Name\"] did not match pattern")
-    ensure(Items in params => forall(params[Items], item, len(item) >=_int 1), "Expected len(item) >= 1, got "{len(item)})
-    ensure(Items in params => forall(params[Items], item, len(item) <=_int 50), "Expected len(item) <= 50, got "{len(item)})
-    ensure(Tags in params => forallDict(params[Tags], tag_key, tag_val, len(tag_key) >=_int 1), "Expected len(tag_key) >= 1, got "{len(tag_key)})
+    ensure(Items in params => forall(params[Items], item, stringLen(item) >=_int 1), "Expected len(item) >= 1, got "{stringLen(item)})
+    ensure(Items in params => forall(params[Items], item, stringLen(item) <=_int 50), "Expected len(item) <= 50, got "{stringLen(item)})
+    ensure(Tags in params => forallDict(params[Tags], tag_key, tag_val, stringLen(tag_key) >=_int 1), "Expected len(tag_key) >= 1, got "{stringLen(tag_key)})
   ]
   postconditions: [
   ]


### PR DESCRIPTION
The old `lenExpr` DDM op is kept as an alias that deserializes to `SpecExpr.stringLen`, while the new `stringLenExpr` op uses the renamed representation. Serialization (`toDDM`) emits the new `stringLenExpr` name. This ensures existing serialized pyspecs continue to parse after the #1048 rename.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
