### PR TITLE
Remove extra space on error messages

### DIFF
--- a/Strata/Util/FileRange.lean
+++ b/Strata/Util/FileRange.lean
@@ -104,7 +104,7 @@ def DiagnosticModel.withRange (fr : FileRange) (msg : Format) (type : Diagnostic
 /-- Format a DiagnosticModel using a FileMap to convert byte offsets to line/column positions. -/
 def DiagnosticModel.format (dm : DiagnosticModel) (fileMap : Option Lean.FileMap) (includeEnd? : Bool := true) : Std.Format :=
   let rangeStr := dm.fileRange.format fileMap includeEnd?
-  if dm.fileRange.range.isNone then
+  if rangeStr.isEmpty then
     f!"{dm.message}"
   else
     f!"{rangeStr} {dm.message}"

--- a/StrataTest/Languages/Core/Examples/TypeDecl.lean
+++ b/StrataTest/Languages/Core/Examples/TypeDecl.lean
@@ -123,7 +123,7 @@ type int := bool;
 #end
 
 /--
-error:  ❌ Type checking error.
+error: ❌ Type checking error.
 This type declaration's name is reserved!
 int := bool
 KnownTypes' names:

--- a/StrataTest/Languages/Core/Examples/TypeDeclStmt.lean
+++ b/StrataTest/Languages/Core/Examples/TypeDeclStmt.lean
@@ -170,7 +170,7 @@ procedure P () {
 #end
 
 /--
-error:  ❌ Type checking error.
+error: ❌ Type checking error.
 Type 'T' is already declared
 -/
 #guard_msgs in

--- a/StrataTest/Languages/Core/Tests/DuplicateBlockLabels.lean
+++ b/StrataTest/Languages/Core/Tests/DuplicateBlockLabels.lean
@@ -26,7 +26,7 @@ procedure test () {
 #end
 
 /--
-error:  ❌ Type checking error.
+error: ❌ Type checking error.
 Block label "foo" shadows an enclosing block.
 -/
 #guard_msgs in

--- a/StrataTest/Languages/Core/Tests/ShadowedVars.lean
+++ b/StrataTest/Languages/Core/Tests/ShadowedVars.lean
@@ -21,7 +21,7 @@ procedure Test(g : int)
 #end
 
 /--
-error:  ❌ Type checking error.
+error: ❌ Type checking error.
 Variable g of type int already in context.
 -/
 #guard_msgs in
@@ -38,7 +38,7 @@ procedure Test()
 #end
 
 /--
-error:  ❌ Type checking error.
+error: ❌ Type checking error.
 Variable g of type bool already in context.
 -/
 #guard_msgs in


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Removes an unnecessary extra space on error message formatting.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
