### PR TITLE
fix : Issue 1102

### DIFF
--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1718,17 +1718,18 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
       | some (.Constant _ (.ConString _ str) _) => some str.val
       | _ => none
     -- Check if condition contains a Hole - if so, hoist to variable
-    let (condStmts, finalCondExpr, condCtx) :=
+    let (condStmts, finalCondExpr, condCtx, isHoisted) :=
       match condExpr.val with
       | .Hole =>
         let freshVar := s!"assert_cond_{test.toAst.ann.start.byteIdx}"
         let varType := mkHighTypeMd .TBool
         let varDecl := mkStmtExprMd (StmtExpr.LocalVariable freshVar varType (some condExpr))
         let varRef := mkStmtExprMd (StmtExpr.Identifier freshVar)
-        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "bool")] })
-      | _ => ([], condExpr, ctx)
+        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "bool")] }, true)
+      | _ => ([], condExpr, ctx, false)
 
-    let assertStmt := mkStmtExprMdWithLoc (StmtExpr.Assert { condition := Any_to_bool finalCondExpr, summary }) md
+    let coercedCond := if isHoisted then finalCondExpr else Any_to_bool finalCondExpr
+    let assertStmt := mkStmtExprMdWithLoc (StmtExpr.Assert { condition := coercedCond, summary }) md
 
     -- Wrap in block if we hoisted condition
     let result := if condStmts.isEmpty then

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1717,18 +1717,25 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let summary := match msg.val with
       | some (.Constant _ (.ConString _ str) _) => some str.val
       | _ => none
-    -- Check if condition contains a Hole - if so, hoist to variable
-    let (condStmts, finalCondExpr, condCtx, isHoisted) :=
+    let (condStmts, finalCondExpr, condCtx) :=
       match condExpr.val with
       | .Hole =>
         let freshVar := s!"assert_cond_{test.toAst.ann.start.byteIdx}"
         let varType := mkHighTypeMd .TBool
         let varDecl := mkStmtExprMd (StmtExpr.LocalVariable freshVar varType (some condExpr))
         let varRef := mkStmtExprMd (StmtExpr.Identifier freshVar)
-        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "bool")] }, true)
-      | _ => ([], condExpr, ctx, false)
+        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "bool")] })
+      | _ => ([], condExpr, ctx)
 
-    let coercedCond := if isHoisted then finalCondExpr else Any_to_bool finalCondExpr
+    let isBoolTypedIdent : Bool :=
+      match finalCondExpr.val with
+      | .Identifier name =>
+        match condCtx.variableTypes.find? (fun (n, _) => n == name) with
+        | some (_, ty) => ty == PyLauType.Bool
+        | none => false
+      | _ => false
+    let coercedCond :=
+      if isBoolTypedIdent then finalCondExpr else Any_to_bool finalCondExpr
     let assertStmt := mkStmtExprMdWithLoc (StmtExpr.Assert { condition := coercedCond, summary }) md
 
     -- Wrap in block if we hoisted condition

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -659,6 +659,8 @@ def pyAnalyzeLaurelCommand : Command where
         let msg := s!"Laurel to Core translation failed: {laurelTranslateErrors}"
         let hasStrataBug := laurelTranslateErrors.any
           (fun d => d.type == DiagnosticType.StrataBug)
+        -- If any diagnostic is a StrataBug, treat the whole failure as internal
+        -- (a Strata bug takes priority over known limitations).
         if hasStrataBug then
           exitPyAnalyzeInternalError msg
         else

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -656,7 +656,13 @@ def pyAnalyzeLaurelCommand : Command where
     let coreProgram ←
       match coreProgramOption with
       | none =>
-        exitPyAnalyzeInternalError s!"Laurel to Core translation failed: {laurelTranslateErrors}"
+        let msg := s!"Laurel to Core translation failed: {laurelTranslateErrors}"
+        let hasStrataBug := laurelTranslateErrors.any
+          (fun d => d.type == DiagnosticType.StrataBug)
+        if hasStrataBug then
+          exitPyAnalyzeInternalError msg
+        else
+          exitPyAnalyzeKnownLimitation msg
       | some core => pure core
 
     if verbose then

--- a/StrataTestExtra/Languages/Python/Issue1102/isinstance_int.py
+++ b/StrataTestExtra/Languages/Python/Issue1102/isinstance_int.py
@@ -1,0 +1,4 @@
+def main():
+    assert isinstance(5, int)
+
+main()

--- a/StrataTestExtra/Languages/Python/Issue1102/isinstance_list.py
+++ b/StrataTestExtra/Languages/Python/Issue1102/isinstance_list.py
@@ -1,0 +1,4 @@
+def main():
+    assert isinstance([1], list)
+
+main()

--- a/StrataTestExtra/Languages/Python/Issue1102Test.lean
+++ b/StrataTestExtra/Languages/Python/Issue1102Test.lean
@@ -1,0 +1,47 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import StrataTest.Languages.Python.TestExamples
+import StrataTest.Util.TestDiagnostics
+
+open StrataTest.Util
+open Strata.Python (processPythonFile withPython)
+open Strata.Parser (stringInputContext)
+open Strata
+
+namespace Strata.Python.Issue1102
+
+/-! Regression test for #1102: `isinstance(...)` inside `assert` must not
+produce a translation-time type error. Fixtures live alongside this file
+under `Issue1102/`. -/
+
+private meta def fixtureDir : System.FilePath :=
+  "StrataTestExtra/Languages/Python/Issue1102"
+
+private def translationErrors (ds : Array Diagnostic) : Array Diagnostic :=
+  ds.filter fun d =>
+    d.type == Strata.DiagnosticType.UserError ||
+    d.type == Strata.DiagnosticType.StrataBug
+
+private def expectNoTranslationErrors
+    (pythonCmd : System.FilePath) (pyFile : String) : IO Unit := do
+  let path := fixtureDir / pyFile
+  let source ← IO.FS.readFile path
+  let diags ← processPythonFile pythonCmd (stringInputContext pyFile source)
+  let errs := translationErrors diags
+  if errs.size ≠ 0 then
+    throw <| .userError
+      s!"{pyFile}: expected 0 translation errors, got {errs.size}: {errs.map (·.message)}"
+
+#guard_msgs in
+#eval withPython fun pythonCmd =>
+  expectNoTranslationErrors pythonCmd "isinstance_int.py"
+
+#guard_msgs in
+#eval withPython fun pythonCmd =>
+  expectNoTranslationErrors pythonCmd "isinstance_list.py"
+
+end Strata.Python.Issue1102


### PR DESCRIPTION
## Summary

Fixes #1102. Two independent issues surfaced by the hypothesmith fuzzer (seed `1777894483`):

1. **`isinstance(...)` inside `assert` produced a Laurel type error.** The assert translator hoists `.Hole` conditions into a fresh `bool` variable, then wrapped the result in `Any_to_bool`, which is ill-typed (`Any → bool` applied to `bool`). Now the coercion is skipped when hoisting has produced a `bool`.

2. **Known Laurel limitations were reported as internal errors.** `pyAnalyzeLaurel` classified every Laurel-to-Core translation failure as `Internal error`, including legitimate `UserError`-level diagnostics like "calls to procedures are not supported in functions or contracts" (triggered here by `str(e)` on a caught exception, where `e : PythonError` is a composite and `str` resolves to a generated procedure). Now only `StrataBug` diagnostics map to `Internal error`; `UserError` and `NotYetImplemented` map to `Known limitation`.