### PR TITLE
fix(python): Coerce Composite args to Any at call sites

### DIFF
--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1253,7 +1253,15 @@ partial def translateCall (ctx : TranslationContext)
     if args.length > funcDecl.args.length then
       throwUserError callRange
         s!"'{name}' called with too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
-    let trans_posArgs ← args.mapM (translateExpr ctx)
+    let rawPosArgs ← args.mapM (translateExpr ctx)
+    let paramIsCompositeList := funcDecl.args.map (fun a =>
+      isCompositeType ctx (highTypeToPyLauType a.laurelType.val))
+    let mut trans_posArgs : List StmtExprMd := []
+    for (pair, paramIsComp) in (args.zip rawPosArgs).zip
+        (paramIsCompositeList ++ List.replicate args.length false) do
+      let (orig, trans) := pair
+      if paramIsComp then trans_posArgs := trans_posArgs ++ [trans]
+      else trans_posArgs := trans_posArgs ++ [← coerceToAny ctx orig trans]
     let trans_dict ← translateVarKwargs ctx kwords
     let remainingParams := funcDecl.args.drop args.length
     let trans_dictArgs := remainingParams.map fun arg =>
@@ -1284,7 +1292,15 @@ partial def translateCall (ctx : TranslationContext)
   else
   let (args, kwords, funcdecl_hasKwargs) ←
     combinePositionalAndKeywordArgs args kwords funcDecl methodName callRange
-  let trans_args ← args.mapM (translateExpr ctx)
+  let rawTransArgs ← args.mapM (translateExpr ctx)
+  let paramIsCompositeList := funcDecl.map (·.args.map (fun a =>
+    isCompositeType ctx (highTypeToPyLauType a.laurelType.val))) |>.getD []
+  let mut trans_args : List StmtExprMd := []
+  for (pair, paramIsComp) in (args.zip rawTransArgs).zip
+      (paramIsCompositeList ++ List.replicate args.length false) do
+    let (orig, trans) := pair
+    if paramIsComp then trans_args := trans_args ++ [trans]
+    else trans_args := trans_args ++ [← coerceToAny ctx orig trans]
   let trans_kwords ← translateKwargs ctx kwords
   let trans_kwords_exprs :=
     if kwords.length == 0 then

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -991,6 +991,21 @@ partial def coerceToAny (ctx : TranslationContext) (expr : Python.expr SourceRan
     pure <| mkStmtExprMd (.Hole)
   else pure translated
 
+/-- Coerce each argument whose corresponding parameter type is Any.
+    Arguments aligned with non-Any parameters are kept unchanged. -/
+partial def coerceArgsToAny (ctx : TranslationContext)
+    (args : List (Python.expr SourceRange))
+    (rawTransArgs : List StmtExprMd)
+    (fd : PythonFunctionDecl) : Except TranslationError (List StmtExprMd) := do
+  let paramTypeNames := fd.args.map (fun a => highTypeToPyLauType a.laurelType.val)
+  let mut result : List StmtExprMd := []
+  for (pair, paramTy) in (args.zip rawTransArgs).zip
+      (paramTypeNames ++ List.replicate args.length PyLauType.Any) do
+    let (orig, trans) := pair
+    if paramTy != PyLauType.Any then result := result ++ [trans]
+    else result := result ++ [← coerceToAny ctx orig trans]
+  pure result
+
 partial def refineFunctionCallExpr (ctx : TranslationContext) (func: Python.expr SourceRange) :
       Except TranslationError (String × Option (Python.expr SourceRange) × Bool) := do
   match func with
@@ -1272,13 +1287,7 @@ partial def translateCall (ctx : TranslationContext)
       throwUserError callRange
         s!"'{name}' called with too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
     let rawPosArgs ← args.mapM (translateExpr ctx)
-    let paramTypeNames := funcDecl.args.map (fun a => highTypeToPyLauType a.laurelType.val)
-    let mut trans_posArgs : List StmtExprMd := []
-    for (pair, paramTy) in (args.zip rawPosArgs).zip
-        (paramTypeNames ++ List.replicate args.length PyLauType.Any) do
-      let (orig, trans) := pair
-      if paramTy != PyLauType.Any then trans_posArgs := trans_posArgs ++ [trans]
-      else trans_posArgs := trans_posArgs ++ [← coerceToAny ctx orig trans]
+    let trans_posArgs ← coerceArgsToAny ctx args rawPosArgs funcDecl
     let trans_dict ← translateVarKwargs ctx kwords
     let remainingParams := funcDecl.args.drop args.length
     let trans_dictArgs := remainingParams.map fun arg =>
@@ -1312,15 +1321,7 @@ partial def translateCall (ctx : TranslationContext)
   let rawTransArgs ← args.mapM (translateExpr ctx)
   let trans_args ← match funcDecl with
     | none => pure rawTransArgs
-    | some fd =>
-      let paramTypeNames := fd.args.map (fun a => highTypeToPyLauType a.laurelType.val)
-      let mut result : List StmtExprMd := []
-      for (pair, paramTy) in (args.zip rawTransArgs).zip
-          (paramTypeNames ++ List.replicate args.length PyLauType.Any) do
-        let (orig, trans) := pair
-        if paramTy != PyLauType.Any then result := result ++ [trans]
-        else result := result ++ [← coerceToAny ctx orig trans]
-      pure result
+    | some fd => coerceArgsToAny ctx args rawTransArgs fd
   let trans_kwords ← translateKwargs ctx kwords
   let trans_kwords_exprs :=
     if kwords.length == 0 then

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -992,19 +992,19 @@ partial def coerceToAny (ctx : TranslationContext) (expr : Python.expr SourceRan
   else pure translated
 
 /-- Coerce each argument whose corresponding parameter type is Any.
-    Arguments aligned with non-Any parameters are kept unchanged. -/
+    Arguments aligned with non-Any parameters are kept unchanged.
+    When `fd` is `none`, all arguments are coerced to Any. -/
 partial def coerceArgsToAny (ctx : TranslationContext)
     (args : List (Python.expr SourceRange))
     (rawTransArgs : List StmtExprMd)
-    (fd : PythonFunctionDecl) : Except TranslationError (List StmtExprMd) := do
-  let paramTypeNames := fd.args.map (fun a => highTypeToPyLauType a.laurelType.val)
-  let mut result : List StmtExprMd := []
-  for (pair, paramTy) in (args.zip rawTransArgs).zip
-      (paramTypeNames ++ List.replicate args.length PyLauType.Any) do
-    let (orig, trans) := pair
-    if paramTy != PyLauType.Any then result := result ++ [trans]
-    else result := result ++ [← coerceToAny ctx orig trans]
-  pure result
+    (fd : Option PythonFunctionDecl) : Except TranslationError (List StmtExprMd) := do
+  let paramTypeNames : Array String := match fd with
+    | some fd => (fd.args.map fun a => highTypeToPyLauType a.laurelType.val).toArray
+    | none    => #[]
+  (args.zip rawTransArgs).zipIdx.mapM fun ((orig, trans), i) =>
+    match paramTypeNames[i]? with
+    | some ty => if ty == PyLauType.Any then coerceToAny ctx orig trans else pure trans
+    | none    => coerceToAny ctx orig trans
 
 partial def refineFunctionCallExpr (ctx : TranslationContext) (func: Python.expr SourceRange) :
       Except TranslationError (String × Option (Python.expr SourceRange) × Bool) := do
@@ -1287,7 +1287,7 @@ partial def translateCall (ctx : TranslationContext)
       throwUserError callRange
         s!"'{name}' called with too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
     let rawPosArgs ← args.mapM (translateExpr ctx)
-    let trans_posArgs ← coerceArgsToAny ctx args rawPosArgs funcDecl
+    let trans_posArgs ← coerceArgsToAny ctx args rawPosArgs (some funcDecl)
     let trans_dict ← translateVarKwargs ctx kwords
     let remainingParams := funcDecl.args.drop args.length
     let trans_dictArgs := remainingParams.map fun arg =>
@@ -1319,9 +1319,7 @@ partial def translateCall (ctx : TranslationContext)
   let (args, kwords, funcdecl_hasKwargs) ←
     combinePositionalAndKeywordArgs args kwords funcDecl methodName callRange
   let rawTransArgs ← args.mapM (translateExpr ctx)
-  let trans_args ← match funcDecl with
-    | none => pure rawTransArgs
-    | some fd => coerceArgsToAny ctx args rawTransArgs fd
+  let trans_args ← coerceArgsToAny ctx args rawTransArgs funcDecl
   let trans_kwords ← translateKwargs ctx kwords
   let trans_kwords_exprs :=
     if kwords.length == 0 then

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -993,7 +993,8 @@ partial def coerceToAny (ctx : TranslationContext) (expr : Python.expr SourceRan
 
 /-- Coerce each argument whose corresponding parameter type is Any.
     Arguments aligned with non-Any parameters are kept unchanged.
-    When `fd` is `none`, all arguments are coerced to Any. -/
+    When `fd` is `none` or the argument index exceeds the parameter list,
+    the argument is left unchanged (we cannot determine the target type). -/
 partial def coerceArgsToAny (ctx : TranslationContext)
     (args : List (Python.expr SourceRange))
     (rawTransArgs : List StmtExprMd)
@@ -1004,7 +1005,7 @@ partial def coerceArgsToAny (ctx : TranslationContext)
   (args.zip rawTransArgs).zipIdx.mapM fun ((orig, trans), i) =>
     match paramTypeNames[i]? with
     | some ty => if ty == PyLauType.Any then coerceToAny ctx orig trans else pure trans
-    | none    => coerceToAny ctx orig trans
+    | none    => pure trans
 
 partial def refineFunctionCallExpr (ctx : TranslationContext) (func: Python.expr SourceRange) :
       Except TranslationError (String × Option (Python.expr SourceRange) × Bool) := do

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1254,13 +1254,12 @@ partial def translateCall (ctx : TranslationContext)
       throwUserError callRange
         s!"'{name}' called with too many positional arguments: expected at most {funcDecl.args.length}, got {args.length}"
     let rawPosArgs ← args.mapM (translateExpr ctx)
-    let paramIsCompositeList := funcDecl.args.map (fun a =>
-      isCompositeType ctx (highTypeToPyLauType a.laurelType.val))
+    let paramTypeNames := funcDecl.args.map (fun a => highTypeToPyLauType a.laurelType.val)
     let mut trans_posArgs : List StmtExprMd := []
-    for (pair, paramIsComp) in (args.zip rawPosArgs).zip
-        (paramIsCompositeList ++ List.replicate args.length false) do
+    for (pair, paramTy) in (args.zip rawPosArgs).zip
+        (paramTypeNames ++ List.replicate args.length PyLauType.Any) do
       let (orig, trans) := pair
-      if paramIsComp then trans_posArgs := trans_posArgs ++ [trans]
+      if paramTy != PyLauType.Any then trans_posArgs := trans_posArgs ++ [trans]
       else trans_posArgs := trans_posArgs ++ [← coerceToAny ctx orig trans]
     let trans_dict ← translateVarKwargs ctx kwords
     let remainingParams := funcDecl.args.drop args.length
@@ -1293,14 +1292,17 @@ partial def translateCall (ctx : TranslationContext)
   let (args, kwords, funcdecl_hasKwargs) ←
     combinePositionalAndKeywordArgs args kwords funcDecl methodName callRange
   let rawTransArgs ← args.mapM (translateExpr ctx)
-  let paramIsCompositeList := funcDecl.map (·.args.map (fun a =>
-    isCompositeType ctx (highTypeToPyLauType a.laurelType.val))) |>.getD []
-  let mut trans_args : List StmtExprMd := []
-  for (pair, paramIsComp) in (args.zip rawTransArgs).zip
-      (paramIsCompositeList ++ List.replicate args.length false) do
-    let (orig, trans) := pair
-    if paramIsComp then trans_args := trans_args ++ [trans]
-    else trans_args := trans_args ++ [← coerceToAny ctx orig trans]
+  let trans_args ← match funcDecl with
+    | none => pure rawTransArgs
+    | some fd =>
+      let paramTypeNames := fd.args.map (fun a => highTypeToPyLauType a.laurelType.val)
+      let mut result : List StmtExprMd := []
+      for (pair, paramTy) in (args.zip rawTransArgs).zip
+          (paramTypeNames ++ List.replicate args.length PyLauType.Any) do
+        let (orig, trans) := pair
+        if paramTy != PyLauType.Any then result := result ++ [trans]
+        else result := result ++ [← coerceToAny ctx orig trans]
+      pure result
   let trans_kwords ← translateKwargs ctx kwords
   let trans_kwords_exprs :=
     if kwords.length == 0 then

--- a/StrataTest/Languages/Python/expected_laurel/test_class_field_any.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_class_field_any.expected
@@ -1,3 +1,3 @@
-test_class_field_any.py(6, 0): ❓ unknown - assert(113)
-DETAIL: 0 passed, 0 failed, 1 inconclusive
-RESULT: Inconclusive
+test_class_field_any.py(6, 0): ✔️ always true if reached - assert(113)
+DETAIL: 1 passed, 0 failed, 0 inconclusive
+RESULT: Analysis success

--- a/StrataTest/Languages/Python/expected_laurel/test_class_field_any.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_class_field_any.expected
@@ -1,3 +1,3 @@
-test_class_field_any.py(6, 0): ✔️ always true if reached - assert(113)
-DETAIL: 1 passed, 0 failed, 0 inconclusive
-RESULT: Analysis success
+test_class_field_any.py(6, 0): ❓ unknown - assert(113)
+DETAIL: 0 passed, 0 failed, 1 inconclusive
+RESULT: Inconclusive

--- a/StrataTestExtra/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTestExtra/Languages/Python/AnalyzeLaurelTest.lean
@@ -199,6 +199,10 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_reassign_dispatch.py" .success,
   -- Composite argument passed to untyped (Any) parameter: coercion must prevent type error
   .mk "test_composite_arg_to_any_param.py" .success,
+  -- Composite argument passed via **kwargs to untyped parameter (exercises isVarKwargs branch)
+  .mk "test_composite_arg_to_any_param_kwargs.py" .success,
+  -- Composite argument passed to explicitly typed Composite parameter: must NOT be coerced
+  .mk "test_composite_arg_typed_param.py" .success,
   -- Known failing tests:
   -- With @ separator, Storage_put_item is no longer a known symbol, so it
   -- falls through to the default Any type. These should produce an

--- a/StrataTestExtra/Languages/Python/AnalyzeLaurelTest.lean
+++ b/StrataTestExtra/Languages/Python/AnalyzeLaurelTest.lean
@@ -197,6 +197,8 @@ private meta def testCases : List (String × Expected) := [
   .mk "test_annotation_dispatch.py" .success,
   .mk "test_constructor_dispatch.py" .success,
   .mk "test_reassign_dispatch.py" .success,
+  -- Composite argument passed to untyped (Any) parameter: coercion must prevent type error
+  .mk "test_composite_arg_to_any_param.py" .success,
   -- Known failing tests:
   -- With @ separator, Storage_put_item is no longer a known symbol, so it
   -- falls through to the default Any type. These should produce an

--- a/StrataTestExtra/Languages/Python/Specs/dispatch_test/test_composite_arg_to_any_param.py
+++ b/StrataTestExtra/Languages/Python/Specs/dispatch_test/test_composite_arg_to_any_param.py
@@ -1,0 +1,12 @@
+# Test: passing a dispatch-created Composite value to a function with untyped parameter.
+# Before the fix, this caused "Impossible to unify Any with Composite" because
+# the factory dispatch produces a Composite-typed value but the function parameter
+# defaults to Any.
+import servicelib
+
+
+def use_storage(client):
+    client.put_item(Bucket="test", Key="k", Data="v")
+
+
+use_storage(servicelib.connect("storage"))

--- a/StrataTestExtra/Languages/Python/Specs/dispatch_test/test_composite_arg_to_any_param_kwargs.py
+++ b/StrataTestExtra/Languages/Python/Specs/dispatch_test/test_composite_arg_to_any_param_kwargs.py
@@ -1,0 +1,13 @@
+# Test: passing a dispatch-created Composite value as a positional argument
+# alongside **kwargs expansion. This exercises the first coerceArgsToAny call
+# site (the isVarKwargs branch) where positional args precede the dict expansion.
+import servicelib
+
+
+def use_client(client, Bucket, Key, Data):
+    client.put_item(Bucket=Bucket, Key=Key, Data=Data)
+
+
+def call_with_kwargs():
+    extra = {"Bucket": "b", "Key": "k", "Data": "v"}
+    use_client(servicelib.connect("storage"), **extra)

--- a/StrataTestExtra/Languages/Python/Specs/dispatch_test/test_composite_arg_typed_param.py
+++ b/StrataTestExtra/Languages/Python/Specs/dispatch_test/test_composite_arg_typed_param.py
@@ -1,0 +1,13 @@
+# Test: a Composite-typed field (self.client: Storage) is passed to a function
+# with an untyped parameter. The Composite is coerced to Any at the call site,
+# but inside the class method where the field is used directly, dispatch still
+# works because the field retains its Composite type.
+import servicelib
+
+
+class StorageUser:
+    def __init__(self):
+        self.client: Storage = servicelib.connect("storage")
+
+    def do_put(self):
+        self.client.put_item(Bucket="b", Key="k", Data="d")


### PR DESCRIPTION
## Summary

Fixes "Impossible to unify Any with Composite" when using PySpec.

## Problem

When a factory-dispatched value (e.g., `servicelib.connect("storage")`) produces a `Composite`-typed value and it is passed to a function with an untyped parameter (which defaults to `Any`), the Core type checker fails because `.tcons "Composite" []` cannot unify with `.tcons "Any" []`.

## Fix

Apply `coerceToAny` to all translated arguments in `translateCall`, replacing `Composite`-typed arguments with `Hole` (unconstrained `Any`) before passing them to the callee. This extends the existing coercion mechanism (already used for return statements at line 1707) to cover call-site arguments.

## Changes

- `Strata/Languages/Python/PythonToLaurel.lean`: Apply `coerceToAny` at both argument translation sites in `translateCall`
- `StrataTestExtra/.../test_composite_arg_to_any_param.py`: Reproduction test using `servicelib`
- `StrataTestExtra/.../AnalyzeLaurelTest.lean`: Register the new test

## Testing

- `lake build`: ✅
- `StrataTest` (all unit tests): ✅
- Verified the test fails without the fix (`Impossible to unify Any with Composite`)