### PR TITLE
Support SMT string literals and common string ops in translateTerm

### DIFF
--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -256,6 +256,17 @@ in `Denote.lean`.
 private def mkStringLength (s : Expr) : Expr :=
   .app (.const ``Int.ofNat []) (.app (.const ``String.length []) s)
 
+/--
+Throw unless `α` is the Lean `String` type (as produced by `mkString`). Used
+to guard string-theory operations so that a malformed SMT term such as
+`(.app .str_length [.prim (.int 0)] ...)` is rejected up front, matching the
+behaviour of `Denote.denoteTerm`.
+-/
+private def expectString (α : Expr) : TranslateM Unit :=
+  match α with
+  | .const ``String [] => return ()
+  | _ => throw m!"Error: expected String type, got '{α}'"
+
 def symbolToName (s : String) : Name :=
   -- Quote the string if a natural translation to Name fails
   if s.toName == .anonymous then
@@ -505,10 +516,24 @@ def translateTerm (t : SMT.Term) : TranslateM (Expr × Expr) := do
   | .prim (.string s) =>
     return (mkString, toExpr s)
   | .app .str_length [s] _ =>
-    let (_, s) ← translateTerm s
+    let (α, s) ← translateTerm s
+    expectString α
     return (mkInt, mkStringLength s)
   | .app .str_concat as _ =>
-    leftAssocOp mkStringAppend as
+    -- `Denote.leftAssoc` requires at least two operands and checks that each
+    -- operand has the expected type.  Mirror that here rather than delegating
+    -- to `leftAssocOp`, which does neither.
+    let a :: b :: as := as
+      | throw m!"Error: str_concat expects at least two operands, got '{as.length}'"
+    let (α, a) ← translateTerm a
+    expectString α
+    let (β, b) ← translateTerm b
+    expectString β
+    let as ← as.mapM fun t => do
+      let (γ, e) ← translateTerm t
+      expectString γ
+      return e
+    return (mkString, as.foldl (mkApp2 mkStringAppend) (mkApp2 mkStringAppend a b))
   | t => throw m!"Error: unsupported term '{repr t}'"
 where
   leftAssocOp (op : Expr) (as : List SMT.Term) : TranslateM (Expr × Expr) := do

--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -243,6 +243,19 @@ private def mkBitVecAppend (w v : Nat) : Expr :=
          (mkBitVec w) (mkBitVec v) (mkBitVec (w + v))
          (mkApp2 (.const ``BitVec.instHAppendHAddNat []) (toExpr w) (toExpr v))
 
+private def mkStringAppend : Expr :=
+  mkApp4 (.const ``HAppend.hAppend [0, 0, 0])
+         mkString mkString mkString
+         (mkApp2 (.const ``instHAppendOfAppend [0]) mkString
+                 (.const ``instAppendString []))
+
+/--
+Length of a string as an `Int` (via `Int.ofNat`), matching the semantics used
+in `Denote.lean`.
+-/
+private def mkStringLength (s : Expr) : Expr :=
+  .app (.const ``Int.ofNat []) (.app (.const ``String.length []) s)
+
 def symbolToName (s : String) : Name :=
   -- Quote the string if a natural translation to Name fails
   if s.toName == .anonymous then
@@ -488,6 +501,14 @@ def translateTerm (t : SMT.Term) : TranslateM (Expr × Expr) := do
     let (α, x) ← translateTerm x
     let w ← getBitVecWidth α
     return (mkBitVec (w + i), mkApp3 (.const ``BitVec.zeroExtend []) (toExpr w) (toExpr (w + i)) x)
+  -- SMT-Lib theory of strings
+  | .prim (.string s) =>
+    return (mkString, toExpr s)
+  | .app .str_length [s] _ =>
+    let (_, s) ← translateTerm s
+    return (mkInt, mkStringLength s)
+  | .app .str_concat as _ =>
+    leftAssocOp mkStringAppend as
   | t => throw m!"Error: unsupported term '{repr t}'"
 where
   leftAssocOp (op : Expr) (as : List SMT.Term) : TranslateM (Expr × Expr) := do

--- a/StrataTest/DL/SMT/TranslateTests.lean
+++ b/StrataTest/DL/SMT/TranslateTests.lean
@@ -41,3 +41,26 @@ info: ∀ (α : Type → Type → Type) [inst : ∀ (α_1 α_2 : Type), Nonempty
 #guard_msgs in
 #eval
   elabQuery {} [] (.app .eq [(.app .abs [(.prim (.int (-5)))] (.prim .int)), (.prim (.int 5))] (.prim .bool))
+
+-- SMT-Lib theory of strings: literals and the operations supported by
+-- `Denote.lean` (`str_length`, `str_concat`).
+
+/-- info: "hi" = "hi" -/
+#guard_msgs in
+#eval
+  elabQuery {} [] (.app .eq [(.prim (.string "hi")), (.prim (.string "hi"))] (.prim .bool))
+
+/-- info: Int.ofNat "hello".length = 5 -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq [(.app .str_length [(.prim (.string "hello"))] (.prim .int)), (.prim (.int 5))]
+      (.prim .bool))
+
+/-- info: "hi" ++ " there" = "hi there" -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq [(.app .str_concat [(.prim (.string "hi")), (.prim (.string " there"))] (.prim .string)),
+               (.prim (.string "hi there"))]
+      (.prim .bool))

--- a/StrataTest/DL/SMT/TranslateTests.lean
+++ b/StrataTest/DL/SMT/TranslateTests.lean
@@ -64,3 +64,46 @@ info: ∀ (α : Type → Type → Type) [inst : ∀ (α_1 α_2 : Type), Nonempty
     (.app .eq [(.app .str_concat [(.prim (.string "hi")), (.prim (.string " there"))] (.prim .string)),
                (.prim (.string "hi there"))]
       (.prim .bool))
+
+/-- info: "a" ++ "b" ++ "c" = "abc" -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_concat
+         [(.prim (.string "a")), (.prim (.string "b")), (.prim (.string "c"))]
+         (.prim .string)),
+       (.prim (.string "abc"))]
+      (.prim .bool))
+
+-- Malformed string terms are rejected up front, matching `Denote.denoteTerm`.
+-- Using `.prim (.bool _)` (which translates to type `Prop`) for the
+-- non-string operand keeps the expected error message stable independent of
+-- how `.prim (.int _)` happens to be typed by the translator.
+
+/-- error: Error: expected String type, got 'Prop' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_length [(.prim (.bool true))] (.prim .int)),
+       (.prim (.int 0))]
+      (.prim .bool))
+
+/-- error: Error: str_concat expects at least two operands, got '1' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_concat [(.prim (.string "hi"))] (.prim .string)),
+       (.prim (.string "hi"))]
+      (.prim .bool))
+
+/-- error: Error: expected String type, got 'Prop' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_concat [(.prim (.bool true)), (.prim (.string "hi"))] (.prim .string)),
+       (.prim (.string "hi"))]
+      (.prim .bool))


### PR DESCRIPTION
translateSort already handles .prim .string, but translateTerm had no arm for .prim (.string _): any SMT string literal produced by the encoder would fall through to the catch-all and raise 'unsupported term'. Add the missing arm plus the two string operations already supported in Denote.lean so that the two translators agree on the end-to-end-supported subset.

Specifically, add arms for:
- .prim (.string s) -> (mkString, toExpr s)
- .app .str_length [s] _ -> (mkInt, Int.ofNat s.length)
- .app .str_concat as _ -> (mkString, leftAssocOp mkStringAppend as)

mkStringAppend uses instHAppendOfAppend + instAppendString, which is the same instance chain Lean elaborates inferInstance to for HAppend String String String.

Regression tests in StrataTest/DL/SMT/TranslateTests.lean cover all three arms; each fails on origin/main (catch-all throw observable via #guard_msgs mismatch) and passes with this change. I additionally verified under a Meta.check-enabled harness that the produced Expr type-checks in the kernel, so the (fst = mkString/mkInt, snd = ...) pairs are internally consistent.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
