### PR TITLE
Reject singleton operand lists in leftAssocOp and leftAssocOpBitVec

### DIFF
--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -491,16 +491,20 @@ def translateTerm (t : SMT.Term) : TranslateM (Expr × Expr) := do
   | t => throw m!"Error: unsupported term '{repr t}'"
 where
   leftAssocOp (op : Expr) (as : List SMT.Term) : TranslateM (Expr × Expr) := do
-    let a :: as := as | throw m!"Error: expected at least two arguments for '{op}', got '{as.length}'"
+    let a :: b :: as := as
+      | throw m!"Error: expected at least two arguments for '{op}', got '{as.length}'"
     let (α, a) ← translateTerm a
+    let (_, b) ← translateTerm b
     let as ← as.mapM (translateTerm · >>= pure ∘ Prod.snd)
-    return (α, as.foldl (mkApp2 op) a)
+    return (α, as.foldl (mkApp2 op) (mkApp2 op a b))
   leftAssocOpBitVec (op : Nat → Expr) (as : List SMT.Term) : TranslateM (Expr × Expr) := do
-    let a :: as := as | throw m!"Error: expected at least two arguments for BitVec op, got '{as.length}'"
+    let a :: b :: as := as
+      | throw m!"Error: expected at least two arguments for BitVec op, got '{as.length}'"
     let (α, a) ← translateTerm a
+    let (_, b) ← translateTerm b
     let op := op (← getBitVecWidth α)
     let as ← as.mapM (translateTerm · >>= pure ∘ Prod.snd)
-    return (α, as.foldl (mkApp2 op) a)
+    return (α, as.foldl (mkApp2 op) (mkApp2 op a b))
 
 /--
 Translate assumptions and a conclusion into a right-associated implication

--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -337,8 +337,12 @@ def translateTerm (t : SMT.Term) : TranslateM (Expr × Expr) := do
     leftAssocOp mkIntMul as
   | .app .div as _ =>
     leftAssocOp mkIntDiv as
+  | .app .mod [x, y] _ =>
+    let (α, x) ← translateTerm x
+    let (_, y) ← translateTerm y
+    return (α, mkApp2 mkIntMod x y)
   | .app .mod as _ =>
-    leftAssocOp mkIntMod as
+    throw m!"Error: 'mod' expects exactly two operands, got '{as.length}'"
   | .app .abs [a] _ =>
     let (_, a) ← translateTerm a
     let c := mkApp2 mkIntLT a (toExpr (0 : Int))

--- a/StrataTest/DL/SMT/TranslateTests.lean
+++ b/StrataTest/DL/SMT/TranslateTests.lean
@@ -41,3 +41,65 @@ info: ∀ (α : Type → Type → Type) [inst : ∀ (α_1 α_2 : Type), Nonempty
 #guard_msgs in
 #eval
   elabQuery {} [] (.app .eq [(.app .abs [(.prim (.int (-5)))] (.prim .int)), (.prim (.int 5))] (.prim .bool))
+
+-- `leftAssocOp` and `leftAssocOpBitVec` require at least two operands,
+-- matching the existing error message and `Denote.leftAssoc`.  Singletons
+-- used to silently pass through the first operand; now they throw.
+
+/-- error: Error: expected at least two arguments for 'HAdd.hAdd', got '1' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .add [(.prim (.int 0))] (.prim .int)),
+       (.prim (.int 0))]
+      (.prim .bool))
+
+/-- error: Error: expected at least two arguments for 'And', got '1' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .and
+      [(.app .eq [(.prim (.int 0)), (.prim (.int 0))] (.prim .bool))]
+      (.prim .bool))
+
+/-- error: Error: expected at least two arguments for BitVec op, got '1' -/
+#guard_msgs in
+#eval
+  let a : SMT.TermVar := { id := "a", ty := .prim (.bitvec 8) }
+  elabQuery {} []
+    (.quant .all [a] a
+      (.app .eq
+        [(.app .bvadd [(.var a)] (.prim (.bitvec 8))), (.var a)]
+        (.prim .bool)))
+
+/-- error: Error: expected at least two arguments for BitVec op, got '1' -/
+#guard_msgs in
+#eval
+  let a : SMT.TermVar := { id := "a", ty := .prim (.bitvec 8) }
+  elabQuery {} []
+    (.quant .all [a] a
+      (.app .eq
+        [(.app .bvand [(.var a)] (.prim (.bitvec 8))), (.var a)]
+        (.prim .bool)))
+
+-- Empty-operand lists are still rejected, as before.
+
+/-- error: Error: expected at least two arguments for 'HAdd.hAdd', got '0' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq [(.app .add [] (.prim .int)), (.prim (.int 0))] (.prim .bool))
+
+-- Binary and ternary uses still produce the expected left-associated Expr.
+
+/-- info: 1 + 2 + 3 = 6 -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .add
+         [(.prim (.int 1)), (.prim (.int 2)), (.prim (.int 3))]
+         (.prim .int)),
+       (.prim (.int 6))]
+      (.prim .bool))

--- a/StrataTest/DL/SMT/TranslateTests.lean
+++ b/StrataTest/DL/SMT/TranslateTests.lean
@@ -103,3 +103,25 @@ info: ∀ (α : Type → Type → Type) [inst : ∀ (α_1 α_2 : Type), Nonempty
          (.prim .int)),
        (.prim (.int 6))]
       (.prim .bool))
+
+-- `.app .mod` is strictly binary in the SMT-Lib `Ints` theory and in
+-- `Denote.denoteTerm`, so `translateTerm` now rejects any other arity rather
+-- than silently lowering e.g. `.app .mod [x, y, z]` to `(x % y) % z`.
+
+/-- info: 10 % 3 = 1 -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .mod [(.prim (.int 10)), (.prim (.int 3))] (.prim .int)),
+       (.prim (.int 1))]
+      (.prim .bool))
+
+/-- error: Error: 'mod' expects exactly two operands, got '3' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .mod [(.prim (.int 10)), (.prim (.int 3)), (.prim (.int 2))] (.prim .int)),
+       (.prim (.int 1))]
+      (.prim .bool))


### PR DESCRIPTION
Both helpers' error message already said 'expected at least two arguments', but the destructuring `let a :: as := as | throw ...` only rejected the empty list: a singleton like `.app .add [x]` or `.app .bvadd [x]` silently returned just `x`.  This diverged from `Denote.leftAssoc`, which uses `let t₁ :: t₂ :: ts := ts | none` and returns `none` for fewer than two operands.

Tighten the pattern to `a :: b :: as := as | throw ...` and seed the `foldl` with `mkApp2 op a b` so the helper's semantics now match the existing error message and `Denote.leftAssoc`.  Empty-operand lists continue to throw with the same message as before.

This affects every variadic caller: `.app .and`, `.app .or`, `.app .add`, `.app .sub`, `.app .mul`, `.app .div`, `.app .mod`, plus `.app .bvadd`, `.app .bvsub`, `.app .bvmul`, `.app .bvand`, `.app .bvor`, `.app .bvxor`.  The Strata Core SMT encoder does not produce singleton applications of any of these ops (ripgrep'd across `SMTEncoder.lean`, `Factory.lean`, and `B3/Verifier/Expression.lean`: every construction passes at least two operands), so well-formed queries are unaffected.  Zero-operand placeholders like `Term.app Op.and [] .bool` that appear as "unreachable" fallbacks in `SMTEncoder.lean` were already rejected by `translateTerm` before this change, and remain rejected.

Regression tests in StrataTest/DL/SMT/TranslateTests.lean cover:
- singleton `.app .add`, `.app .and`, `.app .bvadd`, `.app .bvand` (one per helper+typeclass combination),
- empty-operand `.app .add` (unchanged behaviour),
- ternary `.app .add` producing `1 + 2 + 3 = 6` (preserves left associativity past the new 2-operand seed).

Each singleton-rejection test fails on the previous commit (the term silently translates to its sole operand) and passes here.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
