### PR TITLE
pyAnalyzeLaurel: classify UserError diagnostics as known limitations

### DIFF
--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -657,14 +657,20 @@ def pyAnalyzeLaurelCommand : Command where
       match coreProgramOption with
       | none =>
         let msg := s!"Laurel to Core translation failed: {laurelTranslateErrors}"
-        let hasStrataBug := laurelTranslateErrors.any
-          (fun d => d.type == DiagnosticType.StrataBug)
-        -- If any diagnostic is a StrataBug, treat the whole failure as internal
-        -- (a Strata bug takes priority over known limitations).
-        if hasStrataBug then
+        -- Classify by worst-severity diagnostic: StrataBug (tool bug) outranks
+        -- UserError (user-actionable) outranks NotYetImplemented (wait-for-support).
+        -- An empty list or warnings-only failure with `coreProgramOption = none`
+        -- is itself a tool bug (translation should not silently fail).
+        if laurelTranslateErrors.isEmpty
+            ∨ laurelTranslateErrors.any (·.type == .StrataBug) then
           exitPyAnalyzeInternalError msg
-        else
+        else if laurelTranslateErrors.any (·.type == .UserError) then
+          exitPyAnalyzeUserError msg
+        else if laurelTranslateErrors.any (·.type == .NotYetImplemented) then
           exitPyAnalyzeKnownLimitation msg
+        else
+          -- Only warnings, but translation failed → unexpected.
+          exitPyAnalyzeInternalError msg
       | some core => pure core
 
     if verbose then

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -656,7 +656,15 @@ def pyAnalyzeLaurelCommand : Command where
     let coreProgram ←
       match coreProgramOption with
       | none =>
-        exitPyAnalyzeInternalError s!"Laurel to Core translation failed: {laurelTranslateErrors}"
+        let msg := s!"Laurel to Core translation failed: {laurelTranslateErrors}"
+        let hasStrataBug := laurelTranslateErrors.any
+          (fun d => d.type == DiagnosticType.StrataBug)
+        -- If any diagnostic is a StrataBug, treat the whole failure as internal
+        -- (a Strata bug takes priority over known limitations).
+        if hasStrataBug then
+          exitPyAnalyzeInternalError msg
+        else
+          exitPyAnalyzeKnownLimitation msg
       | some core => pure core
 
     if verbose then


### PR DESCRIPTION
When Laurel-to-Core translation fails, pyAnalyzeLaurel previously reported every failure as 'RESULT: Internal error' (exit 3), including legitimate user-facing limitations such as 'calls to procedures are not supported in functions or contracts'. These are UserError-level diagnostics; reporting them as internal errors conflates genuine compiler bugs with 'not yet supported' constructs.

Classify by diagnostic type: only StrataBug triggers 'Internal error'. UserError and NotYetImplemented trigger 'Known limitation' (exit 4). If the batch contains both a StrataBug and a UserError, the Strata bug takes priority so real compiler issues are not hidden.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
