### PR TITLE
Fix a bug in measuring running times in a few places, more fine-grained running time report

### DIFF
--- a/Strata/DL/Imperative/SMTUtils.lean
+++ b/Strata/DL/Imperative/SMTUtils.lean
@@ -10,7 +10,8 @@ import Strata.DL.SMT.DDMTransform.Parse
 import Strata.DL.SMT.DDMTransform.Translate
 import Strata.DDM.Elab
 import Strata.DDM.Format
-import Strata.Util.Profile
+public import Strata.Util.Profile
+import Strata.Util.Statistics
 public import Strata.DL.Imperative.PureExpr
 public import Strata.DL.Imperative.EvalContext
 
@@ -293,6 +294,13 @@ def addLocationInfo {P : PureExpr} [BEq P.Ident]
       Strata.SMT.Solver.setInfoString message.fst message.snd
     | .none => pure ()
 
+/-- Timing keys tracked by `dischargeObligation`. -/
+inductive Timing where
+  | encodeSMT
+  | runSolver
+
+#derive_prefixed_toString Timing "dischargeObligation"
+
 /--
 Writes the proof obligation to file, discharge the obligation using SMT solver,
 and parse the output of the SMT solver.
@@ -300,24 +308,29 @@ and parse the output of the SMT solver.
 When two-sided checking is enabled, the generated SMT file will contain two
 `(check-sat-assuming)` commands, one for `P ∧ Q` and one for `P ∧ ¬Q`,
 and the return value includes both decisions.
+
+Returns a `TimingInfo` map recording nanosecond durations for the encoding
+(`dischargeObligation.encodeSMT (encodeCore)`) and solver execution
+(`dischargeObligation.runSolver`) phases, merged with sub-timings from
+`encodeCore`.
 -/
 def dischargeObligation {P : PureExpr} [ToFormat P.Ident] [BEq P.Ident]
-  (encodeSMT : Strata.SMT.SolverM (List String × Strata.SMT.EncoderState × Std.HashMap String Nat))
+  (encodeSMT : Strata.SMT.SolverM (List String × Strata.SMT.EncoderState × TimingInfo))
   (typedVarToSMTFn : P.Ident → P.Ty → Except Format (String × Strata.SMT.TermType))
   (vars : List P.TypedIdent)
   (smtsolver filename : String)
   (solver_options : Array String) (printFilename : Bool)
   (satisfiabilityCheck validityCheck : Bool)
   (skipSolver : Bool := false) :
-  IO (Except SolverError (Result P.Ident × Result P.Ident × Strata.SMT.EncoderState × Std.HashMap String Nat)) := do
+  IO (Except SolverError (Result P.Ident × Result P.Ident × Strata.SMT.EncoderState × TimingInfo)) := do
   let handle ← IO.FS.Handle.mk filename IO.FS.Mode.write
   let solver ← Strata.SMT.Solver.fileWriter handle
 
-  let timing : Std.HashMap String Nat := {}
+  let timing : TimingInfo := {}
 
   -- encodeSMT (which calls encodeCore) emits check-sat commands internally
   let (((_ids, estate, encTiming), _solverState), timing) ←
-    recordNanos "dischargeObligation.encodeSMT (encodeCore)" timing do
+    recordNanos (toString Timing.encodeSMT) timing do
       encodeSMT.run solver
   -- Merge encodeCore's internal timing into ours
   let timing := encTiming.fold (init := timing) fun acc k v => acc.insert k v
@@ -327,7 +340,7 @@ def dischargeObligation {P : PureExpr} [ToFormat P.Ident] [BEq P.Ident]
   if skipSolver then
     return .ok (.unknown, .unknown, estate, timing)
 
-  let (solver_output, timing) ← recordNanos "dischargeObligation.runSolver" timing do
+  let (solver_output, timing) ← recordNanos (toString Timing.runSolver) timing do
     runSolver smtsolver (#[filename] ++ solver_options)
 
   match ← solverResult typedVarToSMTFn vars solver_output estate smtsolver satisfiabilityCheck validityCheck with

--- a/Strata/DL/Imperative/SMTUtils.lean
+++ b/Strata/DL/Imperative/SMTUtils.lean
@@ -333,7 +333,7 @@ def dischargeObligation {P : PureExpr} [ToFormat P.Ident] [BEq P.Ident]
     recordNanos (toString Timing.encodeSMT) timing do
       encodeSMT.run solver
   -- Merge encodeCore's internal timing into ours
-  let timing := encTiming.fold (init := timing) fun acc k v => acc.insert k v
+  let timing := TimingInfo.mergeAdd timing encTiming
 
   if printFilename then IO.println s!"Wrote problem to {filename}."
 

--- a/Strata/DL/Imperative/SMTUtils.lean
+++ b/Strata/DL/Imperative/SMTUtils.lean
@@ -10,6 +10,7 @@ import Strata.DL.SMT.DDMTransform.Parse
 import Strata.DL.SMT.DDMTransform.Translate
 import Strata.DDM.Elab
 import Strata.DDM.Format
+import Strata.Util.Profile
 public import Strata.DL.Imperative.PureExpr
 public import Strata.DL.Imperative.EvalContext
 
@@ -301,29 +302,37 @@ When two-sided checking is enabled, the generated SMT file will contain two
 and the return value includes both decisions.
 -/
 def dischargeObligation {P : PureExpr} [ToFormat P.Ident] [BEq P.Ident]
-  (encodeSMT : Strata.SMT.SolverM (List String × Strata.SMT.EncoderState))
+  (encodeSMT : Strata.SMT.SolverM (List String × Strata.SMT.EncoderState × Std.HashMap String Nat))
   (typedVarToSMTFn : P.Ident → P.Ty → Except Format (String × Strata.SMT.TermType))
   (vars : List P.TypedIdent)
   (smtsolver filename : String)
   (solver_options : Array String) (printFilename : Bool)
   (satisfiabilityCheck validityCheck : Bool)
   (skipSolver : Bool := false) :
-  IO (Except SolverError (Result P.Ident × Result P.Ident × Strata.SMT.EncoderState)) := do
+  IO (Except SolverError (Result P.Ident × Result P.Ident × Strata.SMT.EncoderState × Std.HashMap String Nat)) := do
   let handle ← IO.FS.Handle.mk filename IO.FS.Mode.write
   let solver ← Strata.SMT.Solver.fileWriter handle
 
+  let timing : Std.HashMap String Nat := {}
+
   -- encodeSMT (which calls encodeCore) emits check-sat commands internally
-  let ((_ids, estate), _solverState) ← encodeSMT.run solver
+  let (((_ids, estate, encTiming), _solverState), timing) ←
+    recordNanos "dischargeObligation.encodeSMT (encodeCore)" timing do
+      encodeSMT.run solver
+  -- Merge encodeCore's internal timing into ours
+  let timing := encTiming.fold (init := timing) fun acc k v => acc.insert k v
 
   if printFilename then IO.println s!"Wrote problem to {filename}."
 
   if skipSolver then
-    return .ok (.unknown, .unknown, estate)
+    return .ok (.unknown, .unknown, estate, timing)
 
-  let solver_output ← runSolver smtsolver (#[filename] ++ solver_options)
+  let (solver_output, timing) ← recordNanos "dischargeObligation.runSolver" timing do
+    runSolver smtsolver (#[filename] ++ solver_options)
+
   match ← solverResult typedVarToSMTFn vars solver_output estate smtsolver satisfiabilityCheck validityCheck with
   | .error e => return .error e
-  | .ok (satResult, validityResult) => return .ok (satResult, validityResult, estate)
+  | .ok (satResult, validityResult) => return .ok (satResult, validityResult, estate, timing)
 
 ---------------------------------------------------------------------
 end -- public section

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -1104,7 +1104,7 @@ def verifySingleEnv (oblProgram : Program)
     let t0 ← IO.monoNanosNow
     let (obligation, peSatResult?, peValResult?) ← preprocessObligation obligation p options satisfiabilityCheck validityCheck axiomCache axiomNames axiomProgram
     let t1 ← IO.monoNanosNow
-    timingNs := timingNs.insert (toString Verifier.Timing.preprocessObligations) (timingNs.getD (toString Verifier.Timing.preprocessObligations) 0 + (t1 - t0))
+    timingNs := timingNs.add (toString Verifier.Timing.preprocessObligations) (t1 - t0)
 
     -- If evaluator resolved both checks, we're done, unless we always want to generate SMT queries
     if not options.alwaysGenerateSMT then
@@ -1133,7 +1133,7 @@ def verifySingleEnv (oblProgram : Program)
     let needValCheck := validityCheck && peValResult?.isNone
     let (maybeTerms, encNs) ← measureNanos fun () =>
       ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory
-    timingNs := timingNs.insert (toString Verifier.Timing.smtEncoding) (timingNs.getD (toString Verifier.Timing.smtEncoding) 0 + encNs)
+    timingNs := timingNs.add (toString Verifier.Timing.smtEncoding) encNs
 
     match maybeTerms with
     | .error err =>
@@ -1155,10 +1155,10 @@ def verifySingleEnv (oblProgram : Program)
                     counter tempDir needSatCheck needValCheck (externalPhases ++ corePhases)
                     (varDefinitions := varDefs) (varDeclarations := varDecls)
       let t5 ← IO.monoNanosNow
-      timingNs := timingNs.insert (toString Verifier.Timing.solverFileWriting) (timingNs.getD (toString Verifier.Timing.solverFileWriting) 0 + (t5 - t4))
+      timingNs := timingNs.add (toString Verifier.Timing.solverFileWriting) (t5 - t4)
 
       for (key, val) in timing do
-        timingNs := timingNs.insert key (timingNs.getD key 0 + val)
+        timingNs := timingNs.add key val
 
       -- Merge evaluator results with solver results
       let result := match result.outcome with
@@ -1220,6 +1220,8 @@ def verify (program : Program)
     let mut current := program
     let mut state : Transform.CoreTransformState := { Transform.CoreTransformState.emp with factory := some factory }
     let mut step := 0
+    -- Required by `measureNanos`'s `[Inhabited α]` constraint; the default value
+    -- is never observed (it only initializes an IO.Ref that is overwritten before read).
     have : Inhabited (Except Transform.Err Program × Transform.CoreTransformState) :=
       ⟨(.error default, Transform.CoreTransformState.emp)⟩
     for pp in pipelinePhases do

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -32,6 +32,20 @@ open Strata
 
 public section
 
+/-- Timing keys tracked by `encodeCore`. -/
+inductive Timing where
+  | prelude
+  | emitDatatypes
+  | encodeUFs
+  | encodeFunctions
+  | encodeAxioms
+  | defineFunTerms
+  | encodeAssumptions
+  | encodeObligation
+  | epilog
+
+#derive_prefixed_toString Timing "encodeCore"
+
 /-- Encode a verification condition into SMT-LIB format.
 
 This function encodes the path conditions (P) and obligation (Q) into SMT,
@@ -55,15 +69,15 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
     (label : String)
     (varDefinitions : List Core.VarDefinition := [])
     (varDeclarations : List Core.VarDeclaration := []) :
-    SolverM (List String × EncoderState × Std.HashMap String Nat) := do
+    SolverM (List String × EncoderState × TimingInfo) := do
   Solver.setLogic "ALL"
 
-  let timing : Std.HashMap String Nat := {}
+  let timing : TimingInfo := {}
 
-  let ((), timing) ← recordNanos "encodeCore.prelude" timing do
+  let ((), timing) ← recordNanos (toString Timing.prelude) timing do
     prelude
 
-  let ((), timing) ← recordNanos "encodeCore.emitDatatypes" timing do
+  let ((), timing) ← recordNanos (toString Timing.emitDatatypes) timing do
     let _ ← ctx.sorts.mapM (fun s => Solver.declareSort s.name s.arity)
     ctx.emitDatatypes
 
@@ -71,14 +85,14 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
   let varDeclNames := varDeclarations.map (·.name)
   let managedNames := varDefNames ++ varDeclNames
 
-  let (estate, timing) ← recordNanos "encodeCore.encodeUFs" timing do
+  let (estate, timing) ← recordNanos (toString Timing.encodeUFs) timing do
     -- Filter out managed variables from UF declarations (they will be emitted separately)
     let ufsToDecl := if managedNames.isEmpty then ctx.ufs
       else ctx.ufs.filter fun uf => !managedNames.contains uf.id
     let (_ufs, estate) ← ufsToDecl.mapM (fun uf => encodeUF uf) |>.run EncoderState.init
     pure estate
 
-  let (estate, timing) ← recordNanos "encodeCore.encodeFunctions" timing do
+  let (estate, timing) ← recordNanos (toString Timing.encodeFunctions) timing do
     -- Pre-populate encoder state with managed variable names so encodeTerm
     -- recognizes them without emitting declare-fun
     let estate := if managedNames.isEmpty then estate
@@ -89,7 +103,7 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
     let (_ifs, estate) ← ctx.ifs.mapM (fun fn => encodeFunction fn.uf fn.body) |>.run estate
     pure estate
 
-  let ((_axms, estate), timing) ← recordNanos "encodeCore.encodeAxioms" timing do
+  let ((_axms, estate), timing) ← recordNanos (toString Timing.encodeAxioms) timing do
     ctx.axms.mapM (fun ax => encodeTerm ax) |>.run estate
 
   for id in _axms do
@@ -98,25 +112,25 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
   for decl in varDeclarations do
     Solver.declareFun decl.name [] decl.ty
 
-  let (estate, timing) ← recordNanos "encodeCore.defineFunTerms" timing do
+  let (estate, timing) ← recordNanos (toString Timing.defineFunTerms) timing do
     -- Emit variable definitions as define-fun (macro expansions, not constraints)
     varDefinitions.foldlM (init := estate) fun estate def_ => do
       let (bodyEnc, estate) ← (encodeTerm def_.body) |>.run estate
       Solver.defineFunTerm def_.name [] def_.ty bodyEnc
       pure estate
 
-  let ((assumptionIds, estate), timing) ← recordNanos "encodeCore.encodeAssumptions" timing do
+  let ((assumptionIds, estate), timing) ← recordNanos (toString Timing.encodeAssumptions) timing do
     -- Assert assumption terms
     assumptionTerms.mapM (encodeTerm) |>.run estate
 
   for id in assumptionIds do
     Solver.assert id
 
-  let ((obligationId, estate), timing) ← recordNanos "encodeCore.encodeObligation" timing do
+  let ((obligationId, estate), timing) ← recordNanos (toString Timing.encodeObligation) timing do
     -- Encode the obligation term Q (not negated)
     (encodeTerm obligationTerm) |>.run estate
 
-  let (ids, timing) ← recordNanos "encodeCore.epilog" timing do
+  let (ids, timing) ← recordNanos (toString Timing.epilog) timing do
     let ids := estate.ufs.toList.filterMap fun (uf, id) =>
       if uf.args.isEmpty && !managedNames.contains uf.id then some id else none
 
@@ -231,7 +245,7 @@ def dischargeObligation
   (label : String)
   (varDefinitions : List VarDefinition := [])
   (varDeclarations : List VarDeclaration := [])
-  : IO (Except Imperative.SMT.SolverError (SMT.Result × SMT.Result × EncoderState × Std.HashMap String Nat)) := do
+  : IO (Except Imperative.SMT.SolverError (SMT.Result × SMT.Result × EncoderState × TimingInfo)) := do
   -- CVC5 requires --incremental for multiple (check-sat) commands
   let baseFlags := getSolverFlags options
   let needsIncremental := satisfiabilityCheck && validityCheck
@@ -966,7 +980,7 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
     (phases : List AbstractedPhase)
     (varDefinitions : List VarDefinition := [])
     (varDeclarations : List VarDeclaration := [])
-    : EIO DiagnosticModel (VCResult × Std.HashMap String Nat) := do
+    : EIO DiagnosticModel (VCResult × TimingInfo) := do
   let prog := f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
   let counterVal ← counter.get
   counter.set (counterVal + 1)
@@ -1034,6 +1048,17 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
                     lexprModel := model }
     return (result, timing)
 
+namespace Verifier
+
+/-- Timing keys tracked by `verifySingleEnv`. -/
+inductive Timing where
+  | preprocessObligations
+  | smtEncoding
+  | solverFileWriting
+
+#derive_prefixed_toString Timing "verifySingleEnv"
+
+end Verifier
 
 def verifySingleEnv (oblProgram : Program)
     (moreFns : @Lambda.Factory CoreLParams := Lambda.Factory.default)
@@ -1060,7 +1085,7 @@ def verifySingleEnv (oblProgram : Program)
   let mut stats : Statistics := ({} : Statistics)
     |>.increment s!"{Evaluator.Stats.verify_numObligations}" obligations.size
   let mut results := (#[] : VCResults)
-  let mut timingNs : Std.HashMap String Nat := {}
+  let mut timingNs : TimingInfo := {}
   let mut peResolvedCount : Nat := 0
 
   for obligation in obligations do
@@ -1079,7 +1104,7 @@ def verifySingleEnv (oblProgram : Program)
     let t0 ← IO.monoNanosNow
     let (obligation, peSatResult?, peValResult?) ← preprocessObligation obligation p options satisfiabilityCheck validityCheck axiomCache axiomNames axiomProgram
     let t1 ← IO.monoNanosNow
-    timingNs := timingNs.insert "preprocessObligations" (timingNs.getD "preprocessObligations" 0 + (t1 - t0))
+    timingNs := timingNs.insert (toString Verifier.Timing.preprocessObligations) (timingNs.getD (toString Verifier.Timing.preprocessObligations) 0 + (t1 - t0))
 
     -- If evaluator resolved both checks, we're done, unless we always want to generate SMT queries
     if not options.alwaysGenerateSMT then
@@ -1108,7 +1133,7 @@ def verifySingleEnv (oblProgram : Program)
     let needValCheck := validityCheck && peValResult?.isNone
     let (maybeTerms, encNs) ← measureNanos fun () =>
       ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory
-    timingNs := timingNs.insert "smtEncoding" (timingNs.getD "smtEncoding" 0 + encNs)
+    timingNs := timingNs.insert (toString Verifier.Timing.smtEncoding) (timingNs.getD (toString Verifier.Timing.smtEncoding) 0 + encNs)
 
     match maybeTerms with
     | .error err =>
@@ -1130,7 +1155,7 @@ def verifySingleEnv (oblProgram : Program)
                     counter tempDir needSatCheck needValCheck (externalPhases ++ corePhases)
                     (varDefinitions := varDefs) (varDeclarations := varDecls)
       let t5 ← IO.monoNanosNow
-      timingNs := timingNs.insert "solverFileWriting" (timingNs.getD "solverFileWriting" 0 + (t5 - t4))
+      timingNs := timingNs.insert (toString Verifier.Timing.solverFileWriting) (timingNs.getD (toString Verifier.Timing.solverFileWriting) 0 + (t5 - t4))
 
       for (key, val) in timing do
         timingNs := timingNs.insert key (timingNs.getD key 0 + val)
@@ -1152,8 +1177,8 @@ def verifySingleEnv (oblProgram : Program)
         if options.stopOnFirstError then break
 
   if profile then
-    let _ ← (IO.println s!"[profile]     Preprocess obligations: {nsToMs (timingNs.getD "preprocessObligations" 0)}ms" |>.toBaseIO)
-    let _ ← (IO.println s!"[profile]     SMT encoding: {nsToMs (timingNs.getD "smtEncoding" 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]     Preprocess obligations: {nsToMs (timingNs.getD (toString Verifier.Timing.preprocessObligations) 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]     SMT encoding: {nsToMs (timingNs.getD (toString Verifier.Timing.smtEncoding) 0)}ms" |>.toBaseIO)
     -- Print encodeCore.* sub-timings
     let encodeCoreEntries := timingNs.toList.filter (·.1.startsWith "encodeCore.")
       |>.mergeSort (fun a b => a.1 < b.1)
@@ -1161,9 +1186,9 @@ def verifySingleEnv (oblProgram : Program)
       let suffix := key.drop "encodeCore.".length
       let _ ← (IO.println s!"[profile]         {suffix}: {nsToMs val}ms" |>.toBaseIO)
     -- Print dischargeObligation-level timings (encodeCore total, runSolver)
-    let _ ← (IO.println s!"[profile]       encodeCore: {nsToMs (timingNs.getD "dischargeObligation.encodeSMT (encodeCore)" 0)}ms" |>.toBaseIO)
-    let _ ← (IO.println s!"[profile]       runSolver: {nsToMs (timingNs.getD "dischargeObligation.runSolver" 0)}ms" |>.toBaseIO)
-    let _ ← (IO.println s!"[profile]     Solver/file writing: {nsToMs (timingNs.getD "solverFileWriting" 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]       encodeCore: {nsToMs (timingNs.getD (toString Imperative.SMT.Timing.encodeSMT) 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]       runSolver: {nsToMs (timingNs.getD (toString Imperative.SMT.Timing.runSolver) 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]     Solver/file writing: {nsToMs (timingNs.getD (toString Verifier.Timing.solverFileWriting) 0)}ms" |>.toBaseIO)
     let _ ← (IO.println s!"[profile]     Obligations: {obligations.size} total, {peResolvedCount} resolved by evaluator" |>.toBaseIO)
   return (results, stats)
 

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -1156,9 +1156,7 @@ def verifySingleEnv (oblProgram : Program)
                     (varDefinitions := varDefs) (varDeclarations := varDecls)
       let t5 ← IO.monoNanosNow
       timingNs := timingNs.add (toString Verifier.Timing.solverFileWriting) (t5 - t4)
-
-      for (key, val) in timing do
-        timingNs := timingNs.add key val
+      timingNs := TimingInfo.mergeAdd timingNs timing
 
       -- Merge evaluator results with solver results
       let result := match result.outcome with

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -1080,10 +1080,9 @@ def verifySingleEnv (oblProgram : Program)
     -- Need the solver for at least one check
     let needSatCheck := satisfiabilityCheck && peSatResult?.isNone
     let needValCheck := validityCheck && peValResult?.isNone
-    let t2 ← IO.monoNanosNow
-    let maybeTerms := ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory
-    let t3 ← IO.monoNanosNow
-    smtEncodeNs := smtEncodeNs + (t3 - t2)
+    let (maybeTerms, encNs) ← measureNanos fun () =>
+      ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory
+    smtEncodeNs := smtEncodeNs + encNs
     match maybeTerms with
     | .error err =>
       let result := { obligation,
@@ -1156,9 +1155,10 @@ def verify (program : Program)
     let mut state : Transform.CoreTransformState := { Transform.CoreTransformState.emp with factory := some factory }
     let mut step := 0
     for pp in pipelinePhases do
-      let (result, newState) := Transform.runWith current (fun prog => do
-        let (_, next) ← pp.transform prog
-        return next) state
+      let (result, newState) ← profileStep profile s!"    {pp.phase.name}" do
+        pure <| Transform.runWith current (fun prog => do
+          let (_, next) ← pp.transform prog
+          return next) state
       match result with
       | .ok next =>
         current := next

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -55,89 +55,114 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
     (label : String)
     (varDefinitions : List Core.VarDefinition := [])
     (varDeclarations : List Core.VarDeclaration := []) :
-    SolverM (List String × EncoderState) := do
+    SolverM (List String × EncoderState × Std.HashMap String Nat) := do
   Solver.setLogic "ALL"
-  prelude
-  let _ ← ctx.sorts.mapM (fun s => Solver.declareSort s.name s.arity)
-  ctx.emitDatatypes
+
+  let timing : Std.HashMap String Nat := {}
+
+  let ((), timing) ← recordNanos "encodeCore.prelude" timing do
+    prelude
+
+  let ((), timing) ← recordNanos "encodeCore.emitDatatypes" timing do
+    let _ ← ctx.sorts.mapM (fun s => Solver.declareSort s.name s.arity)
+    ctx.emitDatatypes
+
   let varDefNames := varDefinitions.map (·.name)
   let varDeclNames := varDeclarations.map (·.name)
   let managedNames := varDefNames ++ varDeclNames
-  -- Filter out managed variables from UF declarations (they will be emitted separately)
-  let ufsToDecl := if managedNames.isEmpty then ctx.ufs
-    else ctx.ufs.filter fun uf => !managedNames.contains uf.id
-  let (_ufs, estate) ← ufsToDecl.mapM (fun uf => encodeUF uf) |>.run EncoderState.init
-  -- Pre-populate encoder state with managed variable names so encodeTerm
-  -- recognizes them without emitting declare-fun
-  let estate := if managedNames.isEmpty then estate
-    else
-      let managedUfs := ctx.ufs.filter fun uf => managedNames.contains uf.id
-      managedUfs.foldl (init := estate) fun estate uf =>
-        { estate with ufs := estate.ufs.insert uf uf.id }
-  let (_ifs, estate) ← ctx.ifs.mapM (fun fn => encodeFunction fn.uf fn.body) |>.run estate
-  let (_axms, estate) ← ctx.axms.mapM (fun ax => encodeTerm ax) |>.run estate
+
+  let (estate, timing) ← recordNanos "encodeCore.encodeUFs" timing do
+    -- Filter out managed variables from UF declarations (they will be emitted separately)
+    let ufsToDecl := if managedNames.isEmpty then ctx.ufs
+      else ctx.ufs.filter fun uf => !managedNames.contains uf.id
+    let (_ufs, estate) ← ufsToDecl.mapM (fun uf => encodeUF uf) |>.run EncoderState.init
+    pure estate
+
+  let (estate, timing) ← recordNanos "encodeCore.encodeFunctions" timing do
+    -- Pre-populate encoder state with managed variable names so encodeTerm
+    -- recognizes them without emitting declare-fun
+    let estate := if managedNames.isEmpty then estate
+      else
+        let managedUfs := ctx.ufs.filter fun uf => managedNames.contains uf.id
+        managedUfs.foldl (init := estate) fun estate uf =>
+          { estate with ufs := estate.ufs.insert uf uf.id }
+    let (_ifs, estate) ← ctx.ifs.mapM (fun fn => encodeFunction fn.uf fn.body) |>.run estate
+    pure estate
+
+  let ((_axms, estate), timing) ← recordNanos "encodeCore.encodeAxioms" timing do
+    ctx.axms.mapM (fun ax => encodeTerm ax) |>.run estate
+
   for id in _axms do
     Solver.assert id
   -- Emit variable declarations as declare-fun
   for decl in varDeclarations do
     Solver.declareFun decl.name [] decl.ty
-  -- Emit variable definitions as define-fun (macro expansions, not constraints)
-  let estate ← varDefinitions.foldlM (init := estate) fun estate def_ => do
-    let (bodyEnc, estate) ← (encodeTerm def_.body) |>.run estate
-    Solver.defineFunTerm def_.name [] def_.ty bodyEnc
-    pure estate
-  -- Assert assumption terms
-  let (assumptionIds, estate) ← assumptionTerms.mapM (encodeTerm) |>.run estate
+
+  let (estate, timing) ← recordNanos "encodeCore.defineFunTerms" timing do
+    -- Emit variable definitions as define-fun (macro expansions, not constraints)
+    varDefinitions.foldlM (init := estate) fun estate def_ => do
+      let (bodyEnc, estate) ← (encodeTerm def_.body) |>.run estate
+      Solver.defineFunTerm def_.name [] def_.ty bodyEnc
+      pure estate
+
+  let ((assumptionIds, estate), timing) ← recordNanos "encodeCore.encodeAssumptions" timing do
+    -- Assert assumption terms
+    assumptionTerms.mapM (encodeTerm) |>.run estate
+
   for id in assumptionIds do
     Solver.assert id
-  -- Encode the obligation term Q (not negated)
-  let (obligationId, estate) ← (encodeTerm obligationTerm) |>.run estate
 
-  let ids := estate.ufs.toList.filterMap fun (uf, id) =>
-    if uf.args.isEmpty && !managedNames.contains uf.id then some id else none
+  let ((obligationId, estate), timing) ← recordNanos "encodeCore.encodeObligation" timing do
+    -- Encode the obligation term Q (not negated)
+    (encodeTerm obligationTerm) |>.run estate
 
-  -- Choose encoding strategy: use check-sat-assuming only when doing both checks
-  let bothChecks := satisfiabilityCheck && validityCheck
+  let (ids, timing) ← recordNanos "encodeCore.epilog" timing do
+    let ids := estate.ufs.toList.filterMap fun (uf, id) =>
+      if uf.args.isEmpty && !managedNames.contains uf.id then some id else none
 
-  if bothChecks then
-    -- Satisfiability check: P ∧ Q satisfiable?
-    Solver.comment "Satisfiability"
-    Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
-      (message := ("sat-message", "Property can be satisfied"))
-    let obligationStr ← Solver.termToSMTString obligationId
-    let _ ← Solver.checkSatAssuming [obligationStr] ids
+    -- Choose encoding strategy: use check-sat-assuming only when doing both checks
+    let bothChecks := satisfiabilityCheck && validityCheck
 
-    -- Validity check: P ∧ ¬Q satisfiable?
-    Solver.comment "Validity"
-    Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
-      (message := ("unsat-message", "Property is always true"))
-    let negObligationStr := s!"(not {obligationStr})"
-    let _ ← Solver.checkSatAssuming [negObligationStr] ids
-  else
-    if satisfiabilityCheck then
-      -- P ∧ Q satisfiable?
+    if bothChecks then
+      -- Satisfiability check: P ∧ Q satisfiable?
       Solver.comment "Satisfiability"
       Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
         (message := ("sat-message", "Property can be satisfied"))
-      Solver.assert obligationId
-      let _ ← Solver.checkSat ids
-    else if validityCheck then
-      -- P ∧ ¬Q satisfiable?
+      let obligationStr ← Solver.termToSMTString obligationId
+      let _ ← Solver.checkSatAssuming [obligationStr] ids
+
+      -- Validity check: P ∧ ¬Q satisfiable?
       Solver.comment "Validity"
       Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
         (message := ("unsat-message", "Property is always true"))
-      Solver.assert (← encodeTerm (Factory.not obligationTerm) |>.run estate).1
-      let _ ← Solver.checkSat ids
+      let negObligationStr := s!"(not {obligationStr})"
+      let _ ← Solver.checkSatAssuming [negObligationStr] ids
+    else
+      if satisfiabilityCheck then
+        -- P ∧ Q satisfiable?
+        Solver.comment "Satisfiability"
+        Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
+          (message := ("sat-message", "Property can be satisfied"))
+        Solver.assert obligationId
+        let _ ← Solver.checkSat ids
+      else if validityCheck then
+        -- P ∧ ¬Q satisfiable?
+        Solver.comment "Validity"
+        Imperative.SMT.addLocationInfo (P := Core.Expression) (md := md)
+          (message := ("unsat-message", "Property is always true"))
+        Solver.assert (← encodeTerm (Factory.not obligationTerm) |>.run estate).1
+        let _ ← Solver.checkSat ids
 
-  -- Emit the property summary (or label) as the final message in the SMT-LIB output.
-  -- Use `setInfoString` so the value is quoted and escaped per SMT-LIB 2.6+
-  -- (doubled `""` for embedded quotes). C-style `\"` escaping would be rejected
-  -- by SMT-LIB consumers: backslash is a literal character in string contexts,
-  -- and the following `"` would close the string.
-  let rawMsg := md.getPropertySummary.getD label
-  Solver.setInfoString "final-message" rawMsg
+    -- Emit the property summary (or label) as the final message in the SMT-LIB output.
+    -- Use `setInfoString` so the value is quoted and escaped per SMT-LIB 2.6+
+    -- (doubled `""` for embedded quotes). C-style `\"` escaping would be rejected
+    -- by SMT-LIB consumers: backslash is a literal character in string contexts,
+    -- and the following `"` would close the string.
+    let rawMsg := md.getPropertySummary.getD label
+    Solver.setInfoString "final-message" rawMsg
+    pure ids
 
-  return (ids, estate)
+  return (ids, estate, timing)
 
 end -- public section
 end Strata.SMT.Encoder
@@ -206,7 +231,7 @@ def dischargeObligation
   (label : String)
   (varDefinitions : List VarDefinition := [])
   (varDeclarations : List VarDeclaration := [])
-  : IO (Except Imperative.SMT.SolverError (SMT.Result × SMT.Result × EncoderState)) := do
+  : IO (Except Imperative.SMT.SolverError (SMT.Result × SMT.Result × EncoderState × Std.HashMap String Nat)) := do
   -- CVC5 requires --incremental for multiple (check-sat) commands
   let baseFlags := getSolverFlags options
   let needsIncremental := satisfiabilityCheck && validityCheck
@@ -941,7 +966,7 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
     (phases : List AbstractedPhase)
     (varDefinitions : List VarDefinition := [])
     (varDeclarations : List VarDeclaration := [])
-    : EIO DiagnosticModel VCResult := do
+    : EIO DiagnosticModel (VCResult × Std.HashMap String Nat) := do
   let prog := f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
   let counterVal ← counter.get
   counter.set (counterVal + 1)
@@ -973,13 +998,14 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
       | .crash d   => .solverCrash d
     dbg_trace f!"\n\nObligation {obligation.label}: {vcError}\
                  {if options.verbose >= VerboseMode.debug then prog else ""}"
-    return { obligation := obligation,
-             outcome := Except.error vcError,
-             verbose := options.verbose,
-             checkLevel := options.checkLevel,
-             checkMode := options.checkMode,
-             lexprModel := [] }
-  | .ok (satResult, validityResult, estate) =>
+    return (
+      { obligation := obligation
+        outcome := Except.error vcError
+        verbose := options.verbose
+        checkLevel := options.checkLevel
+        checkMode := options.checkMode
+        lexprModel := [] }, {})
+  | .ok (satResult, validityResult, estate, timing) =>
     -- Convert unvalidated sat results to unknown when phases require validation
     let (adjSat, satPhaseLog) := satResult.adjustForPhases phases obligation
     let (adjVal, valPhaseLog) := validityResult.adjustForPhases phases obligation
@@ -1006,7 +1032,7 @@ def getObligationResult (assumptionTerms : List Term) (obligationTerm : Term)
                     checkLevel := options.checkLevel,
                     checkMode := options.checkMode,
                     lexprModel := model }
-    return result
+    return (result, timing)
 
 
 def verifySingleEnv (oblProgram : Program)
@@ -1034,10 +1060,9 @@ def verifySingleEnv (oblProgram : Program)
   let mut stats : Statistics := ({} : Statistics)
     |>.increment s!"{Evaluator.Stats.verify_numObligations}" obligations.size
   let mut results := (#[] : VCResults)
-  let mut preprocessNs : Nat := 0
-  let mut smtEncodeNs : Nat := 0
-  let mut solverNs : Nat := 0
+  let mut timingNs : Std.HashMap String Nat := {}
   let mut peResolvedCount : Nat := 0
+
   for obligation in obligations do
     -- Determine which checks to perform based on metadata or check mode/amount
     let (satisfiabilityCheck, validityCheck) :=
@@ -1054,7 +1079,8 @@ def verifySingleEnv (oblProgram : Program)
     let t0 ← IO.monoNanosNow
     let (obligation, peSatResult?, peValResult?) ← preprocessObligation obligation p options satisfiabilityCheck validityCheck axiomCache axiomNames axiomProgram
     let t1 ← IO.monoNanosNow
-    preprocessNs := preprocessNs + (t1 - t0)
+    timingNs := timingNs.insert "preprocessObligations" (timingNs.getD "preprocessObligations" 0 + (t1 - t0))
+
     -- If evaluator resolved both checks, we're done, unless we always want to generate SMT queries
     if not options.alwaysGenerateSMT then
       if let (some peSat, some peVal) := (peSatResult?, peValResult?) then
@@ -1082,7 +1108,8 @@ def verifySingleEnv (oblProgram : Program)
     let needValCheck := validityCheck && peValResult?.isNone
     let (maybeTerms, encNs) ← measureNanos fun () =>
       ProofObligation.toSMTTerms E obligation { SMT.Context.default with uniqueBoundNames := options.uniqueBoundNames } options.useArrayTheory
-    smtEncodeNs := smtEncodeNs + encNs
+    timingNs := timingNs.insert "smtEncoding" (timingNs.getD "smtEncoding" 0 + encNs)
+
     match maybeTerms with
     | .error err =>
       let result := { obligation,
@@ -1099,11 +1126,15 @@ def verifySingleEnv (oblProgram : Program)
     | .ok (assumptionTerms, varDefs, varDecls, obligationTerm, ctx, encStats) =>
       stats := stats.merge encStats
       let t4 ← IO.monoNanosNow
-      let result ← getObligationResult assumptionTerms obligationTerm ctx obligation p options
+      let (result, timing) ← getObligationResult assumptionTerms obligationTerm ctx obligation p options
                     counter tempDir needSatCheck needValCheck (externalPhases ++ corePhases)
                     (varDefinitions := varDefs) (varDeclarations := varDecls)
       let t5 ← IO.monoNanosNow
-      solverNs := solverNs + (t5 - t4)
+      timingNs := timingNs.insert "solverFileWriting" (timingNs.getD "solverFileWriting" 0 + (t5 - t4))
+
+      for (key, val) in timing do
+        timingNs := timingNs.insert key (timingNs.getD key 0 + val)
+
       -- Merge evaluator results with solver results
       let result := match result.outcome with
         | .ok solverOutcome =>
@@ -1119,10 +1150,20 @@ def verifySingleEnv (oblProgram : Program)
           let prog := f!"\n\n[DEBUG] Evaluated program:\n{Core.formatProgram p}"
           dbg_trace f!"\n\nResult: {result}\n{prog}"
         if options.stopOnFirstError then break
+
   if profile then
-    let _ ← (IO.println s!"[profile]     Preprocess obligations: {nsToMs preprocessNs}ms" |>.toBaseIO)
-    let _ ← (IO.println s!"[profile]     SMT encoding: {nsToMs smtEncodeNs}ms" |>.toBaseIO)
-    let _ ← (IO.println s!"[profile]     Solver/file writing: {nsToMs solverNs}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]     Preprocess obligations: {nsToMs (timingNs.getD "preprocessObligations" 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]     SMT encoding: {nsToMs (timingNs.getD "smtEncoding" 0)}ms" |>.toBaseIO)
+    -- Print encodeCore.* sub-timings
+    let encodeCoreEntries := timingNs.toList.filter (·.1.startsWith "encodeCore.")
+      |>.mergeSort (fun a b => a.1 < b.1)
+    for (key, val) in encodeCoreEntries do
+      let suffix := key.drop "encodeCore.".length
+      let _ ← (IO.println s!"[profile]         {suffix}: {nsToMs val}ms" |>.toBaseIO)
+    -- Print dischargeObligation-level timings (encodeCore total, runSolver)
+    let _ ← (IO.println s!"[profile]       encodeCore: {nsToMs (timingNs.getD "dischargeObligation.encodeSMT (encodeCore)" 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]       runSolver: {nsToMs (timingNs.getD "dischargeObligation.runSolver" 0)}ms" |>.toBaseIO)
+    let _ ← (IO.println s!"[profile]     Solver/file writing: {nsToMs (timingNs.getD "solverFileWriting" 0)}ms" |>.toBaseIO)
     let _ ← (IO.println s!"[profile]     Obligations: {obligations.size} total, {peResolvedCount} resolved by evaluator" |>.toBaseIO)
   return (results, stats)
 
@@ -1154,11 +1195,15 @@ def verify (program : Program)
     let mut current := program
     let mut state : Transform.CoreTransformState := { Transform.CoreTransformState.emp with factory := some factory }
     let mut step := 0
+    have : Inhabited (Except Transform.Err Program × Transform.CoreTransformState) :=
+      ⟨(.error default, Transform.CoreTransformState.emp)⟩
     for pp in pipelinePhases do
-      let (result, newState) ← profileStep profile s!"    {pp.phase.name}" do
-        pure <| Transform.runWith current (fun prog => do
+      let ((result, newState), passNs) ← measureNanos fun () =>
+        Transform.runWith current (fun prog => do
           let (_, next) ← pp.transform prog
           return next) state
+      if profile then
+        let _ ← (IO.println s!"[profile]     {pp.phase.name}: {nsToMs passNs}ms" |>.toBaseIO)
       match result with
       | .ok next =>
         current := next

--- a/Strata/Util/Profile.lean
+++ b/Strata/Util/Profile.lean
@@ -7,6 +7,15 @@ module
 
 @[inline] public def nsToMs (ns : Nat) : Nat := (ns + 500000) / 1000000
 
+/-- Measure the wall-clock nanoseconds taken by a pure expression.
+    Takes a thunk to ensure the expression is not evaluated before timing starts.
+    The `t1 == 0` trick creates a data dependency preventing reordering. -/
+@[inline] public def measureNanos [Inhabited α] (expr : Unit → α) : BaseIO (α × Nat) := do
+  let t1 ← IO.monoNanosNow
+  let result := if t1 == 0 then default else expr ()
+  let t2 ← IO.monoNanosNow
+  pure (result, t2 - t1)
+
 /-- Run an action, printing its elapsed time in milliseconds to stdout when `profile` is true. -/
 public def profileStep {m α} [Monad m] [MonadLiftT BaseIO m]
     (profile : Bool) (name : String) (action : m α) : m α := do

--- a/Strata/Util/Profile.lean
+++ b/Strata/Util/Profile.lean
@@ -28,13 +28,24 @@ public abbrev TimingInfo := Std.HashMap String Nat
   let result ← ref.get
   pure (result, t2 - t1)
 
-/-- Run an action and record its elapsed nanoseconds into a `TimingInfo` under the given key. -/
+/-- Run an action and record its elapsed nanoseconds into a `TimingInfo` under
+    the given key. The measurement is accumulated via `TimingInfo.add`, so
+    repeated calls with the same key sum their durations.
+
+    Unlike `measureNanos`, this does not need `@[noinline]`: `action` is a
+    monadic computation, so its IO primitives are sequenced by `>>=` and cannot
+    be reordered across `IO.monoNanosNow`.
+
+    Caveat: if the `α` returned by `action` is a lazy pure value (e.g.
+    `pure (expensivePureComputation)`), the thunk is not forced here, and the
+    recorded time will reflect only the IO sequencing, not the pure work. For
+    timing pure computations, use `measureNanos` (which forces via `IO.Ref`). -/
 public def recordNanos {m α} [Monad m] [MonadLiftT BaseIO m]
     (key : String) (timing : TimingInfo) (action : m α) : m (α × TimingInfo) := do
   let t0 ← IO.monoNanosNow
   let result ← action
   let t1 ← IO.monoNanosNow
-  pure (result, timing.insert key (t1 - t0))
+  pure (result, timing.add key (t1 - t0))
 
 /-- Run an action, printing its elapsed time in milliseconds to stdout when `profile` is true. -/
 public def profileStep {m α} [Monad m] [MonadLiftT BaseIO m]

--- a/Strata/Util/Profile.lean
+++ b/Strata/Util/Profile.lean
@@ -7,23 +7,26 @@ module
 
 public import Std.Data.HashMap.Basic
 
+/-- A map from timing label to elapsed nanoseconds. -/
+public abbrev TimingInfo := Std.HashMap String Nat
+
 @[inline] public def nsToMs (ns : Nat) : Nat := (ns + 500000) / 1000000
 
 /-- Measure the wall-clock nanoseconds taken by a pure expression.
-    Takes a thunk to ensure the expression is not evaluated before timing starts.
-    The `t1 == 0` trick prevents hoisting `result` above t1.
-    Writing `result` to an `IO.Ref` forces its evaluation before t2 is read. -/
-public def measureNanos [Inhabited α] (expr : Unit → α) : BaseIO (α × Nat) := do
+    The `@[noinline]` prevents the compiler from hoisting `expr ()` out of
+    this function. The `IO.Ref.set` forces evaluation of `expr ()` between
+    the two timestamp reads (IO actions are sequenced). -/
+@[noinline] public def measureNanos [Inhabited α] (expr : Unit → α) : BaseIO (α × Nat) := do
   let ref ← IO.mkRef (default : α)
   let t1 ← IO.monoNanosNow
-  let result := if t1 == 0 then default else expr ()
-  ref.set result
+  ref.set (expr ())
   let t2 ← IO.monoNanosNow
+  let result ← ref.get
   pure (result, t2 - t1)
 
-/-- Run an action and return its result along with the elapsed nanoseconds. -/
+/-- Run an action and record its elapsed nanoseconds into a `TimingInfo` under the given key. -/
 @[inline] public def recordNanos {m α} [Monad m] [MonadLiftT BaseIO m]
-    (key : String) (timing : Std.HashMap String Nat) (action : m α) : m (α × Std.HashMap String Nat) := do
+    (key : String) (timing : TimingInfo) (action : m α) : m (α × TimingInfo) := do
   let t0 ← IO.monoNanosNow
   let result ← action
   let t1 ← IO.monoNanosNow

--- a/Strata/Util/Profile.lean
+++ b/Strata/Util/Profile.lean
@@ -5,16 +5,29 @@
 -/
 module
 
+public import Std.Data.HashMap.Basic
+
 @[inline] public def nsToMs (ns : Nat) : Nat := (ns + 500000) / 1000000
 
 /-- Measure the wall-clock nanoseconds taken by a pure expression.
     Takes a thunk to ensure the expression is not evaluated before timing starts.
-    The `t1 == 0` trick creates a data dependency preventing reordering. -/
-@[inline] public def measureNanos [Inhabited α] (expr : Unit → α) : BaseIO (α × Nat) := do
+    The `t1 == 0` trick prevents hoisting `result` above t1.
+    Writing `result` to an `IO.Ref` forces its evaluation before t2 is read. -/
+public def measureNanos [Inhabited α] (expr : Unit → α) : BaseIO (α × Nat) := do
+  let ref ← IO.mkRef (default : α)
   let t1 ← IO.monoNanosNow
   let result := if t1 == 0 then default else expr ()
+  ref.set result
   let t2 ← IO.monoNanosNow
   pure (result, t2 - t1)
+
+/-- Run an action and return its result along with the elapsed nanoseconds. -/
+@[inline] public def recordNanos {m α} [Monad m] [MonadLiftT BaseIO m]
+    (key : String) (timing : Std.HashMap String Nat) (action : m α) : m (α × Std.HashMap String Nat) := do
+  let t0 ← IO.monoNanosNow
+  let result ← action
+  let t1 ← IO.monoNanosNow
+  pure (result, timing.insert key (t1 - t0))
 
 /-- Run an action, printing its elapsed time in milliseconds to stdout when `profile` is true. -/
 public def profileStep {m α} [Monad m] [MonadLiftT BaseIO m]

--- a/Strata/Util/Profile.lean
+++ b/Strata/Util/Profile.lean
@@ -6,6 +6,7 @@
 module
 
 public import Std.Data.HashMap.Basic
+import Std.Data.HashMap.Lemmas
 
 /-- A map from timing label to elapsed nanoseconds. -/
 public abbrev TimingInfo := Std.HashMap String Nat
@@ -13,6 +14,19 @@ public abbrev TimingInfo := Std.HashMap String Nat
 /-- Accumulate nanoseconds into an existing key (defaulting to 0). -/
 @[inline] public def TimingInfo.add (t : TimingInfo) (key : String) (ns : Nat) : TimingInfo :=
   t.insert key (t.getD key 0 + ns)
+
+/-- Merge `b` into `a` by summing values for overlapping keys. -/
+@[inline] public def TimingInfo.mergeAdd (a b : TimingInfo) : TimingInfo :=
+  b.fold (init := a) fun acc k v => acc.add k v
+
+theorem TimingInfo.add_getD_self (t : TimingInfo) (k : String) (v : Nat) :
+    (t.add k v).getD k 0 = t.getD k 0 + v := by
+  simp [TimingInfo.add]
+
+theorem TimingInfo.add_getD_of_ne (t : TimingInfo) (k k' : String) (v : Nat)
+    (h : k ≠ k') : (t.add k v).getD k' 0 = t.getD k' 0 := by
+  simp [TimingInfo.add, Std.HashMap.getD_insert, h]
+
 
 @[inline] public def nsToMs (ns : Nat) : Nat := (ns + 500000) / 1000000
 

--- a/Strata/Util/Profile.lean
+++ b/Strata/Util/Profile.lean
@@ -10,6 +10,10 @@ public import Std.Data.HashMap.Basic
 /-- A map from timing label to elapsed nanoseconds. -/
 public abbrev TimingInfo := Std.HashMap String Nat
 
+/-- Accumulate nanoseconds into an existing key (defaulting to 0). -/
+@[inline] public def TimingInfo.add (t : TimingInfo) (key : String) (ns : Nat) : TimingInfo :=
+  t.insert key (t.getD key 0 + ns)
+
 @[inline] public def nsToMs (ns : Nat) : Nat := (ns + 500000) / 1000000
 
 /-- Measure the wall-clock nanoseconds taken by a pure expression.
@@ -25,7 +29,7 @@ public abbrev TimingInfo := Std.HashMap String Nat
   pure (result, t2 - t1)
 
 /-- Run an action and record its elapsed nanoseconds into a `TimingInfo` under the given key. -/
-@[inline] public def recordNanos {m α} [Monad m] [MonadLiftT BaseIO m]
+public def recordNanos {m α} [Monad m] [MonadLiftT BaseIO m]
     (key : String) (timing : TimingInfo) (action : m α) : m (α × TimingInfo) := do
   let t0 ← IO.monoNanosNow
   let result ← action

--- a/StrataTest/DL/Imperative/SMTEncoder.lean
+++ b/StrataTest/DL/Imperative/SMTEncoder.lean
@@ -72,7 +72,7 @@ def ProofObligation.toSMTTerms (E : Env) (d : Imperative.ProofObligation Arith.P
   let obligation_term := Factory.not obligation_pos_term
   .ok (assumptions_terms ++ [obligation_term])
 
-def encodeArithToSMTTerms (ts : List Term) : SolverM (List String × EncoderState × Std.HashMap String Nat) := do
+def encodeArithToSMTTerms (ts : List Term) : SolverM (List String × EncoderState × TimingInfo) := do
   Solver.setLogic "ALL"
   let estate := EncoderState.init
   let (termEncs, estate) ← ts.mapM (Strata.SMT.Encoder.encodeTerm) |>.run estate

--- a/StrataTest/DL/Imperative/SMTEncoder.lean
+++ b/StrataTest/DL/Imperative/SMTEncoder.lean
@@ -7,6 +7,7 @@
 import StrataTest.DL.Imperative.Arith
 import Strata.DL.Imperative.EvalContext
 import Strata.DL.SMT.SMT
+import Strata.Util.Profile
 import Init.Data.String.Extra
 
 namespace Arith
@@ -80,7 +81,8 @@ def encodeArithToSMTTerms (ts : List Term) : SolverM (List String × EncoderStat
     Solver.assert t
   let ids := estate.ufs.values
   let _ ← Solver.checkSat ids
-  return (ids, estate, {})
+  let timing : TimingInfo := default
+  return (ids, estate, timing)
 
 ---------------------------------------------------------------------
 

--- a/StrataTest/DL/Imperative/SMTEncoder.lean
+++ b/StrataTest/DL/Imperative/SMTEncoder.lean
@@ -72,7 +72,7 @@ def ProofObligation.toSMTTerms (E : Env) (d : Imperative.ProofObligation Arith.P
   let obligation_term := Factory.not obligation_pos_term
   .ok (assumptions_terms ++ [obligation_term])
 
-def encodeArithToSMTTerms (ts : List Term) : SolverM (List String × EncoderState) := do
+def encodeArithToSMTTerms (ts : List Term) : SolverM (List String × EncoderState × Std.HashMap String Nat) := do
   Solver.setLogic "ALL"
   let estate := EncoderState.init
   let (termEncs, estate) ← ts.mapM (Strata.SMT.Encoder.encodeTerm) |>.run estate
@@ -80,7 +80,7 @@ def encodeArithToSMTTerms (ts : List Term) : SolverM (List String × EncoderStat
     Solver.assert t
   let ids := estate.ufs.values
   let _ ← Solver.checkSat ids
-  return (ids, estate)
+  return (ids, estate, {})
 
 ---------------------------------------------------------------------
 

--- a/StrataTest/DL/Imperative/Verify.lean
+++ b/StrataTest/DL/Imperative/Verify.lean
@@ -58,7 +58,7 @@ def verify (cmds : Commands) (verbose : Bool) :
                 "cvc5" filename.toString
                 #["--produce-models"] false false true false)
         match ans with
-        | Except.ok (_, result, estate) =>
+        | Except.ok (_, result, estate, _) =>
            let vcres := { obligation, result, estate }
            results := results.push vcres
            if result ≠ .unsat then

--- a/StrataTest/Util/Profile.lean
+++ b/StrataTest/Util/Profile.lean
@@ -1,0 +1,18 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+import Strata.Util.Profile
+
+def measureNanos_nonzero : BaseIO Bool := do
+  let (_, ns) ← measureNanos fun () =>
+    -- Large enough to comfortably exceed monoNanosNow resolution on any host.
+    (List.range 200000).foldl (· + ·) 0
+  pure (ns > 0)
+
+#eval show IO Unit from do
+  unless (← measureNanos_nonzero.toIO) do
+    throw <| IO.userError "measureNanos regressed to 0 ns"


### PR DESCRIPTION
Lean sometimes reorders invocation of current time function with other code:

```
let t1 ← IO.monoNanosNow
let res := (some heavyweight work)
let t2 ← IO.monoNanosNow
let elapsedTime := t2 - t1
```
into:
```
let res := (some heavyweight work)
let t1 ← IO.monoNanosNow
let t2 ← IO.monoNanosNow
let elapsedTime := t2 - t1 // This is trivially zero!
```

And this made the SMT encoding time (the ProofObligation object -> SMT Term, Definition, etc) appearing as zero ms, but actually it was taking around 20% of the whole VC dischare process.

Also, this pull request adds much more fine-grained reports on running times: it reports on (1) each Core transform, and (2) each SMT query generation.

```
[profile]     ProcedureInlining: 0ms             
[profile]     FilterProcedures: 0ms           
[profile]     CallElim: 0ms                   
[profile]     PrecondElim: 1ms  
[profile]     FilterProcedures: 0ms       
[profile]     LoopElim: 0ms
[profile]     typeCheck: 2ms
[profile]     symbolicEval: 2ms             
[profile]     ANFEncoder: 0ms  
[profile]   Program transformations: 5ms
[profile]   Build axiom relevance cache: 0ms
[profile]     Preprocess obligations: 3ms
[profile]     SMT encoding: 8ms
[profile]         defineFunTerms: 2ms
[profile]         emitDatatypes: 1ms
[profile]         encodeAssumptions: 0ms
[profile]         encodeAxioms: 0ms
[profile]         encodeFunctions: 1ms
[profile]         encodeObligation: 0ms
[profile]         encodeUFs: 3ms
[profile]         epilog: 3ms
[profile]         prelude: 0ms
[profile]       encodeCore: 24ms
[profile]       runSolver: 0ms
[profile]     Solver/file writing: 26ms
[profile]     Obligations: 20 total, 0 resolved by evaluator
[profile]   VC discharge: 38ms

``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
