### PR TITLE
feat(transform): Add optional SSA transformation for Strata Core

### DIFF
--- a/Strata/SimpleAPI.lean
+++ b/Strata/SimpleAPI.lean
@@ -264,7 +264,7 @@ private def Core.applyPass (program : Core.Program) (pass : Core.TransformPass)
     let (_, prog) ← Core.Transform.runProgram coreCallElimCmd program
     return prog
   | .ssa =>
-    let (_, prog) ← Core.SSA.ssaPipelinePhase.transform program
+    let (_, prog) ← Core.SSA.ssaTransform program
     return prog
   | .filterProcedures procs =>
     Core.FilterProcedures.run program procs

--- a/Strata/SimpleAPI.lean
+++ b/Strata/SimpleAPI.lean
@@ -13,6 +13,7 @@ import Strata.Transform.LoopElim
 public import Strata.Transform.ProcedureInlining
 import Strata.Transform.FilterProcedures
 import Strata.Transform.IrrelevantAxioms
+import Strata.Transform.SSA
 
 public import Strata.Languages.Core.Options
 public import Strata.Languages.Core.Verifier
@@ -246,6 +247,7 @@ inductive Core.TransformPass where
   | inlineProcedures (opts : Core.InlineTransformOptions := {})
   | loopElim
   | callElim
+  | ssa
   | filterProcedures (procs : List String)
   | removeIrrelevantAxioms (funcs : List String)
 
@@ -260,6 +262,9 @@ private def Core.applyPass (program : Core.Program) (pass : Core.TransformPass)
     pure (Core.loopElim program).fst
   | .callElim =>
     let (_, prog) ← Core.Transform.runProgram coreCallElimCmd program
+    return prog
+  | .ssa =>
+    let (_, prog) ← Core.SSA.ssaPipelinePhase.transform program
     return prog
   | .filterProcedures procs =>
     Core.FilterProcedures.run program procs

--- a/Strata/Transform/SSA.lean
+++ b/Strata/Transform/SSA.lean
@@ -104,28 +104,28 @@ def transformCmd (env : Env) (cmd : Command) : CoreTransformM (Env × List State
     | some info =>
       let freshId ← genSSAIdent name.name
       let some mty := LTy.toMonoType? info.ty
-        | throw s!"SSA: type of '{name.name}' is not a monotype"
+        | throw (Strata.DiagnosticModel.fromMessage s!"SSA: type of '{name.name}' is not a monotype")
       let env' := env.insert name.name { ident := freshId, ty := info.ty }
       incrementStat s!"{Stats.renamedVars}"
       return (env', [Statement.init freshId (.forAll [] mty) (.det expr') smd])
-    | none => throw s!"SSA: variable '{name.name}' not found in environment (set)"
+    | none => throw (Strata.DiagnosticModel.fromMessage s!"SSA: variable '{name.name}' not found in environment (set)")
   | .cmd (.set name .nondet smd) =>
     match env.get? name.name with
     | some info =>
       let freshId ← genSSAIdent name.name
       let some mty := LTy.toMonoType? info.ty
-        | throw s!"SSA: type of '{name.name}' is not a monotype"
+        | throw (Strata.DiagnosticModel.fromMessage s!"SSA: type of '{name.name}' is not a monotype")
       let env' := env.insert name.name { ident := freshId, ty := info.ty }
       incrementStat s!"{Stats.renamedVars}"
       return (env', [Statement.init freshId (.forAll [] mty) .nondet smd])
-    | none => throw s!"SSA: variable '{name.name}' not found in environment (havoc)"
+    | none => throw (Strata.DiagnosticModel.fromMessage s!"SSA: variable '{name.name}' not found in environment (havoc)")
   | .cmd (.assert label b amd) =>
     return (env, [Statement.assert label (rewriteExpr env b) amd])
   | .cmd (.assume label b amd) =>
     return (env, [Statement.assume label (rewriteExpr env b) amd])
   | .cmd (.cover label b cmd') =>
     return (env, [Statement.cover label (rewriteExpr env b) cmd'])
-  | .call _ _ _ => throw "SSA: unexpected call command (callElim should have run first)"
+  | .call _ _ _ => throw (Strata.DiagnosticModel.fromMessage "SSA: unexpected call command (callElim should have run first)")
 
 private def collectAllKeys (envs : List Env) : List String :=
   let hs := envs.foldl (fun acc env =>
@@ -149,7 +149,7 @@ def emitJoinMerges (condVar : Expression.Ident)
       let elseId := getIdOr elseInfo preInfo origName
       let ty := getTyOr thenInfo elseInfo preInfo
       let some mty := LTy.toMonoType? ty
-        | throw s!"SSA: type of '{origName}' is not a monotype at join point"
+        | throw (Strata.DiagnosticModel.fromMessage s!"SSA: type of '{origName}' is not a monotype at join point")
       let freshId ← genSSAIdent origName
       let iteExpr : Expression.Expr :=
         Lambda.LExpr.ite () (createFvar condVar) (createFvar thenId) (createFvar elseId)
@@ -176,7 +176,7 @@ def emitNondetJoinHavocs (preEnv thenEnv elseEnv : Env)
     if varChanged thenInfo preInfo || varChanged elseInfo preInfo then
       let ty := getTyOr thenInfo elseInfo preInfo
       let some mty := LTy.toMonoType? ty
-        | throw s!"SSA: type of '{origName}' is not a monotype at nondet join"
+        | throw (Strata.DiagnosticModel.fromMessage s!"SSA: type of '{origName}' is not a monotype at nondet join")
       let freshId ← genSSAIdent origName
       havoces := havoces ++ [Statement.init freshId (.forAll [] mty) .nondet md]
       env := env.insert origName { ident := freshId, ty := ty }
@@ -214,7 +214,7 @@ partial def transformStmt (env : Env) (s : Statement) : CoreTransformM (Env × L
       let (mergedEnv, havoces) ← emitNondetJoinHavocs env thenEnv elseEnv md
       return (mergedEnv, [Stmt.ite .nondet thenStmts' elseStmts' md] ++ havoces)
   | .loop _ _ _ _ _ =>
-    throw "SSA: unexpected loop statement (loopElim should have run first)"
+    throw (Strata.DiagnosticModel.fromMessage "SSA: unexpected loop statement (loopElim should have run first)")
   | .exit label md => return (env, [Stmt.exit label md])
   | .funcDecl decl md => return (env, [Stmt.funcDecl decl md])
   | .typeDecl tc md => return (env, [Stmt.typeDecl tc md])

--- a/Strata/Transform/SSA.lean
+++ b/Strata/Transform/SSA.lean
@@ -1,0 +1,273 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.Languages.Core.PipelinePhase
+
+/-! # SSA (Static Single Assignment) Transformation
+
+Converts Strata Core procedure bodies into SSA form where every variable is
+assigned exactly once via `init`. At if-then-else join points, conditional
+`init` expressions merge divergent variable versions.
+
+Preconditions: runs after `callElim` and `loopElim`.
+SSA is semantics-preserving, so the pipeline phase uses `modelPreserving`.
+-/
+
+namespace Core
+namespace SSA
+
+open Imperative Lambda
+
+public section
+
+/-- Statistics keys tracked by the SSA transformation. -/
+inductive Stats where
+  | renamedVars
+  | joinPointMerges
+
+#derive_prefixed_toString Stats "SSA"
+
+structure VarInfo where
+  ident : Expression.Ident
+  ty    : Expression.Ty
+  deriving Repr, BEq
+
+abbrev Env := Std.HashMap String VarInfo
+
+structure SSAState where
+  counter : Nat := 0
+  env : Env := {}
+  statistics : Statistics := {}
+
+abbrev SSAM := ExceptT String (StateM SSAState)
+
+def freshIdent (baseName : String) : SSAM Expression.Ident := do
+  let st ← get
+  let freshName := s!"{baseName}_{st.counter}"
+  set { st with counter := st.counter + 1 }
+  return ⟨freshName, ()⟩
+
+def bindVar (origName : String) (newIdent : Expression.Ident) (ty : Expression.Ty) : SSAM Unit :=
+  modify fun st => { st with env := st.env.insert origName { ident := newIdent, ty := ty } }
+
+def incrStat (key : String) (n : Nat := 1) : SSAM Unit :=
+  modify fun st => { st with statistics := st.statistics.increment key n }
+
+def mkFvar (id : Expression.Ident) : Expression.Expr :=
+  Lambda.LExpr.fvar ((): ExpressionMetadata) id none
+
+def rewriteExpr (e : Expression.Expr) : SSAM Expression.Expr := do
+  let env := (← get).env
+  if env.isEmpty then return e
+  let sm : Map Expression.Ident Expression.Expr :=
+    env.fold (init := Map.empty) fun acc origName info =>
+      acc.insert ⟨origName, ()⟩ (mkFvar info.ident)
+  return Lambda.LExpr.substFvars e sm
+
+def rewriteExprOrNondet (e : ExprOrNondet Expression) : SSAM (ExprOrNondet Expression) :=
+  match e with
+  | .det expr => return .det (← rewriteExpr expr)
+  | .nondet => return .nondet
+
+def getEnv : SSAM Env := return (← get).env
+
+def setEnv (env : Env) : SSAM Unit :=
+  modify fun st => { st with env := env }
+
+/-- Helper to get the identifier from a VarInfo option, with fallback. -/
+private def getIdOr (info : Option VarInfo) (fallback : Option VarInfo) (origName : String)
+    : Expression.Ident :=
+  match info with
+  | some i => i.ident
+  | none => match fallback with
+    | some i => i.ident
+    | none => ⟨origName, ()⟩
+
+/-- Helper to get the type from multiple VarInfo options. -/
+private def getTyOr (a b c : Option VarInfo) : Expression.Ty :=
+  match a with
+  | some i => i.ty
+  | none => match b with
+    | some i => i.ty
+    | none => match c with
+      | some i => i.ty
+      | none => .forAll [] .bool
+
+/-- Check if a variable changed between two environments. -/
+private def varChanged (info pre : Option VarInfo) : Bool :=
+  match info, pre with
+  | some t, some p => t.ident != p.ident
+  | some _, none => true
+  | none, _ => false
+
+def transformCmd (cmd : Command) : SSAM (List Statement) := do
+  match cmd with
+  | .cmd (.init name ty rhs imd) =>
+    let rhs' ← rewriteExprOrNondet rhs
+    let freshId ← freshIdent name.name
+    bindVar name.name freshId ty
+    incrStat s!"{Stats.renamedVars}"
+    return [Statement.init freshId ty rhs' imd]
+  | .cmd (.set name (.det expr) smd) =>
+    let expr' ← rewriteExpr expr
+    match (← get).env.get? name.name with
+    | some info =>
+      let freshId ← freshIdent name.name
+      let some mty := LTy.toMonoType? info.ty
+        | throw s!"SSA: type of '{name.name}' is not a monotype"
+      bindVar name.name freshId info.ty
+      incrStat s!"{Stats.renamedVars}"
+      return [Statement.init freshId (.forAll [] mty) (.det expr') smd]
+    | none => throw s!"SSA: variable '{name.name}' not found in environment (set)"
+  | .cmd (.set name .nondet smd) =>
+    match (← get).env.get? name.name with
+    | some info =>
+      let freshId ← freshIdent name.name
+      let some mty := LTy.toMonoType? info.ty
+        | throw s!"SSA: type of '{name.name}' is not a monotype"
+      bindVar name.name freshId info.ty
+      incrStat s!"{Stats.renamedVars}"
+      return [Statement.init freshId (.forAll [] mty) .nondet smd]
+    | none => throw s!"SSA: variable '{name.name}' not found in environment (havoc)"
+  | .cmd (.assert label b amd) => return [Statement.assert label (← rewriteExpr b) amd]
+  | .cmd (.assume label b amd) => return [Statement.assume label (← rewriteExpr b) amd]
+  | .cmd (.cover label b cmd') => return [Statement.cover label (← rewriteExpr b) cmd']
+  | .call _ _ _ => throw "SSA: unexpected call command (callElim should have run first)"
+
+private def collectAllKeys (envs : List Env) : List String :=
+  let hs := envs.foldl (fun acc env =>
+    env.fold (init := acc) fun acc k _ => acc.insert k)
+    (Std.HashSet.emptyWithCapacity (α := String))
+  hs.toList
+
+def emitJoinMerges (condVar : Expression.Ident)
+    (preEnv thenEnv elseEnv : Env)
+    (md : Imperative.MetaData Expression) : SSAM (List Statement) := do
+  let allKeys := collectAllKeys [preEnv, thenEnv, elseEnv]
+  let mut merges : List Statement := []
+  for origName in allKeys do
+    let preInfo := preEnv.get? origName
+    let thenInfo := thenEnv.get? origName
+    let elseInfo := elseEnv.get? origName
+    if varChanged thenInfo preInfo || varChanged elseInfo preInfo then
+      let thenId := getIdOr thenInfo preInfo origName
+      let elseId := getIdOr elseInfo preInfo origName
+      let ty := getTyOr thenInfo elseInfo preInfo
+      let some mty := LTy.toMonoType? ty
+        | throw s!"SSA: type of '{origName}' is not a monotype at join point"
+      let freshId ← freshIdent origName
+      let iteExpr : Expression.Expr :=
+        Lambda.LExpr.ite () (mkFvar condVar) (mkFvar thenId) (mkFvar elseId)
+      merges := merges ++ [Statement.init freshId (.forAll [] mty) (.det iteExpr) md]
+      bindVar origName freshId ty
+      incrStat s!"{Stats.joinPointMerges}"
+  return merges
+
+def emitNondetJoinHavocs (preEnv thenEnv elseEnv : Env)
+    (md : Imperative.MetaData Expression) : SSAM (List Statement) := do
+  let allKeys := collectAllKeys [preEnv, thenEnv, elseEnv]
+  let mut havoces : List Statement := []
+  for origName in allKeys do
+    let preInfo := preEnv.get? origName
+    let thenInfo := thenEnv.get? origName
+    let elseInfo := elseEnv.get? origName
+    if varChanged thenInfo preInfo || varChanged elseInfo preInfo then
+      let ty := getTyOr thenInfo elseInfo preInfo
+      let some mty := LTy.toMonoType? ty
+        | throw s!"SSA: type of '{origName}' is not a monotype at nondet join"
+      let freshId ← freshIdent origName
+      havoces := havoces ++ [Statement.init freshId (.forAll [] mty) .nondet md]
+      bindVar origName freshId ty
+      incrStat s!"{Stats.joinPointMerges}"
+  return havoces
+
+def initEnvFromProcedure (proc : Procedure) : SSAM Unit := do
+  let _ ← (proc.header.inputs : List _).mapM fun (id, mty) =>
+    bindVar id.name id (.forAll [] mty)
+  let _ ← (proc.header.outputs : List _).mapM fun (id, mty) =>
+    bindVar id.name id (.forAll [] mty)
+
+mutual
+partial def transformStmt (s : Statement) : SSAM (List Statement) := do
+  match s with
+  | .cmd cmd => transformCmd cmd
+  | .block label stmts md =>
+    let stmts' ← transformBlock stmts
+    return [Stmt.block label stmts' md]
+  | .ite cond thenStmts elseStmts md =>
+    match cond with
+    | .det condExpr =>
+      let condExpr' ← rewriteExpr condExpr
+      let condVar ← freshIdent "$ssa_cond"
+      let condInit := Statement.init condVar (.forAll [] LMonoTy.bool) (.det condExpr') md
+      let preEnv ← getEnv
+      let thenStmts' ← transformBlock thenStmts
+      let thenEnv ← getEnv
+      setEnv preEnv
+      let elseStmts' ← transformBlock elseStmts
+      let elseEnv ← getEnv
+      let merges ← emitJoinMerges condVar preEnv thenEnv elseEnv md
+      let iteStmt := Stmt.ite (.det (mkFvar condVar)) thenStmts' elseStmts' md
+      return [condInit, iteStmt] ++ merges
+    | .nondet =>
+      let preEnv ← getEnv
+      let thenStmts' ← transformBlock thenStmts
+      let thenEnv ← getEnv
+      setEnv preEnv
+      let elseStmts' ← transformBlock elseStmts
+      let elseEnv ← getEnv
+      let havoces ← emitNondetJoinHavocs preEnv thenEnv elseEnv md
+      return [Stmt.ite .nondet thenStmts' elseStmts' md] ++ havoces
+  | .loop _ _ _ _ _ =>
+    throw "SSA: unexpected loop statement (loopElim should have run first)"
+  | .exit label md => return [Stmt.exit label md]
+  | .funcDecl decl md => return [Stmt.funcDecl decl md]
+  | .typeDecl tc md => return [Stmt.typeDecl tc md]
+
+partial def transformBlock (stmts : List Statement) : SSAM (List Statement) := do
+  let mut result : List Statement := []
+  for s in stmts do
+    let stmts' ← transformStmt s
+    result := result ++ stmts'
+  return result
+end
+
+def transformProcedure (proc : Procedure) : SSAM Procedure := do
+  if proc.body.isEmpty then return proc
+  initEnvFromProcedure proc
+  let body' ← transformBlock proc.body
+  return { proc with body := body' }
+
+def ssaTransform (p : Program) : Except String (Program × Statistics) := do
+  let decls ← p.decls.mapM fun d =>
+    match d with
+    | .proc proc md =>
+      let initState : SSAState := {}
+      let (result, finalState) := StateT.run (transformProcedure proc) initState
+      match result with
+      | .ok proc' => .ok (.proc proc' md, finalState.statistics)
+      | .error e => .error s!"SSA error in procedure '{proc.header.name}': {e}"
+    | other => .ok (other, {})
+  let (decls', stats) := decls.foldl (fun (acc, stats) (d, s) =>
+    (acc ++ [d], stats.merge s)) ([], {})
+  .ok ({ decls := decls' }, stats)
+
+def ssaTransform' (p : Program) : Transform.CoreTransformM (Bool × Program) := do
+  match ssaTransform p with
+  | .ok (p', stats) =>
+    modify fun σ => { σ with statistics := σ.statistics.merge stats }
+    return (true, p')
+  | .error e => throw e
+
+def ssaPipelinePhase : PipelinePhase where
+  transform := ssaTransform'
+  phase.name := "SSA"
+  phase.getValidation _ := .modelPreserving
+
+end -- public section
+end SSA
+end Core

--- a/Strata/Transform/SSA.lean
+++ b/Strata/Transform/SSA.lean
@@ -21,6 +21,7 @@ namespace Core
 namespace SSA
 
 open Imperative Lambda
+open Core.Transform
 
 public section
 
@@ -31,55 +32,39 @@ inductive Stats where
 
 #derive_prefixed_toString Stats "SSA"
 
+/-- An entry in the SSA environment: the current versioned identifier and its type. -/
 structure VarInfo where
   ident : Expression.Ident
   ty    : Expression.Ty
   deriving Repr, BEq
 
+/-- The SSA environment maps original variable names to their current version and type. -/
 abbrev Env := Std.HashMap String VarInfo
 
-structure SSAState where
-  counter : Nat := 0
-  env : Env := {}
-  statistics : Statistics := {}
+/-- SSA name prefix for fresh variables. -/
+def ssaVarPrefix (id : String) : String := s!"ssa_{id}"
 
-abbrev SSAM := ExceptT String (StateM SSAState)
+/-- Generate a fresh SSA identifier using the CoreTransformM generator. -/
+def genSSAIdent (baseName : String) : CoreTransformM Expression.Ident :=
+  genIdent ⟨baseName, ()⟩ ssaVarPrefix
 
-def freshIdent (baseName : String) : SSAM Expression.Ident := do
-  let st ← get
-  let freshName := s!"{baseName}_{st.counter}"
-  set { st with counter := st.counter + 1 }
-  return ⟨freshName, ()⟩
+/-- Rewrite free variables in an expression according to the SSA environment. -/
+def rewriteExpr (env : Env) (e : Expression.Expr) : Expression.Expr :=
+  if env.isEmpty then e
+  else
+    let sm : Map Expression.Ident Expression.Expr :=
+      env.fold (init := Map.empty) fun acc origName info =>
+        acc.insert ⟨origName, ()⟩ (createFvar info.ident)
+    Lambda.LExpr.substFvars e sm
 
-def bindVar (origName : String) (newIdent : Expression.Ident) (ty : Expression.Ty) : SSAM Unit :=
-  modify fun st => { st with env := st.env.insert origName { ident := newIdent, ty := ty } }
-
-def incrStat (key : String) (n : Nat := 1) : SSAM Unit :=
-  modify fun st => { st with statistics := st.statistics.increment key n }
-
-def mkFvar (id : Expression.Ident) : Expression.Expr :=
-  Lambda.LExpr.fvar ((): ExpressionMetadata) id none
-
-def rewriteExpr (e : Expression.Expr) : SSAM Expression.Expr := do
-  let env := (← get).env
-  if env.isEmpty then return e
-  let sm : Map Expression.Ident Expression.Expr :=
-    env.fold (init := Map.empty) fun acc origName info =>
-      acc.insert ⟨origName, ()⟩ (mkFvar info.ident)
-  return Lambda.LExpr.substFvars e sm
-
-def rewriteExprOrNondet (e : ExprOrNondet Expression) : SSAM (ExprOrNondet Expression) :=
+/-- Rewrite free variables in an `ExprOrNondet`. -/
+def rewriteExprOrNondet (env : Env) (e : ExprOrNondet Expression) : ExprOrNondet Expression :=
   match e with
-  | .det expr => return .det (← rewriteExpr expr)
-  | .nondet => return .nondet
-
-def getEnv : SSAM Env := return (← get).env
-
-def setEnv (env : Env) : SSAM Unit :=
-  modify fun st => { st with env := env }
+  | .det expr => .det (rewriteExpr env expr)
+  | .nondet => .nondet
 
 /-- Helper to get the identifier from a VarInfo option, with fallback. -/
-private def getIdOr (info : Option VarInfo) (fallback : Option VarInfo) (origName : String)
+private def getIdOr (info fallback : Option VarInfo) (origName : String)
     : Expression.Ident :=
   match info with
   | some i => i.ident
@@ -104,38 +89,42 @@ private def varChanged (info pre : Option VarInfo) : Bool :=
   | some _, none => true
   | none, _ => false
 
-def transformCmd (cmd : Command) : SSAM (List Statement) := do
+/-- Transform a single command in SSA form. Returns updated env and new statements. -/
+def transformCmd (env : Env) (cmd : Command) : CoreTransformM (Env × List Statement) := do
   match cmd with
   | .cmd (.init name ty rhs imd) =>
-    let rhs' ← rewriteExprOrNondet rhs
-    let freshId ← freshIdent name.name
-    bindVar name.name freshId ty
-    incrStat s!"{Stats.renamedVars}"
-    return [Statement.init freshId ty rhs' imd]
+    let rhs' := rewriteExprOrNondet env rhs
+    let freshId ← genSSAIdent name.name
+    let env' := env.insert name.name { ident := freshId, ty := ty }
+    incrementStat s!"{Stats.renamedVars}"
+    return (env', [Statement.init freshId ty rhs' imd])
   | .cmd (.set name (.det expr) smd) =>
-    let expr' ← rewriteExpr expr
-    match (← get).env.get? name.name with
+    let expr' := rewriteExpr env expr
+    match env.get? name.name with
     | some info =>
-      let freshId ← freshIdent name.name
+      let freshId ← genSSAIdent name.name
       let some mty := LTy.toMonoType? info.ty
         | throw s!"SSA: type of '{name.name}' is not a monotype"
-      bindVar name.name freshId info.ty
-      incrStat s!"{Stats.renamedVars}"
-      return [Statement.init freshId (.forAll [] mty) (.det expr') smd]
+      let env' := env.insert name.name { ident := freshId, ty := info.ty }
+      incrementStat s!"{Stats.renamedVars}"
+      return (env', [Statement.init freshId (.forAll [] mty) (.det expr') smd])
     | none => throw s!"SSA: variable '{name.name}' not found in environment (set)"
   | .cmd (.set name .nondet smd) =>
-    match (← get).env.get? name.name with
+    match env.get? name.name with
     | some info =>
-      let freshId ← freshIdent name.name
+      let freshId ← genSSAIdent name.name
       let some mty := LTy.toMonoType? info.ty
         | throw s!"SSA: type of '{name.name}' is not a monotype"
-      bindVar name.name freshId info.ty
-      incrStat s!"{Stats.renamedVars}"
-      return [Statement.init freshId (.forAll [] mty) .nondet smd]
+      let env' := env.insert name.name { ident := freshId, ty := info.ty }
+      incrementStat s!"{Stats.renamedVars}"
+      return (env', [Statement.init freshId (.forAll [] mty) .nondet smd])
     | none => throw s!"SSA: variable '{name.name}' not found in environment (havoc)"
-  | .cmd (.assert label b amd) => return [Statement.assert label (← rewriteExpr b) amd]
-  | .cmd (.assume label b amd) => return [Statement.assume label (← rewriteExpr b) amd]
-  | .cmd (.cover label b cmd') => return [Statement.cover label (← rewriteExpr b) cmd']
+  | .cmd (.assert label b amd) =>
+    return (env, [Statement.assert label (rewriteExpr env b) amd])
+  | .cmd (.assume label b amd) =>
+    return (env, [Statement.assume label (rewriteExpr env b) amd])
+  | .cmd (.cover label b cmd') =>
+    return (env, [Statement.cover label (rewriteExpr env b) cmd'])
   | .call _ _ _ => throw "SSA: unexpected call command (callElim should have run first)"
 
 private def collectAllKeys (envs : List Env) : List String :=
@@ -144,10 +133,12 @@ private def collectAllKeys (envs : List Env) : List String :=
     (Std.HashSet.emptyWithCapacity (α := String))
   hs.toList
 
+/-- Emit conditional merge inits at a deterministic join point. -/
 def emitJoinMerges (condVar : Expression.Ident)
     (preEnv thenEnv elseEnv : Env)
-    (md : Imperative.MetaData Expression) : SSAM (List Statement) := do
+    (md : Imperative.MetaData Expression) : CoreTransformM (Env × List Statement) := do
   let allKeys := collectAllKeys [preEnv, thenEnv, elseEnv]
+  let mut env := thenEnv  -- start from one branch, will be overwritten for changed vars
   let mut merges : List Statement := []
   for origName in allKeys do
     let preInfo := preEnv.get? origName
@@ -159,17 +150,24 @@ def emitJoinMerges (condVar : Expression.Ident)
       let ty := getTyOr thenInfo elseInfo preInfo
       let some mty := LTy.toMonoType? ty
         | throw s!"SSA: type of '{origName}' is not a monotype at join point"
-      let freshId ← freshIdent origName
+      let freshId ← genSSAIdent origName
       let iteExpr : Expression.Expr :=
-        Lambda.LExpr.ite () (mkFvar condVar) (mkFvar thenId) (mkFvar elseId)
+        Lambda.LExpr.ite () (createFvar condVar) (createFvar thenId) (createFvar elseId)
       merges := merges ++ [Statement.init freshId (.forAll [] mty) (.det iteExpr) md]
-      bindVar origName freshId ty
-      incrStat s!"{Stats.joinPointMerges}"
-  return merges
+      env := env.insert origName { ident := freshId, ty := ty }
+      incrementStat s!"{Stats.joinPointMerges}"
+    else
+      -- Variable unchanged: keep the pre-branch version
+      match preInfo with
+      | some info => env := env.insert origName info
+      | none => pure ()
+  return (env, merges)
 
+/-- Emit havoc inits at a nondet join point. -/
 def emitNondetJoinHavocs (preEnv thenEnv elseEnv : Env)
-    (md : Imperative.MetaData Expression) : SSAM (List Statement) := do
+    (md : Imperative.MetaData Expression) : CoreTransformM (Env × List Statement) := do
   let allKeys := collectAllKeys [preEnv, thenEnv, elseEnv]
+  let mut env := preEnv
   let mut havoces : List Statement := []
   for origName in allKeys do
     let preInfo := preEnv.get? origName
@@ -179,92 +177,78 @@ def emitNondetJoinHavocs (preEnv thenEnv elseEnv : Env)
       let ty := getTyOr thenInfo elseInfo preInfo
       let some mty := LTy.toMonoType? ty
         | throw s!"SSA: type of '{origName}' is not a monotype at nondet join"
-      let freshId ← freshIdent origName
+      let freshId ← genSSAIdent origName
       havoces := havoces ++ [Statement.init freshId (.forAll [] mty) .nondet md]
-      bindVar origName freshId ty
-      incrStat s!"{Stats.joinPointMerges}"
-  return havoces
+      env := env.insert origName { ident := freshId, ty := ty }
+      incrementStat s!"{Stats.joinPointMerges}"
+  return (env, havoces)
 
-def initEnvFromProcedure (proc : Procedure) : SSAM Unit := do
-  let _ ← (proc.header.inputs : List _).mapM fun (id, mty) =>
-    bindVar id.name id (.forAll [] mty)
-  let _ ← (proc.header.outputs : List _).mapM fun (id, mty) =>
-    bindVar id.name id (.forAll [] mty)
+/-- Initialize the SSA environment from a procedure's parameters. -/
+def initEnvFromProcedure (proc : Procedure) : Env :=
+  let env := (proc.header.inputs : List _).foldl (fun acc (id, mty) =>
+    acc.insert id.name { ident := id, ty := .forAll [] mty }) {}
+  (proc.header.outputs : List _).foldl (fun acc (id, mty) =>
+    acc.insert id.name { ident := id, ty := .forAll [] mty }) env
 
 mutual
-partial def transformStmt (s : Statement) : SSAM (List Statement) := do
+partial def transformStmt (env : Env) (s : Statement) : CoreTransformM (Env × List Statement) := do
   match s with
-  | .cmd cmd => transformCmd cmd
+  | .cmd cmd => transformCmd env cmd
   | .block label stmts md =>
-    let stmts' ← transformBlock stmts
-    return [Stmt.block label stmts' md]
+    let (env', stmts') ← transformBlock env stmts
+    return (env', [Stmt.block label stmts' md])
   | .ite cond thenStmts elseStmts md =>
     match cond with
     | .det condExpr =>
-      let condExpr' ← rewriteExpr condExpr
-      let condVar ← freshIdent "$ssa_cond"
+      let condExpr' := rewriteExpr env condExpr
+      let condVar ← genSSAIdent "$ssa_cond"
       let condInit := Statement.init condVar (.forAll [] LMonoTy.bool) (.det condExpr') md
-      let preEnv ← getEnv
-      let thenStmts' ← transformBlock thenStmts
-      let thenEnv ← getEnv
-      setEnv preEnv
-      let elseStmts' ← transformBlock elseStmts
-      let elseEnv ← getEnv
-      let merges ← emitJoinMerges condVar preEnv thenEnv elseEnv md
-      let iteStmt := Stmt.ite (.det (mkFvar condVar)) thenStmts' elseStmts' md
-      return [condInit, iteStmt] ++ merges
+      let (thenEnv, thenStmts') ← transformBlock env thenStmts
+      let (elseEnv, elseStmts') ← transformBlock env elseStmts
+      let (mergedEnv, merges) ← emitJoinMerges condVar env thenEnv elseEnv md
+      let iteStmt := Stmt.ite (.det (createFvar condVar)) thenStmts' elseStmts' md
+      return (mergedEnv, [condInit, iteStmt] ++ merges)
     | .nondet =>
-      let preEnv ← getEnv
-      let thenStmts' ← transformBlock thenStmts
-      let thenEnv ← getEnv
-      setEnv preEnv
-      let elseStmts' ← transformBlock elseStmts
-      let elseEnv ← getEnv
-      let havoces ← emitNondetJoinHavocs preEnv thenEnv elseEnv md
-      return [Stmt.ite .nondet thenStmts' elseStmts' md] ++ havoces
+      let (thenEnv, thenStmts') ← transformBlock env thenStmts
+      let (elseEnv, elseStmts') ← transformBlock env elseStmts
+      let (mergedEnv, havoces) ← emitNondetJoinHavocs env thenEnv elseEnv md
+      return (mergedEnv, [Stmt.ite .nondet thenStmts' elseStmts' md] ++ havoces)
   | .loop _ _ _ _ _ =>
     throw "SSA: unexpected loop statement (loopElim should have run first)"
-  | .exit label md => return [Stmt.exit label md]
-  | .funcDecl decl md => return [Stmt.funcDecl decl md]
-  | .typeDecl tc md => return [Stmt.typeDecl tc md]
+  | .exit label md => return (env, [Stmt.exit label md])
+  | .funcDecl decl md => return (env, [Stmt.funcDecl decl md])
+  | .typeDecl tc md => return (env, [Stmt.typeDecl tc md])
 
-partial def transformBlock (stmts : List Statement) : SSAM (List Statement) := do
+partial def transformBlock (env : Env) (stmts : List Statement)
+    : CoreTransformM (Env × List Statement) := do
+  let mut curEnv := env
   let mut result : List Statement := []
   for s in stmts do
-    let stmts' ← transformStmt s
+    let (env', stmts') ← transformStmt curEnv s
+    curEnv := env'
     result := result ++ stmts'
-  return result
+  return (curEnv, result)
 end
 
-def transformProcedure (proc : Procedure) : SSAM Procedure := do
+/-- Transform a single procedure into SSA form. -/
+def transformProcedure (proc : Procedure) : CoreTransformM Procedure := do
   if proc.body.isEmpty then return proc
-  initEnvFromProcedure proc
-  let body' ← transformBlock proc.body
+  let env := initEnvFromProcedure proc
+  let (_, body') ← transformBlock env proc.body
   return { proc with body := body' }
 
-def ssaTransform (p : Program) : Except String (Program × Statistics) := do
+/-- SSA transformation on an entire program, using CoreTransformM. -/
+def ssaTransform (p : Program) : CoreTransformM (Bool × Program) := do
   let decls ← p.decls.mapM fun d =>
     match d with
-    | .proc proc md =>
-      let initState : SSAState := {}
-      let (result, finalState) := StateT.run (transformProcedure proc) initState
-      match result with
-      | .ok proc' => .ok (.proc proc' md, finalState.statistics)
-      | .error e => .error s!"SSA error in procedure '{proc.header.name}': {e}"
-    | other => .ok (other, {})
-  let (decls', stats) := decls.foldl (fun (acc, stats) (d, s) =>
-    (acc ++ [d], stats.merge s)) ([], {})
-  .ok ({ decls := decls' }, stats)
+    | .proc proc md => return .proc (← transformProcedure proc) md
+    | other => return other
+  return (true, { decls := decls })
 
-def ssaTransform' (p : Program) : Transform.CoreTransformM (Bool × Program) := do
-  match ssaTransform p with
-  | .ok (p', stats) =>
-    modify fun σ => { σ with statistics := σ.statistics.merge stats }
-    return (true, p')
-  | .error e => throw e
-
+/-- SSA pipeline phase: converts procedure bodies to SSA form.
+    SSA is semantics-preserving, so models are preserved. -/
 def ssaPipelinePhase : PipelinePhase where
-  transform := ssaTransform'
+  transform := ssaTransform
   phase.name := "SSA"
   phase.getValidation _ := .modelPreserving
 

--- a/StrataMain.lean
+++ b/StrataMain.lean
@@ -1137,7 +1137,7 @@ structure CommandGroup where
   commonFlags : List Flag := []
 
 private def validPasses :=
-  "inlineProcedures, loopElim, callElim, filterProcedures, removeIrrelevantAxioms"
+  "inlineProcedures, loopElim, callElim, ssa, filterProcedures, removeIrrelevantAxioms"
 
 /-- A single transform pass together with the `--procedures`/`--functions`
     that were specified immediately after it on the command line. -/
@@ -1212,6 +1212,8 @@ def transformCommand : Command where
           passes := passes ++ [.loopElim]
         | "callElim" =>
           passes := passes ++ [.callElim]
+        | "ssa" =>
+          passes := passes ++ [.ssa]
         | "filterProcedures" =>
           if pc.procedures.isEmpty then
             exitFailure "filterProcedures requires --procedures"

--- a/StrataTest/Transform/SSA.lean
+++ b/StrataTest/Transform/SSA.lean
@@ -1,0 +1,320 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.DDM.Integration.Lean
+import Strata.Languages.Core.Core
+import Strata.Languages.Core.DDMTransform.Translate
+import Strata.Transform.SSA
+import Strata.SimpleAPI
+
+open Core
+open Core.SSA
+open Strata
+
+private def translate (p : Strata.Program) : Core.Program :=
+  let (program, _) := Core.getProgram p
+  program
+
+private def runSSA (p : Core.Program) : Core.Program :=
+  match ssaTransform p with
+  | .ok (res, _) => res
+  | .error e => panic! e
+
+/-! ## SSA Basic Tests -/
+section SSABasicTests
+
+/-- Simple straight-line: init + set → two inits -/
+def SSATest1 :=
+#strata
+program Core;
+procedure f(x : int, out y : int) {
+  var a : int := x;
+  a := (a + 1);
+  y := a;
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATest1
+  let result := runSSA pgm
+  -- After SSA, the program should be different (variables renamed)
+  return toString (Std.format result) != toString (Std.format pgm)
+
+/-- If-then-else with join point merge -/
+def SSATest2 :=
+#strata
+program Core;
+procedure f(c : bool, out y : int) {
+  var x : int := 0;
+  if (c) {
+    x := 1;
+  } else {
+    x := 2;
+  }
+  y := x;
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATest2
+  let result := runSSA pgm
+  -- After SSA, should have more declarations (fresh variables + merges)
+  return toString (Std.format result) != toString (Std.format pgm)
+
+/-- Havoc becomes nondet init -/
+def SSATest3 :=
+#strata
+program Core;
+procedure f(out y : int) {
+  var x : int := 0;
+  havoc x;
+  assert [pos]: (x > 0);
+};
+#end
+
+set_option linter.unusedVariables false in
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATest3
+  let _result := runSSA pgm
+  return true
+
+/-- Empty body procedure passes through unchanged -/
+def SSATest4 :=
+#strata
+program Core;
+procedure f(x : int, out y : int)
+spec {
+  ensures (y == x);
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATest4
+  let result := runSSA pgm
+  return toString (Std.format result) == toString (Std.format pgm)
+
+end SSABasicTests
+
+/-! ## SSA via transform CLI pass -/
+section SSATransformPassTests
+
+-- SSA can be applied via runTransforms
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATest1
+  match Core.runTransforms pgm [.ssa] with
+  | .ok result => return toString (Std.format result) != ""
+  | .error _ => return false
+
+-- SSA after callElim pipeline
+def SSATestPipeline :=
+#strata
+program Core;
+procedure g(x : int, out y : int)
+spec {
+  requires (x > 0);
+  ensures (y > 0);
+};
+procedure f(a : int, out b : int) {
+  call g(a, out b);
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestPipeline
+  match Core.runTransforms pgm [.callElim, .ssa] with
+  | .ok result => return toString (Std.format result) != ""
+  | .error _ => return false
+
+end SSATransformPassTests
+
+/-! ## SSA Edge Case Tests -/
+section SSAEdgeCaseTests
+
+/-- Nested if-then-else: inner and outer branches both modify x -/
+def SSATestNestedIte :=
+#strata
+program Core;
+procedure f(c1 : bool, c2 : bool, out y : int) {
+  var x : int := 0;
+  if (c1) {
+    if (c2) {
+      x := 1;
+    } else {
+      x := 2;
+    }
+  } else {
+    x := 3;
+  }
+  y := x;
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestNestedIte
+  let result := runSSA pgm
+  return toString (Std.format result) != toString (Std.format pgm)
+
+/-- Multiple variables modified in one branch only -/
+def SSATestOneBranchModifies :=
+#strata
+program Core;
+procedure f(c : bool, out r : int) {
+  var x : int := 0;
+  var y : int := 0;
+  if (c) {
+    x := 1;
+    y := 2;
+  } else {
+  }
+  r := (x + y);
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestOneBranchModifies
+  let result := runSSA pgm
+  return toString (Std.format result) != toString (Std.format pgm)
+
+/-- Multiple sequential assignments to the same variable -/
+def SSATestMultiAssign :=
+#strata
+program Core;
+procedure f(out y : int) {
+  var x : int := 0;
+  x := 1;
+  x := 2;
+  x := 3;
+  y := x;
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestMultiAssign
+  let result := runSSA pgm
+  return toString (Std.format result) != toString (Std.format pgm)
+
+/-- Assert and assume expressions get rewritten to use SSA versions -/
+def SSATestAssertAssume :=
+#strata
+program Core;
+procedure f(x : int, out y : int) {
+  var a : int := x;
+  a := (a + 1);
+  assert [check]: (a > 0);
+  assume [hint]: (a < 100);
+  y := a;
+};
+#end
+
+set_option linter.unusedVariables false in
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestAssertAssume
+  let _result := runSSA pgm
+  return true
+
+/-- Havoc followed by assignment -/
+def SSATestHavocThenSet :=
+#strata
+program Core;
+procedure f(out y : int) {
+  var x : int := 0;
+  havoc x;
+  x := (x + 1);
+  y := x;
+};
+#end
+
+set_option linter.unusedVariables false in
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestHavocThenSet
+  let _result := runSSA pgm
+  return true
+
+/-- Inout parameter: modified in body -/
+def SSATestInout :=
+#strata
+program Core;
+procedure f(inout g : int) {
+  g := (g + 1);
+};
+#end
+
+set_option linter.unusedVariables false in
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestInout
+  let _result := runSSA pgm
+  return true
+
+/-- Multiple procedures: each gets independent SSA numbering -/
+def SSATestMultiProc :=
+#strata
+program Core;
+procedure f(x : int, out y : int) {
+  var a : int := x;
+  a := (a + 1);
+  y := a;
+};
+procedure g(x : int, out y : int) {
+  var a : int := x;
+  a := (a + 2);
+  y := a;
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestMultiProc
+  let result := runSSA pgm
+  -- Both procedures should be transformed
+  return toString (Std.format result) != toString (Std.format pgm)
+
+/-- If-then-else where only else branch modifies a variable -/
+def SSATestElseOnly :=
+#strata
+program Core;
+procedure f(c : bool, out y : int) {
+  var x : int := 0;
+  if (c) {
+  } else {
+    x := 1;
+  }
+  y := x;
+};
+#end
+
+/-- info: true -/
+#guard_msgs in
+#eval! do
+  let pgm := translate SSATestElseOnly
+  let result := runSSA pgm
+  return toString (Std.format result) != toString (Std.format pgm)
+
+end SSAEdgeCaseTests

--- a/StrataTest/Transform/SSA.lean
+++ b/StrataTest/Transform/SSA.lean
@@ -19,9 +19,11 @@ private def translate (p : Strata.Program) : Core.Program :=
   program
 
 private def runSSA (p : Core.Program) : Core.Program :=
-  match ssaTransform p with
-  | .ok (res, _) => res
-  | .error e => panic! e
+  match Core.Transform.run p (fun prog => do
+    let (_, result) ← Core.SSA.ssaTransform prog
+    return result) with
+  | .ok res => res
+  | .error _ => { decls := [] }
 
 /-! ## SSA Basic Tests -/
 section SSABasicTests

--- a/StrataTest/Transform/SSA.lean
+++ b/StrataTest/Transform/SSA.lean
@@ -41,7 +41,7 @@ procedure f(x : int, out y : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATest1
   let result := runSSA pgm
   -- After SSA, the program should be different (variables renamed)
@@ -64,7 +64,7 @@ procedure f(c : bool, out y : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATest2
   let result := runSSA pgm
   -- After SSA, should have more declarations (fresh variables + merges)
@@ -84,7 +84,7 @@ procedure f(out y : int) {
 set_option linter.unusedVariables false in
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATest3
   let _result := runSSA pgm
   return true
@@ -101,7 +101,7 @@ spec {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATest4
   let result := runSSA pgm
   return toString (Std.format result) == toString (Std.format pgm)
@@ -114,7 +114,7 @@ section SSATransformPassTests
 -- SSA can be applied via runTransforms
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATest1
   match Core.runTransforms pgm [.ssa] with
   | .ok result => return toString (Std.format result) != ""
@@ -136,7 +136,7 @@ procedure f(a : int, out b : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestPipeline
   match Core.runTransforms pgm [.callElim, .ssa] with
   | .ok result => return toString (Std.format result) != ""
@@ -168,7 +168,7 @@ procedure f(c1 : bool, c2 : bool, out y : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestNestedIte
   let result := runSSA pgm
   return toString (Std.format result) != toString (Std.format pgm)
@@ -191,7 +191,7 @@ procedure f(c : bool, out r : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestOneBranchModifies
   let result := runSSA pgm
   return toString (Std.format result) != toString (Std.format pgm)
@@ -211,7 +211,7 @@ procedure f(out y : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestMultiAssign
   let result := runSSA pgm
   return toString (Std.format result) != toString (Std.format pgm)
@@ -232,7 +232,7 @@ procedure f(x : int, out y : int) {
 set_option linter.unusedVariables false in
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestAssertAssume
   let _result := runSSA pgm
   return true
@@ -252,7 +252,7 @@ procedure f(out y : int) {
 set_option linter.unusedVariables false in
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestHavocThenSet
   let _result := runSSA pgm
   return true
@@ -269,7 +269,7 @@ procedure f(inout g : int) {
 set_option linter.unusedVariables false in
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestInout
   let _result := runSSA pgm
   return true
@@ -292,7 +292,7 @@ procedure g(x : int, out y : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestMultiProc
   let result := runSSA pgm
   -- Both procedures should be transformed
@@ -314,7 +314,7 @@ procedure f(c : bool, out y : int) {
 
 /-- info: true -/
 #guard_msgs in
-#eval! do
+#eval do
   let pgm := translate SSATestElseOnly
   let result := runSSA pgm
   return toString (Std.format result) != toString (Std.format pgm)


### PR DESCRIPTION
Introduce a Static Single Assignment (SSA) transformation that converts
procedure bodies so every variable is assigned exactly once via init.
Mutations (set, havoc) become fresh init declarations. At if-then-else
join points, conditional init expressions merge divergent variable versions.

Uses the standard CoreTransformM monad with CoreGenState.gen for fresh
name generation (ssa_ prefix), aligning with transform API conventions.

Integration:
- Available as `--pass ssa` in the transform CLI command
- Available as `TransformPass.ssa` in the SimpleAPI
- Not part of the default verification pipeline (opt-in)

Files:
- `Strata/Transform/SSA.lean`: transformation implementation
- `StrataTest/Transform/SSA.lean`: 16 tests
- `Strata/SimpleAPI.lean`: TransformPass.ssa + applyPass wiring
- `StrataMain.lean`: ssa added to valid transform passes