### PR TITLE
lake: build Strata lib as a test-driver dependency

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -27,7 +27,12 @@ globs = ["StrataTest.+"]
 [[lean_exe]]
 name = "StrataTestMain"
 root = "Scripts.StrataTestMain"
-needs = ["StrataTest"]
+# `Strata` is listed explicitly because the driver spawns `lean` on files
+# under `StrataTestExtra/` (which is not a `lean_lib`). Those files import
+# modules from the `Strata` library that are not in `StrataTest`'s transitive
+# closure (e.g., `Strata.DDM.Integration.Java`), so without this the oleans
+# would be missing when running `lake test` from a clean `.lake`.
+needs = ["Strata", "StrataTest"]
 
 [[lean_exe]]
 name = "StrataToCBMC"


### PR DESCRIPTION
The `StrataTestMain` test driver spawns `lean` on files under `StrataTestExtra/`, which is not declared as a `lean_lib`. Some of those files (e.g. `DDM/Integration/Java/TestGen.lean`) import modules from the `Strata` library that are not in `StrataTest`'s transitive closure, most notably `Strata.DDM.Integration.Java`.

Before this change, `lake test` on a clean `.lake` would only build the closure reachable from `StrataTest` and then fail at subprocess time with:

  error: object file '.../Strata/DDM/Integration/Java.olean' of module
  Strata.DDM.Integration.Java does not exist

Running `lake build` first masked the bug because the `Strata` library is in `defaultTargets`.

Add `Strata` to the `needs` list of `StrataTestMain` so Lake builds the full `Strata` library before the test driver runs, regardless of whether `lake build` was run beforehand.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
