### PR TITLE
Fix bug: ADT constructors do not change `Map` to `Array` when using useArrayTheory option.

### DIFF
--- a/Strata/Languages/Core/SMTEncoder.lean
+++ b/Strata/Languages/Core/SMTEncoder.lean
@@ -95,7 +95,7 @@ def SMT.Context.withTypeFactory (ctx : SMT.Context) (tf : @Lambda.TypeFactory Co
 Helper function to convert LMonoTy to TermType for datatype constructor fields.
 Handles monomorphic types and type variables (as `.constr tv []`).
 -/
-private def lMonoTyToTermType (ty : LMonoTy) : TermType :=
+private def lMonoTyToTermType (useArrayTheory : Bool := false) (ty : LMonoTy) : TermType :=
   match ty with
   | .bitvec n => .bitvec n
   | .tcons "bool" [] => .bool
@@ -103,14 +103,18 @@ private def lMonoTyToTermType (ty : LMonoTy) : TermType :=
   | .tcons "real" [] => .real
   | .tcons "string" [] => .string
   | .tcons "regex" [] => .regex
-  | .tcons name args => .constr name (args.map lMonoTyToTermType)
+  | .tcons name args =>
+    if name == "Map" && useArrayTheory then
+      .constr "Array" (args.map $ lMonoTyToTermType useArrayTheory)
+    else
+      .constr name (args.map $ lMonoTyToTermType useArrayTheory)
   | .ftvar tv => .constr tv []
 
 /-- Convert a datatype's constructors to typed SMT constructors. -/
-private def datatypeConstructorsToSMT (d : LDatatype CoreLParams.IDMeta) : List SMTConstructor :=
+private def datatypeConstructorsToSMT (d : LDatatype CoreLParams.IDMeta) (useArrayTheory : Bool := false): List SMTConstructor :=
   d.constrs.map fun c =>
     let fields := c.args.map fun (name, fieldTy) =>
-      (d.name ++ ".." ++ name.name, lMonoTyToTermType fieldTy)
+      (d.name ++ ".." ++ name.name, lMonoTyToTermType useArrayTheory fieldTy)
     { name := c.name.name, args := fields }
 
 /-- Ensures that all datatypes in the SMT encoding do not have arrow-typed
@@ -133,7 +137,7 @@ Uses the TypeFactory ordering (already topologically sorted).
 Only emits datatypes that have been seen (added via addDatatype).
 Single-element blocks use declare-datatype, multi-element blocks use declare-datatypes.
 -/
-def SMT.Context.emitDatatypes (ctx : SMT.Context) : Strata.SMT.SolverM Unit := do
+def SMT.Context.emitDatatypes (ctx : SMT.Context) (useArrayTheory : Bool := false): Strata.SMT.SolverM Unit := do
   match validateDatatypesForSMT ctx.typeFactory ctx.seenDatatypes with
   | .error msg => throw (IO.userError (toString msg))
   | .ok () => pure ()
@@ -142,10 +146,10 @@ def SMT.Context.emitDatatypes (ctx : SMT.Context) : Strata.SMT.SolverM Unit := d
     match usedBlock with
     | [] => pure ()
     | [d] =>
-      let constructors := datatypeConstructorsToSMT d
+      let constructors := datatypeConstructorsToSMT d useArrayTheory
       Strata.SMT.Solver.declareDatatype d.name d.typeArgs constructors
     | _ =>
-      let dts := usedBlock.map fun d => (d.name, d.typeArgs, datatypeConstructorsToSMT d)
+      let dts := usedBlock.map fun d => (d.name, d.typeArgs, datatypeConstructorsToSMT d useArrayTheory)
       Strata.SMT.Solver.declareDatatypes dts
 
 @[expose] abbrev BoundVars := List (String × TermType)
@@ -639,7 +643,7 @@ partial def toSMTOp (E : Env) (fn : CoreIdent) (fnty : LMonoTy) (ctx : SMT.Conte
               -- `.bvar`s. Use substFvarsLifting to properly lift indices under binders.
               let bvars := (List.range formals.length).map (fun i => LExpr.bvar () i)
               let body := LExpr.substFvarsLifting body (formals.zip bvars)
-              let (term, ctx) ← toSMTTerm E bvs body ctx
+              let (term, ctx) ← toSMTTerm E bvs body ctx useArrayTheory
               .ok (ctx.addIF uf term,  !ctx.ifs.contains ({ uf := uf, body := term }))
           -- For recursive functions, generate per-constructor axioms
           let recAxioms ← if func.isRecursive && isNew then
@@ -664,7 +668,7 @@ partial def toSMTOp (E : Env) (fn : CoreIdent) (fnty : LMonoTy) (ctx : SMT.Conte
             let savedSubst := ctx.tySubst
             let ctx ← allAxioms.foldlM (fun acc_ctx (ax: LExpr CoreLParams.mono) => do
               let current_axiom_ctx := acc_ctx.addSubst smt_ty_inst
-                let (axiom_term, new_ctx) ← toSMTTerm E [] ax current_axiom_ctx
+                let (axiom_term, new_ctx) ← toSMTTerm E [] ax current_axiom_ctx useArrayTheory
                 .ok (new_ctx.addAxiom axiom_term)
             ) ctx
             let ctx := ctx.restoreSubst savedSubst

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -51,6 +51,7 @@ when needed for the validity check (line 64 for check-sat-assuming, line 77 for 
 def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
     (assumptionTerms : List Term) (obligationTerm : Term)
     (md : Imperative.MetaData Core.Expression)
+    (useArrayTheory : Bool)
     (satisfiabilityCheck validityCheck : Bool)
     (label : String)
     (varDefinitions : List Core.VarDefinition := [])
@@ -59,7 +60,7 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
   Solver.setLogic "ALL"
   prelude
   let _ ← ctx.sorts.mapM (fun s => Solver.declareSort s.name s.arity)
-  ctx.emitDatatypes
+  ctx.emitDatatypes useArrayTheory
   let varDefNames := varDefinitions.map (·.name)
   let varDeclNames := varDeclarations.map (·.name)
   let managedNames := varDefNames ++ varDeclNames
@@ -218,7 +219,7 @@ def dischargeObligation
   Imperative.SMT.dischargeObligation
     (P := Core.Expression)
     (Strata.SMT.Encoder.encodeCore ctx (getSolverPrelude options.solver)
-      assumptionTerms obligationTerm md satisfiabilityCheck validityCheck
+      assumptionTerms obligationTerm md options.useArrayTheory satisfiabilityCheck validityCheck
       (label := label) (varDefinitions := varDefinitions) (varDeclarations := varDeclarations))
     (typedVarToSMTFn ctx)
     vars

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -51,7 +51,7 @@ when needed for the validity check (line 64 for check-sat-assuming, line 77 for 
 def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
     (assumptionTerms : List Term) (obligationTerm : Term)
     (md : Imperative.MetaData Core.Expression)
-    (useArrayTheory : Bool)
+    (useArrayTheory : Bool := false)
     (satisfiabilityCheck validityCheck : Bool)
     (label : String)
     (varDefinitions : List Core.VarDefinition := [])

--- a/StrataTest/Languages/Core/Tests/SMTEncoderDatatypeTest.lean
+++ b/StrataTest/Languages/Core/Tests/SMTEncoderDatatypeTest.lean
@@ -71,13 +71,13 @@ def treeDatatype : LDatatype Unit :=
 Convert an expression to full SMT string including datatype declarations.
 `blocks` is a list of mutual blocks (each block is a list of mutually recursive datatypes).
 -/
-def toSMTStringWithDatatypeBlocks (e : LExpr CoreLParams.mono) (blocks : List (List (LDatatype Unit))) : IO String := do
+def toSMTStringWithDatatypeBlocks (e : LExpr CoreLParams.mono) (blocks : List (List (LDatatype Unit))) (useArrayTheory : Bool := false): IO String := do
   match Env.init.addDatatypes blocks with
   | .error msg => return s!"Error creating environment: {msg}"
   | .ok env =>
     -- Set the TypeFactory for correct datatype emission ordering
     let ctx := SMT.Context.default.withTypeFactory env.datatypes
-    match toSMTTerm env [] e ctx with
+    match toSMTTerm env [] e ctx useArrayTheory with
     | .error err => return err.pretty
     | .ok (smt, ctx) =>
       -- Emit the full SMT output including datatype declarations
@@ -85,7 +85,7 @@ def toSMTStringWithDatatypeBlocks (e : LExpr CoreLParams.mono) (blocks : List (L
       let solver ← Strata.SMT.Solver.bufferWriter b
       match (← ((do
         -- First emit datatypes
-        ctx.emitDatatypes
+        ctx.emitDatatypes useArrayTheory
         -- Then encode the term
         let _ ← (Strata.SMT.Encoder.encodeTerm smt).run Strata.SMT.EncoderState.init
         pure ()
@@ -102,8 +102,8 @@ def toSMTStringWithDatatypeBlocks (e : LExpr CoreLParams.mono) (blocks : List (L
 Convert an expression to full SMT string including datatype declarations.
 Each datatype is treated as its own (non-mutual) block.
 -/
-def toSMTStringWithDatatypes (e : LExpr CoreLParams.mono) (datatypes : List (LDatatype Unit)) : IO String :=
-  toSMTStringWithDatatypeBlocks e (datatypes.map (fun d => [d]))
+def toSMTStringWithDatatypes (e : LExpr CoreLParams.mono) (datatypes : List (LDatatype Unit)) (useArrayTheory : Bool := false): IO String :=
+  toSMTStringWithDatatypeBlocks e (datatypes.map (fun d => [d])) useArrayTheory
 
 /-! ## Test Cases with Guard Messages -/
 
@@ -511,33 +511,6 @@ info: (declare-datatype IntList (
   [[intListDatatype]]
   listLenFunc
 
-/-! ## useArrayTheory Tests for Datatype Constructors -/
-
-/-- Helper that emits datatypes with useArrayTheory=true -/
-def toSMTStringWithDatatypesArrayTheory (e : LExpr CoreLParams.mono) (datatypes : List (LDatatype Unit)) : IO String := do
-  let blocks := datatypes.map (fun d => [d])
-  match Env.init.addDatatypes blocks with
-  | .error msg => return s!"Error creating environment: {msg}"
-  | .ok env =>
-    let ctx := SMT.Context.default.withTypeFactory env.datatypes
-    match toSMTTerm env [] e ctx (useArrayTheory := true) with
-    | .error err => return err.pretty
-    | .ok (smt, ctx) =>
-      let b ← IO.mkRef { : IO.FS.Stream.Buffer }
-      let solver ← Strata.SMT.Solver.bufferWriter b
-      match (← ((do
-        ctx.emitDatatypes (useArrayTheory := true)
-        let _ ← (Strata.SMT.Encoder.encodeTerm smt).run Strata.SMT.EncoderState.init
-        pure ()
-      ).run solver).toBaseIO) with
-      | .error e => return s!"Error: {e}"
-      | .ok _ =>
-        let contents ← b.get
-        if h: contents.data.IsValidUTF8 then
-          return String.fromUTF8 contents.data h
-        else
-          return "Invalid UTF-8 in output"
-
 /-- Container = MkContainer (data: Map int int) -/
 def containerWithMapDatatype : LDatatype Unit :=
   { name := "Container"
@@ -557,9 +530,9 @@ info: (declare-datatype Container (
 (declare-const c Container)
 -/
 #guard_msgs in
-#eval format <$> toSMTStringWithDatatypesArrayTheory
+#eval format <$> toSMTStringWithDatatypes
   (.fvar () (⟨"c", ()⟩) (.some (.tcons "Container" [])))
-  [containerWithMapDatatype]
+  [containerWithMapDatatype] true
 
 -- Test: Same datatype without useArrayTheory should keep Map
 /--
@@ -572,6 +545,33 @@ info: (declare-datatype Container (
 #eval format <$> toSMTStringWithDatatypes
   (.fvar () (⟨"c", ()⟩) (.some (.tcons "Container" [])))
   [containerWithMapDatatype]
+
+-- Test: ADT testers with Map type should emit Array when useArrayTheory=true
+/--
+info: (declare-datatype Container (
+  (MkContainer (Container..data (Array Int Int)))))
+; xs
+(declare-const xs Container)
+-/
+#guard_msgs in
+#eval format <$> toSMTStringWithDatatypes
+  (.app () (.op () (⟨"Container..isMkContainer", ()⟩) (.some (.arrow (.tcons "Container" []) .bool)))
+    (.fvar () (⟨"xs", ()⟩) (.some (.tcons "Container" []))))
+  [containerWithMapDatatype] true
+
+-- Test: ADT destructors with Map type should emit Array when useArrayTheory=true
+/--
+info: (declare-datatype Container (
+  (MkContainer (Container..data (Array Int Int)))))
+; xs
+(declare-const xs Container)
+-/
+#guard_msgs in
+#eval format <$> toSMTStringWithDatatypes
+  (.app () (.op () (⟨"Container..data", ()⟩) (.some (.arrow (.tcons "Container" []) (.tcons "Map" [.int, .int]))))
+    (.fvar () (⟨"xs", ()⟩) (.some (.tcons "Container" []))))
+  [containerWithMapDatatype] true
+
 
 end DatatypeTests
 

--- a/StrataTest/Languages/Core/Tests/SMTEncoderDatatypeTest.lean
+++ b/StrataTest/Languages/Core/Tests/SMTEncoderDatatypeTest.lean
@@ -511,6 +511,68 @@ info: (declare-datatype IntList (
   [[intListDatatype]]
   listLenFunc
 
+/-! ## useArrayTheory Tests for Datatype Constructors -/
+
+/-- Helper that emits datatypes with useArrayTheory=true -/
+def toSMTStringWithDatatypesArrayTheory (e : LExpr CoreLParams.mono) (datatypes : List (LDatatype Unit)) : IO String := do
+  let blocks := datatypes.map (fun d => [d])
+  match Env.init.addDatatypes blocks with
+  | .error msg => return s!"Error creating environment: {msg}"
+  | .ok env =>
+    let ctx := SMT.Context.default.withTypeFactory env.datatypes
+    match toSMTTerm env [] e ctx (useArrayTheory := true) with
+    | .error err => return err.pretty
+    | .ok (smt, ctx) =>
+      let b ← IO.mkRef { : IO.FS.Stream.Buffer }
+      let solver ← Strata.SMT.Solver.bufferWriter b
+      match (← ((do
+        ctx.emitDatatypes (useArrayTheory := true)
+        let _ ← (Strata.SMT.Encoder.encodeTerm smt).run Strata.SMT.EncoderState.init
+        pure ()
+      ).run solver).toBaseIO) with
+      | .error e => return s!"Error: {e}"
+      | .ok _ =>
+        let contents ← b.get
+        if h: contents.data.IsValidUTF8 then
+          return String.fromUTF8 contents.data h
+        else
+          return "Invalid UTF-8 in output"
+
+/-- Container = MkContainer (data: Map int int) -/
+def containerWithMapDatatype : LDatatype Unit :=
+  { name := "Container"
+    typeArgs := []
+    constrs := [
+      { name := ⟨"MkContainer", ()⟩,
+        args := [(⟨"data", ()⟩, .tcons "Map" [.int, .int])],
+        testerName := "Container..isMkContainer" }
+    ]
+    constrs_ne := by decide }
+
+-- Test: ADT constructor field with Map type should emit Array when useArrayTheory=true
+/--
+info: (declare-datatype Container (
+  (MkContainer (Container..data (Array Int Int)))))
+; c
+(declare-const c Container)
+-/
+#guard_msgs in
+#eval format <$> toSMTStringWithDatatypesArrayTheory
+  (.fvar () (⟨"c", ()⟩) (.some (.tcons "Container" [])))
+  [containerWithMapDatatype]
+
+-- Test: Same datatype without useArrayTheory should keep Map
+/--
+info: (declare-datatype Container (
+  (MkContainer (Container..data (Map Int Int)))))
+; c
+(declare-const c Container)
+-/
+#guard_msgs in
+#eval format <$> toSMTStringWithDatatypes
+  (.fvar () (⟨"c", ()⟩) (.some (.tcons "Container" [])))
+  [containerWithMapDatatype]
+
 end DatatypeTests
 
 end Core


### PR DESCRIPTION
*Description of changes:*

**Bug:** When `useArrayTheory` is enabled, the SMT encoder correctly converts `Map` types to `Array` in variable declarations and function signatures, but it did *not* perform this conversion for fields inside ADT (algebraic data type) constructor declarations. This caused a type mismatch: a datatype field would be declared with type `Map` while the rest of the encoding used `Array`.

**Fix:** Thread the `useArrayTheory` flag through the datatype emission pipeline:
- `lMonoTyToTermType` now accepts `useArrayTheory` and converts `Map` to `Array` when enabled.
- `datatypeConstructorsToSMT` passes the flag to `lMonoTyToTermType`.
- `SMT.Context.emitDatatypes` accepts and forwards the flag.
- `encodeCore` in `Verifier.lean` passes `options.useArrayTheory` to `emitDatatypes`.

**Test:** Added a unit test in `SMTEncoderDatatypeTest.lean` that verifies a datatype with a `Map`-typed field emits `(Array Int Int)` when `useArrayTheory=true` and `(Map Int Int)` when `useArrayTheory=false`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
