### PR TITLE
Fix namespace collision and SMACK assert encoding in BoogieToStrata

### DIFF
--- a/Strata/Languages/Core/DDMTransform/Translate.lean
+++ b/Strata/Languages/Core/DDMTransform/Translate.lean
@@ -453,8 +453,8 @@ partial def dealiasTypeExpr (p : Program) (te : TypeExpr) : TypeExpr :=
   match te with
   | (.fvar _ idx #[]) =>
     match p.globalContext.kindOf! idx with
-    | .expr te => te
-    | .type [] (.some te) => te
+    | .expr te => dealiasTypeExpr p te
+    | .type [] (.some te) => dealiasTypeExpr p te
     | _ => te
   | _ => te
 

--- a/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
+++ b/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
@@ -149,6 +149,38 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         Assert.Equal(expectedExitCode, proc.ExitCode);
     }
 
+    /// <summary>
+    /// Regression test: an assert_.<type> procedure with an existing ensures clause
+    /// should emit a single spec block containing both the synthetic requires and the
+    /// original ensures — not two separate spec blocks.
+    /// </summary>
+    [Fact]
+    public void SmackAssertWithEnsuresProducesSingleSpecBlock() {
+        var filePath = Path.Combine(TestsDirectory, "SmackAssertDuplicateSpec.bpl");
+        Assert.True(File.Exists(filePath), $"Test file does not exist: {filePath}");
+
+        var (exitCode, standardOutput, errorOutput) = RunTranslation(filePath);
+        Assert.Equal(0, exitCode);
+
+        // Count occurrences of "spec {" in the output.
+        // There should be exactly one spec block for the assert_ procedure.
+        var specCount = 0;
+        var searchFrom = 0;
+        while (true) {
+            var idx = standardOutput.IndexOf("spec {", searchFrom, StringComparison.Ordinal);
+            if (idx < 0) break;
+            specCount++;
+            searchFrom = idx + 1;
+        }
+
+        output.WriteLine($"Output:\n{standardOutput}");
+        Assert.Equal(1, specCount);
+
+        // The single spec block should contain both requires and ensures
+        Assert.Contains("requires", standardOutput);
+        Assert.Contains("ensures", standardOutput);
+    }
+
     [Fact]
     public void ErrorCodeWithNoArguments() {
         var result = BoogieToStrata.Main(Array.Empty<string>());

--- a/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
+++ b/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
@@ -181,6 +181,38 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         Assert.Contains("ensures", standardOutput);
     }
 
+    /// <summary>
+    /// Regression test: old() expressions must use the renamed name when a
+    /// variable has a name collision (e.g., global var `main` vs procedure `main`).
+    /// Previously, IdentifierExpr with Decl != null used NameOf() correctly, but
+    /// had a silent fallback to Name() when Decl was null — which would emit the
+    /// unrenamed (wrong) name in the collision case. Post-resolution, Decl should
+    /// always be non-null; the fallback masked potential bugs.
+    /// </summary>
+    [Fact]
+    public void OldExprUsesRenamedNameOnCollision() {
+        var filePath = Path.Combine(TestsDirectory, "OldExprRenameCollision.bpl");
+        Assert.True(File.Exists(filePath), $"Test file does not exist: {filePath}");
+
+        var (exitCode, standardOutput, errorOutput) = RunTranslation(filePath);
+
+        output.WriteLine($"Output:\n{standardOutput}");
+        if (!string.IsNullOrEmpty(errorOutput)) {
+            output.WriteLine($"Error output: {errorOutput}");
+        }
+
+        Assert.Equal(0, exitCode);
+
+        // The output should contain an `old` expression referencing the *renamed*
+        // variable (e.g., __var_main), not the raw name `main` which is the procedure.
+        // Look for the pattern "old __var_main" or similar renamed form.
+        Assert.Contains("old __var_main", standardOutput);
+
+        // Also ensure the output does NOT contain "old main" (unrenamed fallback).
+        // This would indicate the fallback to Name() was used instead of NameOf().
+        Assert.DoesNotContain("old main", standardOutput);
+    }
+
     [Fact]
     public void ErrorCodeWithNoArguments() {
         var result = BoogieToStrata.Main(Array.Empty<string>());

--- a/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
+++ b/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
@@ -172,20 +172,24 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
     }
 
     /// <summary>
-    /// Regression test: an assert_.<type> procedure with an existing ensures clause
-    /// should emit a single spec block containing both the synthetic requires and the
-    /// original ensures — not two separate spec blocks.
+    /// Regression test: assert_.<type> procedures must produce a single
+    /// merged spec block, not duplicates, regardless of whether the input
+    /// already has user-written specs. Two cases:
+    ///   1. existing ensures only — synthetic requires merges in.
+    ///   2. existing requires — synthetic requires is added alongside,
+    ///      not silently dropped.
     /// </summary>
     [Fact]
-    public void SmackAssertWithEnsuresProducesSingleSpecBlock() {
+    public void SmackAssertProducesSingleMergedSpecBlock() {
         var filePath = Path.Combine(TestsDirectory, "SmackAssertDuplicateSpec.bpl");
         Assert.True(File.Exists(filePath), $"Test file does not exist: {filePath}");
 
         var (exitCode, standardOutput, errorOutput) = RunTranslation(filePath);
         Assert.Equal(0, exitCode);
 
-        // Count occurrences of "spec {" in the output.
-        // There should be exactly one spec block for the assert_ procedure.
+        // Three procedures (assert_.i32, assert_.i32_with_req, main); the two
+        // assert_.<type> ones each produce one spec block; main has none.
+        // Count occurrences of "spec {" in the output: must be exactly 2.
         var specCount = 0;
         var searchFrom = 0;
         while (true) {
@@ -196,11 +200,32 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         }
 
         output.WriteLine($"Output:\n{standardOutput}");
-        Assert.Equal(1, specCount);
+        Assert.Equal(2, specCount);
 
-        // The single spec block should contain both requires and ensures
+        // Overall sanity: the output contains at least one of each clause kind.
+        // (assert_.i32 has an `ensures`, both procedures have at least one
+        // `requires`.)
         Assert.Contains("requires", standardOutput);
         Assert.Contains("ensures", standardOutput);
+
+        // The critical regression check: BOTH clauses must appear in the
+        // SECOND procedure's spec block (assert_.i32_with_req) — i.e., the
+        // requires-already-present case must not silently drop the synthetic
+        // clause. Procedures emit in source order, so the second `spec {` is
+        // assert_.i32_with_req's.
+        var firstSpec = standardOutput.IndexOf("spec {", StringComparison.Ordinal);
+        Assert.True(firstSpec >= 0, "Expected at least one spec block");
+        var secondSpecStart = standardOutput.IndexOf("spec {", firstSpec + 1, StringComparison.Ordinal);
+        Assert.True(secondSpecStart >= 0, "Expected a second spec block for assert_.i32_with_req");
+        var secondSpecEnd = standardOutput.IndexOf("}", secondSpecStart, StringComparison.Ordinal);
+        Assert.True(secondSpecEnd > secondSpecStart, "Second spec block missing closing brace");
+        var secondSpec = standardOutput.Substring(secondSpecStart, secondSpecEnd - secondSpecStart);
+
+        // The user-written `requires (p.0 > -1)` (sanitized to `p_0 > -(1)`)
+        // and the synthetic `requires (p.0 != 0)` (sanitized to `p_0 != 0`)
+        // must both be present in this single spec block.
+        Assert.Contains("p_0 > -(1)", secondSpec);
+        Assert.Contains("p_0 != 0", secondSpec);
     }
 
     /// <summary>

--- a/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
+++ b/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
@@ -51,7 +51,28 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         }
     }
 
+    /// <summary>
+    /// Returns true if the first 5 lines of <paramref name="filePath"/> contain
+    /// the literal token "{:smack}". Files carrying this marker opt into the
+    /// --smack CLI flag, which gates the assert_.<type> synthetic-requires
+    /// injection and InferModifies=true.
+    /// </summary>
+    private static bool HasSmackMarker(string filePath) {
+        if (!File.Exists(filePath)) return false;
+        using var reader = new StreamReader(filePath);
+        for (var i = 0; i < 5; i++) {
+            var line = reader.ReadLine();
+            if (line == null) break;
+            if (line.Contains("{:smack}", StringComparison.Ordinal)) return true;
+        }
+        return false;
+    }
+
     private (int, string, string) RunTranslation(string filePath) {
+        return RunTranslation(filePath, HasSmackMarker(filePath));
+    }
+
+    private (int, string, string) RunTranslation(string filePath, bool smack) {
         // Capture console output
         using var consoleOutput = new StringWriter();
         using var consoleError = new StringWriter();
@@ -62,7 +83,8 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         try {
             Console.SetOut(consoleOutput);
             Console.SetError(consoleError);
-            exitCode = BoogieToStrata.Main([filePath]);
+            var args = smack ? new[] { "--smack", filePath } : new[] { filePath };
+            exitCode = BoogieToStrata.Main(args);
         } catch (Exception) {
             exitCode = 1;
         } finally {

--- a/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
+++ b/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
@@ -293,6 +293,60 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         Assert.Contains("inout g", standardOutput);
     }
 
+    /// <summary>
+    /// Pin down the --smack gate: without the flag, the assert_.<type>
+    /// pattern is treated as an opaque procedure (no synthetic requires
+    /// injected). Translation succeeds; the output does not contain a
+    /// requires clause for the assert_ procedure.
+    /// </summary>
+    [Fact]
+    public void SmackAssertWithoutFlagDoesNotInjectRequires() {
+        var filePath = Path.Combine(TestsDirectory, "SmackAssert.bpl");
+        Assert.True(File.Exists(filePath), $"Test file does not exist: {filePath}");
+
+        var (exitCode, standardOutput, errorOutput) = RunTranslation(filePath, smack: false);
+
+        output.WriteLine($"Output:\n{standardOutput}");
+        if (!string.IsNullOrEmpty(errorOutput)) {
+            output.WriteLine($"Error output: {errorOutput}");
+        }
+
+        Assert.Equal(0, exitCode);
+
+        // Without --smack, no synthetic requires is added, so no `requires`
+        // clause should appear anywhere in the translation of this file
+        // (the .bpl has no user-written requires either).
+        Assert.DoesNotContain("requires", standardOutput);
+    }
+
+    /// <summary>
+    /// Pin down the --smack gate: without the flag, InferModifies is off.
+    /// A program that omits an explicit `modifies` clause on a procedure
+    /// that mutates a global is rejected at typecheck.
+    /// </summary>
+    [Fact]
+    public void InferModifiesOffWithoutSmackFlag() {
+        var filePath = Path.Combine(TestsDirectory, "InferModifiesGlobal.bpl");
+        Assert.True(File.Exists(filePath), $"Test file does not exist: {filePath}");
+
+        var (exitCode, standardOutput, errorOutput) = RunTranslation(filePath, smack: false);
+
+        output.WriteLine($"Exit code: {exitCode}");
+        output.WriteLine($"Output:\n{standardOutput}");
+        if (!string.IsNullOrEmpty(errorOutput)) {
+            output.WriteLine($"Error output: {errorOutput}");
+        }
+
+        // Without --smack, ResolveAndTypecheck rejects the program because
+        // procedure p mutates global g without an explicit `modifies g;`
+        // clause. BoogieToStrata.Main writes a "Failed to typecheck" line
+        // to stderr and returns exit code 1. Pin both signals so a future
+        // regression that fails for an unrelated reason (parse error,
+        // arg-handling change) doesn't silently pass this test.
+        Assert.Equal(1, exitCode);
+        Assert.Contains("Failed to typecheck", errorOutput);
+    }
+
     [Fact]
     public void ErrorCodeWithNoArguments() {
         var result = BoogieToStrata.Main(Array.Empty<string>());

--- a/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
+++ b/Tools/BoogieToStrata/IntegrationTests/BoogieToStrataIntegrationTests.cs
@@ -213,6 +213,39 @@ public class BoogieToStrataIntegrationTests(ITestOutputHelper output) {
         Assert.DoesNotContain("old main", standardOutput);
     }
 
+    /// <summary>
+    /// Regression test for InferModifies = true.
+    ///
+    /// SMACK-generated Boogie can omit explicit modifies clauses on procedures.
+    /// With InferModifies = true, Boogie's ModSetCollector infers them so that
+    /// the translator correctly emits globals as `inout` parameters (modified)
+    /// rather than read-only parameters.
+    ///
+    /// This test uses a .bpl file where procedure p() assigns to global g but
+    /// has no `modifies g;` clause.  If InferModifies is working, the output
+    /// should contain `inout g` for procedure p.
+    /// </summary>
+    [Fact]
+    public void InferModifiesEmitsInoutForMutatedGlobal() {
+        var filePath = Path.Combine(TestsDirectory, "InferModifiesGlobal.bpl");
+        Assert.True(File.Exists(filePath), $"Test file does not exist: {filePath}");
+
+        var (exitCode, standardOutput, errorOutput) = RunTranslation(filePath);
+
+        output.WriteLine($"Output:\n{standardOutput}");
+        if (!string.IsNullOrEmpty(errorOutput)) {
+            output.WriteLine($"Error output: {errorOutput}");
+        }
+
+        // Translation must succeed — if InferModifies is broken, Boogie would
+        // reject the program because g is assigned without a modifies clause.
+        Assert.Equal(0, exitCode);
+
+        // The inferred modifies clause should cause the translator to emit
+        // `inout g` on procedure p's parameter list.
+        Assert.Contains("inout g", standardOutput);
+    }
+
     [Fact]
     public void ErrorCodeWithNoArguments() {
         var result = BoogieToStrata.Main(Array.Empty<string>());

--- a/Tools/BoogieToStrata/Source/BoogieToStrata.cs
+++ b/Tools/BoogieToStrata/Source/BoogieToStrata.cs
@@ -3,29 +3,59 @@ using Microsoft.Boogie;
 namespace BoogieToStrata;
 
 public static class BoogieToStrata {
+    private const string Usage = "Usage: BoogieToStrata [--smack] <inputFile>";
+
+    private static bool _smack;
+
     private static void PrintResolvedProgram(ExecutionEngineOptions options, ProcessedProgram prog) {
         var writer = new TokenTextWriter(Console.Out, options);
-        // smack: true here preserves pre-task behavior; Task 3 wires the real value
-        // from the parsed CLI flag.
-        StrataGenerator.EmitProgramAsStrata(options, prog.Program, writer, smack: true);
+        StrataGenerator.EmitProgramAsStrata(options, prog.Program, writer, _smack);
+    }
+
+    /// <summary>
+    /// Parse args into (smack, filename). Returns false on any malformed
+    /// invocation (zero or two-plus positional args, unknown flags); the
+    /// caller should print Usage and return exit code 1.
+    /// </summary>
+    private static bool TryParseArgs(string[] args, out bool smack, out string filename) {
+        smack = false;
+        filename = "";
+        string? positional = null;
+        foreach (var arg in args) {
+            if (arg == "--smack") {
+                smack = true;
+            } else if (arg.StartsWith("--")) {
+                return false; // unknown flag
+            } else if (positional == null) {
+                positional = arg;
+            } else {
+                return false; // two positional args
+            }
+        }
+        if (positional == null) return false; // no positional arg
+        filename = positional;
+        return true;
     }
 
     public static int Main(string[] args) {
-        if (args.Length != 1) {
-            Console.Error.WriteLine("Usage: BoogieToStrata <inputFile>");
+        if (!TryParseArgs(args, out var smack, out var filename)) {
+            Console.Error.WriteLine(Usage);
             return 1;
         }
-
-        var filename = args[0];
+        _smack = smack;
 
         var options = new CommandLineOptions(Console.Out, new ConsolePrinter()) {
             Verify = false,
             TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates,
-            // SMACK-generated Boogie often omits explicit `modifies` clauses on procedures that mutate globals.
-            // InferModifies runs ModSetCollector.CollectModifies to populate empty modifies clauses and
-            // suppresses modifies-clause typechecking (via CheckModifies), so that ResolveAndTypecheck
+            // Under --smack, SMACK-generated Boogie often omits explicit
+            // `modifies` clauses on procedures that mutate globals.
+            // InferModifies runs ModSetCollector.CollectModifies to populate
+            // empty modifies clauses and suppresses modifies-clause
+            // typechecking (via CheckModifies), so that ResolveAndTypecheck
             // does not reject SMACK programs missing modifies clauses.
-            InferModifies = true
+            // For strict Boogie input (no --smack), this stays false and
+            // missing modifies clauses are reported as typecheck errors.
+            InferModifies = smack
         };
 
         var boogieEngine = ExecutionEngine.CreateWithoutSharedCache(options);

--- a/Tools/BoogieToStrata/Source/BoogieToStrata.cs
+++ b/Tools/BoogieToStrata/Source/BoogieToStrata.cs
@@ -5,7 +5,9 @@ namespace BoogieToStrata;
 public static class BoogieToStrata {
     private static void PrintResolvedProgram(ExecutionEngineOptions options, ProcessedProgram prog) {
         var writer = new TokenTextWriter(Console.Out, options);
-        StrataGenerator.EmitProgramAsStrata(options, prog.Program, writer);
+        // smack: true here preserves pre-task behavior; Task 3 wires the real value
+        // from the parsed CLI flag.
+        StrataGenerator.EmitProgramAsStrata(options, prog.Program, writer, smack: true);
     }
 
     public static int Main(string[] args) {

--- a/Tools/BoogieToStrata/Source/BoogieToStrata.cs
+++ b/Tools/BoogieToStrata/Source/BoogieToStrata.cs
@@ -18,7 +18,9 @@ public static class BoogieToStrata {
 
         var options = new CommandLineOptions(Console.Out, new ConsolePrinter()) {
             Verify = false,
-            TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates
+            TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates,
+            InferModifies = true,
+            Prune = true
         };
 
         var boogieEngine = ExecutionEngine.CreateWithoutSharedCache(options);

--- a/Tools/BoogieToStrata/Source/BoogieToStrata.cs
+++ b/Tools/BoogieToStrata/Source/BoogieToStrata.cs
@@ -19,8 +19,7 @@ public static class BoogieToStrata {
         var options = new CommandLineOptions(Console.Out, new ConsolePrinter()) {
             Verify = false,
             TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates,
-            InferModifies = true,
-            Prune = true
+            InferModifies = true
         };
 
         var boogieEngine = ExecutionEngine.CreateWithoutSharedCache(options);

--- a/Tools/BoogieToStrata/Source/BoogieToStrata.cs
+++ b/Tools/BoogieToStrata/Source/BoogieToStrata.cs
@@ -19,6 +19,10 @@ public static class BoogieToStrata {
         var options = new CommandLineOptions(Console.Out, new ConsolePrinter()) {
             Verify = false,
             TypeEncodingMethod = CoreOptions.TypeEncoding.Predicates,
+            // SMACK-generated Boogie often omits explicit `modifies` clauses on procedures that mutate globals.
+            // InferModifies runs ModSetCollector.CollectModifies to populate empty modifies clauses and
+            // suppresses modifies-clause typechecking (via CheckModifies), so that ResolveAndTypecheck
+            // does not reject SMACK programs missing modifies clauses.
             InferModifies = true
         };
 

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -56,6 +56,13 @@ public class StrataGenerator : ReadOnlyVisitor {
     // declaration. Keyed by Boogie Declaration object to avoid ambiguity
     // when two entities share the same original name (e.g., const main and
     // procedure main). First-seen wins; later entities get prefixed.
+    //
+    // Registration order determines who wins a collision:
+    //   1. Procedures  — registered first, always keep their name.
+    //   2. Implementations — claimed defensively (they share names with
+    //      their procedures, but claiming guards against edge cases).
+    //   3. Constants, Functions, Globals — registered last; in a
+    //      proc-vs-const collision the constant is always renamed.
     private readonly Dictionary<Declaration, string> _renames = new();
 
     private StrataGenerator(VCGenOptions options, TokenTextWriter writer, Program program) {
@@ -87,30 +94,22 @@ public class StrataGenerator : ReadOnlyVisitor {
             // First-seen wins; colliding entities get a suffix (_2, _3, ...).
             var claimed = new HashSet<string>();
 
-            void ClaimOrRename(Declaration decl, string originalName, string prefix) {
-                var sanitized = SanitizeNameForStrata(originalName);
-                if (claimed.Add(sanitized)) return;
-                var candidate = $"{prefix}{sanitized}";
-                if (!claimed.Add(candidate)) {
-                    var i = 2;
-                    while (!claimed.Add($"{candidate}_{i}")) i++;
-                    candidate = $"{candidate}_{i}";
-                }
-                generator._renames[decl] = candidate;
-            }
-
             foreach (var proc in p.Procedures)
-                ClaimOrRename(proc, proc.Name, "__proc_");
+                ClaimOrRename(proc, proc.Name, "__proc_", claimed, generator._renames);
+            // Defensive: implementations share names with their corresponding
+            // procedures, so they would normally never collide. Claiming them
+            // here guards against edge cases (e.g., an implementation whose
+            // procedure was pruned or renamed upstream).
             foreach (var impl in p.Implementations) {
                 var sanitized = SanitizeNameForStrata(impl.Name);
                 claimed.Add(sanitized);
             }
             foreach (var c in liveDeclarations.OfType<Constant>())
-                ClaimOrRename(c, c.TypedIdent.Name, "__const_");
+                ClaimOrRename(c, c.TypedIdent.Name, "__const_", claimed, generator._renames);
             foreach (var f in liveDeclarations.OfType<Function>())
-                ClaimOrRename(f, f.Name, "__func_");
+                ClaimOrRename(f, f.Name, "__func_", claimed, generator._renames);
             foreach (var g in p.GlobalVariables)
-                ClaimOrRename(g, g.Name, "__var_");
+                ClaimOrRename(g, g.Name, "__var_", claimed, generator._renames);
 
             var typeConstructors = p.TopLevelDeclarations.OfType<TypeCtorDecl>().ToList();
             if (typeConstructors.Count != 0) {
@@ -241,6 +240,29 @@ public class StrataGenerator : ReadOnlyVisitor {
             .Replace('#', '_')
             .Replace('^', '_')
             .Replace("$", "_");
+    }
+
+    /// <summary>
+    /// Claim a sanitized name for <paramref name="decl"/>, or rename it if the
+    /// name is already taken. The first declaration to claim a name wins;
+    /// subsequent colliders get a prefixed (and possibly suffixed) name recorded
+    /// in <paramref name="renames"/>.
+    /// </summary>
+    private static void ClaimOrRename(
+        Declaration decl,
+        string originalName,
+        string prefix,
+        HashSet<string> claimed,
+        Dictionary<Declaration, string> renames) {
+        var sanitized = SanitizeNameForStrata(originalName);
+        if (claimed.Add(sanitized)) return;
+        var candidate = $"{prefix}{sanitized}";
+        if (!claimed.Add(candidate)) {
+            var i = 2;
+            while (!claimed.Add($"{candidate}_{i}")) i++;
+            candidate = $"{candidate}_{i}";
+        }
+        renames[decl] = candidate;
     }
 
     private void AddUniqueConst(Type t, string name) {

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -1850,14 +1850,17 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override Procedure VisitProcedure(Procedure node) {
         if (!_program.Implementations.Any(i => i.Name.Equals(node.Name))) {
-            // SMACK encodes C assert(expr) as a call to assert_.*(cond).
-            // Inject a synthetic requires precondition so the call-elimination
-            // pass generates a VC checking the condition is non-zero.
-            // We add it to node.Requires so WriteProcedureHeader emits it
-            // inside a single spec block alongside any existing specs.
+            // Under --smack, SMACK encodes C assert(expr) as a call to
+            // assert_.*(cond). Inject a synthetic requires precondition so the
+            // call-elimination pass generates a VC checking the condition is
+            // non-zero. We add it to node.Requires so WriteProcedureHeader
+            // emits it inside a single spec block alongside any existing
+            // specs. The injection always fires when the name pattern matches
+            // (no Requires.Count == 0 guard) — if the procedure already has a
+            // hand-written requires, both clauses appear in the merged spec
+            // block, preserving the SMACK invariant unconditionally.
             Requires? syntheticReq = null;
-            if (node.Name.StartsWith("assert_.") && node.InParams.Count > 0
-                && node.Requires.Count == 0) {
+            if (_smack && node.Name.StartsWith("assert_.") && node.InParams.Count > 0) {
                 var param = node.InParams[0];
                 var paramExpr = new IdentifierExpr(param.tok, param);
                 var zero = new LiteralExpr(param.tok, Microsoft.BaseTypes.BigNum.FromInt(0));

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -1816,22 +1816,30 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override Procedure VisitProcedure(Procedure node) {
         if (!_program.Implementations.Any(i => i.Name.Equals(node.Name))) {
-            WriteProcedureHeader(node);
             // SMACK encodes C assert(expr) as a call to assert_.*(cond).
-            // Emit a requires precondition so the call-elimination pass
-            // generates a VC checking the condition is non-zero.
+            // Inject a synthetic requires precondition so the call-elimination
+            // pass generates a VC checking the condition is non-zero.
+            // We add it to node.Requires so WriteProcedureHeader emits it
+            // inside a single spec block alongside any existing specs.
+            Requires? syntheticReq = null;
             if (node.Name.StartsWith("assert_.") && node.InParams.Count > 0
                 && node.Requires.Count == 0) {
-                var firstParam = Name(node.InParams[0].TypedIdent.Name);
-                WriteLine("spec {");
-                IncIndent();
-                Indent();
-                WriteLine($"requires ({firstParam} != 0);");
-                DecIndent();
-                WriteText("}");
+                var param = node.InParams[0];
+                var paramExpr = new IdentifierExpr(param.tok, param);
+                var zero = new LiteralExpr(param.tok, Microsoft.BaseTypes.BigNum.FromInt(0));
+                var neqExpr = Expr.Neq(paramExpr, zero);
+                syntheticReq = new Requires(false, neqExpr);
+                node.Requires.Add(syntheticReq);
             }
+
+            WriteProcedureHeader(node);
             WriteLine(";");
             WriteLine();
+
+            // Remove the synthetic requires to avoid mutating the shared AST.
+            if (syntheticReq != null) {
+                node.Requires.Remove(syntheticReq);
+            }
         }
 
         return node;

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -962,7 +962,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     private void EmitSimpleAssign(SimpleAssignLhs lhs, Expr rhs) {
         Indent();
-        WriteText($"{Name(lhs.AssignedVariable.Name)} := ");
+        WriteText($"{NameOf(lhs.AssignedVariable.Decl, lhs.AssignedVariable.Name)} := ");
         VisitExpr(rhs);
         WriteLine(";");
     }
@@ -1002,12 +1002,12 @@ public class StrataGenerator : ReadOnlyVisitor {
         var needComma = false;
         foreach (var g in _globalVariables.Where(g => modifiesNames.Contains(g.Name))) {
             if (needComma) WriteText(", ");
-            WriteText($"inout {Name(g.Name)}");
+            WriteText($"inout {NameOf(g, g.Name)}");
             needComma = true;
         }
         foreach (var g in _globalVariables.Where(g => !modifiesNames.Contains(g.Name))) {
             if (needComma) WriteText(", ");
-            WriteText(Name(g.Name));
+            WriteText(NameOf(g, g.Name));
             needComma = true;
         }
         foreach (var arg in node.Ins) {
@@ -1027,7 +1027,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override Cmd VisitHavocCmd(HavocCmd node) {
         foreach (var x in node.Vars) {
-            IndentLine($"havoc {Name(x.Name)};");
+            IndentLine($"havoc {NameOf(x.Decl, x.Name)};");
         }
 
         // All assumptions come after all havocs! This allows where clauses
@@ -1567,7 +1567,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override GlobalVariable VisitGlobalVariable(GlobalVariable node) {
         var ti = node.TypedIdent;
-        WriteText($"var {Name(ti.Name)} : ");
+        WriteText($"var {NameOf(node, ti.Name)} : ");
         VisitType(ti.Type);
         WriteLine(";");
         return node;
@@ -1820,7 +1820,7 @@ public class StrataGenerator : ReadOnlyVisitor {
             // SMACK encodes C assert(expr) as a call to assert_.*(cond).
             // Emit a requires precondition so the call-elimination pass
             // generates a VC checking the condition is non-zero.
-            if (node.Name.StartsWith("assert_") && node.InParams.Count > 0
+            if (node.Name.StartsWith("assert_.") && node.InParams.Count > 0
                 && node.Requires.Count == 0) {
                 var firstParam = Name(node.InParams[0].TypedIdent.Name);
                 WriteLine("spec {");
@@ -1844,7 +1844,7 @@ public class StrataGenerator : ReadOnlyVisitor {
             if (needComma) WriteText(", ");
             var name = v.TypedIdent.Name ?? "";
             if (name == "") name = $"x{n++}";
-            WriteText($"{prefix}{Name(name)} : ");
+            WriteText($"{prefix}{NameOf(v, name)} : ");
             VisitType(v.TypedIdent.Type);
             needComma = true;
         }

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -1860,13 +1860,16 @@ public class StrataGenerator : ReadOnlyVisitor {
                 node.Requires.Add(syntheticReq);
             }
 
-            WriteProcedureHeader(node);
-            WriteLine(";");
-            WriteLine();
-
-            // Remove the synthetic requires to avoid mutating the shared AST.
-            if (syntheticReq != null) {
-                node.Requires.Remove(syntheticReq);
+            try {
+                WriteProcedureHeader(node);
+                WriteLine(";");
+                WriteLine();
+            } finally {
+                // Remove the synthetic requires to avoid mutating the shared
+                // AST, even if WriteProcedureHeader threw.
+                if (syntheticReq != null) {
+                    node.Requires.Remove(syntheticReq);
+                }
             }
         }
 

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -52,6 +52,12 @@ public class StrataGenerator : ReadOnlyVisitor {
     // Global variables collected from the program, used to convert them
     // into inout/input parameters on procedure headers and call sites.
     private List<GlobalVariable> _globalVariables = [];
+    // Maps sanitized constant names to their renamed versions when they
+    // collide with procedure names. In Boogie, constants and procedures
+    // live in separate namespaces, but Strata Core has a single namespace.
+    private readonly Dictionary<string, string> _constantRenames = new();
+    // Set of all sanitized procedure names, used to detect collisions.
+    private readonly HashSet<string> _procedureNames = new();
 
     private StrataGenerator(VCGenOptions options, TokenTextWriter writer, Program program) {
         _options = options;
@@ -73,6 +79,22 @@ public class StrataGenerator : ReadOnlyVisitor {
                     : Pruner.GetLiveDeclarations(options, p, allBlocks.ToList()).LiveDeclarations.ToList();
 
             generator.FindSpecialTypes();
+
+            // Collect all procedure names (sanitized) to detect namespace collisions.
+            foreach (var proc in p.Procedures) {
+                generator._procedureNames.Add(SanitizeNameForStrata(proc.Name));
+            }
+            foreach (var impl in p.Implementations) {
+                generator._procedureNames.Add(SanitizeNameForStrata(impl.Name));
+            }
+
+            // Build rename map for constants that collide with procedure names.
+            foreach (var c in liveDeclarations.OfType<Constant>()) {
+                var sanitized = SanitizeNameForStrata(c.TypedIdent.Name);
+                if (generator._procedureNames.Contains(sanitized)) {
+                    generator._constantRenames[c.TypedIdent.Name] = $"__const_{sanitized}";
+                }
+            }
 
             var typeConstructors = p.TopLevelDeclarations.OfType<TypeCtorDecl>().ToList();
             if (typeConstructors.Count != 0) {
@@ -299,6 +321,17 @@ public class StrataGenerator : ReadOnlyVisitor {
         return SanitizeNameForStrata(name);
     }
 
+    /// <summary>
+    /// Returns the (possibly renamed) name for a constant, handling namespace
+    /// collisions with procedures.
+    /// </summary>
+    private string ConstantName(string originalName) {
+        if (_constantRenames.TryGetValue(originalName, out var renamed)) {
+            return renamed;
+        }
+        return SanitizeNameForStrata(originalName);
+    }
+
     private void WriteLine(string text) {
         _writer.WriteLine(text);
     }
@@ -310,7 +343,11 @@ public class StrataGenerator : ReadOnlyVisitor {
         switch (expr) {
             case IdentifierExpr identExpr:
                 WriteText("old ");
-                WriteText(Name(identExpr.Name));
+                if (identExpr.Decl is Constant && _constantRenames.ContainsKey(identExpr.Name)) {
+                    WriteText(ConstantName(identExpr.Name));
+                } else {
+                    WriteText(Name(identExpr.Name));
+                }
                 break;
             case NAryExpr { Fun: MapSelect } mapSelect:
                 WriteText("(");
@@ -546,7 +583,11 @@ public class StrataGenerator : ReadOnlyVisitor {
             case LiteralExpr literalExpr:
                 throw new StrataConversionException(node.tok, $"Unsupported literal type: {literalExpr}");
             case IdentifierExpr identifierExpr:
-                WriteText(Name(identifierExpr.Name));
+                if (identifierExpr.Decl is Constant && _constantRenames.ContainsKey(identifierExpr.Name)) {
+                    WriteText(ConstantName(identifierExpr.Name));
+                } else {
+                    WriteText(Name(identifierExpr.Name));
+                }
                 break;
             case NAryExpr nAryExpr: {
                 var fun = nAryExpr.Fun;
@@ -1510,7 +1551,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override Constant VisitConstant(Constant node) {
         var ti = node.TypedIdent;
-        var name = Name(ti.Name);
+        var name = ConstantName(ti.Name);
         WriteText($"const {name} : ");
         VisitType(ti.Type);
         if (node.Unique) {
@@ -1773,6 +1814,19 @@ public class StrataGenerator : ReadOnlyVisitor {
     public override Procedure VisitProcedure(Procedure node) {
         if (!_program.Implementations.Any(i => i.Name.Equals(node.Name))) {
             WriteProcedureHeader(node);
+            // SMACK encodes C assert(expr) as a call to assert_.*(cond).
+            // Emit a requires precondition so the call-elimination pass
+            // generates a VC checking the condition is non-zero.
+            if (node.Name.StartsWith("assert_") && node.InParams.Count > 0
+                && node.Requires.Count == 0) {
+                var firstParam = Name(node.InParams[0].TypedIdent.Name);
+                WriteLine("spec {");
+                IncIndent();
+                Indent();
+                WriteLine($"requires ({firstParam} != 0);");
+                DecIndent();
+                WriteText("}");
+            }
             WriteLine(";");
             WriteLine();
         }

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -52,12 +52,11 @@ public class StrataGenerator : ReadOnlyVisitor {
     // Global variables collected from the program, used to convert them
     // into inout/input parameters on procedure headers and call sites.
     private List<GlobalVariable> _globalVariables = [];
-    // Maps sanitized constant names to their renamed versions when they
-    // collide with procedure names. In Boogie, constants and procedures
-    // live in separate namespaces, but Strata Core has a single namespace.
-    private readonly Dictionary<string, string> _constantRenames = new();
-    // Set of all sanitized procedure names, used to detect collisions.
-    private readonly HashSet<string> _procedureNames = new();
+    // Renames for declarations whose sanitized name collides with another
+    // declaration. Boogie has separate namespaces for constants, procedures,
+    // etc., but Strata Core has a single namespace. First-seen wins; later
+    // entities get prefixed with their kind (__const_, __func_, __var_).
+    private readonly Dictionary<string, string> _renames = new();
 
     private StrataGenerator(VCGenOptions options, TokenTextWriter writer, Program program) {
         _options = options;
@@ -80,20 +79,28 @@ public class StrataGenerator : ReadOnlyVisitor {
 
             generator.FindSpecialTypes();
 
-            // Collect all procedure names (sanitized) to detect namespace collisions.
-            foreach (var proc in p.Procedures) {
-                generator._procedureNames.Add(SanitizeNameForStrata(proc.Name));
-            }
-            foreach (var impl in p.Implementations) {
-                generator._procedureNames.Add(SanitizeNameForStrata(impl.Name));
-            }
-
-            // Build rename map for constants that collide with procedure names.
+            // Build rename map for declarations with colliding sanitized names.
+            // Procedures/implementations are claimed first; constants, functions,
+            // and globals that collide get prefixed with their entity kind.
+            var claimed = new HashSet<string>();
+            foreach (var proc in p.Procedures)
+                claimed.Add(SanitizeNameForStrata(proc.Name));
+            foreach (var impl in p.Implementations)
+                claimed.Add(SanitizeNameForStrata(impl.Name));
             foreach (var c in liveDeclarations.OfType<Constant>()) {
                 var sanitized = SanitizeNameForStrata(c.TypedIdent.Name);
-                if (generator._procedureNames.Contains(sanitized)) {
-                    generator._constantRenames[c.TypedIdent.Name] = $"__const_{sanitized}";
-                }
+                if (!claimed.Add(sanitized))
+                    generator._renames[c.TypedIdent.Name] = $"__const_{sanitized}";
+            }
+            foreach (var f in liveDeclarations.OfType<Function>()) {
+                var sanitized = SanitizeNameForStrata(f.Name);
+                if (!claimed.Add(sanitized))
+                    generator._renames[f.Name] = $"__func_{sanitized}";
+            }
+            foreach (var g in p.GlobalVariables) {
+                var sanitized = SanitizeNameForStrata(g.Name);
+                if (!claimed.Add(sanitized))
+                    generator._renames[g.Name] = $"__var_{sanitized}";
             }
 
             var typeConstructors = p.TopLevelDeclarations.OfType<TypeCtorDecl>().ToList();
@@ -322,13 +329,9 @@ public class StrataGenerator : ReadOnlyVisitor {
     }
 
     /// <summary>
-    /// Returns the (possibly renamed) name for a constant, handling namespace
-    /// collisions with procedures.
-    /// </summary>
-    private string ConstantName(string originalName) {
-        if (_constantRenames.TryGetValue(originalName, out var renamed)) {
+    private string ResolveName(string originalName) {
+        if (_renames.TryGetValue(originalName, out var renamed))
             return renamed;
-        }
         return SanitizeNameForStrata(originalName);
     }
 
@@ -343,8 +346,8 @@ public class StrataGenerator : ReadOnlyVisitor {
         switch (expr) {
             case IdentifierExpr identExpr:
                 WriteText("old ");
-                if (identExpr.Decl is Constant && _constantRenames.ContainsKey(identExpr.Name)) {
-                    WriteText(ConstantName(identExpr.Name));
+                if (_renames.ContainsKey(identExpr.Name)) {
+                    WriteText(ResolveName(identExpr.Name));
                 } else {
                     WriteText(Name(identExpr.Name));
                 }
@@ -583,8 +586,8 @@ public class StrataGenerator : ReadOnlyVisitor {
             case LiteralExpr literalExpr:
                 throw new StrataConversionException(node.tok, $"Unsupported literal type: {literalExpr}");
             case IdentifierExpr identifierExpr:
-                if (identifierExpr.Decl is Constant && _constantRenames.ContainsKey(identifierExpr.Name)) {
-                    WriteText(ConstantName(identifierExpr.Name));
+                if (_renames.ContainsKey(identifierExpr.Name)) {
+                    WriteText(ResolveName(identifierExpr.Name));
                 } else {
                     WriteText(Name(identifierExpr.Name));
                 }
@@ -1551,7 +1554,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override Constant VisitConstant(Constant node) {
         var ti = node.TypedIdent;
-        var name = ConstantName(ti.Name);
+        var name = ResolveName(ti.Name);
         WriteText($"const {name} : ");
         VisitType(ti.Type);
         if (node.Unique) {

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -53,10 +53,10 @@ public class StrataGenerator : ReadOnlyVisitor {
     // into inout/input parameters on procedure headers and call sites.
     private List<GlobalVariable> _globalVariables = [];
     // Renames for declarations whose sanitized name collides with another
-    // declaration. Boogie has separate namespaces for constants, procedures,
-    // etc., but Strata Core has a single namespace. First-seen wins; later
-    // entities get prefixed with their kind (__const_, __func_, __var_).
-    private readonly Dictionary<string, string> _renames = new();
+    // declaration. Keyed by Boogie Declaration object to avoid ambiguity
+    // when two entities share the same original name (e.g., const main and
+    // procedure main). First-seen wins; later entities get prefixed.
+    private readonly Dictionary<Declaration, string> _renames = new();
 
     private StrataGenerator(VCGenOptions options, TokenTextWriter writer, Program program) {
         _options = options;
@@ -80,28 +80,37 @@ public class StrataGenerator : ReadOnlyVisitor {
             generator.FindSpecialTypes();
 
             // Build rename map for declarations with colliding sanitized names.
-            // Procedures/implementations are claimed first; constants, functions,
-            // and globals that collide get prefixed with their entity kind.
+            // Two kinds of collision are handled:
+            //   1. Cross-namespace: constant vs procedure sharing the same name
+            //   2. Sanitization: distinct names that map to the same string
+            //      (e.g., $add.i32 and $add_i32 both become _add_i32)
+            // First-seen wins; colliding entities get a suffix (_2, _3, ...).
             var claimed = new HashSet<string>();
+
+            void ClaimOrRename(Declaration decl, string originalName, string prefix) {
+                var sanitized = SanitizeNameForStrata(originalName);
+                if (claimed.Add(sanitized)) return;
+                var candidate = $"{prefix}{sanitized}";
+                if (!claimed.Add(candidate)) {
+                    var i = 2;
+                    while (!claimed.Add($"{candidate}_{i}")) i++;
+                    candidate = $"{candidate}_{i}";
+                }
+                generator._renames[decl] = candidate;
+            }
+
             foreach (var proc in p.Procedures)
-                claimed.Add(SanitizeNameForStrata(proc.Name));
-            foreach (var impl in p.Implementations)
-                claimed.Add(SanitizeNameForStrata(impl.Name));
-            foreach (var c in liveDeclarations.OfType<Constant>()) {
-                var sanitized = SanitizeNameForStrata(c.TypedIdent.Name);
-                if (!claimed.Add(sanitized))
-                    generator._renames[c.TypedIdent.Name] = $"__const_{sanitized}";
+                ClaimOrRename(proc, proc.Name, "__proc_");
+            foreach (var impl in p.Implementations) {
+                var sanitized = SanitizeNameForStrata(impl.Name);
+                claimed.Add(sanitized);
             }
-            foreach (var f in liveDeclarations.OfType<Function>()) {
-                var sanitized = SanitizeNameForStrata(f.Name);
-                if (!claimed.Add(sanitized))
-                    generator._renames[f.Name] = $"__func_{sanitized}";
-            }
-            foreach (var g in p.GlobalVariables) {
-                var sanitized = SanitizeNameForStrata(g.Name);
-                if (!claimed.Add(sanitized))
-                    generator._renames[g.Name] = $"__var_{sanitized}";
-            }
+            foreach (var c in liveDeclarations.OfType<Constant>())
+                ClaimOrRename(c, c.TypedIdent.Name, "__const_");
+            foreach (var f in liveDeclarations.OfType<Function>())
+                ClaimOrRename(f, f.Name, "__func_");
+            foreach (var g in p.GlobalVariables)
+                ClaimOrRename(g, g.Name, "__var_");
 
             var typeConstructors = p.TopLevelDeclarations.OfType<TypeCtorDecl>().ToList();
             if (typeConstructors.Count != 0) {
@@ -328,9 +337,8 @@ public class StrataGenerator : ReadOnlyVisitor {
         return SanitizeNameForStrata(name);
     }
 
-    /// <summary>
-    private string ResolveName(string originalName) {
-        if (_renames.TryGetValue(originalName, out var renamed))
+    private string NameOf(Declaration decl, string originalName) {
+        if (_renames.TryGetValue(decl, out var renamed))
             return renamed;
         return SanitizeNameForStrata(originalName);
     }
@@ -346,11 +354,7 @@ public class StrataGenerator : ReadOnlyVisitor {
         switch (expr) {
             case IdentifierExpr identExpr:
                 WriteText("old ");
-                if (_renames.ContainsKey(identExpr.Name)) {
-                    WriteText(ResolveName(identExpr.Name));
-                } else {
-                    WriteText(Name(identExpr.Name));
-                }
+                WriteText(identExpr.Decl != null ? NameOf(identExpr.Decl, identExpr.Name) : Name(identExpr.Name));
                 break;
             case NAryExpr { Fun: MapSelect } mapSelect:
                 WriteText("(");
@@ -586,11 +590,7 @@ public class StrataGenerator : ReadOnlyVisitor {
             case LiteralExpr literalExpr:
                 throw new StrataConversionException(node.tok, $"Unsupported literal type: {literalExpr}");
             case IdentifierExpr identifierExpr:
-                if (_renames.ContainsKey(identifierExpr.Name)) {
-                    WriteText(ResolveName(identifierExpr.Name));
-                } else {
-                    WriteText(Name(identifierExpr.Name));
-                }
+                WriteText(identifierExpr.Decl != null ? NameOf(identifierExpr.Decl, identifierExpr.Name) : Name(identifierExpr.Name));
                 break;
             case NAryExpr nAryExpr: {
                 var fun = nAryExpr.Fun;
@@ -678,7 +678,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
                         break;
                     case FunctionCall functionCall: {
-                        WriteText($"{Name(functionCall.FunctionName)}(");
+                        WriteText($"{NameOf(functionCall.Func, functionCall.FunctionName)}(");
                         EmitSeparated(args, e => VisitExpr(e), ", ");
                         WriteText(")");
                         break;
@@ -997,7 +997,7 @@ public class StrataGenerator : ReadOnlyVisitor {
         var modifiesNames = new HashSet<string>(callee.Modifies.Select(m => m.Name));
 
         Indent("call ");
-        WriteText($"{Name(callee.Name)}(");
+        WriteText($"{NameOf(callee, callee.Name)}(");
         // Emit: inout globals, then read-only globals, then original args, then out outputs.
         var needComma = false;
         foreach (var g in _globalVariables.Where(g => modifiesNames.Contains(g.Name))) {
@@ -1554,7 +1554,7 @@ public class StrataGenerator : ReadOnlyVisitor {
 
     public override Constant VisitConstant(Constant node) {
         var ti = node.TypedIdent;
-        var name = ResolveName(ti.Name);
+        var name = NameOf(node, ti.Name);
         WriteText($"const {name} : ");
         VisitType(ti.Type);
         if (node.Unique) {
@@ -1725,7 +1725,7 @@ public class StrataGenerator : ReadOnlyVisitor {
     }
 
     public override Function VisitFunction(Function node) {
-        WriteText($"function {Name(node.Name)}");
+        WriteText($"function {NameOf(node, node.Name)}");
         EmitTypeParameters(node.TypeParameters);
         WriteText("(");
         WriteFormals(node.InParams);
@@ -1767,7 +1767,7 @@ public class StrataGenerator : ReadOnlyVisitor {
         var modifiesGlobals = _globalVariables.Where(g => modifiesNames.Contains(g.Name)).ToList();
         var readOnlyGlobals = _globalVariables.Where(g => !modifiesNames.Contains(g.Name)).ToList();
 
-        WriteText($"procedure {Name(proc.Name)}");
+        WriteText($"procedure {NameOf(proc, proc.Name)}");
         EmitTypeParameters(proc.TypeParameters);
         WriteText("(");
         // Emit: inout globals, then read-only globals, then original inputs, then out outputs.

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -64,15 +64,21 @@ public class StrataGenerator : ReadOnlyVisitor {
     //   3. Constants, Functions, Globals — registered last; in a
     //      proc-vs-const collision the constant is always renamed.
     private readonly Dictionary<Declaration, string> _renames = new();
+    // True when the input is SMACK-generated Boogie. Gates SMACK-specific
+    // accommodations (synthetic `requires (p != 0)` on assert_.<type> procedures).
+    // The companion `InferModifies = true` knob is set on the Boogie options
+    // by the BoogieToStrata.Main entrypoint, also gated on this flag.
+    private readonly bool _smack;
 
-    private StrataGenerator(VCGenOptions options, TokenTextWriter writer, Program program) {
+    private StrataGenerator(VCGenOptions options, TokenTextWriter writer, Program program, bool smack) {
         _options = options;
         _writer = writer;
         _program = program;
+        _smack = smack;
     }
 
-    public static void EmitProgramAsStrata(VCGenOptions options, Program p, TokenTextWriter writer) {
-        var generator = new StrataGenerator(options, writer, p);
+    public static void EmitProgramAsStrata(VCGenOptions options, Program p, TokenTextWriter writer, bool smack) {
+        var generator = new StrataGenerator(options, writer, p, smack);
 
         var fieldTypeCollector = new FieldTypeCollector();
         fieldTypeCollector.Visit(p);

--- a/Tools/BoogieToStrata/Source/StrataGenerator.cs
+++ b/Tools/BoogieToStrata/Source/StrataGenerator.cs
@@ -354,7 +354,10 @@ public class StrataGenerator : ReadOnlyVisitor {
         switch (expr) {
             case IdentifierExpr identExpr:
                 WriteText("old ");
-                WriteText(identExpr.Decl != null ? NameOf(identExpr.Decl, identExpr.Name) : Name(identExpr.Name));
+                if (identExpr.Decl == null)
+                    throw new StrataConversionException(identExpr.tok,
+                        $"IdentifierExpr '{identExpr.Name}' has null Decl (expected non-null post-resolution)");
+                WriteText(NameOf(identExpr.Decl, identExpr.Name));
                 break;
             case NAryExpr { Fun: MapSelect } mapSelect:
                 WriteText("(");
@@ -590,7 +593,10 @@ public class StrataGenerator : ReadOnlyVisitor {
             case LiteralExpr literalExpr:
                 throw new StrataConversionException(node.tok, $"Unsupported literal type: {literalExpr}");
             case IdentifierExpr identifierExpr:
-                WriteText(identifierExpr.Decl != null ? NameOf(identifierExpr.Decl, identifierExpr.Name) : Name(identifierExpr.Name));
+                if (identifierExpr.Decl == null)
+                    throw new StrataConversionException(identifierExpr.tok,
+                        $"IdentifierExpr '{identifierExpr.Name}' has null Decl (expected non-null post-resolution)");
+                WriteText(NameOf(identifierExpr.Decl, identifierExpr.Name));
                 break;
             case NAryExpr nAryExpr: {
                 var fun = nAryExpr.Fun;

--- a/Tools/BoogieToStrata/Tests/AssertPrefixFalsePositive.bpl
+++ b/Tools/BoogieToStrata/Tests/AssertPrefixFalsePositive.bpl
@@ -1,3 +1,4 @@
+// {:smack}
 // Regression test: procedures starting with "assert_" but NOT matching
 // SMACK's assert_.TYPE pattern should NOT get a synthetic requires.
 // Only assert_.<type> (literal dot) is the SMACK pattern.

--- a/Tools/BoogieToStrata/Tests/AssertPrefixFalsePositive.bpl
+++ b/Tools/BoogieToStrata/Tests/AssertPrefixFalsePositive.bpl
@@ -1,0 +1,11 @@
+// Regression test: procedures starting with "assert_" but NOT matching
+// SMACK's assert_.TYPE pattern should NOT get a synthetic requires.
+// Only assert_.<type> (literal dot) is the SMACK pattern.
+
+procedure assert_helper(p: int) returns (r: int);
+
+procedure main() returns (r: int)
+{
+  // assert_helper is a normal procedure, passing 0 should be fine
+  call r := assert_helper(0);
+}

--- a/Tools/BoogieToStrata/Tests/AssertPrefixFalsePositive.expect
+++ b/Tools/BoogieToStrata/Tests/AssertPrefixFalsePositive.expect
@@ -1,0 +1,2 @@
+Successfully parsed.
+All 0 goals passed.

--- a/Tools/BoogieToStrata/Tests/GlobalVarRenameCollision.bpl
+++ b/Tools/BoogieToStrata/Tests/GlobalVarRenameCollision.bpl
@@ -1,0 +1,9 @@
+const $a.b: int;   axiom $a.b > 0;
+var   $a_b: int;   // both sanitize to _a_b
+procedure main() returns (r: int)
+  modifies $a_b;
+{
+  $a_b := 1;
+  havoc $a_b;
+  r := $a.b + $a_b;
+}

--- a/Tools/BoogieToStrata/Tests/GlobalVarRenameCollision.expect
+++ b/Tools/BoogieToStrata/Tests/GlobalVarRenameCollision.expect
@@ -1,0 +1,2 @@
+Successfully parsed.
+All 0 goals passed.

--- a/Tools/BoogieToStrata/Tests/InferModifiesGlobal.bpl
+++ b/Tools/BoogieToStrata/Tests/InferModifiesGlobal.bpl
@@ -1,0 +1,16 @@
+// Regression test for InferModifies = true.
+//
+// This procedure mutates the global variable `g` but has NO explicit
+// `modifies g;` clause.  With InferModifies = true, Boogie's
+// ModSetCollector should infer the modifies clause so that the
+// BoogieToStrata translator emits `inout g` for procedure p.
+// If InferModifies is ever disabled or broken, this file will fail
+// to translate correctly (g would be treated as read-only instead
+// of inout).
+
+var g: int;
+
+procedure p()
+{
+  g := 1;
+}

--- a/Tools/BoogieToStrata/Tests/InferModifiesGlobal.bpl
+++ b/Tools/BoogieToStrata/Tests/InferModifiesGlobal.bpl
@@ -1,3 +1,4 @@
+// {:smack}
 // Regression test for InferModifies = true.
 //
 // This procedure mutates the global variable `g` but has NO explicit

--- a/Tools/BoogieToStrata/Tests/InferModifiesGlobal.expect
+++ b/Tools/BoogieToStrata/Tests/InferModifiesGlobal.expect
@@ -1,0 +1,2 @@
+Successfully parsed.
+All 0 goals passed.

--- a/Tools/BoogieToStrata/Tests/NamespaceCollision.bpl
+++ b/Tools/BoogieToStrata/Tests/NamespaceCollision.bpl
@@ -1,0 +1,25 @@
+// Minimal reproduction: namespace collision bug in BoogieToStrata.
+// Boogie allows a constant and procedure to share the same name
+// because they live in separate namespaces. BoogieToStrata emits
+// both into Strata Core's single namespace, causing:
+//   "a declaration of this name already exists"
+
+type ref = int;
+
+const main: ref;
+axiom (main == 1000);
+
+var x: int;
+
+procedure main()
+  modifies x;
+{
+  var y: int;
+  x := 42;
+  assert x == 42;
+  // Use the constant in an expression that doesn't require the axiom to verify
+  y := 0;
+  if (main == 1000) { y := 1; }
+  // This assertion is trivially true regardless of the axiom
+  assert y == 0 || y == 1;
+}

--- a/Tools/BoogieToStrata/Tests/NamespaceCollision.expect
+++ b/Tools/BoogieToStrata/Tests/NamespaceCollision.expect
@@ -1,0 +1,4 @@
+Successfully parsed.
+NamespaceCollision.core.st(23, 4) [assert_0]: ✅ pass
+NamespaceCollision.core.st(33, 4) [assert_1]: ✅ pass
+All 2 goals passed.

--- a/Tools/BoogieToStrata/Tests/OldExprRenameCollision.bpl
+++ b/Tools/BoogieToStrata/Tests/OldExprRenameCollision.bpl
@@ -1,0 +1,17 @@
+// Regression test: old() expression with a renamed (colliding) variable.
+//
+// The global variable `main` collides with procedure `main` after
+// sanitization (cross-namespace collision). The variable must be
+// renamed when emitted. An old() expression referencing that variable
+// must use the *renamed* name, not the raw sanitized name.
+// If the code silently falls back to Name() instead of NameOf(), the
+// old() expression will reference the wrong (procedure) name.
+
+var main: int;
+
+procedure main()
+  modifies main;
+  ensures main == old(main) + 1;
+{
+  main := main + 1;
+}

--- a/Tools/BoogieToStrata/Tests/OldExprRenameCollision.expect
+++ b/Tools/BoogieToStrata/Tests/OldExprRenameCollision.expect
@@ -1,0 +1,3 @@
+Successfully parsed.
+OldExprRenameCollision.core.st(10, 2) [main_ensures_0]: ✅ pass
+All 1 goals passed.

--- a/Tools/BoogieToStrata/Tests/SanitizationCollision.bpl
+++ b/Tools/BoogieToStrata/Tests/SanitizationCollision.bpl
@@ -1,0 +1,25 @@
+// Test case: sanitization collision in BoogieToStrata.
+//
+// SanitizeNameForStrata replaces '.', '$', '@', '#', '^' with '_'.
+// This means distinct Boogie identifiers can map to the same Strata name:
+//   $add.i32  →  _add_i32
+//   $add_i32  →  _add_i32   (collision!)
+//
+// The rename mechanism should detect this and disambiguate.
+
+type i32 = int;
+
+function {:inline} $add.i32(i1: i32, i2: i32) returns (i32) { i1 + i2 }
+function {:inline} $add_i32(i1: i32, i2: i32) returns (i32) { i1 + i2 }
+
+procedure main() returns (r: i32)
+ensures r == 5;
+{
+  var a: i32;
+  var b: i32;
+  a := $add.i32(2, 3);
+  b := $add_i32(2, 3);
+  assert a == 5;
+  assert b == 5;
+  r := a;
+}

--- a/Tools/BoogieToStrata/Tests/SanitizationCollision.expect
+++ b/Tools/BoogieToStrata/Tests/SanitizationCollision.expect
@@ -1,0 +1,5 @@
+Successfully parsed.
+SanitizationCollision.core.st(29, 4) [assert_0]: ✅ pass
+SanitizationCollision.core.st(30, 4) [assert_1]: ✅ pass
+SanitizationCollision.core.st(21, 2) [main_ensures_0]: ✅ pass
+All 3 goals passed.

--- a/Tools/BoogieToStrata/Tests/SmackAssert.bpl
+++ b/Tools/BoogieToStrata/Tests/SmackAssert.bpl
@@ -1,12 +1,9 @@
+// {:smack}
 // Minimal test case for SMACK assert_ pattern recognition.
 // SMACK encodes C assert(expr) as a call to assert_.i32(cond).
 // BoogieToStrata should recognize this pattern and emit:
 //   assert (cond != 0);
 // instead of an opaque procedure call.
-//
-// This test passes 0 (false) to assert — it should be a verification
-// failure, but currently produces "All 0 goals passed" because the
-// call is treated as opaque.
 
 type i32 = int;
 

--- a/Tools/BoogieToStrata/Tests/SmackAssert.bpl
+++ b/Tools/BoogieToStrata/Tests/SmackAssert.bpl
@@ -1,0 +1,21 @@
+// Minimal test case for SMACK assert_ pattern recognition.
+// SMACK encodes C assert(expr) as a call to assert_.i32(cond).
+// BoogieToStrata should recognize this pattern and emit:
+//   assert (cond != 0);
+// instead of an opaque procedure call.
+//
+// This test passes 0 (false) to assert — it should be a verification
+// failure, but currently produces "All 0 goals passed" because the
+// call is treated as opaque.
+
+type i32 = int;
+
+procedure assert_.i32(p.0: i32) returns ($r: i32);
+
+procedure main() returns ($r: i32)
+{
+  // assert(false) — should fail verification
+  call $r := assert_.i32(0);
+  $r := 0;
+  return;
+}

--- a/Tools/BoogieToStrata/Tests/SmackAssert.expect
+++ b/Tools/BoogieToStrata/Tests/SmackAssert.expect
@@ -1,0 +1,3 @@
+Successfully parsed.
+SmackAssert.core.st(21, 6) [callElimAssert_assert__i32_requires_0_2]: ❌ fail
+Finished with 0 goals passed, 1 failed.

--- a/Tools/BoogieToStrata/Tests/SmackAssertDuplicateSpec.bpl
+++ b/Tools/BoogieToStrata/Tests/SmackAssertDuplicateSpec.bpl
@@ -1,16 +1,30 @@
-// Regression test: assert_.<type> procedure with an existing ensures clause
-// should produce a single merged spec block, not two separate spec blocks.
-// Bug: VisitProcedure emitted a second spec { requires ... } block in addition
-// to the one already emitted by WriteProcedureHeader for existing ensures.
+// {:smack}
+// Regression test: assert_.<type> procedures must produce a single
+// merged spec block, not duplicates, regardless of whether the input
+// already has user-written specs.
+//
+// Two procedures exercise the two cases:
+//   1. assert_.i32 has only an existing `ensures` — output must merge
+//      the synthetic `requires (p.0 != 0)` with the existing ensures
+//      into one spec block.
+//   2. assert_.i32_with_req has an existing `requires (p.0 > -1)` —
+//      output must contain BOTH requires clauses (the synthetic one
+//      and the user-written one) in a single spec block, not drop the
+//      synthetic one.
 
 type i32 = int;
 
 procedure assert_.i32(p.0: i32) returns ($r: i32);
   ensures ($r == 0);
 
+procedure assert_.i32_with_req(p.0: i32) returns ($r: i32);
+  requires (p.0 > -1);
+
 procedure main() returns ($r: i32)
 {
   // assert(true) -- should pass because p.0 != 0 holds for 1
   call $r := assert_.i32(1);
+  // call assert_.i32_with_req(1) — both `1 != 0` and `1 > -1` hold
+  call $r := assert_.i32_with_req(1);
   return;
 }

--- a/Tools/BoogieToStrata/Tests/SmackAssertDuplicateSpec.bpl
+++ b/Tools/BoogieToStrata/Tests/SmackAssertDuplicateSpec.bpl
@@ -1,0 +1,16 @@
+// Regression test: assert_.<type> procedure with an existing ensures clause
+// should produce a single merged spec block, not two separate spec blocks.
+// Bug: VisitProcedure emitted a second spec { requires ... } block in addition
+// to the one already emitted by WriteProcedureHeader for existing ensures.
+
+type i32 = int;
+
+procedure assert_.i32(p.0: i32) returns ($r: i32);
+  ensures ($r == 0);
+
+procedure main() returns ($r: i32)
+{
+  // assert(true) -- should pass because p.0 != 0 holds for 1
+  call $r := assert_.i32(1);
+  return;
+}

--- a/Tools/BoogieToStrata/Tests/TypeSynonymChain.bpl
+++ b/Tools/BoogieToStrata/Tests/TypeSynonymChain.bpl
@@ -1,0 +1,20 @@
+// Regression test for multi-level type synonym resolution.
+// dealiasTypeExpr must recurse through: ref → i64 → int
+// Without recursive resolution, comparison and arithmetic on `ref`
+// trigger a panic because the type stays as a synonym instead of
+// resolving to the base `int` type.
+
+type i64 = int;
+type ref = i64;
+
+procedure main() returns (r: ref)
+ensures r >= 0;
+{
+  var a: ref;
+  var b: ref;
+  a := 3;
+  b := a + 4;
+  assert b == 7;
+  assert a <= b;
+  r := b;
+}

--- a/Tools/BoogieToStrata/Tests/TypeSynonymChain.expect
+++ b/Tools/BoogieToStrata/Tests/TypeSynonymChain.expect
@@ -1,0 +1,5 @@
+Successfully parsed.
+TypeSynonymChain.core.st(22, 4) [assert_0]: ✅ pass
+TypeSynonymChain.core.st(23, 4) [assert_1]: ✅ pass
+TypeSynonymChain.core.st(14, 2) [main_ensures_0]: ✅ pass
+All 3 goals passed.


### PR DESCRIPTION
*Issue #, if available:* #1148

*Description of changes:*

1. Namespace collision (issue 1 in #1148): Constants that share a name with a procedure are now prefixed with __const_ in the Strata output.  The rename is applied consistently in declarations and references.

2. Recursive synonym resolution (Fixes issue 2 in #1148): DealiasTypeExpr now recurses on its result, resolving synonym chains like ref := i64 := int fully to the base type. Previously it resolved only one level, causing panics on comparison/arithmetic operators applied to multi-level type synonyms.

3. SMACK assert encoding (issue 3 in #1148): Procedures named assert_.* now get a requires (arg != 0) precondition emitted. Call elimination generates VCs at each call site, making SMACK assertions verifiable.

4. InferModifies: SMACK-generated Boogie often omits explicit `modifies` clauses on procedures that mutate globals. Setting `InferModifies = true` in BoogieToStrata has two effects: (1) it runs `ModSetCollector.CollectModifies(program)` to populate empty modifies clauses, and (2) through `CheckModifies` in Boogie's resolution context, it suppresses typechecking of modifies clauses. Without this, `ResolveAndTypecheck` would reject SMACK programs that omit modifies clauses.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.