### PR TITLE
Add PR template warning about repository split

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+**Warning:** This repository will shortly undergo a split into several separate repositories. If you're creating a PR that crosses the boundaries between these repositories, you may want to hold off until the split is complete or be prepared to rework your PR into multiple PRs once the split is complete.
+
+The code that will be moved includes:
+- Strata/DDM/*
+- Strata/Languages/Boole/*
+- Strata/Languages/Python/* along with Tools/Python/*
+- Tools/BoogieToStrata


### PR DESCRIPTION
Add a pull request description template that warns about the upcoming repository split.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
