### PR TITLE
Add variable name to error message

### DIFF
--- a/Strata/DL/Imperative/CmdType.lean
+++ b/Strata/DL/Imperative/CmdType.lean
@@ -37,9 +37,9 @@ def Cmd.typeCheck {P C T} [ToFormat P.Ident] [ToFormat P.Ty] [ToFormat (Cmd P)]
         else
           let (xty, τ) ← TC.preprocess ctx τ xty
           let (expr, ety, τ) ← TC.inferType ctx τ c expr
-          let τ ← (TC.unifyTypes τ [(xty, ety)]).mapError fun _ =>
-            md.toDiagnosticF f!"Variable '{x}' expected type {xty} but \
-              initialization expression has inferred type {ety}."
+          let τ ← (TC.unifyTypes τ [(xty, ety)]).mapError fun e =>
+            md.toDiagnosticF f!"Variable {x} expected type {xty} but \
+              initialization expression has inferred type {ety}: {TC.typeErrorFmt e}"
           let (xty, τ) ← TC.postprocess ctx τ xty
           let τ := TC.update τ x xty
           let c := Cmd.init x xty (.det expr) md
@@ -60,7 +60,8 @@ def Cmd.typeCheck {P C T} [ToFormat P.Ident] [ToFormat P.Ty] [ToFormat (Cmd P)]
       match e with
       | .det expr =>
         let (expr, ety, τ) ← TC.inferType ctx τ c expr
-        let τ ← TC.unifyTypes τ [(xty, ety)]
+        let τ ← (TC.unifyTypes τ [(xty, ety)]).mapError fun e =>
+          md.toDiagnosticF f!"Variable {x} expected type {xty} but expression has type {ety}: {TC.typeErrorFmt e}"
         let c := Cmd.set x (.det expr) md
         .ok (c, τ)
       | .nondet =>

--- a/Strata/DL/Imperative/CmdType.lean
+++ b/Strata/DL/Imperative/CmdType.lean
@@ -37,7 +37,9 @@ def Cmd.typeCheck {P C T} [ToFormat P.Ident] [ToFormat P.Ty] [ToFormat (Cmd P)]
         else
           let (xty, τ) ← TC.preprocess ctx τ xty
           let (expr, ety, τ) ← TC.inferType ctx τ c expr
-          let τ ← TC.unifyTypes τ [(xty, ety)]
+          let τ ← (TC.unifyTypes τ [(xty, ety)]).mapError fun _ =>
+            md.toDiagnosticF f!"Variable '{x}' expected type {xty} but \
+              initialization expression has inferred type {ety}."
           let (xty, τ) ← TC.postprocess ctx τ xty
           let τ := TC.update τ x xty
           let c := Cmd.init x xty (.det expr) md

--- a/StrataTest/DL/Imperative/ArithType.lean
+++ b/StrataTest/DL/Imperative/ArithType.lean
@@ -138,7 +138,7 @@ TEnv:
 private def testProgram2 : Cmds Arith.PureExpr :=
   [.init "x" .Bool (.det (.Num 0)) .empty]
 
-/-- info: error: Types .Bool and Num cannot be unified! -/
+/-- info: error: Variable x expected type .Bool but initialization expression has inferred type Num: Types .Bool and Num cannot be unified! -/
 #guard_msgs in
 #eval do let (cs, τ) ← Cmds.typeCheck () TEnv.init testProgram2
           return format (cs, τ)

--- a/StrataTest/Languages/Core/Tests/StatementTypeTests.lean
+++ b/StrataTest/Languages/Core/Tests/StatementTypeTests.lean
@@ -88,6 +88,19 @@ subst:
                     ]
           return format ans
 
+/-- info: error: Variable x expected type bool but initialization expression has inferred type int: Impossible to unify bool with int. -/
+#guard_msgs in
+#eval do let ans ← typeCheck LContext.default TEnv.default Program.init none
+                    [.init "x" t[bool] (.det eb[#2]) .empty]
+          return format ans
+
+/-- info: error: Variable x expected type bool but expression has type int: Impossible to unify bool with int. -/
+#guard_msgs in
+#eval do let ans ← typeCheck LContext.default TEnv.default Program.init none
+                    [.init "x" t[bool] (.det eb[#true]) .empty,
+                     .set "x" eb[#2] .empty]
+          return format ans
+
 /-- info: error: Variable x of type bool already in context. -/
 #guard_msgs in
 #eval do let ans ← typeCheck LContext.default TEnv.default Program.init none


### PR DESCRIPTION
Add the variable name to the error message when unification fails on initialization.