### PR TITLE
Remove ability to initialize variable with nondeterministic variables

### DIFF
--- a/Strata/DL/Lambda/LExprTypeEnv.lean
+++ b/Strata/DL/Lambda/LExprTypeEnv.lean
@@ -1218,18 +1218,6 @@ def TEnv.maybeGenMonoTypes [ToFormat IDMeta] (Env : TEnv IDMeta) (ids : IdentTs 
       .ok (xty :: ans, Env)
 
 /--
-Insert `fvi` (where `fvi` is the `i`-th element of `fvs`) in the oldest context
-in `Env`, only if `fvi` doesn't already exist in some context in `Env`.
-
-If `fvi` has no type annotation, a fresh type variable is put in the context.
--/
-def TEnv.addInOldestContext [ToFormat IDMeta] [DecidableEq IDMeta] (fvs : IdentTs LMonoTy IDMeta) (Env : TEnv IDMeta) : Except Format (TEnv IDMeta) := do
-  let (monotys, Env) ← maybeGenMonoTypes Env fvs
-  let tys := monotys.map (fun mty => LTy.forAll [] mty)
-  let types := Env.context.types.addInOldest fvs.idents tys
-  return Env.updateContext { Env.genEnv.context with types := types }
-
-/--
 Add a well-formed `alias` to the context, where the type definition is first
 de-aliased.
 -/

--- a/Strata/Languages/Boole/Verify.lean
+++ b/Strata/Languages/Boole/Verify.lean
@@ -550,11 +550,8 @@ private def lowerVarStatement (m : SourceRange) (ds : BooleDDM.DeclList SourceRa
   let mut newBVarsRev : List Core.Expression.Expr := []
   for d in declListToList ds do
     let (id, ty) ← toCoreBind d
-    let n := (← get).globalVarCounter
-    modify fun st => { st with globalVarCounter := n + 1 }
-    let initName := mkIdent s!"init_{id.name}_{n}"
     newBVarsRev := (.fvar () id none : Core.Expression.Expr) :: newBVarsRev
-    outRev := Core.Statement.init id ty (.det (.fvar () initName none)) (← toCoreMetaData m) :: outRev
+    outRev := Core.Statement.init id ty .nondet (← toCoreMetaData m) :: outRev
   modify fun st => { st with bvars := st.bvars ++ newBVarsRev.reverse.toArray }
   return outRev.reverse
 

--- a/Strata/Languages/Core/CmdType.lean
+++ b/Strata/Languages/Core/CmdType.lean
@@ -58,15 +58,8 @@ bound variables.
 -/
 def inferType (C: LContext CoreLParams) (Env: TEnv Unit) (c : Cmd Expression) (e : LExpr CoreLParams.mono) :
     Except DiagnosticModel ((LExpr CoreLParams.mono) × LTy × TEnv Unit) := do
-  -- We only allow free variables to appear in `init` statements. Any other
-  -- occurrence leads to an error.
-  let T ← match c with
-    | .init _ _ _ _ =>
-      let efv := LExpr.freeVars e
-      (Env.addInOldestContext efv).mapError DiagnosticModel.fromFormat
-    | _ =>
-      let _ ← Env.freeVarCheck e f!"[{c}]" |>.mapError DiagnosticModel.fromFormat
-      .ok Env
+  let _ ← Env.freeVarCheck e f!"[{c}]" |>.mapError DiagnosticModel.fromFormat
+  let T := Env
   let (ea, T) ← LExpr.resolve C T e |>.mapError DiagnosticModel.fromFormat
   let ety := ea.toLMonoTy
   return (ea.unresolved, (.forAll [] ety), T)

--- a/StrataTest/Languages/Core/Tests/StatementTypeTests.lean
+++ b/StrataTest/Languages/Core/Tests/StatementTypeTests.lean
@@ -48,7 +48,7 @@ info: ok: context:
 types:   [(zinit, bool) (x, int) (y, int)]
 aliases: []
 state:
-tyGen: 1
+tyGen: 0
 tyPrefix: $__ty
 exprGen: 0
 exprPrefix: $__var
@@ -104,7 +104,7 @@ info: ok: context:
 types:   [(x, int)]
 aliases: []
 state:
-tyGen: 2
+tyGen: 1
 tyPrefix: $__ty
 exprGen: 0
 exprPrefix: $__var
@@ -143,11 +143,11 @@ info: ok: context:
 types:   [(fn, ∀[a]. (arrow a a)) (m1, (arrow int int)) (m2, (arrow (arrow bool int) int))]
 aliases: []
 state:
-tyGen: 10
+tyGen: 8
 tyPrefix: $__ty
 exprGen: 1
 exprPrefix: $__var
-subst: [($__ty0, int) ($__ty2, int) ($__ty6, (arrow bool int)) ($__ty7, bool) ($__ty5, (arrow bool int)) ($__ty3, (arrow bool int)) ($__ty9, int)]
+subst: [($__ty0, int) ($__ty1, int) ($__ty4, (arrow bool int)) ($__ty5, bool) ($__ty3, (arrow bool int)) ($__ty2, (arrow bool int)) ($__ty7, int)]
 -/
 #guard_msgs in
 #eval do let ans ← typeCheck LContext.default (TEnv.default.updateContext { types := [[("fn", t[∀a. %a → %a])]] })


### PR DESCRIPTION
Previously, the RHS of an `init` statement could involve uninitialized variables, which were implicitly nondetermistic and which were used to implement default expressions for `init`. Since https://github.com/strata-org/Strata/pull/432 added an explicit `.nondet` initialization method, this workaround is no longer needed, and this PR removes that capability. The Boole -> Core translation used a similar method; this PR also changes it to use `.nondet`.