### PR TITLE
fix: SMT Solver.spawn stderr pipe opened but reader dropped; solver may SIGPIPE

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+**Warning:** This repository will shortly undergo a split into several separate repositories. If you're creating a PR that crosses the boundaries between these repositories, you may want to hold off until the split is complete or be prepared to rework your PR into multiple PRs once the split is complete.
+
+The code that will be moved includes:
+- Strata/DDM/*
+- Strata/Languages/Boole/*
+- Strata/Languages/Python/* along with Tools/Python/*
+- Tools/BoogieToStrata

--- a/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
@@ -108,8 +108,8 @@ def convertMetaData (md : Imperative.MetaData Core.Expression)
     match elem.fld with
     | .label l => match elem.value with
       | .msg s => some ⟨.label l, .msg s⟩
-      | .fileRange r => some ⟨.label l, .fileRange r⟩
       | .switch b => some ⟨.label l, .switch b⟩
+      | .provenance p => some ⟨.label l, .provenance p⟩
       | .expr _ => none
     | .var _ => none
 

--- a/Strata/DL/Imperative/Cmd.lean
+++ b/Strata/DL/Imperative/Cmd.lean
@@ -183,7 +183,7 @@ instance (P : PureExpr) : HasVarsImp P (Cmds P) where
   definedVars := Cmds.definedVars
   modifiedVars := Cmds.modifiedVars
   -- order matters for Havoc, so needs to override the default
-  touchedVars := List.flatMap HasVarsImp.touchedVars
+  modifiedOrDefinedVars := List.flatMap HasVarsImp.modifiedOrDefinedVars
 
 ---------------------------------------------------------------------
 

--- a/Strata/DL/Imperative/CmdSemantics.lean
+++ b/Strata/DL/Imperative/CmdSemantics.lean
@@ -44,7 +44,7 @@ when the command signals a failure.
 
 /-- ### Well-Formedness of `SemanticStore`s -/
 
-def isDefined {P : PureExpr} (σ : SemanticStore P) (vs : List P.Ident) : Prop :=
+@[expose] def isDefined {P : PureExpr} (σ : SemanticStore P) (vs : List P.Ident) : Prop :=
   ∀ v, v ∈ vs → (σ v).isSome = true
 
 def isNotDefined {P : PureExpr} (σ : SemanticStore P) (vs : List P.Ident) : Prop :=
@@ -239,7 +239,7 @@ def WellFormedSemanticEvalVal {P : PureExpr} [HasVal P]
 @[expose] def WellFormedSemanticEvalVar {P : PureExpr} [HasFvar P] (δ : SemanticEval P)
     : Prop := (∀ e v σ, HasFvar.getFvar e = some v → δ σ e = σ v)
 
-def WellFormedSemanticEvalExprCongr {P : PureExpr} [HasVarsPure P P.Expr] (δ : SemanticEval P)
+@[expose] def WellFormedSemanticEvalExprCongr {P : PureExpr} [HasVarsPure P P.Expr] (δ : SemanticEval P)
     : Prop := ∀ e σ σ', (∀ x ∈ HasVarsPure.getVars e, σ x = σ' x) → δ σ e = δ σ' e
 
 /--

--- a/Strata/DL/Imperative/HasVars.lean
+++ b/Strata/DL/Imperative/HasVars.lean
@@ -21,7 +21,7 @@ class HasVarsPure (P : PureExpr) (α : Type) where
 class HasVarsImp (P : PureExpr) (α : Type) where
   definedVars : α → List P.Ident
   modifiedVars : α → List P.Ident
-  touchedVars : α → List P.Ident
+  modifiedOrDefinedVars : α → List P.Ident
           := λ e ↦ definedVars e ++ modifiedVars e
 
 ---------------------------------------------------------------------
@@ -42,7 +42,7 @@ class HasVarsTrans
   definedVarsTrans : (String → Option PT) → α → List P.Ident
   modifiedVarsTrans : (String → Option PT) → α → List P.Ident
   getVarsTrans : (String → Option PT) → α → List P.Ident
-  touchedVarsTrans : (String → Option PT) → α → List P.Ident
+  modifiedOrDefinedVarsTrans : (String → Option PT) → α → List P.Ident
   allVarsTrans : (String → Option PT) → α → List P.Ident
   := λ π a ↦ modifiedVarsTrans π a ++ getVarsTrans π a
 

--- a/Strata/DL/Imperative/KleeneSemanticsProps.lean
+++ b/Strata/DL/Imperative/KleeneSemanticsProps.lean
@@ -37,6 +37,28 @@ theorem eval_tt_is_tt
 /-! ## Kleene small-step helpers -/
 
 omit [HasVal P] [HasBoolVal P] in
+theorem kleene_block_inner_star
+    (σ_parent : SemanticStore P)
+    (inner inner' : KleeneConfig P (Cmd P))
+    (h : StepKleeneStar P (EvalCmd P) inner inner') :
+    StepKleeneStar P (EvalCmd P) (.block σ_parent inner) (.block σ_parent inner') := by
+  induction h with
+  | refl => exact .refl _
+  | step _ mid _ hstep _ ih => exact .step _ _ _ (.step_block_body hstep) ih
+
+omit [HasVal P] [HasBoolVal P] in
+/-- Lift an inner execution through a block wrapper to terminal (with projection). -/
+theorem kleene_block_terminal
+    (σ_parent : SemanticStore P)
+    (inner : KleeneConfig P (Cmd P)) (ρ' : Env P)
+    (h : StepKleeneStar P (EvalCmd P) inner (.terminal ρ')) :
+    StepKleeneStar P (EvalCmd P) (.block σ_parent inner)
+      (.terminal { ρ' with store := projectStore σ_parent ρ'.store }) :=
+  ReflTrans_Transitive _ _ _ _
+    (kleene_block_inner_star σ_parent inner (.terminal ρ') h)
+    (.step _ _ _ .step_block_done (.refl _))
+
+omit [HasVal P] [HasBoolVal P] in
 theorem kleene_seq_inner_star
     (inner inner' : KleeneConfig P (Cmd P)) (s2 : KleeneStmt P (Cmd P))
     (h : StepKleeneStar P (EvalCmd P) inner inner') :

--- a/Strata/DL/Imperative/KleeneStmt.lean
+++ b/Strata/DL/Imperative/KleeneStmt.lean
@@ -41,6 +41,11 @@ inductive KleeneStmt (P : PureExpr) (Cmd : Type) : Type where
   | choice   (s1 s2 : KleeneStmt P Cmd)
   /-- Execute `s` an arbitrary number of times (possibly zero). -/
   | loop     (s : KleeneStmt P Cmd)
+  /-- Execute `s` in a scoped block: variables initialized inside are
+      projected away on exit (matching the deterministic `.block` semantics).
+      There is no label unlike Imperative.Stmt.block because KleeneStmt doesn't
+      have .exit. -/
+  | block    (s : KleeneStmt P Cmd)
   deriving Inhabited
 
 abbrev KleeneStmt.init {P : PureExpr} (name : P.Ident) (ty : P.Ty) (expr : P.Expr) (md : MetaData P) :=
@@ -62,6 +67,7 @@ def KleeneStmt.definedVars [HasVarsImp P C] (s : KleeneStmt P C) : List P.Ident 
   | .seq s1 s2 => KleeneStmt.definedVars s1 ++ KleeneStmt.definedVars s2
   | .choice s1 s2 => KleeneStmt.definedVars s1 ++ KleeneStmt.definedVars s2
   | .loop s => KleeneStmt.definedVars s
+  | .block s => KleeneStmt.definedVars s
 
 def KleeneStmts.definedVars [HasVarsImp P C] (ss : List (KleeneStmt P C)) : List P.Ident :=
   match ss with
@@ -77,6 +83,7 @@ def KleeneStmt.modifiedVars [HasVarsImp P C] (s : KleeneStmt P C) : List P.Ident
   | .seq s1 s2 => KleeneStmt.modifiedVars s1 ++ KleeneStmt.modifiedVars s2
   | .choice s1 s2 => KleeneStmt.modifiedVars s1 ++ KleeneStmt.modifiedVars s2
   | .loop s => KleeneStmt.modifiedVars s
+  | .block s => KleeneStmt.modifiedVars s
 
 def KleeneStmts.modifiedVars [HasVarsImp P C] (ss : List (KleeneStmt P C)) : List P.Ident :=
   match ss with
@@ -101,6 +108,7 @@ def formatKleeneStmt (P : PureExpr) (s : KleeneStmt P C)
   | .seq s1 s2 => f!"({formatKleeneStmt P s1}) ; ({formatKleeneStmt P s2})"
   | .choice s1 s2 => f!"({formatKleeneStmt P s1}) | ({formatKleeneStmt P s2})"
   | .loop s => f!"({formatKleeneStmt P s})*"
+  | .block s => f!"block({formatKleeneStmt P s})"
 
 instance [ToFormat P.Ident] [ToFormat P.Expr] [ToFormat P.Ty] [ToFormat C]
         : ToFormat (KleeneStmt P C) where

--- a/Strata/DL/Imperative/KleeneStmtSemantics.lean
+++ b/Strata/DL/Imperative/KleeneStmtSemantics.lean
@@ -17,7 +17,7 @@ public section
 /-! # Small-step semantics for non-deterministic statements
 
 A configuration is either executing a `KleeneStmt`, sequencing two parts
-(left config + right continuation), or terminated.
+(left config + right continuation), a block context, or terminated.
 -/
 
 /-- Configurations for small-step execution of `KleeneStmt`. -/
@@ -28,6 +28,9 @@ inductive KleeneConfig (P : PureExpr) (CmdT : Type) : Type where
   | seq : KleeneConfig P CmdT → KleeneStmt P CmdT → KleeneConfig P CmdT
   /-- Execution has finished. -/
   | terminal : Env P → KleeneConfig P CmdT
+  /-- A block context for scoping. The `SemanticStore P` is the parent store;
+      on exit, variables init'd inside are projected away. -/
+  | block : SemanticStore P → KleeneConfig P CmdT → KleeneConfig P CmdT
 
 /-! ## Configuration accessors -/
 
@@ -35,16 +38,19 @@ inductive KleeneConfig (P : PureExpr) (CmdT : Type) : Type where
   | .stmt _ ρ => ρ.store
   | .seq inner _ => inner.getStore
   | .terminal ρ => ρ.store
+  | .block _ inner => inner.getStore
 
 @[expose] def KleeneConfig.getEval : KleeneConfig P CmdT → SemanticEval P
   | .stmt _ ρ => ρ.eval
   | .seq inner _ => inner.getEval
   | .terminal ρ => ρ.eval
+  | .block _ inner => inner.getEval
 
 @[expose] def KleeneConfig.getEnv : KleeneConfig P CmdT → Env P
   | .stmt _ ρ => ρ
   | .seq inner _ => inner.getEnv
   | .terminal ρ => ρ
+  | .block _ inner => inner.getEnv
 
 /-! ## Single-step relation -/
 
@@ -89,11 +95,21 @@ inductive StepKleene
       (.stmt (.loop s) ρ)
       (.terminal ρ)
 
-  /-- A loop can execute one iteration then continue looping. -/
+  /-- A loop can execute one iteration then continue looping.
+      Each iteration's body runs in its own block scope, sequenced with the
+      recursive loop step.  When the body's block terminates, projection drops
+      any variables initialized inside the body, so the next iteration starts
+      with the same `isSome`-domain as the loop entry. -/
   | step_loop_step :
     StepKleene EvalCmd
       (.stmt (.loop s) ρ)
-      (.seq (.stmt s ρ) (.loop s))
+      (.seq (.block ρ.store (.stmt s ρ)) (.loop s))
+
+  /-- A block statement enters a block context, saving the parent store. -/
+  | step_block :
+    StepKleene EvalCmd
+      (.stmt (.block s) ρ)
+      (.block ρ.store (.stmt s ρ))
 
   /-- A seq context steps its inner config forward. -/
   | step_seq_inner :
@@ -109,6 +125,20 @@ inductive StepKleene
     StepKleene EvalCmd
       (.seq (.terminal ρ') s2)
       (.stmt s2 ρ')
+
+  /-- A block context steps its inner config forward. -/
+  | step_block_body :
+    StepKleene EvalCmd inner inner' →
+    ----
+    StepKleene EvalCmd
+      (.block σ_parent inner)
+      (.block σ_parent inner')
+
+  /-- When a block's inner config reaches terminal, project the store. -/
+  | step_block_done :
+    StepKleene EvalCmd
+      (.block σ_parent (.terminal ρ'))
+      (.terminal { ρ' with store := projectStore σ_parent ρ'.store })
 
 end
 

--- a/Strata/DL/Imperative/MetaData.lean
+++ b/Strata/DL/Imperative/MetaData.lean
@@ -8,9 +8,10 @@ module
 public import Strata.DL.Imperative.PureExpr
 public import Strata.DL.Util.DecidableEq
 public import Strata.Util.FileRange
+public import Strata.Util.Provenance
 
 namespace Imperative
-open Strata
+open Strata (DiagnosticModel DiagnosticType FileRange Provenance Uri SourceRange)
 
 public section
 
@@ -69,23 +70,23 @@ instance [Repr P.Ident] : Repr (MetaDataElem.Field P) where
       | .label s => f!"MetaDataElem.Field.label {s}"
     Repr.addAppParen res prec
 
-/-- A metadata value, which can be either an expression, a message, or a fileRange -/
+/-- A metadata value, which can be either an expression, a message, a switch, or a provenance. -/
 inductive MetaDataElem.Value (P : PureExpr) where
   /-- Metadata value in the form of a structured expression. -/
   | expr (e : P.Expr)
   /-- Metadata value in the form of an arbitrary string. -/
   | msg (s : String)
-  /-- Metadata value in the form of a fileRange. -/
-  | fileRange (r: FileRange)
   /-- Metadata value in the form of a boolean switch. -/
   | switch (b : Bool)
+  /-- Metadata value in the form of a provenance (source location or synthesized origin). -/
+  | provenance (p : Provenance)
 
 instance [ToFormat P.Expr] : ToFormat (MetaDataElem.Value P) where
   format f := match f with
               | .expr e => f!"{e}"
               | .msg s => f!"{s}"
-              | .fileRange r => f!"{r}"
               | .switch b => f!"{b}"
+              | .provenance p => f!"{p}"
 
 instance [Repr P.Expr] : Repr (MetaDataElem.Value P) where
   reprPrec v prec :=
@@ -93,16 +94,16 @@ instance [Repr P.Expr] : Repr (MetaDataElem.Value P) where
       match v with
       | .expr e => f!".expr {reprPrec e prec}"
       | .msg s => f!".msg {s}"
-      | .fileRange fr => f!".fileRange {fr}"
       | .switch b => f!".switch {repr b}"
+      | .provenance p => f!".provenance {repr p}"
     Repr.addAppParen res prec
 
 def MetaDataElem.Value.beq [BEq P.Expr] (v1 v2 : MetaDataElem.Value P) :=
   match v1, v2 with
   | .expr e1, .expr e2 => e1 == e2
   | .msg m1, .msg m2 => m1 == m2
-  | .fileRange r1, .fileRange r2 => r1 == r2
   | .switch b1, .switch b2 => b1 == b2
+  | .provenance p1, .provenance p2 => p1 == p2
   | _, _ => false
 
 instance [BEq P.Expr] : BEq (MetaDataElem.Value P) where
@@ -178,7 +179,8 @@ instance [Repr P.Expr] [Repr P.Ident] : Repr (MetaDataElem P) where
 /-! ### Common metadata fields -/
 
 @[match_pattern]
-abbrev MetaData.fileRange : MetaDataElem.Field P := .label "fileRange"
+abbrev MetaData.provenanceField : MetaDataElem.Field P := .label "provenance"
+
 @[match_pattern]
 abbrev MetaData.reachCheck : MetaDataElem.Field P := .label "reachCheck"
 @[match_pattern]
@@ -222,18 +224,31 @@ def MetaData.hasSatisfiabilityCheck {P : PureExpr} [BEq P.Ident] (md : MetaData 
     | _ => false
   | none => false
 
+/-- Get the provenance from metadata. -/
+def getProvenance {P : PureExpr} [BEq P.Ident] (md : MetaData P) : Option Provenance := do
+  let elem ← md.findElem Imperative.MetaData.provenanceField
+  match elem.value with
+  | .provenance p => some p
+  | _ => none
+
 def getFileRange {P : PureExpr} [BEq P.Ident] (md: MetaData P) : Option FileRange := do
-  let fileRangeElement <- md.findElem Imperative.MetaData.fileRange
-  match fileRangeElement.value with
-    | .fileRange fileRange =>
-      some fileRange
-    | _ => none
+  let p ← getProvenance md
+  p.toFileRange
+
+/-- Create metadata with a provenance element. -/
+def MetaData.ofProvenance {P : PureExpr} (p : Provenance) : MetaData P :=
+  #[{ fld := MetaData.provenanceField, value := .provenance p }]
+
+/-- Create metadata from a source range and URI, storing provenance. -/
+def MetaData.ofSourceRange {P : PureExpr} (uri : Uri) (sr : SourceRange) : MetaData P :=
+  MetaData.ofProvenance (Provenance.ofSourceRange uri sr)
 
 /-- Create a DiagnosticModel from metadata and a message.
-    Uses the file range from metadata if available, otherwise uses a default location. -/
+    Uses provenance or file range from metadata if available, otherwise uses a default location. -/
 def MetaData.toDiagnostic {P : PureExpr} [BEq P.Ident] (md : MetaData P) (msg : String) (type : DiagnosticType := DiagnosticType.UserError): DiagnosticModel :=
-  match getFileRange md with
-  | some fr => DiagnosticModel.withRange fr msg type
+  match getProvenance md with
+  | some (.loc uri range) => DiagnosticModel.withRange { file := uri, range } msg type
+  | some (.synthesized _) => DiagnosticModel.fromMessage msg type
   | none => DiagnosticModel.fromMessage msg type
 
 /-- Create a DiagnosticModel from metadata and a Format message. -/
@@ -261,7 +276,16 @@ def getRelatedFileRanges {P : PureExpr} [BEq P.Ident] (md: MetaData P) : Array F
   md.filterMap fun elem =>
     if elem.fld == Imperative.MetaData.relatedFileRange then
       match elem.value with
-      | .fileRange fr => some fr
+      | .provenance p => p.toFileRange
+      | _ => none
+    else none
+
+/-- Get all related provenances from metadata, in order. -/
+private def getRelatedProvenances {P : PureExpr} [BEq P.Ident] (md: MetaData P) : Array Provenance :=
+  md.filterMap fun elem =>
+    if elem.fld == Imperative.MetaData.relatedFileRange then
+      match elem.value with
+      | .provenance p => some p
       | _ => none
     else none
 
@@ -270,20 +294,21 @@ def MetaData.eraseAllElems {P : PureExpr} [BEq P.Ident]
     (md : MetaData P) (fld : MetaDataElem.Field P) : MetaData P :=
   md.filter (fun e => !(e.fld == fld))
 
-/-- Replace the primary file range with a new one, shifting existing related
-    file ranges and prepending the old primary range. -/
+/-- Replace the primary provenance with a new one, shifting existing related
+    provenances and prepending the old primary provenance. -/
 def MetaData.setCallSiteFileRange {P : PureExpr} [BEq P.Ident]
     (md : MetaData P) (callSiteRange : MetaData P) : MetaData P :=
-  match getFileRange callSiteRange, getFileRange md with
-  | some csRange, some origRange =>
-    let existingRelated := getRelatedFileRanges md
-    let md := md.eraseElem MetaData.fileRange
+  match getProvenance callSiteRange, getProvenance md with
+  | some csProv, some origProv =>
+    let existingRelated := getRelatedProvenances md
+    let md := md.eraseElem MetaData.provenanceField
     let md := md.eraseAllElems MetaData.relatedFileRange
-    let md := md.pushElem MetaData.fileRange (.fileRange csRange)
-    let md := md.pushElem MetaData.relatedFileRange (.fileRange origRange)
-    existingRelated.foldl (fun md fr => md.pushElem MetaData.relatedFileRange (.fileRange fr)) md
-  | some csRange, none =>
-    md.pushElem MetaData.fileRange (.fileRange csRange)
+    let md := md.pushElem MetaData.provenanceField (.provenance csProv)
+    let md := md.pushElem MetaData.relatedFileRange (.provenance origProv)
+    existingRelated.foldl (fun md p => md.pushElem MetaData.relatedFileRange (.provenance p)) md
+  | some csProv, none =>
+    let md := md.eraseElem MetaData.provenanceField
+    md.pushElem MetaData.provenanceField (.provenance csProv)
   | none, _ => md
 
 /-- Metadata field for property type classification (e.g., "divisionByZero"). -/

--- a/Strata/DL/Imperative/SemanticsProps.lean
+++ b/Strata/DL/Imperative/SemanticsProps.lean
@@ -137,7 +137,6 @@ private theorem step_hasFailure_monotone
   | step_seq_exit => exact hf
   | step_block_body _ ih => exact ih hf
   | step_block_done => exact hf
-  | step_block_exit_none => exact hf
   | step_block_exit_match _ => exact hf
   | step_block_exit_mismatch _ => exact hf
 

--- a/Strata/DL/Imperative/Stmt.lean
+++ b/Strata/DL/Imperative/Stmt.lean
@@ -43,10 +43,9 @@ inductive Stmt (P : PureExpr) (Cmd : Type) : Type where
   | loop     (guard : ExprOrNondet P) (measure : Option P.Expr)
              (invariants : List (String × P.Expr))
              (body : List (Stmt P Cmd)) (md : MetaData P)
-  /-- An exit statement that transfers control out of the nearest enclosing
-  block with the given label. If no label is provided, exits the nearest
-  enclosing block. -/
-  | exit     (label : Option String) (md : MetaData P)
+  /-- An exit statement that transfers control out of the enclosing block
+  with the given label. -/
+  | exit     (label : String) (md : MetaData P)
   /-- A function declaration within a statement block. -/
   | funcDecl (decl : PureFunc P) (md : MetaData P)
   /-- A type declaration within a statement block. -/
@@ -80,7 +79,7 @@ def Stmt.inductionOn {P : PureExpr} {Cmd : Type}
       (body : List (Stmt P Cmd)) (md : MetaData P),
       (∀ s, s ∈ body → motive s) →
       motive (Stmt.loop guard measure invariant body md))
-    (exit_case : ∀ (label : Option String) (md : MetaData P),
+    (exit_case : ∀ (label : String) (md : MetaData P),
       motive (Stmt.exit label md))
     (funcDecl_case : ∀ (decl : PureFunc P) (md : MetaData P),
       motive (Stmt.funcDecl decl md))
@@ -304,31 +303,40 @@ mutual
 /-- Get all variables modified/defined by the statement `s`.
     Note that we need a separate function because order matters here for sub-blocks
  -/
-@[simp]
-def Stmt.touchedVars [HasVarsImp P C] (s : Stmt P C) : List P.Ident :=
+def Stmt.modifiedOrDefinedVars [HasVarsImp P C] (s : Stmt P C) : List P.Ident :=
   match s with
-  | .block _ bss _ => Block.touchedVars bss
-  | .ite _ tbss ebss _ => Block.touchedVars tbss ++ Block.touchedVars ebss
+  | .block _ bss _ => Block.modifiedOrDefinedVars bss
+  | .ite _ tbss ebss _ => Block.modifiedOrDefinedVars tbss ++ Block.modifiedOrDefinedVars ebss
   | _ => Stmt.definedVars s ++ Stmt.modifiedVars s
 
-@[simp]
-def Block.touchedVars [HasVarsImp P C] (ss : Block P C) : List P.Ident :=
+def Block.modifiedOrDefinedVars [HasVarsImp P C] (ss : Block P C) : List P.Ident :=
   match ss with
   | [] => []
-  | s :: srest => Stmt.touchedVars s ++ Block.touchedVars srest
+  | s :: srest => Stmt.modifiedOrDefinedVars s ++ Block.modifiedOrDefinedVars srest
+end
+
+mutual
+/-- Get all variables touched (modified, defined, or read) by the statement `s`. -/
+def Stmt.touchedVars [HasVarsImp P C] [HasVarsPure P P.Expr] [HasVarsPure P C]
+    (s : Stmt P C) : List P.Ident :=
+  Stmt.modifiedOrDefinedVars s ++ Stmt.getVars s
+
+def Block.touchedVars [HasVarsImp P C] [HasVarsPure P P.Expr] [HasVarsPure P C]
+    (ss : Block P C) : List P.Ident :=
+  Block.modifiedOrDefinedVars ss ++ Block.getVars ss
 end
 
 instance (P : PureExpr) [HasVarsImp P C] : HasVarsImp P (Stmt P C) where
   definedVars := Stmt.definedVars
   modifiedVars := Stmt.modifiedVars
   -- order matters for Havoc, so needs to override the default
-  touchedVars := Stmt.touchedVars
+  modifiedOrDefinedVars := Stmt.modifiedOrDefinedVars
 
 instance (P : PureExpr) [HasVarsImp P C] : HasVarsImp P (Block P C) where
   definedVars := Block.definedVars
   modifiedVars := Block.modifiedVars
   -- order matters for Havoc, so needs to override the default
-  touchedVars := Block.touchedVars
+  modifiedOrDefinedVars := Block.modifiedOrDefinedVars
 
 ---------------------------------------------------------------------
 
@@ -356,9 +364,7 @@ def formatStmt (P : PureExpr) (s : Stmt P C)
       let beforeBody := nestD f!"{line}{guard}{line}({measure}){line}{invFmt}"
       let children := group f!"{beforeBody}{line}{body}"
       f!"{md}while{children}"
-  | .exit label md => match label with
-    | some l => f!"{md}exit {l}"
-    | none => f!"{md}exit"
+  | .exit label md => f!"{md}exit {label}"
   | .funcDecl _ md => f!"{md}funcDecl <function>"
   | .typeDecl tc md => f!"{md}type {tc.name} (arity {tc.numargs})"
 
@@ -390,29 +396,24 @@ instance [ToFormat P.Ident] [ToFormat P.Expr] [ToFormat P.Ty] [ToFormat C]
 by an enclosing `block` — either within `s` itself or with a label in
 `labels` (representing blocks that enclose `s` externally).
 
-When `s.exitsCoveredByBlocks []`, execution of `s` can never produce `.exiting`.
+When `s.exitsCoveredByBlocks []`, execution of `s` can never produce `.exiting`. -/
 
-The labels have type `Option String` (not `String`) so that `exit` without
-destination block label can be considered as covered even when it is surrounded
-by unlabeled blocks (`[None]`). -/
-
-@[expose] def Stmt.exitsCoveredByBlocks : List (Option String) → Stmt P CmdT → Prop
+@[expose] def Stmt.exitsCoveredByBlocks : List String → Stmt P CmdT → Prop
   | _, .cmd _ => True
-  | labels, .block l ss _ => Block.exitsCoveredByBlocks (.some l :: labels) ss
+  | labels, .block l ss _ => Block.exitsCoveredByBlocks (l :: labels) ss
   | labels, .ite _ tss ess _ => Block.exitsCoveredByBlocks labels tss ∧ Block.exitsCoveredByBlocks labels ess
   | labels, .loop _ _ _ body _ => Block.exitsCoveredByBlocks labels body
-  | labels, .exit none _ => labels.length > 0
-  | labels, .exit (some l) _ => .some l ∈ labels
+  | labels, .exit l _ => l ∈ labels
   | _, .funcDecl _ _ => True
   | _, .typeDecl _ _ => True
 where
-  Block.exitsCoveredByBlocks : List (Option String) → List (Stmt P CmdT) → Prop
+  Block.exitsCoveredByBlocks : List String → List (Stmt P CmdT) → Prop
     | _, [] => True
     | labels, s :: ss => Stmt.exitsCoveredByBlocks labels s ∧ Block.exitsCoveredByBlocks labels ss
 
 theorem block_exitsCoveredByBlocks_append
     {P : PureExpr} {CmdT : Type}
-    (labels : List (Option String)) (ss₁ ss₂ : List (Stmt P CmdT))
+    (labels : List String) (ss₁ ss₂ : List (Stmt P CmdT))
     (h₁ : Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks labels ss₁)
     (h₂ : Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks labels ss₂) :
     Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks labels (ss₁ ++ ss₂) := by
@@ -424,7 +425,7 @@ theorem block_exitsCoveredByBlocks_append
     can only help. -/
 theorem exitsCoveredByBlocks_weaken
     {P : PureExpr} {CmdT : Type}
-    (labels₁ labels₂ : List (Option String))
+    (labels₁ labels₂ : List String)
     (hsub : ∀ l, l ∈ labels₁ → l ∈ labels₂) :
     (∀ (s : Stmt P CmdT),
       s.exitsCoveredByBlocks labels₁ → s.exitsCoveredByBlocks labels₂) ∧
@@ -449,8 +450,8 @@ theorem exitsCoveredByBlocks_weaken
   | cmd _ => intros; trivial
   | block l ss _ ih =>
     intro labels₁ labels₂ hsub h
-    show Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks (.some l :: labels₂) ss
-    exact ih (.some l :: labels₁) (.some l :: labels₂)
+    show Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks (l :: labels₂) ss
+    exact ih (l :: labels₁) (l :: labels₂)
       (fun x hx => by cases hx with
         | head => exact .head _
         | tail _ hm => exact .tail _ (hsub x hm))
@@ -461,14 +462,9 @@ theorem exitsCoveredByBlocks_weaken
   | loop _ _ _ body _ ih =>
     intro labels₁ labels₂ hsub h
     exact ih labels₁ labels₂ hsub h
-  | exit label _ =>
+  | exit l _ =>
     intro labels₁ labels₂ hsub h
-    cases label with
-    | none =>
-      show labels₂.length > 0
-      exact List.length_pos_iff_exists_mem.mpr
-        (let ⟨x, hx⟩ := List.length_pos_iff_exists_mem.mp h; ⟨x, hsub x hx⟩)
-    | some l => exact hsub (.some l) h
+    exact hsub l h
   | funcDecl _ _ => intros; trivial
   | typeDecl _ _ => intros; trivial
   | nil => intros; trivial
@@ -480,7 +476,7 @@ theorem exitsCoveredByBlocks_weaken
     for any labels (since `.cmd` has no exit statements). -/
 theorem all_cmd_exitsCoveredByBlocks
     {P : PureExpr} {CmdT : Type}
-    (labels : List (Option String)) (ss : List (Stmt P CmdT))
+    (labels : List String) (ss : List (Stmt P CmdT))
     (h : ∀ s ∈ ss, ∃ c, s = Stmt.cmd c) :
     Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks labels ss := by
   induction ss with

--- a/Strata/DL/Imperative/StmtEval.lean
+++ b/Strata/DL/Imperative/StmtEval.lean
@@ -23,7 +23,7 @@ inductive RunConfig (P : PureExpr) (CmdT : Type) (S : Type) where
   | stmt   : Stmt P CmdT → S → RunConfig P CmdT S
   | stmts  : List (Stmt P CmdT) → S → RunConfig P CmdT S
   | terminal : S → RunConfig P CmdT S
-  | exiting  : Option String → S → RunConfig P CmdT S
+  | exiting  : String → S → RunConfig P CmdT S
   | block  : String → RunConfig P CmdT S → RunConfig P CmdT S
   | seq    : RunConfig P CmdT S → List (Stmt P CmdT) → RunConfig P CmdT S
 
@@ -96,10 +96,9 @@ def runStep [BEq P.Expr] [HasBool P]
   | .block label inner =>
     match inner with
     | .terminal ρ' => .terminal (ops.popScope ρ')
-    | .exiting .none ρ' => .terminal (ops.popScope ρ')
-    | .exiting (.some l) ρ' =>
+    | .exiting l ρ' =>
       if l == label then .terminal (ops.popScope ρ')
-      else .exiting (.some l) (ops.popScope ρ')
+      else .exiting l (ops.popScope ρ')
     | _ => .block label (runStep ops inner)
 
 def runStmt [BEq P.Expr] [HasBool P]

--- a/Strata/DL/Imperative/StmtSemantics.lean
+++ b/Strata/DL/Imperative/StmtSemantics.lean
@@ -66,12 +66,14 @@ inductive Config (P : PureExpr) (CmdT : Type) : Type where
   /-- A terminal configuration, indicating that execution has finished. -/
   | terminal : Env P → Config P CmdT
   /-- An exiting configuration, indicating that an exit statement was encountered.
-      The optional label identifies which block to exit to. -/
-  | exiting : Option String → Env P → Config P CmdT
+      The label identifies which block to exit to. -/
+  | exiting : String → Env P → Config P CmdT
   /-- A block context: execute the inner config, then consume matching exits.
       The label is `Option String` — `none` denotes an unnamed block that only
-      catches unlabeled exits. -/
-  | block : Option String → Config P CmdT → Config P CmdT
+      catches unlabeled exits.  The `SemanticStore P` is the parent store at
+      block entry; on exit, the result is projected through it so that
+      variables initialized inside the block are not visible outside. -/
+  | block : Option String → SemanticStore P → Config P CmdT → Config P CmdT
   /-- A sequence context: execute the first statement (as a sub-config), then
       continue with the remaining statements. -/
   | seq : Config P CmdT → List (Stmt P CmdT) → Config P CmdT
@@ -86,7 +88,7 @@ variable {P : PureExpr} {CmdT : Type}
   | .stmts _ ρ => ρ
   | .terminal ρ => ρ
   | .exiting _ ρ => ρ
-  | .block _ inner => inner.getEnv
+  | .block _ _ inner => inner.getEnv
   | .seq inner _ => inner.getEnv
 
 /-- Extract the store from a configuration. -/
@@ -130,7 +132,7 @@ where
   | .stmts ss _, label => Stmt.noMatchingAssert.Stmts.noMatchingAssert ss label
   | .terminal _, _ => True
   | .exiting _ _, _ => True
-  | .block _ inner, label => inner.noMatchingAssert label
+  | .block _ _ inner, label => inner.noMatchingAssert label
   | .seq inner ss, label =>
     inner.noMatchingAssert label ∧ Stmt.noMatchingAssert.Stmts.noMatchingAssert ss label
 
@@ -140,19 +142,30 @@ def Config.noFuncDecl : Config P CmdT → Prop
   | .stmts ss _ => Block.noFuncDecl ss = true
   | .terminal _ => True
   | .exiting _ _ => True
-  | .block _ inner => Config.noFuncDecl inner
+  | .block _ _ inner => Config.noFuncDecl inner
   | .seq inner ss => Config.noFuncDecl inner ∧ Block.noFuncDecl ss = true
 
-/-- Extend `exitsCoveredByBlocks` to configurations. -/
-@[expose] def Config.exitsCoveredByBlocks : List (Option String) → Config P CmdT → Prop
+/-- Extend `exitsCoveredByBlocks` to configurations.
+
+    The label list has type `List String` (matching `Stmt.exit`'s mandatory-label
+    AST).  An anonymous (`.none`) `Config.block` (introduced by the loop/if's body
+    wrapper) does NOT contribute a label — labeled exits cannot match `.none`,
+    and unlabeled exits do not exist as user statements. -/
+@[expose] def Config.exitsCoveredByBlocks : List String → Config P CmdT → Prop
   | labels, .stmt s _ => s.exitsCoveredByBlocks labels
   | labels, .stmts ss _ => Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks labels ss
   | _, .terminal _ => True
-  | labels, .exiting none _ => labels.length > 0
-  | labels, .exiting (some l) _ => .some l ∈ labels
-  | labels, .block l inner => Config.exitsCoveredByBlocks (l :: labels) inner
+  | labels, .exiting l _ => l ∈ labels
+  | labels, .block none _ inner => Config.exitsCoveredByBlocks labels inner
+  | labels, .block (some l) _ inner => Config.exitsCoveredByBlocks (l :: labels) inner
   | labels, .seq inner ss =>
     Config.exitsCoveredByBlocks labels inner ∧ Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks labels ss
+
+/-- Project an inner store through a parent store: keep the inner value only
+    for variables that were already defined in the parent. Variables that were
+    not defined in the parent (i.e., init'd inside the block) become `none`. -/
+@[expose] def projectStore (σ_parent σ_inner : SemanticStore P) : SemanticStore P :=
+  fun x => if (σ_parent x).isSome then σ_inner x else none
 
 /-! ## Single-step relation -/
 
@@ -184,11 +197,13 @@ inductive StepStmt
 
   /-- A labeled block steps to a block context that wraps its body as `.stmts`.
       The AST label `label : String` is lifted into `.some label` for the
-      `Config.block` wrapper (whose label is `Option String`). -/
+      `Config.block` wrapper (whose label is `Option String`).
+      The parent store `ρ.store` is saved so that block-local variables
+      can be popped on exit. -/
   | step_block :
     StepStmt EvalCmd extendEval
       (.stmt (.block label ss _) ρ)
-      (.block (.some label) (.stmts ss ρ))
+      (.block (.some label) ρ.store (.stmts ss ρ))
 
   /-- If the condition of an `ite` statement evaluates to true, step to the
       then branch. -/
@@ -231,9 +246,11 @@ inductive StepStmt
       labeled pairs `(String × P.Expr)`; only the expression part is
       evaluated.
 
-      The body+recursion is wrapped in an unnamed `.block`, so an unlabeled
-      `exit` inside the body terminates the loop (and nothing else), while a
-      labeled `exit` propagates past the loop. -/
+      The body alone is wrapped in an unnamed `.block`, sequenced with the
+      recursive loop.  This means each iteration runs the body in its own
+      block scope: variables `init`'d inside body are projected away at the
+      end of each iteration, allowing the next iteration's body to re-`init`
+      the same names. -/
   | step_loop_enter {hasInvFailure : Bool} :
     ρ.eval ρ.store g = .some HasBool.tt →
     (∀ le ∈ inv, ρ.eval ρ.store le.2 = .some HasBool.tt ∨
@@ -243,8 +260,10 @@ inductive StepStmt
     ----
     StepStmt EvalCmd extendEval
       (.stmt (.loop (.det g) m inv body md) ρ)
-      (.block .none (.stmts (body ++ [.loop (.det g) m inv body md])
-        { ρ with hasFailure := ρ.hasFailure || hasInvFailure }))
+      (.seq
+        (.block .none ρ.store (.stmts body
+          { ρ with hasFailure := ρ.hasFailure || hasInvFailure }))
+        [.loop (.det g) m inv body md])
 
   /-- If a loop guard is false, terminate the loop.  As with `step_loop_enter`,
       invariants must be boolean-valued and any `ff` result flips `hasFailure`. -/
@@ -261,16 +280,18 @@ inductive StepStmt
 
   /-- Non-deterministic loop: enter the body.  Same invariant-boolean
       condition as the deterministic case.  As with the det variant, the
-      body is wrapped in an unnamed `.block` so that an unlabeled `exit`
-      terminates just the loop. -/
+      body alone is wrapped in an unnamed `.block` and sequenced with the
+      recursive loop, giving each iteration its own block scope. -/
   | step_loop_nondet_enter {hasInvFailure : Bool} :
     (∀ le ∈ inv, ρ.eval ρ.store le.2 = .some HasBool.tt ∨
                  ρ.eval ρ.store le.2 = .some HasBool.ff) →
     (hasInvFailure ↔ ∃ le ∈ inv, ρ.eval ρ.store le.2 = .some HasBool.ff) →
     StepStmt EvalCmd extendEval
       (.stmt (.loop .nondet m inv body md) ρ)
-      (.block .none (.stmts (body ++ [.loop .nondet m inv body md])
-        { ρ with hasFailure := ρ.hasFailure || hasInvFailure }))
+      (.seq
+        (.block .none ρ.store (.stmts body
+          { ρ with hasFailure := ρ.hasFailure || hasInvFailure }))
+        [.loop .nondet m inv body md])
 
   /-- Non-deterministic loop: exit the loop. -/
   | step_loop_nondet_exit {hasInvFailure : Bool} :
@@ -340,39 +361,37 @@ inductive StepStmt
     StepStmt EvalCmd extendEval inner inner' →
     ----
     StepStmt EvalCmd extendEval
-      (.block label inner)
-      (.block label inner')
+      (.block label σ_parent inner)
+      (.block label σ_parent inner')
 
-  /-- When a block's inner body reaches terminal, the block terminates. -/
+  /-- When a block's inner body reaches terminal, the block terminates.
+      The resulting store is projected through the parent store: only variables
+      that existed before the block keep their (possibly updated) values;
+      variables initialized inside the block are discarded. -/
   | step_block_done :
     StepStmt EvalCmd extendEval
-      (.block label (.terminal ρ'))
-      (.terminal ρ')
+      (.block label σ_parent (.terminal ρ'))
+      (.terminal { ρ' with store := projectStore σ_parent ρ'.store })
 
-  /-- When a block's inner body exits with no label, the block consumes the exit
-      (regardless of the block's own label). -/
-  | step_block_exit_none :
-    StepStmt EvalCmd extendEval
-      (.block label (.exiting .none ρ'))
-      (.terminal ρ')
-
-  /-- When a block's inner body exits with a matching label, the block consumes it. -/
+  /-- When a block's inner body exits with a matching label, the block consumes it.
+      Store is projected. -/
   | step_block_exit_match :
     label = .some l →
     ----
     StepStmt EvalCmd extendEval
-      (.block label (.exiting (.some l) ρ'))
-      (.terminal ρ')
+      (.block label σ_parent (.exiting l ρ'))
+      (.terminal { ρ' with store := projectStore σ_parent ρ'.store })
 
   /-- When a block's inner body exits with a non-matching label, the exit propagates.
-      "Non-matching" covers both the unnamed-block (`.none`) case and any other
-      mismatched `some` label. -/
+      Includes the case where the block's own label is `.none` (anonymous loop/ite
+      wrapper, which never matches a labeled exit) as well as any other mismatched
+      `.some` label.  Store is projected since we're leaving this block. -/
   | step_block_exit_mismatch :
     label ≠ .some l →
     ----
     StepStmt EvalCmd extendEval
-      (.block label (.exiting (.some l) ρ'))
-      (.exiting (.some l) ρ')
+      (.block label σ_parent (.exiting l ρ'))
+      (.exiting l { ρ' with store := projectStore σ_parent ρ'.store })
 
 end
 
@@ -462,8 +481,9 @@ theorem seq_inner_star
 theorem block_inner_star
     (inner inner' : Config P CmdT)
     (label : Option String)
+    (σ_parent : SemanticStore P)
     (h : StepStmtStar P EvalCmd extendEval inner inner') :
-    StepStmtStar P EvalCmd extendEval (.block label inner) (.block label inner') := by
+    StepStmtStar P EvalCmd extendEval (.block label σ_parent inner) (.block label σ_parent inner') := by
   induction h with
   | refl => exact .refl _
   | step _ mid _ hstep _ ih => exact .step _ _ _ (.step_block_body hstep) ih
@@ -525,7 +545,7 @@ theorem seq_reaches_terminal
 /-- Invert a seq execution reaching exiting: either the inner exited
     (propagated), or the inner terminated and the tail exited. -/
 theorem seq_reaches_exiting
-    {inner : Config P CmdT} {ss : List (Stmt P CmdT)} {lbl : Option String} {ρ' : Env P}
+    {inner : Config P CmdT} {ss : List (Stmt P CmdT)} {lbl : String} {ρ' : Env P}
     (hstar : StepStmtStar P EvalCmd extendEval (.seq inner ss) (.exiting lbl ρ')) :
     (StepStmtStar P EvalCmd extendEval inner (.exiting lbl ρ')) ∨
     (∃ ρ₁, StepStmtStar P EvalCmd extendEval inner (.terminal ρ₁) ∧
@@ -550,16 +570,21 @@ theorem seq_reaches_exiting
     | step_seq_exit => exact .inl (htgt ▸ hrest)
 
 /-- Invert a block execution reaching terminal: the inner either
-    terminated or exited (caught by the block). -/
+    terminated or exited (caught by the block).  In both cases the inner
+    reaches a config whose env projects to `ρ'` via the parent store. -/
 theorem block_reaches_terminal
-    {inner : Config P CmdT} {l : Option String} {ρ' : Env P}
-    (hstar : StepStmtStar P EvalCmd extendEval (.block l inner) (.terminal ρ')) :
-    StepStmtStar P EvalCmd extendEval inner (.terminal ρ') ∨
-    (∃ lbl, StepStmtStar P EvalCmd extendEval inner (.exiting lbl ρ')) := by
+    {inner : Config P CmdT} {l : Option String} {σ_parent : SemanticStore P} {ρ' : Env P}
+    (hstar : StepStmtStar P EvalCmd extendEval (.block l σ_parent inner) (.terminal ρ')) :
+    (∃ ρ_inner, StepStmtStar P EvalCmd extendEval inner (.terminal ρ_inner) ∧
+      ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store }) ∨
+    (∃ lbl ρ_inner, StepStmtStar P EvalCmd extendEval inner (.exiting lbl ρ_inner) ∧
+      ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store }) := by
   suffices ∀ src tgt, StepStmtStar P EvalCmd extendEval src tgt →
-      ∀ inner ρ', src = .block l inner → tgt = .terminal ρ' →
-      StepStmtStar P EvalCmd extendEval inner (.terminal ρ') ∨
-      (∃ lbl, StepStmtStar P EvalCmd extendEval inner (.exiting lbl ρ')) from
+      ∀ inner ρ', src = .block l σ_parent inner → tgt = .terminal ρ' →
+      (∃ ρ_inner, StepStmtStar P EvalCmd extendEval inner (.terminal ρ_inner) ∧
+        ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store }) ∨
+      (∃ lbl ρ_inner, StepStmtStar P EvalCmd extendEval inner (.exiting lbl ρ_inner) ∧
+        ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store }) from
     this _ _ hstar _ _ rfl rfl
   intro src tgt hstar_g
   induction hstar_g with
@@ -569,29 +594,30 @@ theorem block_reaches_terminal
     cases hstep with
     | step_block_body h =>
       match ih _ _ rfl htgt with
-      | .inl hterm => exact .inl (.step _ _ _ h hterm)
-      | .inr ⟨lbl, hexit⟩ => exact .inr ⟨lbl, .step _ _ _ h hexit⟩
-    | step_block_done => subst htgt; exact .inl hrest
-    | step_block_exit_none =>
+      | .inl ⟨ρ_inner, hterm, heq⟩ => exact .inl ⟨ρ_inner, .step _ _ _ h hterm, heq⟩
+      | .inr ⟨lbl, ρ_inner, hexit, heq⟩ => exact .inr ⟨lbl, ρ_inner, .step _ _ _ h hexit, heq⟩
+    | step_block_done =>
       subst htgt; cases hrest with
-      | refl => exact .inr ⟨.none, .refl _⟩
+      | refl => exact .inl ⟨_, .refl _, rfl⟩
       | step _ _ _ h _ => cases h
     | step_block_exit_match =>
       subst htgt; cases hrest with
-      | refl => exact .inr ⟨.some _, .refl _⟩
+      | refl => exact .inr ⟨_, _, .refl _, rfl⟩
       | step _ _ _ h _ => cases h
     | step_block_exit_mismatch =>
       subst htgt; cases hrest with | step _ _ _ h _ => cases h
 
 /-- Invert a block execution reaching exiting: the inner must have
-    exited with a label that didn't match the block. -/
+    exited with a label that didn't match the block.  The env is projected. -/
 theorem block_reaches_exiting
-    {inner : Config P CmdT} {l : Option String} {lbl : Option String} {ρ' : Env P}
-    (hstar : StepStmtStar P EvalCmd extendEval (.block l inner) (.exiting lbl ρ')) :
-    ∃ lbl_inner, StepStmtStar P EvalCmd extendEval inner (.exiting lbl_inner ρ') := by
+    {inner : Config P CmdT} {l : Option String} {σ_parent : SemanticStore P} {lbl : String} {ρ' : Env P}
+    (hstar : StepStmtStar P EvalCmd extendEval (.block l σ_parent inner) (.exiting lbl ρ')) :
+    ∃ lbl_inner ρ_inner, StepStmtStar P EvalCmd extendEval inner (.exiting lbl_inner ρ_inner) ∧
+      ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store } := by
   suffices ∀ src tgt, StepStmtStar P EvalCmd extendEval src tgt →
-      ∀ inner lbl ρ', src = .block l inner → tgt = .exiting lbl ρ' →
-      ∃ lbl_inner, StepStmtStar P EvalCmd extendEval inner (.exiting lbl_inner ρ') from
+      ∀ inner lbl ρ', src = .block l σ_parent inner → tgt = .exiting lbl ρ' →
+      ∃ lbl_inner ρ_inner, StepStmtStar P EvalCmd extendEval inner (.exiting lbl_inner ρ_inner) ∧
+        ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store } from
     this _ _ hstar _ _ _ rfl rfl
   intro src tgt hstar_g
   induction hstar_g with
@@ -600,19 +626,14 @@ theorem block_reaches_exiting
     intro inner lbl ρ' hsrc htgt; subst hsrc
     cases hstep with
     | step_block_body h =>
-      have ⟨lbl_inner, hexit⟩ := ih _ _ _ rfl htgt
-      exact ⟨lbl_inner, .step _ _ _ h hexit⟩
-    | step_block_done =>
-      subst htgt; cases hrest with | step _ _ _ h _ => cases h
-    | step_block_exit_none =>
-      subst htgt; cases hrest with | step _ _ _ h _ => cases h
-    | step_block_exit_match =>
-      subst htgt; cases hrest with | step _ _ _ h _ => cases h
+      have ⟨lbl_inner, ρ_inner, hexit, heq⟩ := ih _ _ _ rfl htgt
+      exact ⟨lbl_inner, ρ_inner, .step _ _ _ h hexit, heq⟩
     | step_block_exit_mismatch =>
-      subst htgt
-      cases hrest with
-      | refl => exact ⟨_, .refl _⟩
+      subst htgt; cases hrest with
+      | refl => exact ⟨_, _, .refl _, rfl⟩
       | step _ _ _ h _ => cases h
+    | step_block_done | step_block_exit_match =>
+      subst htgt; cases hrest with | step _ _ _ h _ => cases h
 
 /-! ## Trace construction helpers -/
 
@@ -621,7 +642,7 @@ theorem block_reaches_exiting
 theorem step_block_enter (l : String) (body : List (Stmt P CmdT))
     (md : MetaData P) (ρ : Env P) :
     StepStmtStar P EvalCmd extendEval
-      (.stmt (.block l body md) ρ) (.block (.some l) (.stmts body ρ)) :=
+      (.stmt (.block l body md) ρ) (.block (.some l) ρ.store (.stmts body ρ)) :=
   .step _ _ _ .step_block (.refl _)
 
 /-- If a prefix of a statement list terminates, the full list steps
@@ -686,7 +707,7 @@ private def ConfigSE : Config P CmdT → Config P CmdT → Prop
   | .stmts ss₁ ρ₁, .stmts ss₂ ρ₂ => ss₁ = ss₂ ∧ ρ₁.store = ρ₂.store ∧ ρ₁.eval = ρ₂.eval
   | .terminal ρ₁, .terminal ρ₂ => ρ₁.store = ρ₂.store ∧ ρ₁.eval = ρ₂.eval
   | .exiting l₁ ρ₁, .exiting l₂ ρ₂ => l₁ = l₂ ∧ ρ₁.store = ρ₂.store ∧ ρ₁.eval = ρ₂.eval
-  | .block l₁ i₁, .block l₂ i₂ => l₁ = l₂ ∧ ConfigSE i₁ i₂
+  | .block l₁ σ₁ i₁, .block l₂ σ₂ i₂ => l₁ = l₂ ∧ σ₁ = σ₂ ∧ ConfigSE i₁ i₂
   | .seq i₁ ss₁, .seq i₂ ss₂ => ss₁ = ss₂ ∧ ConfigSE i₁ i₂
   | _, _ => False
 
@@ -746,47 +767,46 @@ private def step_simulation
     | _ => exact nomatch heq
   | step_block_body h =>
     cases c₂ with
-    | block _ i₂ =>
+    | block _ _ i₂ =>
       have hrs := heq.1; subst hrs
-      have ⟨c₂', h₂, heq₂⟩ := step_simulation _ _ _ h heq.2
-      exact ⟨_, .step_block_body h₂, ⟨rfl, heq₂⟩⟩
+      have hσ := heq.2.1; subst hσ
+      have ⟨c₂', h₂, heq₂⟩ := step_simulation _ _ _ h heq.2.2
+      exact ⟨_, .step_block_body h₂, ⟨rfl, rfl, heq₂⟩⟩
     | _ => exact nomatch heq
   | step_block_done =>
     cases c₂ with
-    | block _ i₂ =>
+    | block _ _ i₂ =>
       have hrs := heq.1; subst hrs
+      have hσ := heq.2.1; subst hσ
       cases i₂ with
-      | terminal ρ₂ => exact ⟨_, .step_block_done, ⟨heq.2.1, heq.2.2⟩⟩
-      | _ => exact nomatch heq.2
-    | _ => exact nomatch heq
-  | step_block_exit_none =>
-    cases c₂ with
-    | block _ i₂ =>
-      cases i₂ with
-      | exiting l₂ ρ₂ =>
-        have hl := heq.2.1; cases hl
-        exact ⟨_, .step_block_exit_none, ⟨heq.2.2.1, heq.2.2.2⟩⟩
-      | _ => exact nomatch heq.2
+      | terminal ρ₂ =>
+        have hse := heq.2.2
+        exact ⟨_, .step_block_done, ⟨congrArg (projectStore _) hse.1, hse.2⟩⟩
+      | _ => exact nomatch heq.2.2
     | _ => exact nomatch heq
   | step_block_exit_match hl =>
     cases c₂ with
-    | block _ i₂ =>
+    | block _ _ i₂ =>
       have hlb := heq.1; subst hlb
+      have hσ := heq.2.1; subst hσ
       cases i₂ with
       | exiting l₂ ρ₂ =>
-        have hl₂ := heq.2.1; subst hl₂
-        exact ⟨_, .step_block_exit_match hl, ⟨heq.2.2.1, heq.2.2.2⟩⟩
-      | _ => exact nomatch heq.2
+        have hl₂ := heq.2.2.1; subst hl₂
+        have hse := heq.2.2.2
+        exact ⟨_, .step_block_exit_match hl, ⟨congrArg (projectStore _) hse.1, hse.2⟩⟩
+      | _ => exact nomatch heq.2.2
     | _ => exact nomatch heq
   | step_block_exit_mismatch hl =>
     cases c₂ with
-    | block _ i₂ =>
+    | block _ _ i₂ =>
       have hlb := heq.1; subst hlb
+      have hσ := heq.2.1; subst hσ
       cases i₂ with
       | exiting l₂ ρ₂ =>
-        have hl₂ := heq.2.1; subst hl₂
-        exact ⟨_, .step_block_exit_mismatch hl, ⟨rfl, heq.2.2.1, heq.2.2.2⟩⟩
-      | _ => exact nomatch heq.2
+        have hl₂ := heq.2.2.1; subst hl₂
+        have hse := heq.2.2.2
+        exact ⟨_, .step_block_exit_mismatch hl, ⟨rfl, congrArg (projectStore _) hse.1, hse.2⟩⟩
+      | _ => exact nomatch heq.2.2
     | _ => exact nomatch heq
 
 /-- The terminal state's store and eval are independent of the starting
@@ -817,9 +837,30 @@ theorem smallStep_hasFailure_irrel
 
 /-! ## Well-paired exits: preservation and no-escape -/
 
+omit [HasBool P] [HasNot P] in
+/-- Helper: when the inner of a block reaches `.exiting l` and the
+    block's label (if some) doesn't match `l`, then `l` must be in the outer
+    labels list.  The conclusion is `l ∈ labels`, which is exactly the
+    `Config.exitsCoveredByBlocks` of `.exiting l ρ''` for any ρ''. -/
+private theorem block_exit_mismatch_unfold {labels : List String}
+    {label : Option String} {σ_parent : SemanticStore P} {l : String} {ρ' ρ'' : Env P}
+    (h : Config.exitsCoveredByBlocks labels
+          (.block label σ_parent (.exiting l ρ' : Config P CmdT)))
+    (hne : label ≠ .some l) :
+    Config.exitsCoveredByBlocks labels (.exiting l ρ'' : Config P CmdT) := by
+  show l ∈ labels
+  cases label with
+  | none => exact h
+  | some lb =>
+    have h' : l ∈ lb :: labels := h
+    rw [List.mem_cons] at h'
+    rcases h' with hh | hh
+    · exact absurd (by rw [hh]) hne
+    · exact hh
+
 /-- A single step preserves `Config.exitsCoveredByBlocks`. -/
 private theorem step_preserves_exitsCoveredByBlocks
-    (labels : List (Option String))
+    (labels : List String)
     (c₁ c₂ : Config P CmdT)
     (hstep : StepStmt P EvalCmd extendEval c₁ c₂)
     (hwp : c₁.exitsCoveredByBlocks labels) :
@@ -839,27 +880,21 @@ private theorem step_preserves_exitsCoveredByBlocks
   | step_ite_nondet_false => intro _ hwp; exact hwp.2
   | step_loop_enter _ _ =>
     intro labels hwp
-    -- Goal: (.block .none (.stmts (body ++ [.loop ...]) ρ')) covers labels
-    --  ↔ .stmts (body ++ [...]) covers (none :: labels).
+    -- Goal: .seq (.block .none ρ.store (.stmts body ρ')) [.loop ...] covers labels.
+    -- The .block .none label doesn't extend the labels list (Config.exitsCoveredByBlocks's
+    -- .block none case just descends).
     simp only [Config.exitsCoveredByBlocks, Stmt.exitsCoveredByBlocks] at hwp ⊢
-    have hbody := (exitsCoveredByBlocks_weaken (P := P) (CmdT := CmdT)
-      labels (.none :: labels) (fun l hl => .tail _ hl)).2 _ hwp
-    exact block_exitsCoveredByBlocks_append (P := P) (CmdT := CmdT) (.none :: labels) _ _
-      hbody ⟨hbody, True.intro⟩
+    exact ⟨hwp, hwp, True.intro⟩
   | step_loop_exit => intro _ _; trivial
   | step_loop_nondet_enter =>
     intro labels hwp
     simp only [Config.exitsCoveredByBlocks, Stmt.exitsCoveredByBlocks] at hwp ⊢
-    have hbody := (exitsCoveredByBlocks_weaken (P := P) (CmdT := CmdT)
-      labels (.none :: labels) (fun l hl => .tail _ hl)).2 _ hwp
-    exact block_exitsCoveredByBlocks_append (P := P) (CmdT := CmdT) (.none :: labels) _ _
-      hbody ⟨hbody, True.intro⟩
+    exact ⟨hwp, hwp, True.intro⟩
   | step_loop_nondet_exit => intro _ _; trivial
   | step_exit =>
     intro labels hwp
-    -- hwp is about .stmt (.exit lbl md) but goal is about .exiting lbl
-    -- Both pattern-match on the Option lbl; case split to reduce.
-    revert hwp; cases ‹Option String› <;> exact id
+    -- hwp : l ∈ labels (from .stmt (.exit l)), goal: .exiting (.some l) covers labels = l ∈ labels
+    exact hwp
   | step_funcDecl => intro _ _; trivial
   | step_typeDecl => intro _ _; trivial
   | step_stmts_nil => intro _ _; trivial
@@ -867,14 +902,17 @@ private theorem step_preserves_exitsCoveredByBlocks
   | step_seq_inner _ ih => intro labels hwp; exact ⟨ih labels hwp.1, hwp.2⟩
   | step_seq_done => intro _ hwp; exact hwp.2
   | step_seq_exit => intro _ hwp; exact hwp.1
-  | step_block_body _ ih => intro labels hwp; exact ih _ hwp
+  | step_block_body _ ih =>
+    intro labels hwp
+    rename_i inner inner' label σ_parent _
+    cases label with
+    | none => exact ih labels hwp
+    | some l => exact ih (l :: labels) hwp
   | step_block_done => intro _ _; trivial
-  | step_block_exit_none => intro _ _; trivial
   | step_block_exit_match => intro _ _; trivial
   | step_block_exit_mismatch hne =>
     intro labels hwp
-    simp only [Config.exitsCoveredByBlocks, List.mem_cons] at hwp ⊢
-    exact hwp.resolve_left (fun h => hne (h ▸ rfl))
+    exact block_exit_mismatch_unfold (P := P) (CmdT := CmdT) hwp hne
 
 /-- Well-paired statements cannot escape via `.exiting`:
     if all exits in `s` are caught by enclosing blocks
@@ -882,21 +920,17 @@ private theorem step_preserves_exitsCoveredByBlocks
 theorem exitsCoveredByBlocks_noEscape
     (s : Stmt P CmdT)
     (hwp : s.exitsCoveredByBlocks []) :
-    ∀ (ρ : Env P) (lbl : Option String) (ρ' : Env P),
+    ∀ (ρ : Env P) (lbl : String) (ρ' : Env P),
       ¬ StepStmtStar P EvalCmd extendEval (.stmt s ρ) (.exiting lbl ρ') := by
   intro ρ lbl ρ' hstar
   -- Prove Config.exitsCoveredByBlocks [] is preserved, then show .exiting contradicts it.
   suffices ∀ c₁ c₂,
-      c₁.exitsCoveredByBlocks ([] : List (Option String)) →
+      c₁.exitsCoveredByBlocks ([] : List String) →
       StepStmtStar P EvalCmd extendEval c₁ c₂ →
-      c₂.exitsCoveredByBlocks ([] : List (Option String)) by
+      c₂.exitsCoveredByBlocks ([] : List String) by
     have hwp' := this _ _ (show Config.exitsCoveredByBlocks [] (.stmt s ρ) from hwp) hstar
-    -- Config.exitsCoveredByBlocks [] (.exiting lbl ρ') requires:
-    --   lbl = none → [].length > 0 (False)
-    --   lbl = some l → l ∈ [] (False)
-    cases lbl with
-    | none => exact absurd hwp' (by simp [Config.exitsCoveredByBlocks])
-    | some l => exact absurd hwp' (by simp [Config.exitsCoveredByBlocks])
+    -- Config.exitsCoveredByBlocks [] (.exiting lbl ρ') requires lbl ∈ [] (False).
+    exact absurd hwp' (by simp [Config.exitsCoveredByBlocks])
   intro c₁ c₂ hwp_c hstar_c
   induction hstar_c with
   | refl => exact hwp_c
@@ -909,17 +943,15 @@ theorem exitsCoveredByBlocks_noEscape
 theorem block_exitsCoveredByBlocks_noEscape
     (bss : List (Stmt P CmdT))
     (hwp : Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks [] bss) :
-    ∀ (ρ : Env P) (lbl : Option String) (ρ' : Env P),
+    ∀ (ρ : Env P) (lbl : String) (ρ' : Env P),
       ¬ StepStmtStar P EvalCmd extendEval (.stmts bss ρ) (.exiting lbl ρ') := by
   intro ρ lbl ρ' hstar
   suffices ∀ c₁ c₂,
-      c₁.exitsCoveredByBlocks ([] : List (Option String)) →
+      c₁.exitsCoveredByBlocks ([] : List String) →
       StepStmtStar P EvalCmd extendEval c₁ c₂ →
-      c₂.exitsCoveredByBlocks ([] : List (Option String)) by
+      c₂.exitsCoveredByBlocks ([] : List String) by
     have hwp' := this _ _ (show Config.exitsCoveredByBlocks [] (.stmts bss ρ) from hwp) hstar
-    cases lbl with
-    | none => exact absurd hwp' (by simp [Config.exitsCoveredByBlocks])
-    | some l => exact absurd hwp' (by simp [Config.exitsCoveredByBlocks])
+    exact absurd hwp' (by simp [Config.exitsCoveredByBlocks])
   intro c₁ c₂ hwp_c hstar_c
   induction hstar_c with
   | refl => exact hwp_c
@@ -930,20 +962,20 @@ theorem block_exitsCoveredByBlocks_noEscape
     and `cfg` is neither terminal nor exiting, then `cfg = .block l inner'`
     for some `inner'` with `inner →* inner'`. -/
 theorem block_star_extract_inner
-    {l : Option String} {inner cfg : Config P CmdT}
-    (h_star : StepStmtStar P EvalCmd extendEval (.block l inner) cfg)
+    {l : Option String} {σ_parent : SemanticStore P} {inner cfg : Config P CmdT}
+    (h_star : StepStmtStar P EvalCmd extendEval (.block l σ_parent inner) cfg)
     (h_no_exit : ∀ lbl ρ', ¬ StepStmtStar P EvalCmd extendEval
         inner (.exiting lbl ρ'))
     (h_not_terminal : ∀ ρ', cfg ≠ .terminal ρ')
     (h_not_exiting : ∀ lbl ρ', cfg ≠ .exiting lbl ρ') :
-    ∃ inner', cfg = .block l inner' ∧
+    ∃ inner', cfg = .block l σ_parent inner' ∧
       StepStmtStar P EvalCmd extendEval inner inner' := by
   suffices ∀ c₁ c₂,
       StepStmtStar P EvalCmd extendEval c₁ c₂ →
-      ∀ inner₀, c₁ = .block l inner₀ →
+      ∀ inner₀, c₁ = .block l σ_parent inner₀ →
       (∀ lbl ρ', ¬ StepStmtStar P EvalCmd extendEval inner₀ (.exiting lbl ρ')) →
       (∀ ρ', c₂ ≠ .terminal ρ') → (∀ lbl ρ', c₂ ≠ .exiting lbl ρ') →
-      ∃ inner', c₂ = .block l inner' ∧
+      ∃ inner', c₂ = .block l σ_parent inner' ∧
         StepStmtStar P EvalCmd extendEval inner₀ inner' from
     this _ _ h_star _ rfl h_no_exit h_not_terminal h_not_exiting
   intro c₁ c₂ h_star
@@ -961,7 +993,6 @@ theorem block_star_extract_inner
       cases hrest with
       | refl => exact absurd rfl (h_nt _)
       | step _ _ _ h _ => exact nomatch h
-    | step_block_exit_none => exact absurd (.refl _) (h_ne _ _)
     | step_block_exit_match => exact absurd (.refl _) (h_ne _ _)
     | step_block_exit_mismatch => exact absurd (.refl _) (h_ne _ _)
 
@@ -1003,38 +1034,20 @@ private theorem step_preserves_eval_noFuncDecl
     exact ⟨rfl, hnofd.2⟩
   | step_loop_enter =>
     intro hnofd
-    refine ⟨rfl, ?_⟩
-    simp only [Config.noFuncDecl, Stmt.noFuncDecl] at hnofd ⊢
-    -- Need: Block.noFuncDecl (body ++ [loop]) from Block.noFuncDecl body
-    have h_append : ∀ (ss₁ ss₂ : List (Stmt P CmdT)),
-        Block.noFuncDecl ss₁ = true → Block.noFuncDecl ss₂ = true →
-        Block.noFuncDecl (ss₁ ++ ss₂) = true := by
-      intro ss₁; induction ss₁ with
-      | nil => intro _ _ h; exact h
-      | cons s ss ih =>
-        intro ss₂ h₁ h₂
-        simp only [Block.noFuncDecl] at h₁ ⊢
-        cases hs : Stmt.noFuncDecl s
-        · simp [hs] at h₁
-        · simp_all [Block.noFuncDecl]
-    exact h_append _ _ hnofd (by simp [Block.noFuncDecl, Stmt.noFuncDecl, hnofd])
+    refine ⟨rfl, ?_, ?_⟩
+    · -- Goal: inner Config has noFuncDecl
+      simp only [Config.noFuncDecl, Stmt.noFuncDecl] at hnofd ⊢
+      exact hnofd
+    · -- Goal: rest = [loop ...] has Block.noFuncDecl
+      simp only [Config.noFuncDecl, Stmt.noFuncDecl] at hnofd ⊢
+      simp [Block.noFuncDecl, Stmt.noFuncDecl, hnofd]
   | step_loop_exit => intro _; exact ⟨rfl, trivial⟩
   | step_loop_nondet_enter =>
     intro hnofd
-    refine ⟨rfl, ?_⟩
-    simp only [Config.noFuncDecl, Stmt.noFuncDecl] at hnofd ⊢
-    have h_append : ∀ (ss₁ ss₂ : List (Stmt P CmdT)),
-        Block.noFuncDecl ss₁ = true → Block.noFuncDecl ss₂ = true →
-        Block.noFuncDecl (ss₁ ++ ss₂) = true := by
-      intro ss₁; induction ss₁ with
-      | nil => intro _ _ h; exact h
-      | cons s ss ih =>
-        intro ss₂ h₁ h₂
-        simp only [Block.noFuncDecl] at h₁ ⊢
-        cases hs : Stmt.noFuncDecl s
-        · simp [hs] at h₁
-        · simp_all [Block.noFuncDecl]
-    exact h_append _ _ hnofd (by simp [Block.noFuncDecl, Stmt.noFuncDecl, hnofd])
+    refine ⟨rfl, ?_, ?_⟩
+    · simp only [Config.noFuncDecl, Stmt.noFuncDecl] at hnofd ⊢; exact hnofd
+    · simp only [Config.noFuncDecl, Stmt.noFuncDecl] at hnofd ⊢
+      simp [Block.noFuncDecl, Stmt.noFuncDecl, hnofd]
   | step_loop_nondet_exit => intro _; exact ⟨rfl, trivial⟩
   | step_exit => intro _; exact ⟨rfl, trivial⟩
   | step_funcDecl =>
@@ -1054,7 +1067,6 @@ private theorem step_preserves_eval_noFuncDecl
   | step_seq_exit => intro _; exact ⟨rfl, trivial⟩
   | step_block_body _ ih => intro hnofd; exact ih hnofd
   | step_block_done => intro _; exact ⟨rfl, trivial⟩
-  | step_block_exit_none => intro _; exact ⟨rfl, trivial⟩
   | step_block_exit_match => intro _; exact ⟨rfl, trivial⟩
   | step_block_exit_mismatch => intro _; exact ⟨rfl, trivial⟩
 
@@ -1134,7 +1146,7 @@ structure AssertId where
     aid.label = label ∧ aid.expr = expr
   | .stmt (.loop _ _ inv _ _) _, aid => (aid.label, aid.expr) ∈ inv
   | .stmts ((.loop _ _ inv _ _) :: _) _, aid => (aid.label, aid.expr) ∈ inv
-  | .block _ inner, aid => isAtAssert inner aid
+  | .block _ _ inner, aid => isAtAssert inner aid
   | .seq inner _, aid => isAtAssert inner aid
   | _, _ => False
 
@@ -1175,7 +1187,7 @@ private theorem noMatchingAssert_not_isAtAssert
     intro hat
     exact hno.1.1 label expr hat rfl
   | .terminal _ | .exiting _ _ => simp [isAtAssert]
-  | .block _ inner => exact noMatchingAssert_not_isAtAssert inner label expr hno
+  | .block _ _ inner => exact noMatchingAssert_not_isAtAssert inner label expr hno
   | .seq inner _ => exact noMatchingAssert_not_isAtAssert inner label expr hno.1
 
 omit [HasFvar P] [HasBool P] [HasNot P] in
@@ -1204,16 +1216,14 @@ private def step_preserves_noMatchingAssert
   | step_ite_nondet_true => exact hno.1
   | step_ite_nondet_false => exact hno.2
   | step_loop_enter =>
+    -- New shape: .seq (.block .none ρ.store (.stmts body ρ')) [loop]
+    -- noMatchingAssert: inner covers, AND [loop] covers.
     simp only [Config.noMatchingAssert, Stmt.noMatchingAssert] at hno ⊢
-    apply stmts_noMatchingAssert_append
-    · exact hno.2
-    · exact ⟨hno, True.intro⟩
+    exact ⟨hno.2, hno, True.intro⟩
   | step_loop_exit => trivial
   | step_loop_nondet_enter =>
     simp only [Config.noMatchingAssert, Stmt.noMatchingAssert] at hno ⊢
-    apply stmts_noMatchingAssert_append
-    · exact hno.2
-    · exact ⟨hno, True.intro⟩
+    exact ⟨hno.2, hno, True.intro⟩
   | step_loop_nondet_exit => trivial
   | step_exit => trivial
   | step_funcDecl => trivial
@@ -1230,7 +1240,6 @@ private def step_preserves_noMatchingAssert
     have := step_preserves_noMatchingAssert (c₁ := _) (c₂ := _) (label := _) h hno
     exact this
   | step_block_done => trivial
-  | step_block_exit_none => trivial
   | step_block_exit_match => trivial
   | step_block_exit_mismatch => trivial
 
@@ -1261,13 +1270,13 @@ theorem noMatchingAssert_implies_no_reachable_assert
     then the config must be `.block label inner` where `inner` is reachable
     from the block's body and satisfies `isAtAssert`. -/
 theorem block_isAtAssert_inner
-    (label : String) (inner₀ cfg : Config P (Cmd P)) (a : AssertId P)
-    (hstar : StepStmtStar P (EvalCmd P) extendEval (.block label inner₀) cfg)
+    (label : String) (σ_parent : SemanticStore P) (inner₀ cfg : Config P (Cmd P)) (a : AssertId P)
+    (hstar : StepStmtStar P (EvalCmd P) extendEval (.block label σ_parent inner₀) cfg)
     (hat : isAtAssert P cfg a) :
-    ∃ inner, cfg = .block label inner ∧
+    ∃ inner, cfg = .block label σ_parent inner ∧
       StepStmtStar P (EvalCmd P) extendEval inner₀ inner ∧
       isAtAssert P inner a := by
-  generalize hsrc : Config.block label inner₀ = src at hstar
+  generalize hsrc : Config.block label σ_parent inner₀ = src at hstar
   induction hstar generalizing inner₀ with
   | refl => subst hsrc; exact ⟨inner₀, rfl, .refl _, hat⟩
   | step _ mid _ hstep hrest ih =>
@@ -1276,9 +1285,6 @@ theorem block_isAtAssert_inner
       have ⟨inner, heq, hreach, hat'⟩ := ih _ hat rfl
       exact ⟨inner, heq, .step _ _ _ hinner hreach, hat'⟩
     | step_block_done => cases hrest with
-      | refl => exact absurd hat (by simp [isAtAssert])
-      | step _ _ _ h _ => exact absurd h (by intro h; cases h)
-    | step_block_exit_none => cases hrest with
       | refl => exact absurd hat (by simp [isAtAssert])
       | step _ _ _ h _ => exact absurd h (by intro h; cases h)
     | step_block_exit_match => cases hrest with
@@ -1412,8 +1418,8 @@ theorem step_preserves_noFailure
       IsAtAssert (.stmt (.loop g m inv body md) ρ) ⟨lbl, e⟩)
     (h_IsAtAssert_seq : ∀ {inner ss a},
       IsAtAssert inner a → IsAtAssert (.seq inner ss) a)
-    (h_IsAtAssert_block : ∀ {label inner a},
-      IsAtAssert inner a → IsAtAssert (.block label inner) a)
+    (h_IsAtAssert_block : ∀ {label σ_parent inner a},
+      IsAtAssert inner a → IsAtAssert (.block label σ_parent inner) a)
     (c₁ c₂ : Config P CmdT)
     (hv : ∀ a cfg, StepStmtStar P EvalCmd extendEval c₁ cfg →
       IsAtAssert cfg a → cfg.getEval cfg.getStore a.expr = some HasBool.tt)
@@ -1448,7 +1454,7 @@ theorem step_preserves_noFailure
   | step_block_body h ih =>
     exact ih
       (fun a cfg hr hat =>
-        hv a (.block _ cfg) (block_inner_star P EvalCmd extendEval _ _ _ hr) (h_IsAtAssert_block hat)) hnf
+        hv a (.block _ _ cfg) (block_inner_star P EvalCmd extendEval _ _ _ _ hr) (h_IsAtAssert_block hat)) hnf
   | _ => intros; exact hnf
 
 theorem allAssertsValid_preserves_noFailure

--- a/Strata/DL/SMT/DDMTransform/Translate.lean
+++ b/Strata/DL/SMT/DDMTransform/Translate.lean
@@ -7,6 +7,7 @@ module
 
 public import Strata.DL.SMT.DDMTransform.Parse
 public import Strata.DL.SMT.Term
+public import Strata.Util.Provenance
 public import Strata.Util.Tactics
 import Strata.DDM.Elab.LoadedDialects
 
@@ -16,87 +17,91 @@ public section
 
 namespace SMTDDM
 
-private def mkQualifiedIdent (s:String):QualifiedIdent SourceRange :=
-  .qualifiedIdentImplicit SourceRange.none (Ann.mk SourceRange.none s)
+/-- Annotation used for all synthesized SMT DDM nodes. -/
+private abbrev smtProv : Provenance := .synthesized .smtEncode
 
-private def mkSimpleSymbol (s:String):SimpleSymbol SourceRange :=
+/-- Wrap a value with the SMT provenance annotation. -/
+private abbrev smtAnn (v : α) : Ann α Provenance := Ann.mk smtProv v
+
+private def mkQualifiedIdent (s:String):QualifiedIdent Provenance :=
+  .qualifiedIdentImplicit smtProv (smtAnn s)
+
+private def mkSimpleSymbol (s:String):SimpleSymbol Provenance :=
   match List.find? (fun (_,sym) => sym = s) specialCharsInSimpleSymbol with
   | .some (name,_) =>
     -- This needs hard-coded for now.
     (match name with
-    | "plus" => .simple_symbol_plus SourceRange.none
-    | "minus" => .simple_symbol_minus SourceRange.none
-    | "star" => .simple_symbol_star SourceRange.none
-    | "eq" => .simple_symbol_eq SourceRange.none
-    | "percent" => .simple_symbol_percent SourceRange.none
-    | "questionmark" => .simple_symbol_questionmark SourceRange.none
-    | "period" => .simple_symbol_period SourceRange.none
-    | "tilde" => .simple_symbol_tilde SourceRange.none
-    | "amp" => .simple_symbol_amp SourceRange.none
-    | "caret" => .simple_symbol_caret SourceRange.none
-    | "lt" => .simple_symbol_lt SourceRange.none
-    | "gt" => .simple_symbol_gt SourceRange.none
-    | "at" => .simple_symbol_at SourceRange.none
-    | "le" => .simple_symbol_le SourceRange.none
-    | "ge" => .simple_symbol_ge SourceRange.none
-    | "implies" => .simple_symbol_implies SourceRange.none
+    | "plus" => .simple_symbol_plus smtProv
+    | "minus" => .simple_symbol_minus smtProv
+    | "star" => .simple_symbol_star smtProv
+    | "eq" => .simple_symbol_eq smtProv
+    | "percent" => .simple_symbol_percent smtProv
+    | "questionmark" => .simple_symbol_questionmark smtProv
+    | "period" => .simple_symbol_period smtProv
+    | "tilde" => .simple_symbol_tilde smtProv
+    | "amp" => .simple_symbol_amp smtProv
+    | "caret" => .simple_symbol_caret smtProv
+    | "lt" => .simple_symbol_lt smtProv
+    | "gt" => .simple_symbol_gt smtProv
+    | "at" => .simple_symbol_at smtProv
+    | "le" => .simple_symbol_le smtProv
+    | "ge" => .simple_symbol_ge smtProv
+    | "implies" => .simple_symbol_implies smtProv
     | _ => panic! s!"Unknown simple symbol: {name}")
   | .none =>
-    .simple_symbol_qid SourceRange.none (mkQualifiedIdent s)
+    .simple_symbol_qid smtProv (mkQualifiedIdent s)
 
-private def mkSymbol (s:String):Symbol SourceRange :=
-  .symbol SourceRange.none (mkSimpleSymbol s)
+private def mkSymbol (s:String):Symbol Provenance :=
+  .symbol smtProv (mkSimpleSymbol s)
 
-private def mkIdentifier (s:String):SMTIdentifier SourceRange :=
-  .iden_simple SourceRange.none (mkSymbol s)
+private def mkIdentifier (s:String):SMTIdentifier Provenance :=
+  .iden_simple smtProv (mkSymbol s)
 
 private def translateFromTermPrim (t:SMT.TermPrim):
-    Except String (SMTDDM.Term SourceRange) := do
-  let srnone := SourceRange.none
+    Except String (SMTDDM.Term Provenance) := do
   match t with
   | .bool b =>
-    let ss:SimpleSymbol SourceRange :=
-      if b then .simple_symbol_tt srnone else .simple_symbol_ff srnone
-    return (.qual_identifier srnone
-      (.qi_ident srnone (.iden_simple srnone (.symbol srnone ss))))
+    let ss:SimpleSymbol Provenance :=
+      if b then .simple_symbol_tt smtProv else .simple_symbol_ff smtProv
+    return (.qual_identifier smtProv
+      (.qi_ident smtProv (.iden_simple smtProv (.symbol smtProv ss))))
   | .int i =>
     let abs_i := if i < 0 then -i else i
     if i >= 0 then
-      return .spec_constant_term srnone (.sc_numeral srnone abs_i.toNat)
+      return .spec_constant_term smtProv (.sc_numeral smtProv abs_i.toNat)
     else
       -- SMT-LIB represents negative integers as (- N), i.e. unary minus
       -- applied to the absolute value.
-      let posTerm := Term.spec_constant_term srnone (.sc_numeral srnone abs_i.toNat)
-      return .qual_identifier_args srnone
-        (.qi_ident srnone (mkIdentifier "-"))
-        (Ann.mk srnone #[posTerm])
+      let posTerm := Term.spec_constant_term smtProv (.sc_numeral smtProv abs_i.toNat)
+      return .qual_identifier_args smtProv
+        (.qi_ident smtProv (mkIdentifier "-"))
+        (smtAnn #[posTerm])
   | .real dec =>
-    return .spec_constant_term srnone (.sc_decimal srnone dec)
+    return .spec_constant_term smtProv (.sc_decimal smtProv dec)
   | .bitvec (n := n) bv =>
     let bvty := mkSymbol (s!"bv{bv.toNat}")
-    let val:Index SourceRange := .ind_numeral srnone n
-    return (.qual_identifier srnone
-      (.qi_ident srnone (.iden_indexed srnone bvty (Ann.mk srnone #[val]))))
+    let val:Index Provenance := .ind_numeral smtProv n
+    return (.qual_identifier smtProv
+      (.qi_ident smtProv (.iden_indexed smtProv bvty (smtAnn #[val]))))
   | .string s =>
-    return .spec_constant_term srnone (.sc_str srnone s)
+    return .spec_constant_term smtProv (.sc_str smtProv s)
 
 -- List of SMTSort to Array.
-private def translateFromSMTSortList (l: List (SMTSort SourceRange)):
-    Array (SMTSort SourceRange) :=
+private def translateFromSMTSortList (l: List (SMTSort Provenance)):
+    Array (SMTSort Provenance) :=
   l.toArray
 
 private def translateFromTermType (t:SMT.TermType):
-    Except String (SMTDDM.SMTSort SourceRange) := do
-  let srnone := SourceRange.none
+    Except String (SMTDDM.SMTSort Provenance) := do
   match t with
   | .prim tp =>
     match tp with
     | .bitvec n =>
-      let idx : Index SourceRange := .ind_numeral srnone n
-      return (.smtsort_ident srnone
-        (.iden_indexed srnone
+      let idx : Index Provenance := .ind_numeral smtProv n
+      return (.smtsort_ident smtProv
+        (.iden_indexed smtProv
           (mkSymbol "BitVec")
-          (Ann.mk srnone #[idx])))
+          (smtAnn #[idx])))
     | .trigger =>
       throw "don't know how to translate a trigger type"
     | _ =>
@@ -107,122 +112,116 @@ private def translateFromTermType (t:SMT.TermType):
           | .string => .ok "String"
           | .regex => .ok "RegLan"
           | _ => throw "unreachable"
-      return .smtsort_ident srnone (mkIdentifier res)
+      return .smtsort_ident smtProv (mkIdentifier res)
   | .option ty =>
     let argty ← translateFromTermType ty
-    return .smtsort_param srnone (mkIdentifier "Option") (Ann.mk srnone #[argty])
+    return .smtsort_param smtProv (mkIdentifier "Option") (smtAnn #[argty])
   | .constr id args =>
     let argtys <- args.mapM translateFromTermType
     let argtys_array := translateFromSMTSortList argtys
     if argtys_array.isEmpty then
-      return .smtsort_ident srnone (mkIdentifier id)
+      return .smtsort_ident smtProv (mkIdentifier id)
     else
-      return .smtsort_param srnone (mkIdentifier id) (Ann.mk srnone argtys_array)
+      return .smtsort_param smtProv (mkIdentifier id) (smtAnn argtys_array)
 
 -- Helper: convert an Index to an SExpr
-private def indexToSExpr (idx : SMTDDM.Index SourceRange)
-    : SMTDDM.SExpr SourceRange :=
-  let srnone := SourceRange.none
+private def indexToSExpr (idx : SMTDDM.Index Provenance)
+    : SMTDDM.SExpr Provenance :=
   match idx with
-  | .ind_numeral _ n => .se_spec_const srnone (.sc_numeral srnone n)
-  | .ind_symbol _ sym => .se_symbol srnone sym
+  | .ind_numeral _ n => .se_spec_const smtProv (.sc_numeral smtProv n)
+  | .ind_symbol _ sym => .se_symbol smtProv sym
 
 -- Helper: convert an indexed identifier to an SExpr: (_ sym idx1 idx2 ...)
-private def indexedIdentToSExpr (sym : SMTDDM.Symbol SourceRange)
-    (indices : Ann (Array (SMTDDM.Index SourceRange)) SourceRange)
-    : SMTDDM.SExpr SourceRange :=
-  let srnone := SourceRange.none
-  let underscoreSym := SMTDDM.SExpr.se_symbol srnone (mkSymbol "_")
+private def indexedIdentToSExpr (sym : SMTDDM.Symbol Provenance)
+    (indices : Ann (Array (SMTDDM.Index Provenance)) Provenance)
+    : SMTDDM.SExpr Provenance :=
+  let underscoreSym := SMTDDM.SExpr.se_symbol smtProv (mkSymbol "_")
   let idxSExprs := indices.val.toList.map indexToSExpr
-  .se_ls srnone (Ann.mk srnone ((underscoreSym :: .se_symbol srnone sym :: idxSExprs).toArray))
+  .se_ls smtProv (smtAnn ((underscoreSym :: .se_symbol smtProv sym :: idxSExprs).toArray))
 
 -- Helper: convert an SMTSort to an SExpr for use in pattern attributes
-private def sortToSExpr (s : SMTDDM.SMTSort SourceRange)
-    : Except String (SMTDDM.SExpr SourceRange) := do
-  let srnone := SourceRange.none
+private def sortToSExpr (s : SMTDDM.SMTSort Provenance)
+    : Except String (SMTDDM.SExpr Provenance) := do
   match s with
-  | .smtsort_ident _ (.iden_simple _ sym) => return .se_symbol srnone sym
+  | .smtsort_ident _ (.iden_simple _ sym) => return .se_symbol smtProv sym
   | .smtsort_ident _ (.iden_indexed _ sym indices) =>
     return indexedIdentToSExpr sym indices
   | .smtsort_param _ (.iden_simple _ sym) args =>
     let argsSExpr ← args.val.toList.mapM sortToSExpr
-    return .se_ls srnone (Ann.mk srnone ((.se_symbol srnone sym :: argsSExpr).toArray))
+    return .se_ls smtProv (smtAnn ((.se_symbol smtProv sym :: argsSExpr).toArray))
   | _ => throw s!"Doesn't know how to convert sort {repr s} to SMTDDM.SExpr"
   termination_by SizeOf.sizeOf s
   decreasing_by cases args; simp_all; term_by_mem
 
 
 -- Helper: convert a QualIdentifier to an SExpr for use in pattern attributes
-private def qiToSExpr (qi : SMTDDM.QualIdentifier SourceRange)
-    : Except String (SMTDDM.SExpr SourceRange) := do
-  let srnone := SourceRange.none
+private def qiToSExpr (qi : SMTDDM.QualIdentifier Provenance)
+    : Except String (SMTDDM.SExpr Provenance) := do
   match qi with
-  | .qi_ident _ (.iden_simple _ sym) => pure (.se_symbol srnone sym)
+  | .qi_ident _ (.iden_simple _ sym) => pure (.se_symbol smtProv sym)
   | .qi_ident _ (.iden_indexed _ sym indices) =>
     pure (indexedIdentToSExpr sym indices)
   | .qi_isort _ (.iden_simple _ sym) sort =>
     let sortSExpr ← sortToSExpr sort
-    let asSym := SMTDDM.SExpr.se_symbol srnone (mkSymbol "as")
-    pure (.se_ls srnone (Ann.mk srnone #[asSym, .se_symbol srnone sym, sortSExpr]))
+    let asSym := SMTDDM.SExpr.se_symbol smtProv (mkSymbol "as")
+    pure (.se_ls smtProv (smtAnn #[asSym, .se_symbol smtProv sym, sortSExpr]))
   | _ => throw s!"Doesn't know how to convert QI {repr qi} to SMTDDM.SExpr"
 
 -- Helper function to convert a SMTDDM.Term to SExpr for use in pattern attributes
-def termToSExpr (t : SMTDDM.Term SourceRange)
-    : Except String (SMTDDM.SExpr SourceRange) := do
-  let srnone := SourceRange.none
+def termToSExpr (t : SMTDDM.Term Provenance)
+    : Except String (SMTDDM.SExpr Provenance) := do
   match t with
   | .qual_identifier _ qi => qiToSExpr qi
   | .qual_identifier_args _ qi args =>
       let qiSExpr ← qiToSExpr qi
       let argsSExpr ← args.val.mapM termToSExpr
-      return .se_ls srnone (Ann.mk srnone ((qiSExpr :: argsSExpr.toList).toArray))
-  | .spec_constant_term _ s => return .se_spec_const srnone s
+      return .se_ls smtProv (smtAnn ((qiSExpr :: argsSExpr.toList).toArray))
+  | .spec_constant_term _ s => return .se_spec_const smtProv s
   | _ => throw s!"Doesn't know how to convert {repr t} to SMTDDM.SExpr"
   decreasing_by cases args; term_by_mem
 
-partial def translateFromTerm (t:SMT.Term): Except String (SMTDDM.Term SourceRange) := do
-  let srnone := SourceRange.none
+partial def translateFromTerm (t:SMT.Term): Except String (SMTDDM.Term Provenance) := do
   match t with
   | .prim p => translateFromTermPrim p
   | .var v =>
-    return .qual_identifier srnone (.qi_ident srnone (.iden_simple srnone
-      (.symbol srnone (mkSimpleSymbol v.id))))
+    return .qual_identifier smtProv (.qi_ident smtProv (.iden_simple smtProv
+      (.symbol smtProv (mkSimpleSymbol v.id))))
   | .none _ | .some _ => throw "don't know how to translate none and some"
   | .app op args retTy =>
     let args' <- args.mapM translateFromTerm
     let args_array := args'.toArray
-    let mk_qual_identifier (qi:QualIdentifier SourceRange) : SMTDDM.Term SourceRange :=
+    let mk_qual_identifier (qi:QualIdentifier Provenance) : SMTDDM.Term Provenance :=
       if args_array.isEmpty then
-        (.qual_identifier srnone qi)
+        (.qual_identifier smtProv qi)
       else
-        (.qual_identifier_args srnone qi (Ann.mk srnone args_array))
+        (.qual_identifier_args smtProv qi (smtAnn args_array))
 
     -- Datatype constructors need (as Name RetType) qualification for SMT-LIB
     match op with
     | .datatype_op .constructor name =>
       let retSort ← translateFromTermType retTy
-      let qi := QualIdentifier.qi_isort srnone (mkIdentifier name) retSort
+      let qi := QualIdentifier.qi_isort smtProv (mkIdentifier name) retSort
       return mk_qual_identifier qi
     | .bv (.zero_extend n) =>
-      let iden := SMTIdentifier.iden_indexed srnone (mkSymbol "zero_extend")
-        (Ann.mk srnone #[.ind_numeral srnone n])
-      return mk_qual_identifier (.qi_ident srnone iden)
+      let iden := SMTIdentifier.iden_indexed smtProv (mkSymbol "zero_extend")
+        (smtAnn #[.ind_numeral smtProv n])
+      return mk_qual_identifier (.qi_ident smtProv iden)
     | .str (.re_index n) =>
-      let iden := SMTIdentifier.iden_indexed srnone (mkSymbol "re.^")
-        (Ann.mk srnone #[.ind_numeral srnone n])
-      return mk_qual_identifier (.qi_ident srnone iden)
+      let iden := SMTIdentifier.iden_indexed smtProv (mkSymbol "re.^")
+        (smtAnn #[.ind_numeral smtProv n])
+      return mk_qual_identifier (.qi_ident smtProv iden)
     | .str (.re_loop n₁ n₂) =>
-      let iden := SMTIdentifier.iden_indexed srnone (mkSymbol "re.loop")
-        (Ann.mk srnone #[.ind_numeral srnone n₁, .ind_numeral srnone n₂])
-      return mk_qual_identifier (.qi_ident srnone iden)
+      let iden := SMTIdentifier.iden_indexed smtProv (mkSymbol "re.loop")
+        (smtAnn #[.ind_numeral smtProv n₁, .ind_numeral smtProv n₂])
+      return mk_qual_identifier (.qi_ident smtProv iden)
     | _ =>
-      return mk_qual_identifier (.qi_ident srnone (mkIdentifier op.mkName))
+      return mk_qual_identifier (.qi_ident smtProv (mkIdentifier op.mkName))
   | .quant qkind args tr body =>
-    let args_sorted:List (SMTDDM.SortedVar SourceRange) <-
+    let args_sorted:List (SMTDDM.SortedVar Provenance) <-
       args.mapM
         (fun ⟨name,ty⟩ => do
           let ty' <- translateFromTermType ty
-          return .sorted_var srnone (mkSymbol name) ty')
+          return .sorted_var smtProv (mkSymbol name) ty')
     let args_array := args_sorted.toArray
     if args_array.isEmpty then
       throw "empty quantifier"
@@ -241,7 +240,7 @@ partial def translateFromTerm (t:SMT.Term): Except String (SMTDDM.Term SourceRan
             --   .app .triggers [.app .triggers group₁ .trigger, .app .triggers group₂ .trigger, ...] .trigger
             -- Each inner .app .triggers represents one :pattern group.
             -- If a trigger term is NOT .app .triggers, treat it as a single-term group.
-            let mut patternAttrs : Array (SMTDDM.Attribute SourceRange) := #[]
+            let mut patternAttrs : Array (SMTDDM.Attribute Provenance) := #[]
             for trigTerm in triggerTerms do
               let sexprs ← match trigTerm with
                 | .app .triggers its _ => do
@@ -250,22 +249,22 @@ partial def translateFromTerm (t:SMT.Term): Except String (SMTDDM.Term SourceRan
                 | other => do
                   let ddmTerm ← translateFromTerm other
                   pure [← termToSExpr ddmTerm]
-              let attr : SMTDDM.Attribute SourceRange :=
-                .att_kw srnone
-                  (.kw_symbol srnone (mkSimpleSymbol "pattern"))
-                  (Ann.mk srnone (some (.av_sel srnone (Ann.mk srnone sexprs.toArray))))
+              let attr : SMTDDM.Attribute Provenance :=
+                .att_kw smtProv
+                  (.kw_symbol smtProv (mkSimpleSymbol "pattern"))
+                  (smtAnn (some (.av_sel smtProv (smtAnn sexprs.toArray))))
               patternAttrs := patternAttrs.push attr
             -- Wrap body with bang operator and pattern attributes
-            pure (.bang srnone body (Ann.mk srnone patternAttrs))
+            pure (.bang smtProv body (smtAnn patternAttrs))
         | _ =>
           -- Unexpected trigger format - return body as-is
           pure body
 
       match qkind with
       | .all =>
-        return .forall_smt srnone (Ann.mk srnone args_array) bodyWithPattern
+        return .forall_smt smtProv (smtAnn args_array) bodyWithPattern
       | .exist =>
-        return .exists_smt srnone (Ann.mk srnone args_array) bodyWithPattern
+        return .exists_smt smtProv (smtAnn args_array) bodyWithPattern
 
 
 private def dummy_prg_for_toString :=

--- a/Strata/DL/SMT/Solver.lean
+++ b/Strata/DL/SMT/Solver.lean
@@ -84,7 +84,7 @@ def spawn (path : String) (args : Array String) : IO Solver := do
     let proc ← IO.Process.spawn {
       stdin  := .piped
       stdout := .piped
-      stderr := .piped
+      stderr := .inherit
       cmd    := path
       args   := args
     }

--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -243,6 +243,30 @@ private def mkBitVecAppend (w v : Nat) : Expr :=
          (mkBitVec w) (mkBitVec v) (mkBitVec (w + v))
          (mkApp2 (.const ``BitVec.instHAppendHAddNat []) (toExpr w) (toExpr v))
 
+private def mkStringAppend : Expr :=
+  mkApp4 (.const ``HAppend.hAppend [0, 0, 0])
+         mkString mkString mkString
+         (mkApp2 (.const ``instHAppendOfAppend [0]) mkString
+                 (.const ``instAppendString []))
+
+/--
+Length of a string as an `Int` (via `Int.ofNat`), matching the semantics used
+in `Denote.lean`.
+-/
+private def mkStringLength (s : Expr) : Expr :=
+  .app (.const ``Int.ofNat []) (.app (.const ``String.length []) s)
+
+/--
+Throw unless `α` is the Lean `String` type (as produced by `mkString`). Used
+to guard string-theory operations so that a malformed SMT term such as
+`(.app .str_length [.prim (.int 0)] ...)` is rejected up front, matching the
+behaviour of `Denote.denoteTerm`.
+-/
+private def expectString (α : Expr) : TranslateM Unit :=
+  match α with
+  | .const ``String [] => return ()
+  | _ => throw m!"Error: expected String type, got '{α}'"
+
 def symbolToName (s : String) : Name :=
   -- Quote the string if a natural translation to Name fails
   if s.toName == .anonymous then
@@ -496,6 +520,28 @@ def translateTerm (t : SMT.Term) : TranslateM (Expr × Expr) := do
     let (α, x) ← translateTerm x
     let w ← getBitVecWidth α
     return (mkBitVec (w + i), mkApp3 (.const ``BitVec.zeroExtend []) (toExpr w) (toExpr (w + i)) x)
+  -- SMT-Lib theory of strings
+  | .prim (.string s) =>
+    return (mkString, toExpr s)
+  | .app .str_length [s] _ =>
+    let (α, s) ← translateTerm s
+    expectString α
+    return (mkInt, mkStringLength s)
+  | .app .str_concat as _ =>
+    -- `Denote.leftAssoc` requires at least two operands and checks that each
+    -- operand has the expected type.  Mirror that here rather than delegating
+    -- to `leftAssocOp`, which does neither.
+    let a :: b :: as := as
+      | throw m!"Error: str_concat expects at least two operands, got '{as.length}'"
+    let (α, a) ← translateTerm a
+    expectString α
+    let (β, b) ← translateTerm b
+    expectString β
+    let as ← as.mapM fun t => do
+      let (γ, e) ← translateTerm t
+      expectString γ
+      return e
+    return (mkString, as.foldl (mkApp2 mkStringAppend) (mkApp2 mkStringAppend a b))
   | t => throw m!"Error: unsupported term '{repr t}'"
 where
   leftAssocOp (op : Expr) (as : List SMT.Term) : TranslateM (Expr × Expr) := do

--- a/Strata/Languages/Boole/Verify.lean
+++ b/Strata/Languages/Boole/Verify.lean
@@ -540,8 +540,6 @@ def toCoreStmt (s : BooleDDM.Statement SourceRange) : TranslateM Core.Statement 
     return .block l (← withBVars [] (toCoreBlock b)) (← toCoreMetaData m)
   | .exit_statement m ⟨_, l⟩ =>
     return .exit l (← toCoreMetaData m)
-  | .exit_unlabeled_statement m =>
-    return .exit none (← toCoreMetaData m)
   | .typeDecl_statement m ⟨_, n⟩ ⟨_, args?⟩ =>
     let params := match args? with
       | none => []

--- a/Strata/Languages/Boole/Verify.lean
+++ b/Strata/Languages/Boole/Verify.lean
@@ -161,9 +161,7 @@ private def constructorListToList : BooleDDM.ConstructorList SourceRange → Lis
 
 private def toCoreMetaData (sr : SourceRange) : TranslateM (Imperative.MetaData Core.Expression) := do
   let file := (← get).fileName
-  let uri : Uri := .file file
-  let fileRangeElt := ⟨Imperative.MetaData.fileRange, .fileRange ⟨uri, sr⟩⟩
-  return #[fileRangeElt]
+  return Imperative.MetaData.ofSourceRange (.file file) sr
 
 private def mkCoreApp (op : Core.Expression.Expr) (args : List Core.Expression.Expr) : Core.Expression.Expr :=
   Lambda.LExpr.mkApp () op args

--- a/Strata/Languages/C_Simp/DDMTransform/Translate.lean
+++ b/Strata/Languages/C_Simp/DDMTransform/Translate.lean
@@ -54,10 +54,7 @@ def TransM.error [Inhabited α] (msg : String) : TransM α := do
 /- Metadata -/
 
 def sourceRangeToMetaData (ictx : InputContext) (sr : SourceRange) : Imperative.MetaData C_Simp.Expression :=
-  let file := ictx.fileName
-  let uri : Uri := .file file
-  let fileRangeElt := ⟨ MetaData.fileRange, .fileRange ⟨ uri, sr ⟩ ⟩
-  #[fileRangeElt]
+  Imperative.MetaData.ofSourceRange (.file ictx.fileName) sr
 
 def getOpMetaData (op : Operation) : TransM (Imperative.MetaData C_Simp.Expression) :=
   return sourceRangeToMetaData (← StateT.get).inputCtx op.ann

--- a/Strata/Languages/Core/DDMTransform/FormatCore.lean
+++ b/Strata/Languages/Core/DDMTransform/FormatCore.lean
@@ -828,12 +828,8 @@ partial def stmtToCST {M} [Inhabited M] (s : Core.Statement)
     | .nondet =>
       pure (.while_statement default (.condNondet default) measureCST invs bodyCST)
   | .exit label _md => do
-    match label with
-    | some l =>
-      let labelAnn : Ann String M := ⟨default, l⟩
-      pure (.exit_statement default labelAnn)
-    | none =>
-      pure (.exit_unlabeled_statement default)
+    let labelAnn : Ann String M := ⟨default, label⟩
+    pure (.exit_statement default labelAnn)
   | .funcDecl decl _md => funcDeclToStatement decl
   | .typeDecl tc _md =>
     let nameAnn : Ann String M := ⟨default, tc.name⟩

--- a/Strata/Languages/Core/DDMTransform/Grammar.lean
+++ b/Strata/Languages/Core/DDMTransform/Grammar.lean
@@ -289,7 +289,6 @@ op call_statement (f : Ident, args : CommaSepBy CallArg) : Statement =>
 op block (c : NewlineSepBy Statement) : Block => "{\n  " indent(2, c) "\n}";
 op block_statement (label : Ident, b : Block) : Statement => label ": " b:0;
 op exit_statement (label : Ident) : Statement => "exit " label ";";
-op exit_unlabeled_statement : Statement => "exit;";
 
 category SpecElt;
 category Free;

--- a/Strata/Languages/Core/DDMTransform/Translate.lean
+++ b/Strata/Languages/Core/DDMTransform/Translate.lean
@@ -51,10 +51,7 @@ def TransM.error [Inhabited α] (msg : String) : TransM α := do
 /- Metadata -/
 
 def SourceRange.toMetaData (ictx : InputContext) (sr : SourceRange) : Imperative.MetaData Core.Expression :=
-  let file := ictx.fileName
-  let uri: Uri := .file file
-  let fileRangeElt := ⟨ MetaData.fileRange, .fileRange ⟨ uri, sr ⟩ ⟩
-  #[fileRangeElt]
+  Imperative.MetaData.ofSourceRange (.file ictx.fileName) sr
 
 def getOpMetaData (op : Operation) : TransM (Imperative.MetaData Core.Expression) :=
   return op.ann.toMetaData (← StateT.get).inputCtx

--- a/Strata/Languages/Core/DDMTransform/Translate.lean
+++ b/Strata/Languages/Core/DDMTransform/Translate.lean
@@ -1335,10 +1335,7 @@ partial def translateStmt (p : Program) (bindings : TransBindings) (arg : Arg) :
   | q`Core.exit_statement, #[la] =>
     let l ← translateIdent String la
     let md ← getOpMetaData op
-    return ([.exit (some l) md], bindings)
-  | q`Core.exit_unlabeled_statement, #[] =>
-    let md ← getOpMetaData op
-    return ([.exit none md], bindings)
+    return ([.exit l md], bindings)
   | q`Core.funcDecl_statement, #[namea, _typeArgsa, bindingsa, returna, precondsa, bodya, _inlinea] =>
     let name ← translateIdent Core.CoreIdent namea
     let inputs ← translateMonoDeclList bindings bindingsa

--- a/Strata/Languages/Core/Procedure.lean
+++ b/Strata/Languages/Core/Procedure.lean
@@ -351,7 +351,7 @@ instance : HasVarsProcTrans Expression Procedure where
   modifiedVarsTrans := Procedure.modifiedVarsTrans
   getVarsTrans := Procedure.getVarsTrans
   definedVarsTrans := λ _ _ ↦ [] -- procedures cannot define global variables
-  touchedVarsTrans := Procedure.modifiedVarsTrans
+  modifiedOrDefinedVarsTrans := Procedure.modifiedVarsTrans
   allVarsTrans :=
     λ π p ↦ Procedure.getVarsTrans π p ++ Procedure.modifiedVarsTrans π p
 
@@ -360,14 +360,14 @@ instance : HasVarsTrans Expression Statement Procedure where
   modifiedVarsTrans := Statement.modifiedVarsTrans
   getVarsTrans := Statement.getVarsTrans
   definedVarsTrans := Statement.definedVarsTrans
-  touchedVarsTrans := Statement.touchedVarsTrans
+  modifiedOrDefinedVarsTrans := Statement.modifiedOrDefinedVarsTrans
   allVarsTrans := Statement.allVarsTrans
 
 instance : HasVarsTrans Expression (List Statement) Procedure where
   modifiedVarsTrans := Statements.modifiedVarsTrans
   getVarsTrans := Statements.getVarsTrans
   definedVarsTrans := Statements.definedVarsTrans
-  touchedVarsTrans := Statements.touchedVarsTrans
+  modifiedOrDefinedVarsTrans := Statements.modifiedOrDefinedVarsTrans
   allVarsTrans := Statements.allVarsTrans
 
 end

--- a/Strata/Languages/Core/SarifOutput.lean
+++ b/Strata/Languages/Core/SarifOutput.lean
@@ -77,15 +77,12 @@ def outcomeToMessage (outcome : VCOutcome) : String :=
 
 /-- Extract location information from metadata -/
 def extractLocation (files : Map Strata.Uri Lean.FileMap) (md : Imperative.MetaData Expression) : Option Location := do
-  let fileRangeElem ← md.findElem Imperative.MetaData.fileRange
-  match fileRangeElem.value with
-  | .fileRange fr =>
-    let fileMap ← files.find? fr.file
-    let startPos := fileMap.toPosition fr.range.start
-    let uri := match fr.file with
-               | .file path => path
-    pure { uri, startLine := startPos.line, startColumn := startPos.column }
-  | _ => none
+  let fr ← Imperative.getFileRange md
+  let fileMap ← files.find? fr.file
+  let startPos := fileMap.toPosition fr.range.start
+  let uri := match fr.file with
+             | .file path => path
+  pure { uri, startLine := startPos.line, startColumn := startPos.column }
 
 /-- Convert PropertyType to a property classification string for SARIF output -/
 def propertyTypeToClassification : Imperative.PropertyType → String

--- a/Strata/Languages/Core/Statement.lean
+++ b/Strata/Languages/Core/Statement.lean
@@ -215,24 +215,24 @@ def Command.modifiedVars (c : Command) : List Expression.Ident :=
   | .cmd c => c.modifiedVars
   | .call _ args _ => CallArg.getLhs args
 
-def Command.touchedVars (c : Command) : List Expression.Ident :=
+def Command.modifiedOrDefinedVars (c : Command) : List Expression.Ident :=
   Command.definedVars c ++ Command.modifiedVars c
 
 instance : HasVarsImp Expression Command where
   definedVars := Command.definedVars
   modifiedVars := Command.modifiedVars
-  touchedVars := Command.touchedVars
+  modifiedOrDefinedVars := Command.modifiedOrDefinedVars
 
 instance : HasVarsImp Expression Statement where
   definedVars := Stmt.definedVars
   modifiedVars := Stmt.modifiedVars
-  touchedVars := Stmt.touchedVars
+  modifiedOrDefinedVars := Stmt.modifiedOrDefinedVars
 
 instance : HasVarsImp Expression (List Statement) where
   definedVars := Block.definedVars
   modifiedVars := Block.modifiedVars
   -- order matters for Havoc, so needs to override the default
-  touchedVars := Block.touchedVars
+  modifiedOrDefinedVars := Block.modifiedOrDefinedVars
 
 ---------------------------------------------------------------------
 
@@ -339,8 +339,8 @@ def Statements.definedVarsTrans
   Block.definedVars s
 
 mutual
-/-- get all variables touched by the statement `s`. -/
-def Statement.touchedVarsTrans
+/-- get all variables modified or defined by the statement `s` (write-set, transitive). -/
+def Statement.modifiedOrDefinedVarsTrans
   {ProcType : Type}
   [HasVarsProcTrans Expression ProcType]
   (π : String → Option ProcType) (s : Statement)
@@ -348,26 +348,26 @@ def Statement.touchedVarsTrans
   match s with
   | .cmd cmd => Command.definedVarsTrans π cmd ++ Command.modifiedVarsTrans π cmd
   | .exit _ _ => []
-  | .block _ bss _ => Statements.touchedVarsTrans π bss
-  | .ite _ tbss ebss _ => Statements.touchedVarsTrans π tbss ++ Statements.touchedVarsTrans π ebss
-  | .loop _ _ _ bss _ => Statements.touchedVarsTrans π bss
+  | .block _ bss _ => Statements.modifiedOrDefinedVarsTrans π bss
+  | .ite _ tbss ebss _ => Statements.modifiedOrDefinedVarsTrans π tbss ++ Statements.modifiedOrDefinedVarsTrans π ebss
+  | .loop _ _ _ bss _ => Statements.modifiedOrDefinedVarsTrans π bss
   | .funcDecl decl _ => [decl.name]  -- Function declaration touches (defines) the function name
   | .typeDecl _ _ => []  -- Type declarations don't touch variables
 
-def Statements.touchedVarsTrans
+def Statements.modifiedOrDefinedVarsTrans
   {ProcType : Type}
   [HasVarsProcTrans Expression ProcType]
   (π : String → Option ProcType) (ss : Statements)
   : List Expression.Ident :=
   match ss with
   | [] => []
-  | s :: srest => Statement.touchedVarsTrans π s ++ Statements.touchedVarsTrans π srest
+  | s :: srest => Statement.modifiedOrDefinedVarsTrans π s ++ Statements.modifiedOrDefinedVarsTrans π srest
 end
 
 def Statement.allVarsTrans
   [HasVarsProcTrans Expression ProcType]
   (π : String → Option ProcType) (s : Statement) :=
-  Statement.getVarsTrans π s ++ Statement.touchedVarsTrans π s
+  Statement.getVarsTrans π s ++ Statement.modifiedOrDefinedVarsTrans π s
 
 def Statements.allVarsTrans
   [HasVarsProcTrans Expression ProcType]

--- a/Strata/Languages/Core/StatementEval.lean
+++ b/Strata/Languages/Core/StatementEval.lean
@@ -585,8 +585,8 @@ private def evalOneStmt (old_var_subst : SubstMap)
     | .nondet =>
       let freshName : CoreIdent := ⟨s!"$__nondet_cond_{Ewn.env.pathConditions.length}", ()⟩
       let freshVar : Expression.Expr := .fvar () freshName none
-      let initStmt := Statement.init freshName (.forAll [] (.tcons "bool" [])) .nondet Imperative.MetaData.empty
-      let iteStmt := Imperative.Stmt.ite (.det freshVar) then_ss else_ss Imperative.MetaData.empty
+      let initStmt := Statement.init freshName (.forAll [] (.tcons "bool" [])) .nondet (Imperative.MetaData.ofProvenance (.synthesized .nondetIte))
+      let iteStmt := Imperative.Stmt.ite (.det freshVar) then_ss else_ss (Imperative.MetaData.ofProvenance (.synthesized .nondetIte))
       evalSub Ewn [initStmt, iteStmt] nextSplitId
     | .det c =>
       let cond' := Ewn.env.exprEval c

--- a/Strata/Languages/Core/StatementSemantics.lean
+++ b/Strata/Languages/Core/StatementSemantics.lean
@@ -375,7 +375,7 @@ def withOldBindings
     aid.label = label ∧ aid.expr = expr
   | .stmt (.loop _ _ inv _ _) _, aid => (aid.label, aid.expr) ∈ inv
   | .stmts ((.loop _ _ inv _ _) :: _) _, aid => (aid.label, aid.expr) ∈ inv
-  | .block _ inner, aid => coreIsAtAssert inner aid
+  | .block _ _ inner, aid => coreIsAtAssert inner aid
   | .seq inner _, aid => coreIsAtAssert inner aid
   | _, _ => False
 
@@ -390,6 +390,13 @@ def withOldBindings
 structure WFEvalExtension (φ : CoreEval → Imperative.PureFunc Expression → CoreEval) : Prop where
   preserves_wfBool : ∀ δ σ decl, Imperative.WellFormedSemanticEvalBool δ →
     Imperative.WellFormedSemanticEvalBool (EvalPureFunc φ δ σ decl)
+  preserves_wfVar : ∀ δ σ decl, Imperative.WellFormedSemanticEvalVar δ →
+    Imperative.WellFormedSemanticEvalVar (EvalPureFunc φ δ σ decl)
+  preserves_wfCong : ∀ δ σ decl, WellFormedCoreEvalCong δ →
+    WellFormedCoreEvalCong (EvalPureFunc φ δ σ decl)
+  preserves_wfExprCongr : ∀ δ σ decl,
+    @Imperative.WellFormedSemanticEvalExprCongr Expression _ δ →
+    @Imperative.WellFormedSemanticEvalExprCongr Expression _ (EvalPureFunc φ δ σ decl)
 
 ---------------------------------------------------------------------
 

--- a/Strata/Languages/Core/StatementSemanticsProps.lean
+++ b/Strata/Languages/Core/StatementSemanticsProps.lean
@@ -1762,9 +1762,9 @@ theorem EvalCmdDefMonotone' :
 theorem EvalCmdTouch
   [HasVal P] [HasFvar P] [HasBool P] [HasBoolVal P] [HasNot P] :
   EvalCmd P δ σ c σ' f →
-  TouchVars σ (HasVarsImp.touchedVars c) σ' := by
+  TouchVars σ (HasVarsImp.modifiedOrDefinedVars c) σ' := by
   intro Heval
-  induction Heval <;> simp [HasVarsImp.touchedVars, Cmd.definedVars, Cmd.modifiedVars]
+  induction Heval <;> simp [HasVarsImp.modifiedOrDefinedVars, Cmd.definedVars, Cmd.modifiedVars]
   case eval_init x' δ σ x v σ' σ₀ e Hsm Hup Hwf =>
     apply TouchVars.init_some Hup
     constructor
@@ -2211,10 +2211,10 @@ theorem CoreStepStar_rec
       CoreStepStar π φ c₂ c₃ → motive c₂ c₃ → motive c₁ c₃)
     {c₁ c₂ : CoreConfig}
     (h : CoreStepStar π φ c₁ c₂) : motive c₁ c₂ := by
-  suffices ∀ c₁ c₂,
+  suffices h_gen : ∀ c₁ c₂,
       Imperative.StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ) c₁ c₂ →
       motive c₁ c₂ by
-    exact this _ _ (CoreStepStar_to_StepStmtStar h)
+    exact h_gen _ _ (CoreStepStar_to_StepStmtStar h)
   intro c₁ c₂ h'
   induction h' with
   | refl => exact h_refl _
@@ -2249,11 +2249,11 @@ theorem core_seq_inner_star
 theorem core_block_inner_star
     {π : String → Option Procedure}
     {φ : CoreEval → PureFunc Expression → CoreEval}
-    (inner inner' : CoreConfig) (label : Option String)
+    (inner inner' : CoreConfig) (label : Option String) (σ_parent : SemanticStore Expression)
     (h : CoreStepStar π φ inner inner') :
-    CoreStepStar π φ (.block label inner) (.block label inner') :=
+    CoreStepStar π φ (.block label σ_parent inner) (.block label σ_parent inner') :=
   StepStmtStar_to_CoreStepStar
-    (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) inner inner' label
+    (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) inner inner' label σ_parent
       (CoreStepStar_to_StepStmtStar h))
 
 /-- Lift `seq_reaches_terminal` from `StepStmtStar` to `CoreStepStar`. -/
@@ -2282,33 +2282,13 @@ theorem core_step_preserves_wfBool
     (hstep : CoreStep π φ c₁ c₂) :
     WellFormedSemanticEvalBool c₂.getEnv.eval := by
   induction hstep with
-  | step_cmd hcmd =>
-    cases hcmd with
-    | cmd_sem _ => simp [Config.getEnv]; exact hwf
-    | @call_sem _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ =>
-        simp only [Config.getEnv]; exact hwf
+  | step_cmd hcmd => cases hcmd with
+    | cmd_sem _ | call_sem _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ =>
+        simp [Config.getEnv]; exact hwf
   | step_block => simp [Config.getEnv]; exact hwf
-  | step_ite_true _ _ => exact hwf
-  | step_ite_false _ _ => exact hwf
-  | step_loop_enter _ _ => exact hwf
-  | step_loop_exit _ _ => exact hwf
-  | step_ite_nondet_true => exact hwf
-  | step_ite_nondet_false => exact hwf
-  | step_loop_nondet_enter => exact hwf
-  | step_loop_nondet_exit => exact hwf
-  | step_exit => exact hwf
   | step_funcDecl => simp [Config.getEnv]; exact h_wf_ext.preserves_wfBool _ _ _ hwf
-  | step_typeDecl => exact hwf
-  | step_stmts_nil => exact hwf
-  | step_stmts_cons => exact hwf
-  | step_seq_inner _ ih => exact ih hwf
-  | step_seq_done => exact hwf
-  | step_seq_exit => exact hwf
-  | step_block_body _ ih => exact ih hwf
-  | step_block_done => exact hwf
-  | step_block_exit_none => exact hwf
-  | step_block_exit_match _ => exact hwf
-  | step_block_exit_mismatch _ => exact hwf
+  | step_seq_inner _ ih | step_block_body _ ih => exact ih hwf
+  | _ => exact hwf
 
 theorem core_wfBool_preserved
     (h_wf_ext : WFEvalExtension φ)
@@ -2316,15 +2296,133 @@ theorem core_wfBool_preserved
     (hwf₀ : WellFormedSemanticEvalBool c₁.getEnv.eval)
     (hstar : CoreStepStar π φ c₁ c₂) :
     WellFormedSemanticEvalBool c₂.getEnv.eval := by
-  suffices ∀ c₁ c₂, WellFormedSemanticEvalBool c₁.getEnv.eval →
+  suffices h_gen : ∀ c₁ c₂, WellFormedSemanticEvalBool c₁.getEnv.eval →
       Imperative.StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ) c₁ c₂ →
       WellFormedSemanticEvalBool c₂.getEnv.eval from
-    this c₁ c₂ hwf₀ (CoreStepStar_to_StepStmtStar hstar)
+    h_gen c₁ c₂ hwf₀ (CoreStepStar_to_StepStmtStar hstar)
   intro c₁ c₂ hwf₀ h
   induction h with
   | refl => exact hwf₀
   | step _ _ _ hstep _ ih =>
     exact ih (core_step_preserves_wfBool π φ h_wf_ext _ _ hwf₀ hstep)
+
+theorem core_step_preserves_wfVar
+    (h_wf_ext : WFEvalExtension φ)
+    (c₁ c₂ : CoreConfig)
+    (hwf : WellFormedSemanticEvalVar c₁.getEnv.eval)
+    (hstep : CoreStep π φ c₁ c₂) :
+    WellFormedSemanticEvalVar c₂.getEnv.eval := by
+  induction hstep with
+  | step_cmd hcmd => cases hcmd with
+    | cmd_sem _ | call_sem _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ =>
+        simp [Config.getEnv]; exact hwf
+  | step_block => simp [Config.getEnv]; exact hwf
+  | step_funcDecl => simp [Config.getEnv]; exact h_wf_ext.preserves_wfVar _ _ _ hwf
+  | step_seq_inner _ ih | step_block_body _ ih => exact ih hwf
+  | _ => exact hwf
+
+theorem core_wfVar_preserved
+    (h_wf_ext : WFEvalExtension φ)
+    (c₁ c₂ : CoreConfig)
+    (hwf₀ : WellFormedSemanticEvalVar c₁.getEnv.eval)
+    (hstar : CoreStepStar π φ c₁ c₂) :
+    WellFormedSemanticEvalVar c₂.getEnv.eval := by
+  suffices h_gen : ∀ c₁ c₂, WellFormedSemanticEvalVar c₁.getEnv.eval →
+      Imperative.StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ) c₁ c₂ →
+      WellFormedSemanticEvalVar c₂.getEnv.eval from
+    h_gen c₁ c₂ hwf₀ (CoreStepStar_to_StepStmtStar hstar)
+  intro c₁ c₂ hwf₀ h
+  induction h with
+  | refl => exact hwf₀
+  | step _ _ _ hstep _ ih =>
+    exact ih (core_step_preserves_wfVar π φ h_wf_ext _ _ hwf₀ hstep)
+
+theorem core_step_preserves_wfCong
+    (h_wf_ext : WFEvalExtension φ)
+    (c₁ c₂ : CoreConfig)
+    (hwf : WellFormedCoreEvalCong c₁.getEnv.eval)
+    (hstep : CoreStep π φ c₁ c₂) :
+    WellFormedCoreEvalCong c₂.getEnv.eval := by
+  induction hstep with
+  | step_cmd hcmd => cases hcmd with
+    | cmd_sem _ | call_sem _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ =>
+        simp [Config.getEnv]; exact hwf
+  | step_block => simp [Config.getEnv]; exact hwf
+  | step_funcDecl => simp [Config.getEnv]; exact h_wf_ext.preserves_wfCong _ _ _ hwf
+  | step_seq_inner _ ih | step_block_body _ ih => exact ih hwf
+  | _ => exact hwf
+
+theorem core_wfCong_preserved
+    (h_wf_ext : WFEvalExtension φ)
+    (c₁ c₂ : CoreConfig)
+    (hwf₀ : WellFormedCoreEvalCong c₁.getEnv.eval)
+    (hstar : CoreStepStar π φ c₁ c₂) :
+    WellFormedCoreEvalCong c₂.getEnv.eval := by
+  suffices h_gen : ∀ c₁ c₂, WellFormedCoreEvalCong c₁.getEnv.eval →
+      Imperative.StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ) c₁ c₂ →
+      WellFormedCoreEvalCong c₂.getEnv.eval from
+    h_gen c₁ c₂ hwf₀ (CoreStepStar_to_StepStmtStar hstar)
+  intro c₁ c₂ hwf₀ h
+  induction h with
+  | refl => exact hwf₀
+  | step _ _ _ hstep _ ih =>
+    exact ih (core_step_preserves_wfCong π φ h_wf_ext _ _ hwf₀ hstep)
+
+theorem core_step_preserves_wfExprCongr
+    (h_wf_ext : WFEvalExtension φ)
+    (c₁ c₂ : CoreConfig)
+    (hwf : @Imperative.WellFormedSemanticEvalExprCongr Expression _ c₁.getEnv.eval)
+    (hstep : CoreStep π φ c₁ c₂) :
+    @Imperative.WellFormedSemanticEvalExprCongr Expression _ c₂.getEnv.eval := by
+  induction hstep with
+  | step_cmd hcmd => cases hcmd with
+    | cmd_sem _ | call_sem _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ =>
+        simp [Config.getEnv]; exact hwf
+  | step_block => simp [Config.getEnv]; exact hwf
+  | step_funcDecl => simp [Config.getEnv]; exact h_wf_ext.preserves_wfExprCongr _ _ _ hwf
+  | step_seq_inner _ ih | step_block_body _ ih => exact ih hwf
+  | _ => exact hwf
+
+theorem core_wfExprCongr_preserved
+    (h_wf_ext : WFEvalExtension φ)
+    (c₁ c₂ : CoreConfig)
+    (hwf₀ : @Imperative.WellFormedSemanticEvalExprCongr Expression _ c₁.getEnv.eval)
+    (hstar : CoreStepStar π φ c₁ c₂) :
+    @Imperative.WellFormedSemanticEvalExprCongr Expression _ c₂.getEnv.eval := by
+  suffices h_gen : ∀ c₁ c₂,
+      @Imperative.WellFormedSemanticEvalExprCongr Expression _ c₁.getEnv.eval →
+      Imperative.StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ) c₁ c₂ →
+      @Imperative.WellFormedSemanticEvalExprCongr Expression _ c₂.getEnv.eval from
+    h_gen c₁ c₂ hwf₀ (CoreStepStar_to_StepStmtStar hstar)
+  intro c₁ c₂ hwf₀ h
+  induction h with
+  | refl => exact hwf₀
+  | step _ _ _ hstep _ ih =>
+    exact ih (core_step_preserves_wfExprCongr π φ h_wf_ext _ _ hwf₀ hstep)
+
+/-! ## projectStore and expression evaluation -/
+
+/-- If an expression evaluates in the projected store, it evaluates identically
+    in the full store.  The projected store only removes variables, and expression
+    evaluation depends only on the variables it references. -/
+theorem eval_projectStore_to_full
+    {δ : CoreEval} {σ₀ σ : SemanticStore Expression}
+    {e : Expression.Expr} {v : Expression.Expr}
+    (h_eval : δ (projectStore σ₀ σ) e = some v)
+    (h_wfVar : WellFormedSemanticEvalVar δ)
+    (h_wfCong : WellFormedCoreEvalCong δ)
+    (h_wfExprCongr : WellFormedSemanticEvalExprCongr δ) :
+    δ σ e = some v := by
+  have h_def := EvalExpressionIsDefined h_wfCong h_wfVar
+    (show (δ (projectStore σ₀ σ) e).isSome from by rw [h_eval]; simp)
+  have h_agree : ∀ x ∈ HasVarsPure.getVars e, (projectStore σ₀ σ) x = σ x := by
+    intro x hx
+    have h_x_def : (projectStore σ₀ σ x).isSome = true := h_def x hx
+    simp only [projectStore] at h_x_def ⊢
+    split
+    · rfl
+    · next h_neg => simp [h_neg] at h_x_def
+  rw [← h_wfExprCongr e (projectStore σ₀ σ) σ h_agree]; exact h_eval
 
 /-! ## Assert-only blocks preserve store -/
 
@@ -2348,12 +2446,12 @@ theorem stmts_allAssert_preserves_store
       | step_stmts_cons =>
         have ⟨ρ₁, h_s, h_r⟩ := core_seq_reaches_terminal h_rest
         have h_store₁ : ρ₁.store = ρ.store := by
-          suffices ∀ (c₁ c₂ : CoreConfig),
+          suffices h_gen : ∀ (c₁ c₂ : CoreConfig),
               CoreStepStar π φ c₁ c₂ →
               c₁ = .stmt (Statement.assert l e md) ρ →
               c₂ = .terminal ρ₁ →
               ρ₁.store = ρ.store by
-            exact this _ _ h_s rfl rfl
+            exact h_gen _ _ h_s rfl rfl
           intro c₁ c₂ hstar heq₁ heq₂
           subst heq₁
           cases hstar with
@@ -2391,8 +2489,8 @@ private theorem coreIsAtAssert_seq_of_inner
     (h : coreIsAtAssert inner a) : coreIsAtAssert (.seq inner ss) a := h
 
 private theorem coreIsAtAssert_block_of_inner
-    {label} {inner : CoreConfig} {a}
-    (h : coreIsAtAssert inner a) : coreIsAtAssert (.block label inner) a := h
+    {label} {σ_parent} {inner : CoreConfig} {a}
+    (h : coreIsAtAssert inner a) : coreIsAtAssert (.block label σ_parent inner) a := h
 
 private theorem evalCommand_failure_implies_assert_ff
     {π : String → Option Procedure} {φ : CoreEval → PureFunc Expression → CoreEval}
@@ -2415,7 +2513,7 @@ theorem core_noFailure_preserved
     (hf₀ : c₁.getEnv.hasFailure = Bool.false)
     (hstar : CoreStepStar π φ c₁ c₂) :
     c₂.getEnv.hasFailure = Bool.false := by
-  suffices ∀ c₁ c₂,
+  suffices h_gen : ∀ c₁ c₂,
       (∀ (a : AssertId Expression) (cfg : CoreConfig),
         CoreStepStar π φ c₁ cfg →
         coreIsAtAssert cfg a →
@@ -2423,7 +2521,7 @@ theorem core_noFailure_preserved
       c₁.getEnv.hasFailure = Bool.false →
       Imperative.StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ) c₁ c₂ →
       c₂.getEnv.hasFailure = Bool.false from
-    this c₁ c₂ hvalid hf₀ (CoreStepStar_to_StepStmtStar hstar)
+    h_gen c₁ c₂ hvalid hf₀ (CoreStepStar_to_StepStmtStar hstar)
   intro c₁ c₂ hvalid hf₀ h
   induction h with
   | refl => exact hf₀

--- a/Strata/Languages/Core/StatementType.lean
+++ b/Strata/Languages/Core/StatementType.lean
@@ -181,20 +181,13 @@ where
             -- Add source location to error messages.
             .error (errorWithSourceLoc e md)
 
-        | .exit label md => do try
+        | .exit l md => do try
           match op with
           | .some _ =>
-            match label with
-            | .none =>
-              if labels.isEmpty then
-                .error <| md.toDiagnosticF f!"{s}: exit occurs outside any block."
-              else
-                .ok (s, Env, C)
-            | .some l =>
-              if labels.contains l then
-                .ok (s, Env, C)
-              else
-                .error <| md.toDiagnosticF f!"{s}: exit label \"{l}\" does not match any enclosing block."
+            if labels.contains l then
+              .ok (s, Env, C)
+            else
+              .error <| md.toDiagnosticF f!"{s}: exit label \"{l}\" does not match any enclosing block."
           | .none => .error <| md.toDiagnosticF f!"{s} occurs outside a procedure."
           catch e =>
             -- Add source location to error messages.

--- a/Strata/Languages/Core/WF.lean
+++ b/Strata/Languages/Core/WF.lean
@@ -69,7 +69,7 @@ structure WFifProp    (Cmd : Type) (p : Program) (cond : ExprOrNondet Expression
 
 structure WFloopProp    (Cmd : Type) (p : Program) (guard : ExprOrNondet Expression) (measure : Option Expression.Expr) (invariant : List (String × Expression.Expr)) (b : Block) : Prop where
 
-structure WFexitProp  (p : Program) (label : Option String) : Prop where
+structure WFexitProp  (p : Program) (label : String) : Prop where
 
 /-- Well-formedness for local function declarations.
     Checks that function parameter names are unique.
@@ -94,7 +94,7 @@ def WFStatementProp (p : Program) (stmt : Statement) : Prop := match stmt with
   | .loop  (guard : ExprOrNondet Expression) (measure : Option Expression.Expr)
            (invariant : List (String × Expression.Expr)) (body : Block) _ =>
      WFloopProp (CmdExt Expression) p guard measure invariant body
-  | .exit (label : Option String) _ => WFexitProp p label
+  | .exit (label : String) _ => WFexitProp p label
   | .funcDecl decl _ => WFfuncDeclProp p decl
   | .typeDecl _ _ => True  -- Type declarations are always well-formed
 

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -45,8 +45,8 @@ private def getArgFileRange (arg : Arg) : TransM (Option FileRange) := do
 
 def getArgMetaData (arg : Arg) : TransM (Imperative.MetaData Core.Expression) := do
   return match (← get).uri with
-  | some uri => #[⟨Imperative.MetaData.fileRange, .fileRange (SourceRange.toFileRange uri arg.ann)⟩]
-  | none => #[⟨Imperative.MetaData.fileRange, .fileRange FileRange.unknown⟩]
+  | some uri => Imperative.MetaData.ofSourceRange uri arg.ann
+  | none => Imperative.MetaData.ofProvenance (.synthesized .laurelParse)
 
 def checkOp (op : Strata.Operation) (name : QualifiedIdent) (argc : Nat) :
   TransM Unit := do

--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -377,8 +377,9 @@ def Condition.mapCondition (f : AstNode StmtExpr → AstNode StmtExpr) (c : Cond
 
 /-- Build Core metadata from an optional source location. -/
 def fileRangeToCoreMd (source : Option FileRange) : Imperative.MetaData Core.Expression :=
-  let fr := source.getD FileRange.unknown
-  Imperative.MetaData.empty.pushElem Imperative.MetaData.fileRange (.fileRange fr)
+  match source with
+  | some fr => Imperative.MetaData.ofSourceRange fr.file fr.range
+  | none => Imperative.MetaData.ofProvenance (.synthesized .laurel)
 
 /-- Build Core metadata from an AstNode's source location. -/
 def astNodeToCoreMd (node : AstNode α) : Imperative.MetaData Core.Expression :=

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -492,11 +492,11 @@ def translateStmt (stmt : StmtExprMd)
   | .Return valueOpt =>
       match valueOpt with
       | none =>
-          return [.exit (some "$body") md]
+          return [.exit "$body" md]
       | some _ =>
           emitDiagnostic $ md.toDiagnostic "Return statement with value should have been eliminated by EliminateValueReturns pass" DiagnosticType.StrataBug
           modify fun s => { s with coreProgramHasSuperfluousErrors := true }
-          return [.exit (some "$body") md]
+          return [.exit "$body" md]
   | .While cond invariants decreasesExpr body =>
       let condExpr ← translateExpr cond
       let invExprs ← invariants.mapM (fun i => do return ("", ← translateExpr i))
@@ -504,7 +504,7 @@ def translateStmt (stmt : StmtExprMd)
       let bodyStmts ← translateStmt body
       return [Imperative.Stmt.loop (.det condExpr) decreasingExprCore invExprs bodyStmts md]
   | .Exit target =>
-      return [Imperative.Stmt.exit (some target) md]
+      return [Imperative.Stmt.exit target md]
   | .Hole _ _ =>
       -- Hole in statement position: treat as havoc (no-op).
       -- This can occur when an unmodeled call's Block is flattened.

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -44,7 +44,7 @@ open Lambda (LMonoTy LTy LExpr)
 public section
 
 private def mdWithUnknownLoc : Imperative.MetaData Core.Expression :=
-  #[⟨Imperative.MetaData.fileRange, .fileRange FileRange.unknown⟩]
+  Imperative.MetaData.ofProvenance (.synthesized .laurelToCore)
 
 def isFieldName (fieldNames : List Identifier) (name : Identifier) : Bool :=
   fieldNames.contains name
@@ -316,8 +316,10 @@ def translateExpr (expr : StmtExprMd)
     all_goals (have := AstNode.sizeOf_val_lt expr; term_by_mem)
 
 def getNameFromMd (md : Imperative.MetaData Core.Expression): String :=
-  let fileRange := (Imperative.getFileRange md).getD (dbg_trace "BUG: metadata without a filerange"; default)
-  s!"({fileRange.range.start})"
+  match Imperative.getProvenance md with
+  | some (.loc _ range) => s!"({range.start})"
+  | some (.synthesized _) => "(0)"
+  | none => "(unknown)"
 
 def defaultExprForType (ty : HighTypeMd) : TranslateM Core.Expression.Expr := do
   match ty.val with

--- a/Strata/Languages/Laurel/TypeHierarchy.lean
+++ b/Strata/Languages/Laurel/TypeHierarchy.lean
@@ -126,8 +126,11 @@ private def checkDiamondFieldAccess (model : SemanticModel) (target : StmtExprMd
   match (computeExprType model target).val with
   | .UserDefined typeName =>
     if isDiamondInheritedField model typeName fieldName then
-      let fileRange := source.getD FileRange.unknown
-      [DiagnosticModel.withRange fileRange s!"fields that are inherited multiple times can not be accessed."]
+      match source with
+      | some fileRange =>
+        [DiagnosticModel.withRange fileRange s!"fields that are inherited multiple times can not be accessed."]
+      | none =>
+        [DiagnosticModel.fromMessage s!"fields that are inherited multiple times can not be accessed."]
     else []
   | _ => []
 

--- a/Strata/Languages/Python/PythonToCore.lean
+++ b/Strata/Languages/Python/PythonToCore.lean
@@ -318,7 +318,7 @@ def noneOrExpr (translation_ctx : TranslationContext) (fname n : String) (e: Cor
 
 def handleCallThrow (jmp_target : String) : Core.Statement :=
   let cond := .app () (.op () "ExceptOrNone..isExceptOrNone_mk_code" none) (.fvar () "maybe_except" none)
-  .ite (.det cond) [.exit (some jmp_target) .empty] [] .empty
+  .ite (.det cond) [.exit jmp_target .empty] [] .empty
 
 def deduplicateTypeAnnotations (l : List (String × Option String)) : List (String × String) := Id.run do
   let mut m : Map String String := []
@@ -623,7 +623,7 @@ partial def exceptHandlersToCore (jmp_targets: List String) (translation_ctx: Tr
     | .none =>
       [.set "exception_ty_matches" (.boolConst () false) md]
     let cond := .fvar () "exception_ty_matches" none
-    let body_if_matches := body.val.toList.flatMap (λ s => (PyStmtToCore jmp_targets.tail! translation_ctx s).fst) ++ [.exit (some jmp_targets[1]!) md]
+    let body_if_matches := body.val.toList.flatMap (λ s => (PyStmtToCore jmp_targets.tail! translation_ctx s).fst) ++ [.exit jmp_targets[1]! md]
     set_ex_ty_matches ++ [.ite (.det cond) body_if_matches [] md]
 
 partial def handleFunctionCall (lhs: List Core.Expression.Ident)
@@ -723,8 +723,8 @@ partial def PyStmtToCore (jmp_targets: List String) (translation_ctx : Translati
       ([.ite (.det (PyExprToCore guard_ctx test).expr) (ArrPyStmtToCore translation_ctx then_b.val).fst (ArrPyStmtToCore translation_ctx else_b.val).fst md], none)
     | .Return _ v =>
       match v.val with
-      | .some v => ([.set "ret" (PyExprToCore translation_ctx v).expr md, .exit (some jmp_targets[0]!) md], none) -- TODO: need to thread return value name here. For now, assume "ret"
-      | .none => ([.exit (some jmp_targets[0]!) md], none)
+      | .some v => ([.set "ret" (PyExprToCore translation_ctx v).expr md, .exit jmp_targets[0]! md], none) -- TODO: need to thread return value name here. For now, assume "ret"
+      | .none => ([.exit jmp_targets[0]! md], none)
     | .For _ tgt itr body _ _ =>
       -- Do one unrolling:
       let guard := .app () (Core.coreOpExpr (.bool .Not)) (.eq () (.app () (.op () "dict_str_any_length" none) (PyExprToCore default itr).expr) (.intConst () 0))

--- a/Strata/Languages/Python/PythonToCore.lean
+++ b/Strata/Languages/Python/PythonToCore.lean
@@ -101,9 +101,7 @@ deriving Inhabited
 
 /-- Create metadata from a SourceRange for attaching to Core statements. -/
 def sourceRangeToMetaData (filePath : String) (sr : SourceRange) : Imperative.MetaData Core.Expression :=
-  let uri : Uri := .file filePath
-  let fileRangeElt := ⟨ Imperative.MetaData.fileRange, .fileRange ⟨ uri, sr ⟩ ⟩
-  #[fileRangeElt]
+  Imperative.MetaData.ofSourceRange (.file filePath) sr
 
 -------------------------------------------------------------------------------
 

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -170,7 +170,7 @@ private def guardProp {p : Prop} [Decidable p] (msg : String)
 
 /-! ## Helper Functions -/
 
-/-- Create metadata from a SourceRange for attaching to Laurel statements. -/
+/-- Create a FileRange from a SourceRange for attaching to Laurel statements. -/
 def sourceRangeToFileRange (filePath : String) (sr : SourceRange) : FileRange :=
   let uri : Uri := .file filePath
   ⟨ uri, sr ⟩

--- a/Strata/Transform/CallElimCorrect.lean
+++ b/Strata/Transform/CallElimCorrect.lean
@@ -3461,7 +3461,7 @@ theorem callElimStatementCorrect [LawfulBEq Expression.Expr] :
                   simp [Imperative.isDefinedOver,
                         Imperative.HasVarsTrans.allVarsTrans,
                         Statement.allVarsTrans,
-                        Statement.touchedVarsTrans,
+                        Statement.modifiedOrDefinedVarsTrans,
                         Command.definedVarsTrans,
                         Command.definedVars,
                         Command.modifiedVarsTrans,

--- a/Strata/Transform/CoreSpecification.lean
+++ b/Strata/Transform/CoreSpecification.lean
@@ -60,6 +60,8 @@ open Core Imperative
 structure ProcEnvWF (proc : Procedure) (ρ : Env Expression) : Prop where
   wfVar  : WellFormedSemanticEvalVar ρ.eval
   wfBool : WellFormedSemanticEvalBool ρ.eval
+  wfCong : WellFormedCoreEvalCong ρ.eval
+  wfExprCongr : WellFormedSemanticEvalExprCongr ρ.eval
   storeDefined : ∀ id ∈ procVerifyInitIdents proc, (ρ.store id).isSome
   -- When a procedure is called, the value of "old g" must be equal to "g"
   -- for in-out parameters.

--- a/Strata/Transform/DetToKleene.lean
+++ b/Strata/Transform/DetToKleene.lean
@@ -27,7 +27,7 @@ def StmtToKleeneStmt {P : PureExpr} [Imperative.HasBool P] [HasNot P]
   Option (Imperative.KleeneStmt P (Cmd P)) :=
   match st with
   | .cmd cmd => some (.cmd cmd)
-  | .block _ bss _ => BlockToKleeneStmt bss
+  | .block _ bss _ => do let b ← BlockToKleeneStmt bss; return .block b
   | .ite cond tss ess md => do
     let t ← BlockToKleeneStmt tss
     let e ← BlockToKleeneStmt ess

--- a/Strata/Transform/DetToKleeneCorrect.lean
+++ b/Strata/Transform/DetToKleeneCorrect.lean
@@ -38,6 +38,7 @@ abbrev Lang.det (extendEval : ExtendEval P) : Lang P :=
 def isAtKleeneAssert : KleeneConfig P (Cmd P) → AssertId P → Prop
   | .stmt (.cmd (.assert label expr _)) _, a => a.label = label ∧ a.expr = expr
   | .seq inner _, a => isAtKleeneAssert inner a
+  | .block _ inner, a => isAtKleeneAssert inner a
   | _, _ => False
 
 abbrev Lang.kleene : Lang P where
@@ -137,15 +138,19 @@ private theorem block_transform_some
 
 omit [HasFvar P] [HasVal P] [HasBoolVal P] in
 private theorem stmtToKleene_some_exitsCovered
-    (labels : List (Option String))
+    (labels : List String)
     (st : Stmt P (Cmd P)) (ns : KleeneStmt P (Cmd P))
     (ht : StmtToKleeneStmt st = some ns) :
     Stmt.exitsCoveredByBlocks (P := P) (CmdT := Cmd P) labels st := by
   match st with
   | .cmd _ => simp [Stmt.exitsCoveredByBlocks]
   | .block l bss _ =>
-    simp [Stmt.exitsCoveredByBlocks]; rw [StmtToKleeneStmt.eq_2] at ht
-    exact blockHelper (l :: labels) bss ns ht
+    simp [StmtToKleeneStmt] at ht
+    match hb : BlockToKleeneStmt bss, ht with
+    | some b, ht =>
+      simp at ht; subst ht
+      simp [Stmt.exitsCoveredByBlocks]
+      exact blockHelper (l :: labels) bss b hb
   | .ite cond tss ess md =>
     match cond with
     | .det _ =>
@@ -170,7 +175,7 @@ private theorem stmtToKleene_some_exitsCovered
   | .exit _ _ => simp [StmtToKleeneStmt.eq_6] at ht
   | .funcDecl _ _ => simp [StmtToKleeneStmt.eq_7] at ht
 where
-  blockHelper (labels : List (Option String)) (bss : List (Stmt P (Cmd P))) (ns : KleeneStmt P (Cmd P))
+  blockHelper (labels : List String) (bss : List (Stmt P (Cmd P))) (ns : KleeneStmt P (Cmd P))
       (ht : BlockToKleeneStmt bss = some ns) :
       Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks (P := P) (CmdT := Cmd P) labels bss := by
     match bss with
@@ -190,8 +195,12 @@ private theorem stmtToKleene_some_noFuncDecl
   match st with
   | .cmd _ => simp [Stmt.noFuncDecl]
   | .block _ bss _ =>
-    simp [Stmt.noFuncDecl]; rw [StmtToKleeneStmt.eq_2] at ht
-    exact blockHelper bss ns ht
+    simp [StmtToKleeneStmt] at ht
+    match hb : BlockToKleeneStmt bss, ht with
+    | some b, ht =>
+      simp at ht; subst ht
+      simp [Stmt.noFuncDecl]
+      exact blockHelper bss b hb
   | .ite cond tss ess md =>
     match cond with
     | .det _ =>
@@ -263,42 +272,31 @@ omit [HasVal P] [HasBoolVal P] in
     exit: the inner reaches terminal with a strictly shorter derivation. -/
 private theorem blockT_reaches_terminal_noExit
     (extendEval : ExtendEval P)
-    {inner : Config P (Cmd P)} {l : Option String} {ρ' : Env P}
-    (hstar : ReflTransT (StepStmt P (EvalCmd P) extendEval) (.block l inner) (.terminal ρ'))
+    {inner : Config P (Cmd P)} {l : Option String} {σ_parent : SemanticStore P} {ρ' : Env P}
+    (hstar : ReflTransT (StepStmt P (EvalCmd P) extendEval) (.block l σ_parent inner) (.terminal ρ'))
     (h_no_exit : ∀ lbl ρ_x,
       ¬ StepStmtStar P (EvalCmd P) extendEval inner (.exiting lbl ρ_x)) :
-    ∃ (h : ReflTransT (StepStmt P (EvalCmd P) extendEval) inner (.terminal ρ')),
+    ∃ (ρ_inner : Env P) (h : ReflTransT (StepStmt P (EvalCmd P) extendEval) inner (.terminal ρ_inner)),
+      ρ' = { ρ_inner with store := projectStore σ_parent ρ_inner.store } ∧
       h.len < hstar.len := by
-  suffices ∀ src tgt (hstar_g : ReflTransT (StepStmt P (EvalCmd P) extendEval) src tgt),
-      ∀ inner ρ', src = .block l inner → tgt = .terminal ρ' →
-      (∀ lbl ρ_x,
-        ¬ StepStmtStar P (EvalCmd P) extendEval inner (.exiting lbl ρ_x)) →
-      ∃ (h : ReflTransT (StepStmt P (EvalCmd P) extendEval) inner (.terminal ρ')),
-        h.len < hstar_g.len from
-    this _ _ hstar _ _ rfl rfl h_no_exit
-  intro src tgt hstar_g
-  induction hstar_g with
-  | refl => intro _ _ hsrc htgt _; subst hsrc; cases htgt
-  | step _ mid _ hstep hrest ih =>
-    intro inner ρ' hsrc htgt h_ne; subst hsrc
-    cases hstep with
-    | step_block_body h =>
-      have h_ne' : ∀ lbl ρ_x, ¬ StepStmtStar P (EvalCmd P) extendEval _ (.exiting lbl ρ_x) :=
-        fun lbl ρ_x hx => h_ne lbl ρ_x (.step _ _ _ h hx)
-      have ⟨h_inner, hlen⟩ := ih _ _ rfl htgt h_ne'
-      exact ⟨.step _ _ _ h h_inner, by simp [ReflTransT.len]; omega⟩
-    | step_block_done =>
-      subst htgt
-      exact ⟨hrest, by simp [ReflTransT.len]⟩
-    | step_block_exit_none =>
-      subst htgt
-      exact absurd (.refl _) (h_ne _ _)
-    | step_block_exit_match =>
-      subst htgt
-      exact absurd (.refl _) (h_ne _ _)
-    | step_block_exit_mismatch =>
-      subst htgt
-      cases hrest with | step _ _ _ h _ => cases h
+  match hstar with
+  | .step _ (.block _ _ inner₁) _ (.step_block_body h) hrest =>
+    have h_no_exit' : ∀ lbl ρ_x,
+        ¬ StepStmtStar P (EvalCmd P) extendEval inner₁ (.exiting lbl ρ_x) := by
+      intro lbl ρ_x hinner₁
+      exact h_no_exit lbl ρ_x (.step _ _ _ h hinner₁)
+    have ⟨ρ_inner, hterm, heq, hlen⟩ := blockT_reaches_terminal_noExit extendEval hrest h_no_exit'
+    exact ⟨ρ_inner, .step _ _ _ h hterm, heq, by simp [ReflTransT.len]; omega⟩
+  | .step _ _ _ .step_block_done hrest =>
+    match hrest with
+    | .refl _ => exact ⟨_, .refl _, rfl, by simp [ReflTransT.len]⟩
+    | .step _ _ _ h _ => exact nomatch h
+  | .step _ _ _ (.step_block_exit_match _) hrest =>
+    exfalso
+    exact h_no_exit _ _ (.refl _)
+  | .step _ _ _ (.step_block_exit_mismatch _) hrest =>
+    match hrest with
+    | .step _ _ _ h _ => exact nomatch h
 
 omit [HasVal P] [HasBoolVal P] in
 private theorem stmtsT_append_terminal
@@ -367,7 +365,7 @@ private def loop_sim
     (hlen : hstarT.len ≤ n) :
     StepKleeneStar P (EvalCmd P)
       (.stmt (.loop (.seq (.cmd (.assume "guard" g md)) b)) ρ₀) (.terminal ρ') := by
-  induction n generalizing ρ₀ with
+  induction n generalizing ρ₀ ρ' with
   | zero =>
     -- hstarT of length 0 = refl, impossible since src ≠ tgt.
     match hstarT, hlen with
@@ -390,46 +388,69 @@ private def loop_sim
       subst h_no
       let ρ₀' : Env P := {ρ₀ with hasFailure := ρ₀.hasFailure || false}
       have hρ₀_eq : ρ₀' = ρ₀ := by simp [ρ₀', Bool.or_false]
-      -- hrest is (.block .none (.stmts (body ++ [loop]) ρ₀')) →*T .terminal ρ'.
-      -- Unwrap the block layer.  The inner config cannot reach .exiting since
-      -- `hcov` ensures body has no escaping exits, and the trailing `[loop]`
-      -- also cannot exit.
-      have h_noescape_body : Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks
-          (P := P) (CmdT := Cmd P) ([] : List (Option String)) (body ++ [.loop (.det g) m [] body md]) :=
-        block_exitsCoveredByBlocks_append (P := P) (CmdT := Cmd P) [] body _ hcov
-          ⟨hcov, True.intro⟩
-      have h_ne : ∀ lbl ρ_x,
-          ¬ StepStmtStar P (EvalCmd P) extendEval
-            (.stmts (body ++ [.loop (.det g) m [] body md]) ρ₀') (.exiting lbl ρ_x) :=
-        block_exitsCoveredByBlocks_noEscape P (EvalCmd P) extendEval
-          (body ++ [.loop (.det g) m [] body md]) h_noescape_body ρ₀'
-      have ⟨hrest', hlen_inner⟩ :=
-        blockT_reaches_terminal_noExit extendEval hrest h_ne
-      have ⟨ρ₁, hbody, hloop_stmtT, hlen_dec⟩ :=
-        stmtsT_append_terminal extendEval body (.loop (.det g) m [] body md) ρ₀' ρ' hrest' hcov
-      -- Convert hbody from (...ρ₀') to (...ρ₀) via hρ₀_eq.
-      have hbody' : StepStmtStar P (EvalCmd P) extendEval (.stmts body ρ₀) (.terminal ρ₁) :=
-        hρ₀_eq ▸ hbody
-      have kleene_body := sim_body ρ₀ ρ₁ hwfb hwfv hbody'
-      have heval_eq : ρ₁.eval = ρ₀.eval :=
-        smallStep_noFuncDecl_preserves_eval_block P (EvalCmd P) extendEval
-          body ρ₀ ρ₁ hnofd_body hbody'
-      have hwfv₁ : WellFormedSemanticEvalVal ρ₁.eval := heval_eq ▸ hwfv
-      have h_assume := kleene_assume_terminal (P := P) (label := "guard") (md := md) hg hwfb
-      have h_iter : StepKleeneStar P (EvalCmd P)
-          (.stmt (.seq (.cmd (.assume "guard" g md)) b) ρ₀) (.terminal ρ₁) :=
-        kleene_seq_terminal _ b ρ₀ ρ₀ ρ₁ h_assume kleene_body
-      have hloop_len : hloop_stmtT.len ≤ n := by
-        simp [ReflTransT.len] at hlen
-        have := hlen_dec
-        have := hlen_inner
-        omega
-      have kleene_loop := ih ρ₁ hwfv₁ hloop_stmtT hloop_len
-      exact .step _ _ _ .step_loop_step
-        (ReflTrans_Transitive _ _ _ _
-          (kleene_seq_inner_star _ _
-            (.loop (.seq (.cmd (.assume "guard" g md)) b)) h_iter)
-          (.step _ _ _ .step_seq_done kleene_loop))
+      -- New shape: hrest : .seq (.block .none ρ₀'.store (.stmts body ρ₀')) [loop] →*T .terminal ρ'.
+      -- Step 1: Split via seqT_reaches_terminal:
+      have ⟨ρ_block, h_block_term, h_loop_stmts, hlen_seq⟩ :=
+        seqT_reaches_terminal extendEval hrest
+      -- Step 2: Unwrap the block. Body cannot exit (by hcov).
+      have h_noescape_body : ∀ lbl ρ_x,
+          ¬ StepStmtStar P (EvalCmd P) extendEval (.stmts body ρ₀') (.exiting lbl ρ_x) :=
+        block_exitsCoveredByBlocks_noEscape P (EvalCmd P) extendEval body hcov ρ₀'
+      have ⟨ρ_inner, h_inner_term, heq_ρ_block, hlen_inner⟩ :=
+        blockT_reaches_terminal_noExit extendEval h_block_term h_noescape_body
+      -- Step 3: Decompose [loop] ρ_block via stmtsT_cons_terminal.
+      have ⟨ρ_x, h_loop_T_T, h_nil, hlen_cons⟩ :=
+        stmtsT_cons_terminal extendEval h_loop_stmts
+      -- h_nil is .stmts [] ρ_x →*T .terminal ρ' — must be step_stmts_nil + refl.
+      have hρ_x_eq : ρ_x = ρ' := by
+        match h_nil with
+        | .step _ _ _ .step_stmts_nil hr2 =>
+          match hr2 with
+          | .refl _ => rfl
+          | .step _ _ _ h _ => exact nomatch h
+      subst hρ_x_eq
+      -- Now: h_inner_term : .stmts body ρ₀' →*T .terminal ρ_inner
+      --      heq_ρ_block : ρ_block = { ρ_inner with store := projectStore ρ₀'.store ρ_inner.store }
+      --      h_loop_T_T : .stmt (.loop ...) ρ_block →*T .terminal ρ'
+      have h_assume : StepKleeneStar P (EvalCmd P)
+          (.stmt (.cmd (.assume "guard" g md)) ρ₀) (.terminal ρ₀) :=
+        kleene_assume_terminal hg hwfb
+      have hterm_body_eq : StepStmtStar P (EvalCmd P) extendEval (.stmts body ρ₀) (.terminal ρ_inner) :=
+        hρ₀_eq ▸ reflTransT_to_prop h_inner_term
+      have h_sim_body : StepKleeneStar P (EvalCmd P) (.stmt b ρ₀) (.terminal ρ_inner) :=
+        sim_body ρ₀ ρ_inner hwfb hwfv hterm_body_eq
+      have h_kleene_assume_b : StepKleeneStar P (EvalCmd P)
+          (.stmt (.seq (.cmd (.assume "guard" g md)) b) ρ₀) (.terminal ρ_inner) :=
+        kleene_seq_terminal _ b ρ₀ ρ₀ ρ_inner h_assume h_sim_body
+      have hwfv_inner : WellFormedSemanticEvalVal ρ_inner.eval := by
+        have := block_noFuncDecl_preserves_eval P (EvalCmd P) extendEval body ρ₀ ρ_inner hnofd_body hterm_body_eq
+        rw [this]; exact hwfv
+      have hwfv_block : WellFormedSemanticEvalVal ρ_block.eval := by
+        rw [heq_ρ_block]; exact hwfv_inner
+      have h_kleene_loop : StepKleeneStar P (EvalCmd P)
+          (.stmt (.loop (.seq (.cmd (.assume "guard" g md)) b)) ρ_block) (.terminal _) :=
+        ih ρ_block _ hwfv_block h_loop_T_T (by simp [ReflTransT.len] at hlen; omega)
+      -- Build Kleene execution: step_loop_step → .seq (.block ρ₀.store (.stmt (assume; b) ρ₀)) (.loop ...)
+      -- Then use seq+block to reach (.terminal ρ_block) via h_kleene_assume_b + project.
+      have heq_ρ_block_full : ρ_block =
+          { ρ_inner with store := projectStore ρ₀.store ρ_inner.store } := by
+        have : ρ₀'.store = ρ₀.store := by rw [hρ₀_eq]
+        rw [heq_ρ_block, this]
+      have h_block_to_ρ_block : StepKleeneStar P (EvalCmd P)
+          (.block ρ₀.store (.stmt (.seq (.cmd (.assume "guard" g md)) b) ρ₀))
+          (.terminal ρ_block) := by
+        rw [heq_ρ_block_full]
+        exact kleene_block_terminal ρ₀.store _ ρ_inner h_kleene_assume_b
+      have h_seq_to_ρ' : StepKleeneStar P (EvalCmd P)
+          (.seq (.block ρ₀.store (.stmt (.seq (.cmd (.assume "guard" g md)) b) ρ₀))
+                (.loop (.seq (.cmd (.assume "guard" g md)) b)))
+          (.terminal _) :=
+        ReflTrans_Transitive _ _ _ _
+          (ReflTrans_Transitive _ _ _ _
+            (kleene_seq_inner_star _ _ (.loop _) h_block_to_ρ_block)
+            (.step _ _ _ .step_seq_done (.refl _)))
+          h_kleene_loop
+      exact .step _ _ _ .step_loop_step h_seq_to_ρ'
 
 /-- Kleene loop simulation: the loop body is executed zero or more times
     non-deterministically. -/
@@ -452,7 +473,7 @@ private def loop_sim_kleene
     (hlen : hstarT.len ≤ n) :
     StepKleeneStar P (EvalCmd P)
       (.stmt (.loop b) ρ₀) (.terminal ρ') := by
-  induction n generalizing ρ₀ with
+  induction n generalizing ρ₀ ρ' with
   | zero =>
     match hstarT, hlen with
     | .step _ _ _ _ _, hlen => simp [ReflTransT.len] at hlen
@@ -474,38 +495,58 @@ private def loop_sim_kleene
       subst h_no
       let ρ₀' : Env P := {ρ₀ with hasFailure := ρ₀.hasFailure || false}
       have hρ₀_eq : ρ₀' = ρ₀ := by simp [ρ₀', Bool.or_false]
-      -- Unwrap the .block .none wrapper; see loop_sim for details.
-      have h_noescape_body : Stmt.exitsCoveredByBlocks.Block.exitsCoveredByBlocks
-          (P := P) (CmdT := Cmd P) ([] : List (Option String)) (body ++ [.loop .nondet m [] body md]) :=
-        block_exitsCoveredByBlocks_append (P := P) (CmdT := Cmd P) [] body _ hcov
-          ⟨hcov, True.intro⟩
-      have h_ne : ∀ lbl ρ_x,
-          ¬ StepStmtStar P (EvalCmd P) extendEval
-            (.stmts (body ++ [.loop .nondet m [] body md]) ρ₀') (.exiting lbl ρ_x) :=
-        block_exitsCoveredByBlocks_noEscape P (EvalCmd P) extendEval
-          (body ++ [.loop .nondet m [] body md]) h_noescape_body ρ₀'
-      have ⟨hrest', hlen_inner⟩ :=
-        blockT_reaches_terminal_noExit extendEval hrest h_ne
-      have ⟨ρ₁, hbody, hloop_stmtT, hlen_dec⟩ :=
-        stmtsT_append_terminal extendEval body (.loop .nondet m [] body md) ρ₀' ρ' hrest' hcov
-      have hbody' : StepStmtStar P (EvalCmd P) extendEval (.stmts body ρ₀) (.terminal ρ₁) :=
-        hρ₀_eq ▸ hbody
-      have kleene_body := sim_body ρ₀ ρ₁ hwfb hwfv hbody'
-      have heval_eq : ρ₁.eval = ρ₀.eval :=
-        smallStep_noFuncDecl_preserves_eval_block P (EvalCmd P) extendEval
-          body ρ₀ ρ₁ hnofd_body hbody'
-      have hwfb₁ : WellFormedSemanticEvalBool ρ₁.eval := heval_eq ▸ hwfb
-      have hwfv₁ : WellFormedSemanticEvalVal ρ₁.eval := heval_eq ▸ hwfv
-      have hloop_len : hloop_stmtT.len ≤ n := by
-        simp [ReflTransT.len] at hlen
-        have := hlen_dec
-        have := hlen_inner
-        omega
-      have kleene_loop := ih ρ₁ hwfb₁ hwfv₁ hloop_stmtT hloop_len
-      exact .step _ _ _ .step_loop_step
-        (ReflTrans_Transitive _ _ _ _
-          (kleene_seq_inner_star _ _ (.loop b) kleene_body)
-          (.step _ _ _ .step_seq_done kleene_loop))
+      -- New shape: hrest : .seq (.block .none ρ₀'.store (.stmts body ρ₀')) [loop] →*T .terminal ρ'
+      have ⟨ρ_block, h_block_term, h_loop_stmts, hlen_seq⟩ :=
+        seqT_reaches_terminal extendEval hrest
+      have h_noescape_body : ∀ lbl ρ_x,
+          ¬ StepStmtStar P (EvalCmd P) extendEval (.stmts body ρ₀') (.exiting lbl ρ_x) :=
+        block_exitsCoveredByBlocks_noEscape P (EvalCmd P) extendEval body hcov ρ₀'
+      have ⟨ρ_inner, h_inner_term, heq_ρ_block, hlen_inner⟩ :=
+        blockT_reaches_terminal_noExit extendEval h_block_term h_noescape_body
+      have ⟨ρ_x, h_loop_T_T, h_nil, hlen_cons⟩ :=
+        stmtsT_cons_terminal extendEval h_loop_stmts
+      have hρ_x_eq : ρ_x = ρ' := by
+        match h_nil with
+        | .step _ _ _ .step_stmts_nil hr2 =>
+          match hr2 with
+          | .refl _ => rfl
+          | .step _ _ _ h _ => exact nomatch h
+      subst hρ_x_eq
+      have hterm_body_eq : StepStmtStar P (EvalCmd P) extendEval (.stmts body ρ₀) (.terminal ρ_inner) :=
+        hρ₀_eq ▸ reflTransT_to_prop h_inner_term
+      have h_sim_body : StepKleeneStar P (EvalCmd P) (.stmt b ρ₀) (.terminal ρ_inner) :=
+        sim_body ρ₀ ρ_inner hwfb hwfv hterm_body_eq
+      have hwfv_inner : WellFormedSemanticEvalVal ρ_inner.eval := by
+        have := block_noFuncDecl_preserves_eval P (EvalCmd P) extendEval body ρ₀ ρ_inner hnofd_body hterm_body_eq
+        rw [this]; exact hwfv
+      have hwfb_inner : WellFormedSemanticEvalBool ρ_inner.eval := by
+        have := block_noFuncDecl_preserves_eval P (EvalCmd P) extendEval body ρ₀ ρ_inner hnofd_body hterm_body_eq
+        rw [this]; exact hwfb
+      have hwfv_block : WellFormedSemanticEvalVal ρ_block.eval := by
+        rw [heq_ρ_block]; exact hwfv_inner
+      have hwfb_block : WellFormedSemanticEvalBool ρ_block.eval := by
+        rw [heq_ρ_block]; exact hwfb_inner
+      have h_kleene_loop : StepKleeneStar P (EvalCmd P)
+          (.stmt (.loop b) ρ_block) (.terminal _) :=
+        ih ρ_block _ hwfb_block hwfv_block h_loop_T_T (by simp [ReflTransT.len] at hlen; omega)
+      have heq_ρ_block_full : ρ_block =
+          { ρ_inner with store := projectStore ρ₀.store ρ_inner.store } := by
+        have : ρ₀'.store = ρ₀.store := by rw [hρ₀_eq]
+        rw [heq_ρ_block, this]
+      have h_block_to_ρ_block : StepKleeneStar P (EvalCmd P)
+          (.block ρ₀.store (.stmt b ρ₀))
+          (.terminal ρ_block) := by
+        rw [heq_ρ_block_full]
+        exact kleene_block_terminal ρ₀.store _ ρ_inner h_sim_body
+      have h_seq_to_ρ' : StepKleeneStar P (EvalCmd P)
+          (.seq (.block ρ₀.store (.stmt b ρ₀)) (.loop b))
+          (.terminal _) :=
+        ReflTrans_Transitive _ _ _ _
+          (ReflTrans_Transitive _ _ _ _
+            (kleene_seq_inner_star _ _ (.loop _) h_block_to_ρ_block)
+            (.step _ _ _ .step_seq_done (.refl _)))
+          h_kleene_loop
+      exact .step _ _ _ .step_loop_step h_seq_to_ρ'
 
 /-! ## Core simulation by strong induction on statement/block size -/
 
@@ -561,18 +602,24 @@ private theorem simulation
             | step _ _ _ h _ => exact nomatch h
 
       | .block _l bss _md =>
-        rw [StmtToKleeneStmt.eq_2] at ht
-        cases hstar with
-        | step _ _ _ h1 r1 => cases h1 with
-          | step_block =>
-            match block_reaches_terminal P (EvalCmd P) extendEval r1 with
-            | .inl hterm =>
-              have : Block.sizeOf bss ≤ n := by
-                simp_all [Stmt.sizeOf]; omega
-              exact ih.2 bss ns this ht ρ₀ ρ' hwfb hwfv hterm
-            | .inr ⟨lbl, hexit⟩ =>
-              exact absurd hexit (block_exitsCoveredByBlocks_noEscape P (EvalCmd P) extendEval bss
-                (stmtToKleene_some_exitsCovered.blockHelper [] bss ns ht) ρ₀ lbl ρ')
+        simp [StmtToKleeneStmt] at ht
+        match hb : BlockToKleeneStmt bss, ht with
+        | some b, ht =>
+          simp at ht; subst ht
+          cases hstar with
+          | step _ _ _ h1 r1 => cases h1 with
+            | step_block =>
+              match block_reaches_terminal P (EvalCmd P) extendEval r1 with
+              | .inl ⟨ρ_inner, hterm, heq_ρ'⟩ =>
+                have hsz_bss : Block.sizeOf bss ≤ n := by
+                  simp_all [Stmt.sizeOf]; omega
+                subst heq_ρ'
+                exact .step _ _ _ .step_block
+                  (kleene_block_terminal ρ₀.store _ ρ_inner
+                    (ih.2 bss b hsz_bss hb ρ₀ ρ_inner hwfb hwfv hterm))
+              | .inr ⟨lbl, ρ_inner, hexit, _⟩ =>
+                exact absurd hexit (block_exitsCoveredByBlocks_noEscape P (EvalCmd P) extendEval bss
+                  (stmtToKleene_some_exitsCovered.blockHelper [] bss b hb) ρ₀ lbl ρ_inner)
 
       | .ite cond tss ess md =>
         match cond with

--- a/Strata/Transform/ProcBodyVerifyCorrect.lean
+++ b/Strata/Transform/ProcBodyVerifyCorrect.lean
@@ -25,7 +25,7 @@ open Core Core.ProcBodyVerify Imperative Lambda Transform Core.WF
 private theorem coreIsAtAssert_not_terminal (ρ : Env Expression) (a : AssertId Expression) :
     ¬ coreIsAtAssert (.terminal ρ) a := by simp [coreIsAtAssert]
 
-private theorem coreIsAtAssert_not_exiting (lbl : Option String) (ρ : Env Expression) (a : AssertId Expression) :
+private theorem coreIsAtAssert_not_exiting (lbl : String) (ρ : Env Expression) (a : AssertId Expression) :
     ¬ coreIsAtAssert (.exiting lbl ρ) a := by simp [coreIsAtAssert]
 
 /-! ## Input Environment Reconstruction, from the prefix statements of ProcBodyVerify
@@ -660,14 +660,14 @@ theorem procBodyVerify_procedureCorrect
       ∃ ρ_init,
         StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
           (.stmt verifyStmt ρ_init)
-          (.block verifyLabel (.seq (.block bodyLabel cfg) postAsserts)) := by
+          (.block (.some verifyLabel) ρ_init.store (.seq (.block (.some bodyLabel) ρ₀.store cfg) postAsserts)) := by
     intro ρ₀ h_wf cfg h_body
     obtain ⟨ρ_init, h_prefix⟩ := h_prefix_trace ρ₀ h_wf
     exact ⟨ρ_init, by
       rw [h_eq]
       exact ReflTrans_Transitive _ _ _ _
         (step_block_enter Expression (EvalCommand π φ) (EvalPureFunc φ) verifyLabel _ #[] ρ_init)
-        (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ verifyLabel
+        (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ (.some verifyLabel) ρ_init.store
           (ReflTrans_Transitive _ _ _ _
             (by rw [List.append_assoc]
                 exact stmts_prefix_terminal_append Expression (EvalCommand π φ) (EvalPureFunc φ)
@@ -677,27 +677,27 @@ theorem procBodyVerify_procedureCorrect
               (seq_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ postAsserts
                 (ReflTrans_Transitive _ _ _ _
                   (step_block_enter Expression (EvalCommand π φ) (EvalPureFunc φ) bodyLabel _ #[] ρ₀)
-                  (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ bodyLabel
+                  (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ (.some bodyLabel) ρ₀.store
                     (CoreStepStar_to_StepStmtStar h_body)))))))⟩
 
   /- Helper: coreIsAtAssert and getEval/getStore are preserved through
      the verifyStmt wrapping (block > seq > block). -/
-  have h_wrapped_assert : ∀ (cfg : CoreConfig) (a : AssertId Expression),
+  have h_wrapped_assert : ∀ (σ_v σ_b : SemanticStore Expression) (cfg : CoreConfig) (a : AssertId Expression),
       coreIsAtAssert cfg a →
-      coreIsAtAssert (.block verifyLabel (.seq (.block bodyLabel cfg) postAsserts)) a := by
-    intro cfg a h
+      coreIsAtAssert (.block (.some verifyLabel) σ_v (.seq (.block (.some bodyLabel) σ_b cfg) postAsserts)) a := by
+    intro σ_v σ_b cfg a h
     simp only [coreIsAtAssert]
     exact h
 
-  have h_wrapped_eval : ∀ (cfg : CoreConfig),
-      Config.getEval (.block verifyLabel (.seq (.block bodyLabel cfg) postAsserts)) =
+  have h_wrapped_eval : ∀ (σ_v σ_b : SemanticStore Expression) (cfg : CoreConfig),
+      Config.getEval (.block (.some verifyLabel) σ_v (.seq (.block (.some bodyLabel) σ_b cfg) postAsserts)) =
       Config.getEval cfg := by
-    intro cfg; simp [Config.getEval, Config.getEnv]
+    intro σ_v σ_b cfg; simp [Config.getEval, Config.getEnv]
 
-  have h_wrapped_store : ∀ (cfg : CoreConfig),
-      Config.getStore (.block verifyLabel (.seq (.block bodyLabel cfg) postAsserts)) =
+  have h_wrapped_store : ∀ (σ_v σ_b : SemanticStore Expression) (cfg : CoreConfig),
+      Config.getStore (.block (.some verifyLabel) σ_v (.seq (.block (.some bodyLabel) σ_b cfg) postAsserts)) =
       Config.getStore cfg := by
-    intro cfg; simp [Config.getStore, Config.getEnv]
+    intro σ_v σ_b cfg; simp [Config.getStore, Config.getEnv]
 
   -- Unfold h_correct for easier application
   have h_correct' : ∀ (a : AssertId Expression) (ρ_init : Env Expression)
@@ -716,10 +716,10 @@ theorem procBodyVerify_procedureCorrect
       coreIsAtAssert cfg a →
       cfg.getEval cfg.getStore a.expr = some HasBool.tt := by
     intro ρ₀ h_wf a cfg h_body h_assert
-    obtain ⟨_, h_vt⟩ := h_embed_body ρ₀ h_wf cfg h_body
-    have h_v := h_correct' a _
-      (.block verifyLabel (.seq (.block bodyLabel cfg) postAsserts))
-      h_vt (h_wrapped_assert cfg a h_assert)
+    obtain ⟨ρ_init, h_vt⟩ := h_embed_body ρ₀ h_wf cfg h_body
+    have h_v := h_correct' a ρ_init
+      (.block (.some verifyLabel) ρ_init.store (.seq (.block (.some bodyLabel) ρ₀.store cfg) postAsserts))
+      h_vt (h_wrapped_assert ρ_init.store ρ₀.store cfg a h_assert)
     rw [h_wrapped_eval, h_wrapped_store] at h_v
     exact h_v
 
@@ -733,9 +733,9 @@ theorem procBodyVerify_procedureCorrect
       (h_body : StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
         (.stmt (Stmt.block "" proc.body #[]) ρ₀) cfg)
       (h_assert : coreIsAtAssert cfg a)
-    -- Extract first step: .stmt (block "" body #[]) ρ₀ → .block "" (.stmts body ρ₀)
+    -- Extract first step: .stmt (block "" body #[]) ρ₀ → .block (.some "") ρ₀.store (.stmts body ρ₀)
     have h_block_star : StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
-        (.block "" (.stmts proc.body ρ₀)) cfg := by
+        (.block (.some "") ρ₀.store (.stmts proc.body ρ₀)) cfg := by
       cases h_body with
       | refl => simp [coreIsAtAssert] at h_assert
       | step _ _ _ hstep hrest => cases hstep; exact hrest
@@ -778,12 +778,16 @@ theorem procBodyVerify_procedureCorrect
       Core.core_wfBool_preserved π φ h_wf_ext
         (.stmts proc.body ρ₀) (.terminal ρ') h_wf.wfBool h_term
 
+    -- After the body block terminates via step_block_done, the store is projected.
+    -- We define the projected env.
+    let ρ_proj : Env Expression := { ρ' with store := projectStore ρ₀.store ρ'.store }
+
     have h_to_post : StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
-        (.stmt verifyStmt ρ_init) (.block verifyLabel (.stmts postAsserts ρ')) := by
+        (.stmt verifyStmt ρ_init) (.block (.some verifyLabel) ρ_init.store (.stmts postAsserts ρ_proj)) := by
       rw [h_eq]
       exact ReflTrans_Transitive _ _ _ _
         (step_block_enter Expression (EvalCommand π φ) (EvalPureFunc φ) verifyLabel _ #[] ρ_init)
-        (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ verifyLabel
+        (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ (.some verifyLabel) ρ_init.store
           (ReflTrans_Transitive _ _ _ _
             (by rw [List.append_assoc]
                 exact stmts_prefix_terminal_append Expression (EvalCommand π φ) (EvalPureFunc φ)
@@ -794,21 +798,38 @@ theorem procBodyVerify_procedureCorrect
                 (seq_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ postAsserts
                   (ReflTrans_Transitive _ _ _ _
                     (step_block_enter Expression (EvalCommand π φ) (EvalPureFunc φ) bodyLabel _ #[] ρ₀)
-                    (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ bodyLabel
+                    (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ (.some bodyLabel) ρ₀.store
                       (CoreStepStar_to_StepStmtStar h_term))))
                 (ReflTrans_Transitive _ _ _ _
                   (seq_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ postAsserts
                     (.step _ _ _ .step_block_done (.refl _)))
                   (.step _ _ _ .step_seq_done (.refl _)))))))
-    -- Show every postcondition assert evaluates to true
-    -- by induction on the suffix of postAsserts
+
+    have h_proj_store_agree : ∀ x, (ρ₀.store x).isSome →
+        ρ_proj.store x = ρ'.store x := by
+      intro x hx
+      simp only [ρ_proj, projectStore]
+      simp [hx]
+
+    have h_proj_eval : ρ_proj.eval = ρ'.eval := rfl
+    have h_proj_hasFailure : ρ_proj.hasFailure = ρ'.hasFailure := rfl
+    have h_wfVar_term : WellFormedSemanticEvalVar ρ'.eval :=
+      Core.core_wfVar_preserved π φ h_wf_ext
+        (.stmts proc.body ρ₀) (.terminal ρ') h_wf.wfVar h_term
+    have h_wfCong_term : Core.WellFormedCoreEvalCong ρ'.eval :=
+      Core.core_wfCong_preserved π φ h_wf_ext
+        (.stmts proc.body ρ₀) (.terminal ρ') h_wf.wfCong h_term
+    have h_wfExprCongr_term : WellFormedSemanticEvalExprCongr ρ'.eval :=
+      Core.core_wfExprCongr_preserved π φ h_wf_ext
+        (.stmts proc.body ρ₀) (.terminal ρ') h_wf.wfExprCongr h_term
+
     have h_all_post_valid : ∀ s ∈ postAsserts, ∀ l e md,
         s = Statement.assert l e md → ρ'.eval ρ'.store e = some HasBool.tt := by
       suffices h_sfx :
           ∀ (sfx : List Statement),
             (∀ s ∈ sfx, ∃ l e md, s = Statement.assert l e md) →
             StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
-              (.stmt verifyStmt ρ_init) (.block verifyLabel (.stmts sfx ρ')) →
+              (.stmt verifyStmt ρ_init) (.block (.some verifyLabel) ρ_init.store (.stmts sfx ρ_proj)) →
             ∀ s ∈ sfx, ∀ l e md,
               s = Statement.assert l e md →
               ρ'.eval ρ'.store e = some HasBool.tt by
@@ -822,33 +843,35 @@ theorem procBodyVerify_procedureCorrect
         have ⟨lh, eh, mdh, h_hd_eq⟩ := h_all_assert hd (.head _)
         subst h_hd_eq
         have h_at_head : coreIsAtAssert
-            (.block verifyLabel (.stmts (Statement.assert lh eh mdh :: tl) ρ'))
+            (.block (.some verifyLabel) ρ_init.store (.stmts (Statement.assert lh eh mdh :: tl) ρ_proj))
             ⟨lh, eh⟩ := by
           simp only [coreIsAtAssert]; exact ⟨trivial, trivial⟩
-        have h_head_eval := h_correct' ⟨lh, eh⟩ ρ_init _ h_trace h_at_head
-        simp only [Config.getEval, Config.getStore] at h_head_eval
+        have h_head_eval_proj := h_correct' ⟨lh, eh⟩ ρ_init _ h_trace h_at_head
+        simp only [Config.getEval, Config.getStore] at h_head_eval_proj
+        have h_head_eval : ρ'.eval ρ'.store eh = some HasBool.tt :=
+          eval_projectStore_to_full h_head_eval_proj h_wfVar_term h_wfCong_term h_wfExprCongr_term
         cases h_mem with
         | head _ =>
           injection h_s_eq with h1; injection h1 with h2
           injection h2 with _ h3; subst h3; exact h_head_eval
         | tail _ h_in_tl =>
           have h_assert_step : StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
-              (.stmt (Statement.assert lh eh mdh) ρ') (.terminal ρ') := by
+              (.stmt (Statement.assert lh eh mdh) ρ_proj) (.terminal ρ_proj) := by
             have h1 : StepStmtStar Expression (EvalCommand π φ) (EvalPureFunc φ)
-                (.stmt (Statement.assert lh eh mdh) ρ')
-                (.terminal ⟨ρ'.store, ρ'.eval, ρ'.hasFailure || false⟩) :=
+                (.stmt (Statement.assert lh eh mdh) ρ_proj)
+                (.terminal ⟨ρ_proj.store, ρ_proj.eval, ρ_proj.hasFailure || false⟩) :=
               .step _ _ _
-                (.step_cmd (@EvalCommand.cmd_sem π φ ρ'.eval ρ'.store
-                  (Cmd.assert lh eh mdh) ρ'.store false
-                  (EvalCmd.eval_assert_pass h_head_eval h_wfb_term)))
+                (.step_cmd (@EvalCommand.cmd_sem π φ ρ_proj.eval ρ_proj.store
+                  (Cmd.assert lh eh mdh) ρ_proj.store false
+                  (EvalCmd.eval_assert_pass h_head_eval_proj (by rw [h_proj_eval]; exact h_wfb_term))))
                 (.refl _)
-            have h2 : (⟨ρ'.store, ρ'.eval, ρ'.hasFailure || false⟩ : Env Expression) = ρ' := by
-              cases ρ'; simp [Bool.or_false]
+            have h2 : (⟨ρ_proj.store, ρ_proj.eval, ρ_proj.hasFailure || false⟩ : Env Expression) = ρ_proj := by
+              cases ρ'; simp [ρ_proj, Bool.or_false]
             rw [h2] at h1; exact h1
           have h_trace_tl := ReflTrans_Transitive _ _ _ _ h_trace
-            (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ verifyLabel
+            (block_inner_star Expression (EvalCommand π φ) (EvalPureFunc φ) _ _ (.some verifyLabel) ρ_init.store
               (stmts_cons_step Expression (EvalCommand π φ) (EvalPureFunc φ)
-                (Statement.assert lh eh mdh) tl ρ' ρ' h_assert_step))
+                (Statement.assert lh eh mdh) tl ρ_proj ρ_proj h_assert_step))
           exact ih (fun s' hs' => h_all_assert s' (.tail _ hs'))
             h_trace_tl s h_in_tl l e md h_s_eq
     -- Prove postconditions hold and hasFailure is false

--- a/Strata/Transform/ProcedureInlining.lean
+++ b/Strata/Transform/ProcedureInlining.lean
@@ -64,7 +64,7 @@ def Statement.replaceLabels
     | .some s' => s'
   match s with
   | .block lbl b m => .block (app lbl) (Block.replaceLabels b map) m
-  | .exit lbl m => .exit (lbl.map app) m
+  | .exit lbl m => .exit (app lbl) m
   | .ite cond thenb elseb m =>
     .ite cond (Block.replaceLabels thenb map) (Block.replaceLabels elseb map) m
   | .loop g measure inv body m =>

--- a/Strata/Transform/Specification.lean
+++ b/Strata/Transform/Specification.lean
@@ -91,7 +91,7 @@ structure Lang (P : PureExpr) [HasFvar P] [HasBool P] [HasNot P] where
   /-- Terminal configuration. -/
   terminalCfg : Env P → CfgT
   /-- Exiting configuration. -/
-  exitingCfg : Option String → Env P → CfgT
+  exitingCfg : String → Env P → CfgT
   /-- Assert detection in configurations. -/
   isAtAssert : CfgT → AssertId P → Prop
   /-- Extract env from a configuration. -/
@@ -287,18 +287,32 @@ theorem seq_cons {s : Stmt P CmdT} {ss : List (Stmt P CmdT)}
           exact h₂ ρ₁ ρ' hmid (hwfb_preserved ρ₁ hterm_s) hf₁ (.inr ⟨lbl, hexit_ss⟩)
 
 omit [HasVal P] in
-/-- Lift a `TripleBlock` to a `Triple` by wrapping in a block. -/
+/-- A postcondition is well-formed if it is stable under `projectStore`. -/
+def PostWF (Post : Env P → Prop) : Prop :=
+  ∀ ρ σ_parent, Post ρ → ρ.hasFailure = false →
+    Post { ρ with store := projectStore σ_parent ρ.store } ∧
+      ({ ρ with store := projectStore σ_parent ρ.store } : Env P).hasFailure = false
+
+omit [HasVal P] in
+/-- Lift a `TripleBlock` to a `Triple` by wrapping in a block.
+    The postcondition `Post` is required to be stable under `projectStore`
+    (it only references variables defined before the block). -/
 theorem TripleBlock.toTriple {ss : List (Stmt P CmdT)} {l : String} {md : MetaData P}
     {Pre Post : Env P → Prop}
-    (h : TripleBlock evalCmd extendEval Pre ss Post) :
+    (h : TripleBlock evalCmd extendEval Pre ss Post)
+    (hpost_proj : PostWF Post) :
     Triple (Lang.imperative P CmdT evalCmd extendEval isAtAssertFn) Pre (.block l ss md) Post := by
   intro ρ₀ ρ' hpre hwfb hf₀ hstar
   cases hstar with
   | step _ _ _ hstep hrest => cases hstep with
     | step_block =>
       match block_reaches_terminal P evalCmd extendEval hrest with
-      | .inl hterm => exact h ρ₀ ρ' hpre hwfb hf₀ (.inl hterm)
-      | .inr ⟨lbl, hexit_inner⟩ => exact h ρ₀ ρ' hpre hwfb hf₀ (.inr ⟨lbl, hexit_inner⟩)
+      | .inl ⟨ρ_inner, hterm, heq⟩ =>
+        have ⟨hpost, hf⟩ := h ρ₀ ρ_inner hpre hwfb hf₀ (.inl hterm)
+        subst heq; exact hpost_proj ρ_inner _ hpost hf
+      | .inr ⟨lbl, ρ_inner, hexit, heq⟩ =>
+        have ⟨hpost, hf⟩ := h ρ₀ ρ_inner hpre hwfb hf₀ (.inr ⟨lbl, hexit⟩)
+        subst heq; exact hpost_proj ρ_inner _ hpost hf
 
 omit [HasVal P] in
 /-- Lift a `Triple` to a `TripleBlock` for a singleton list. -/
@@ -335,9 +349,10 @@ theorem Triple.toTripleBlock {s : Stmt P CmdT}
 
 omit [HasVal P] in
 /-- Empty block is skip. -/
-theorem skip (l : String) (md : MetaData P) (Pre : Env P → Prop) :
+theorem skip (l : String) (md : MetaData P) (Pre : Env P → Prop)
+    (hpre_proj : PostWF Pre) :
     Triple (Lang.imperative P CmdT evalCmd extendEval isAtAssertFn) Pre (.block l [] md) Pre :=
-  TripleBlock.toTriple evalCmd extendEval isAtAssertFn (skip_block evalCmd extendEval Pre)
+  TripleBlock.toTriple evalCmd extendEval isAtAssertFn (skip_block evalCmd extendEval Pre) hpre_proj
 
 omit [HasVal P] in
 /-- If-then-else rule. -/
@@ -397,7 +412,7 @@ theorem hoareTriple_implies_assertValid
     cases hstep with
     | step_block =>
       have ⟨inner, heq_cfg, hinner_star, hat_inner⟩ :=
-        block_isAtAssert_inner P' extendEval _ _ _ _ hrest hat
+        block_isAtAssert_inner P' extendEval _ _ _ _ _ hrest hat
       subst heq_cfg
       cases hinner_star with
       | refl => exact absurd hat_inner (by simp [isAtAssert])
@@ -494,9 +509,9 @@ theorem allAssertsValid_implies_hoareTriple
       .step _ _ _ StepStmt.step_stmts_cons (.refl _)
     have h3 := seq_inner_star P' (EvalCmd P') extendEval _ _ [assert_stmt] hstar_st
     have h_inner := ReflTrans_Transitive _ _ _ _ (ReflTrans_Transitive _ _ _ _ h1 h2) h3
-    have h_block := block_inner_star P' (EvalCmd P') extendEval _ _ block_label h_inner
+    have h_block := block_inner_star P' (EvalCmd P') extendEval _ _ (.some block_label) ρ₀.store h_inner
     have h_start : StepStmtStar P' (EvalCmd P') extendEval
-        (.stmt (.block block_label body block_md) ρ₀) (.block block_label (.stmts body ρ₀)) :=
+        (.stmt (.block block_label body block_md) ρ₀) (.block (.some block_label) ρ₀.store (.stmts body ρ₀)) :=
       .step _ _ _ StepStmt.step_block (.refl _)
     have h_full := ReflTrans_Transitive _ _ _ _ h_start h_block
     have h_result := hvalid a ρ₀ _ trivial h_full hat
@@ -514,12 +529,12 @@ theorem allAssertsValid_implies_hoareTriple
       (.stmts [assert_stmt] ρ') (.seq (.stmt assert_stmt ρ') []) :=
     .step _ _ _ StepStmt.step_stmts_cons (.refl _)
   have h_inner := ReflTrans_Transitive _ _ _ _ (ReflTrans_Transitive _ _ _ _ h1 h2) h3
-  have h_block := block_inner_star P' (EvalCmd P') extendEval _ _ block_label h_inner
+  have h_block := block_inner_star P' (EvalCmd P') extendEval _ _ (.some block_label) ρ₀.store h_inner
   have h_start : StepStmtStar P' (EvalCmd P') extendEval
-      (.stmt (.block block_label body block_md) ρ₀) (.block block_label (.stmts body ρ₀)) :=
+      (.stmt (.block block_label body block_md) ρ₀) (.block (.some block_label) ρ₀.store (.stmts body ρ₀)) :=
     .step _ _ _ StepStmt.step_block (.refl _)
   have h_full := ReflTrans_Transitive _ _ _ _ h_start h_block
-  have h_at : isAtAssert P' (.block block_label (.seq (.stmt assert_stmt ρ') [])) ⟨post_label, post_expr⟩ := by
+  have h_at : isAtAssert P' (.block (.some block_label) ρ₀.store (.seq (.stmt assert_stmt ρ') [])) ⟨post_label, post_expr⟩ := by
     simp [isAtAssert, assert_stmt]
   have h_result := hvalid ⟨post_label, post_expr⟩ ρ₀ _ trivial h_full h_at
   dsimp [Config.getEval, Config.getStore, Config.getEnv] at h_result

--- a/Strata/Transform/StructuredToUnstructured.lean
+++ b/Strata/Transform/StructuredToUnstructured.lean
@@ -146,27 +146,17 @@ match ss with
                         transfer := .condGoto (HasFvar.mkFvar ident) bl kNext })
     let (accumEntry, accumBlocks) ← flushCmds "before_loop$" accum .none lentry
     pure (accumEntry, accumBlocks ++ [b] ++ bbs ++ decreaseBlocks ++ bsNext)
-| .exit l? _md :: _ => do
-  -- Find the continuation of the block labeled `l`, or the most recently-added
-  -- block if `l` is `.none`.
+| .exit l _md :: _ => do
+  -- Find the continuation of the block labeled `l`.
   let bk :=
-    match (l?, exitConts) with
+    match exitConts.lookup (.some l) with
+    | .some k => k
     -- Just keep going if this is an invalid exit. We assume a prior
     -- check to avoid this.
-    | (.none, []) => k
-    | (.none, (_, k) :: _) => k
-    | (.some l, _) =>
-      match exitConts.lookup (.some l) with
-      | .some k => k
-      -- Just keep going if this is an invalid exit. We assume a prior
-      -- check to avoid this.
-      | .none => k
+    | .none => k
   -- Flush the accumulated commands, going to the continuation calculated above.
   -- Any statements after the `.exit` are skipped.
-  let exitName :=
-    match l? with
-    | .some l => s!"block${l}$"
-    | .none => "block$"
+  let exitName := s!"block${l}$"
   flushCmds exitName accum .none bk
 
 def stmtsToCFGM

--- a/Strata/Transform/StructuredToUnstructured.lean
+++ b/Strata/Transform/StructuredToUnstructured.lean
@@ -43,6 +43,9 @@ def flushCmds
     let b := (l, { cmds := accum.reverse, transfer := tr?.getD (.goto k) })
     pure (l, [b])
 
+private abbrev synthesizedMd {P : PureExpr} : MetaData P :=
+  MetaData.ofProvenance (.synthesized .structuredToUnstructured)
+
 /-- Translate a list of statements to basic blocks, accumulating commands -/
 def stmtsToBlocks
   [HasBool P] [HasPassiveCmds P CmdT] [HasInit P CmdT]
@@ -92,7 +95,7 @@ match ss with
     | .nondet => do
       let freshName ← StringGenState.gen "$__nondet_ite$"
       let ident := HasIdent.ident (P := P) freshName
-      let initCmd := HasInit.init ident HasBool.boolTy .nondet MetaData.empty
+      let initCmd := HasInit.init ident HasBool.boolTy .nondet synthesizedMd
       pure (HasFvar.mkFvar ident, [initCmd])
   let (accumEntry, accumBlocks) ← flushCmds "ite$" (accum ++ extraCmds)
     (.some (.condGoto condExpr tl fl)) l
@@ -111,13 +114,13 @@ match ss with
       let mLabel ← StringGenState.gen "loop_measure$"
       let mIdent := HasIdent.ident mLabel
       let mOldExpr := HasFvar.mkFvar mIdent
-      let initCmd  := HasInit.init mIdent HasIntOrder.intTy .nondet MetaData.empty
+      let initCmd  := HasInit.init mIdent HasIntOrder.intTy .nondet synthesizedMd
       let assumeCmd := HasPassiveCmds.assume s!"assume_{mLabel}"
-                         (HasIntOrder.eq mOldExpr mExpr) MetaData.empty
+                         (HasIntOrder.eq mOldExpr mExpr) synthesizedMd
       let lbCmd    := HasPassiveCmds.assert s!"measure_lb_{mLabel}"
-                         (HasNot.not (HasIntOrder.lt mOldExpr HasIntOrder.zero)) MetaData.empty
+                         (HasNot.not (HasIntOrder.lt mOldExpr HasIntOrder.zero)) synthesizedMd
       let decCmd   := HasPassiveCmds.assert s!"measure_decrease_{mLabel}"
-                         (HasIntOrder.lt mExpr mOldExpr) MetaData.empty
+                         (HasIntOrder.lt mExpr mOldExpr) synthesizedMd
       let ldec ← StringGenState.gen "measure_decrease$"
       let decBlock := (ldec, { cmds := [decCmd], transfer := .goto lentry })
       pure ([initCmd, assumeCmd, lbCmd], ldec, [decBlock])
@@ -131,7 +134,7 @@ match ss with
       let assertLabel ←
         if srcLabel.isEmpty then StringGenState.gen "inv$"
         else pure srcLabel
-      pure (HasPassiveCmds.assert assertLabel i MetaData.empty))
+      pure (HasPassiveCmds.assert assertLabel i synthesizedMd))
   -- For nondet guards, introduce a fresh boolean variable
   match c with
   | .det e =>
@@ -141,7 +144,7 @@ match ss with
   | .nondet => do
     let freshName ← StringGenState.gen "$__nondet_loop$"
     let ident := HasIdent.ident (P := P) freshName
-    let initCmd := HasInit.init ident HasBool.boolTy .nondet MetaData.empty
+    let initCmd := HasInit.init ident HasBool.boolTy .nondet synthesizedMd
     let b := (lentry, { cmds := [initCmd] ++ invCmds ++ measureCmds,
                         transfer := .condGoto (HasFvar.mkFvar ident) bl kNext })
     let (accumEntry, accumBlocks) ← flushCmds "before_loop$" accum .none lentry

--- a/Strata/Util/Provenance.lean
+++ b/Strata/Util/Provenance.lean
@@ -1,0 +1,63 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.Util.FileRange
+
+public section
+namespace Strata
+
+/-- Canonical synthesized provenance origins. -/
+inductive SynthesizedOrigin where
+  | smtEncode
+  | nondetIte
+  | laurelParse
+  | laurel
+  | laurelToCore
+  | structuredToUnstructured
+  deriving DecidableEq, Repr, Inhabited
+
+instance : Std.ToFormat SynthesizedOrigin where
+  format
+    | .smtEncode => "smt-encode"
+    | .nondetIte => "nondet-ite"
+    | .laurelParse => "laurel-parse"
+    | .laurel => "laurel"
+    | .laurelToCore => "laurel-to-core"
+    | .structuredToUnstructured => "structured-to-unstructured"
+
+/-- Provenance tracks where an AST node originated from — either a real source
+location or a synthesized origin (e.g., from a translator or encoding pass). -/
+inductive Provenance where
+  /-- A real source location with file and byte range. -/
+  | loc (uri : Uri) (range : SourceRange)
+  /-- A synthesized node with a description of what created it. -/
+  | synthesized (origin : SynthesizedOrigin)
+  deriving DecidableEq, Repr, Inhabited
+
+namespace Provenance
+
+/-- Convert a Provenance to a FileRange, if it has a real location. -/
+def toFileRange : Provenance → Option FileRange
+  | .loc uri range => some { file := uri, range }
+  | .synthesized _ => none
+
+/-- Convert a FileRange to a Provenance. -/
+def ofFileRange (fr : FileRange) : Provenance :=
+  .loc fr.file fr.range
+
+/-- Convert a SourceRange and Uri to a Provenance. -/
+def ofSourceRange (uri : Uri) (sr : SourceRange) : Provenance :=
+  .loc uri sr
+
+instance : Std.ToFormat Provenance where
+  format
+    | .loc uri range => f!"{uri}:{range}"
+    | .synthesized origin => f!"<synthesized:{origin}>"
+
+end Provenance
+end Strata
+end

--- a/StrataTest/Backends/CBMC/GOTO/ToCProverGOTO.lean
+++ b/StrataTest/Backends/CBMC/GOTO/ToCProverGOTO.lean
@@ -245,7 +245,7 @@ info: ok: #[LOCATION 0,
 /-- Test exit statement transformation -/
 def ExampleStmt5 : List (Imperative.Stmt LExprTP (Imperative.Cmd LExprTP)) :=
   [.cmd (.init (Lambda.Identifier.mk "x" ()) mty[bv32] (.det (.const { underlying := (), type := mty[bv32] } (.bitvecConst 32 0))) {}),
-   .exit (some "target_label") {},
+   .exit "target_label" {},
    .cmd (.set (Lambda.Identifier.mk "x" ()) (.det (.const { underlying := (), type := mty[bv32] } (.bitvecConst 32 10))) {}),
    .block "target_label"
      [.cmd (.set (Lambda.Identifier.mk "x" ()) (.det (.const { underlying := (), type := mty[bv32] } (.bitvecConst 32 20))) {})]

--- a/StrataTest/DL/Imperative/FormatStmtTest.lean
+++ b/StrataTest/DL/Imperative/FormatStmtTest.lean
@@ -147,11 +147,7 @@ info: while
 
 -- 14. exit with label
 /-- info: exit target -/
-#guard_msgs in #eval! format (Stmt.exit (some "target") .empty : S)
-
--- 14b. exit without label
-/-- info: exit -/
-#guard_msgs in #eval! format (Stmt.exit none .empty : S)
+#guard_msgs in #eval! format (Stmt.exit "target" .empty : S)
 
 -- 15. funcDecl
 /-- info: funcDecl <function> -/

--- a/StrataTest/DL/Imperative/StepStmtTest.lean
+++ b/StrataTest/DL/Imperative/StepStmtTest.lean
@@ -104,42 +104,80 @@ def noCmd : EvalCmdParam MiniPureExpr CmdT := fun _ _ _ _ _ => False
 
 ---------------------------------------------------------------------
 
-/-! ## Test: `loop { exit }` exactly exits the loop, not the outer block.
+/-! ## Test: `block "L" { loop { exit "L" } }` exits the loop via labeled exit.
 
-A minimal program `loop { exit }` is shown to step to `.terminal`.  This
-verifies that an unlabeled `exit` inside the body terminates just the
-loop (and not the enclosing block).
+The `exit "L"` propagates out of body's per-iteration block and the loop's
+recursive step (mismatch propagates), reaching the labeled outer block.
 -/
 
-/-- The test program: a deterministic `while (true)` loop whose only body
-    statement is an unlabeled `exit`. -/
+/-- The test program: a labeled outer block containing a deterministic
+    `while (true)` loop whose body is `exit "L"`. -/
 def prog : Stmt MiniPureExpr CmdT :=
-  .loop (.det .tt) none [] [.exit none .empty] .empty
+  .block "L"
+    [.loop (.det .tt) none [] [.exit "L" .empty] .empty]
+    .empty
 
 /-- The test: `.stmt prog ρ₀ →* .terminal ρ₀` -/
 theorem progReachesTerminal :
     StepStmtStar MiniPureExpr noCmd miniExtendEval
       (.stmt prog ρ₀) (.terminal ρ₀) := by
-  -- Each step explicitly named; Lean fills the rest.
   have htt : ρ₀.eval ρ₀.store HasBool.tt = some HasBool.tt := rfl
-  -- Step 1: step_loop_enter with hasInvFailure = false.
+  -- Step 1: step_block — enter the outer labeled block.
+  refine .step _ _ _ StepStmt.step_block ?_
+  -- Step 2: step_block_body step_stmts_cons.
+  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_stmts_cons) ?_
+  -- Step 3: step_block_body (step_seq_inner step_loop_enter).
   refine .step _ _ _
-    (StepStmt.step_loop_enter (hasInvFailure := false) htt ?inv_bool ?inv_iff
-      miniEval_wfBool) ?rest
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner
+        (StepStmt.step_loop_enter (hasInvFailure := false) htt ?inv_bool ?inv_iff
+          miniEval_wfBool))) ?_
   · intro _ hmem; nomatch hmem
   · constructor <;> intro h
     · cases h
     · rcases h with ⟨_, hmem, _⟩; nomatch hmem
-  -- Post-state: ρ₀' = {ρ₀ with hasFailure := ρ₀.hasFailure || false} definitionally equal to ρ₀.
-  -- Step 2: step_block_body (step_stmts_cons).
-  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_stmts_cons) ?rest2
-  -- Step 3: step_block_body (step_seq_inner step_exit).
+  -- Now: outer block (L) > seq > seq > body's block (.none) > stmts [exit "L"]
+  -- Step 4: descend into the inner seq, then into the body's block,
+  --         then through stmts_cons.
   refine .step _ _ _
-    (StepStmt.step_block_body (StepStmt.step_seq_inner StepStmt.step_exit)) ?rest3
-  -- Step 4: step_block_body step_seq_exit.
-  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_seq_exit) ?rest4
-  -- Step 5: step_block_exit_none.
-  exact .step _ _ _ StepStmt.step_block_exit_none (.refl _)
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner
+        (StepStmt.step_seq_inner
+          (StepStmt.step_block_body StepStmt.step_stmts_cons)))) ?_
+  -- Step 5: fire the exit "L".
+  refine .step _ _ _
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner
+        (StepStmt.step_seq_inner
+          (StepStmt.step_block_body
+            (StepStmt.step_seq_inner StepStmt.step_exit))))) ?_
+  -- Step 6: step_seq_exit (inner-most seq propagates the exiting).
+  refine .step _ _ _
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner
+        (StepStmt.step_seq_inner
+          (StepStmt.step_block_body StepStmt.step_seq_exit)))) ?_
+  -- Step 7: body's `.block .none` mismatches "L" — propagate via step_block_exit_mismatch.
+  refine .step _ _ _
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner
+        (StepStmt.step_seq_inner
+          (StepStmt.step_block_exit_mismatch (by intro h; cases h))))) ?_
+  -- Step 8-9: propagate exiting through outer seq layers.
+  refine .step _ _ _
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner StepStmt.step_seq_exit)) ?_
+  refine .step _ _ _
+    (StepStmt.step_block_body StepStmt.step_seq_exit) ?_
+  -- Step 10: outer block "L" matches the exit label.
+  -- The store projection equals ρ₀.store since no inits happened.
+  have hproj : projectStore (P := MiniPureExpr) ρ₀.store ρ₀.store = ρ₀.store := by
+    funext x
+    simp [projectStore]
+    intro h; rfl
+  conv => rhs; rw [show ρ₀ = { ρ₀ with store := projectStore ρ₀.store ρ₀.store } from by
+    simp [hproj]]
+  exact .step _ _ _ (StepStmt.step_block_exit_match rfl) (.refl _)
 
 ---------------------------------------------------------------------
 
@@ -148,7 +186,7 @@ theorem progReachesTerminal :
 
 def progIteThen : Stmt MiniPureExpr CmdT :=
   .block "L"
-    [.ite (.det .tt) [.exit none .empty] [] .empty]
+    [.ite (.det .tt) [.exit "L" .empty] [] .empty]
     .empty
 
 /-- The test: `.stmt progIteThen ρ₀ →* .terminal ρ₀` via the `then` branch. -/
@@ -156,29 +194,26 @@ theorem progIteThenReachesTerminal :
     StepStmtStar MiniPureExpr noCmd miniExtendEval
       (.stmt progIteThen ρ₀) (.terminal ρ₀) := by
   have htt : ρ₀.eval ρ₀.store HasBool.tt = some HasBool.tt := rfl
-  -- Step 1: step_block — enter the outer block.
-  refine .step _ _ _ StepStmt.step_block ?rest1
-  -- Step 2: step_block_body (step_stmts_cons) — break the singleton stmts list.
-  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_stmts_cons) ?rest2
-  -- Step 3: step_block_body (step_seq_inner step_ite_true) — take the then branch.
+  refine .step _ _ _ StepStmt.step_block ?_
+  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_stmts_cons) ?_
   refine .step _ _ _
     (StepStmt.step_block_body
-      (StepStmt.step_seq_inner (StepStmt.step_ite_true htt miniEval_wfBool))) ?rest3
-  -- Step 4: step_block_body (step_seq_inner step_stmts_cons) — destructure the then body.
+      (StepStmt.step_seq_inner (StepStmt.step_ite_true htt miniEval_wfBool))) ?_
   refine .step _ _ _
-    (StepStmt.step_block_body (StepStmt.step_seq_inner StepStmt.step_stmts_cons)) ?rest4
-  -- Step 5: step_block_body (step_seq_inner (step_seq_inner step_exit)) — fire the exit.
+    (StepStmt.step_block_body (StepStmt.step_seq_inner StepStmt.step_stmts_cons)) ?_
   refine .step _ _ _
     (StepStmt.step_block_body
-      (StepStmt.step_seq_inner (StepStmt.step_seq_inner StepStmt.step_exit))) ?rest5
-  -- Step 6: step_block_body (step_seq_inner step_seq_exit) — propagate past the inner seq.
+      (StepStmt.step_seq_inner (StepStmt.step_seq_inner StepStmt.step_exit))) ?_
   refine .step _ _ _
     (StepStmt.step_block_body
-      (StepStmt.step_seq_inner StepStmt.step_seq_exit)) ?rest6
-  -- Step 7: step_block_body step_seq_exit — propagate past the outer seq.
-  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_seq_exit) ?rest7
-  -- Step 8: step_block_exit_none — the outer block catches the unlabeled exit.
-  exact .step _ _ _ StepStmt.step_block_exit_none (.refl _)
+      (StepStmt.step_seq_inner StepStmt.step_seq_exit)) ?_
+  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_seq_exit) ?_
+  -- Outer block "L" matches the labeled exit; project store (identity here).
+  have hproj : projectStore (P := MiniPureExpr) ρ₀.store ρ₀.store = ρ₀.store := by
+    funext x; simp [projectStore]; intro _; rfl
+  conv => rhs; rw [show ρ₀ = { ρ₀ with store := projectStore ρ₀.store ρ₀.store } from by
+    simp [hproj]]
+  exact .step _ _ _ (StepStmt.step_block_exit_match rfl) (.refl _)
 
 ---------------------------------------------------------------------
 
@@ -187,7 +222,7 @@ theorem progIteThenReachesTerminal :
 
 def progIteElse : Stmt MiniPureExpr CmdT :=
   .block "L"
-    [.ite (.det .ff) [] [.exit none .empty] .empty]
+    [.ite (.det .ff) [] [.exit "L" .empty] .empty]
     .empty
 
 /-- The test: `.stmt progIteElse ρ₀ →* .terminal ρ₀` via the `else` branch. -/
@@ -210,7 +245,295 @@ theorem progIteElseReachesTerminal :
     (StepStmt.step_block_body
       (StepStmt.step_seq_inner StepStmt.step_seq_exit)) ?rest6
   refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_seq_exit) ?rest7
-  exact .step _ _ _ StepStmt.step_block_exit_none (.refl _)
+  -- Outer block "L" matches the labeled exit; project store (identity here).
+  have hproj : projectStore (P := MiniPureExpr) ρ₀.store ρ₀.store = ρ₀.store := by
+    funext x; simp [projectStore]; intro _; rfl
+  conv => rhs; rw [show ρ₀ = { ρ₀ with store := projectStore ρ₀.store ρ₀.store } from by
+    simp [hproj]]
+  exact .step _ _ _ (StepStmt.step_block_exit_match rfl) (.refl _)
+
+---------------------------------------------------------------------
+
+/-- Now extend `Expr` to include a variable reference so we can test
+    that `getVars` picks up read variables. -/
+inductive Expr2 where
+  | tt
+  | ff
+  | not (e : Expr2)
+  | var (name : String)
+  deriving DecidableEq, Repr, Inhabited
+
+abbrev MiniPureExpr2 : PureExpr :=
+  { Ident := String,
+    EqIdent := instDecidableEqString,
+    Expr := Expr2,
+    Ty := Ty,
+    ExprMetadata := Unit,
+    TyEnv := Unit,
+    TyContext := Unit,
+    EvalEnv := Unit }
+
+instance : HasBool MiniPureExpr2 where
+  tt := .tt
+  ff := .ff
+  tt_is_not_ff := by intro h; cases h
+  boolTy := .Bool
+
+instance : HasNot MiniPureExpr2 where
+  not := .not
+
+/-- Get free variables from `Expr2`. -/
+def Expr2.getVars : Expr2 → List String
+  | .var n => [n]
+  | .not e => e.getVars
+  | _ => []
+
+/-- `HasVarsPure` for `Expr2`: only `.var` contributes a variable. -/
+instance : HasVarsPure MiniPureExpr2 Expr2 where
+  getVars := Expr2.getVars
+
+instance : HasVarsPure MiniPureExpr2 (Cmd MiniPureExpr2) where
+  getVars := Cmd.getVars
+
+/-- Test: `set x := var "y"` has `modifiedOrDefinedVars = ["x"]` (write-set only)
+    but `touchedVars = ["x", "y"]` (includes the read variable "y"). -/
+example : (Stmt.cmd (P := MiniPureExpr2)
+    (Cmd.set (P := MiniPureExpr2) "x" (.det (.var "y")) .empty)).modifiedOrDefinedVars
+    = ["x"] := by native_decide
+
+example : (Stmt.cmd (P := MiniPureExpr2)
+    (Cmd.set (P := MiniPureExpr2) "x" (.det (.var "y")) .empty)).touchedVars
+    = ["x", "y"] := by native_decide
+
+/-- Test: `init z : Bool := var "w"` has `modifiedOrDefinedVars = ["z"]`
+    but `touchedVars = ["z", "w"]`. -/
+example : (Stmt.cmd (P := MiniPureExpr2)
+    (Cmd.init (P := MiniPureExpr2) "z" .Bool (.det (.var "w")) .empty)).modifiedOrDefinedVars
+    = ["z"] := by native_decide
+
+example : (Stmt.cmd (P := MiniPureExpr2)
+    (Cmd.init (P := MiniPureExpr2) "z" .Bool (.det (.var "w")) .empty)).touchedVars
+    = ["z", "w"] := by native_decide
+
+/-- Test: Block touchedVars includes both read and write vars from all stmts. -/
+example : (Block.touchedVars (P := MiniPureExpr2) (C := Cmd MiniPureExpr2)
+    [.cmd (Cmd.init (P := MiniPureExpr2) "a" .Bool (.det (.var "b")) .empty),
+     .cmd (Cmd.set (P := MiniPureExpr2) "c" (.det (.var "d")) .empty)])
+    = ["a", "c", "b", "d"] := by native_decide
+
+example : (Block.modifiedOrDefinedVars (P := MiniPureExpr2) (C := Cmd MiniPureExpr2)
+    [.cmd (Cmd.init (P := MiniPureExpr2) "a" .Bool (.det (.var "b")) .empty),
+     .cmd (Cmd.set (P := MiniPureExpr2) "c" (.det (.var "d")) .empty)])
+    = ["a", "c"] := by native_decide
+
+---------------------------------------------------------------------
+
+/-! ## Block scoping tests
+
+Verify that variables `init`'d inside a block are not visible after the
+block exits. We step through a program and verify the terminal store
+has `none` for block-local variables thanks to `projectStore`. -/
+
+/-- A `HasFvar` instance for `MiniPureExpr` — needed by `EvalCmd`. -/
+instance : HasFvar MiniPureExpr where
+  mkFvar _ := .tt  -- unused but required
+  getFvar _ := none   -- no expression is a free variable reference
+
+/-- `WellFormedSemanticEvalVar` for `miniEval` — trivially holds since
+    `getFvar` always returns `none`. -/
+theorem miniEval_wfVar : WellFormedSemanticEvalVar (P := MiniPureExpr) miniEval := by
+  unfold WellFormedSemanticEvalVar
+  intro e v σ hfv
+  simp [HasFvar.getFvar] at hfv
+
+/-- The standard `EvalCmd` for `Cmd MiniPureExpr`. -/
+def stdEvalCmd : EvalCmdParam MiniPureExpr (Cmd MiniPureExpr) :=
+  EvalCmd MiniPureExpr
+
+/-- A store where "x" is defined (maps to `.tt`), everything else is `none`. -/
+def storeWithX : SemanticStore MiniPureExpr :=
+  fun v => if v == "x" then some .tt else none
+
+/-- Env with "x" defined. -/
+def ρ_x : Env MiniPureExpr :=
+  { store := storeWithX, eval := miniEval, hasFailure := false }
+
+/-- Program: `block B { init y : Bool := tt }`.
+    After stepping, "y" should not be visible (projected away). -/
+def progBlockScope : Stmt MiniPureExpr (Cmd MiniPureExpr) :=
+  .block "B" [.cmd (.init "y" .Bool (.det .tt) .empty)] .empty
+
+/-- Store that has both "x" and "y" defined. -/
+def storeWithXY : SemanticStore MiniPureExpr :=
+  fun v => if v == "x" then some .tt
+            else if v == "y" then some .tt
+            else none
+
+/-- Helper: storeWithXY agrees with storeWithX on all variables except "y". -/
+private theorem storeWithXY_frame :
+    ∀ v : String, "y" ≠ v → storeWithXY v = storeWithX v := by
+  intro v hne
+  unfold storeWithXY storeWithX
+  simp only [beq_iff_eq]
+  split
+  · simp
+  · split
+    · rename_i heq; exact absurd heq.symm hne
+    · rfl
+
+/-- After the block exits, the store should have "x" defined but "y" = none. -/
+theorem blockScopeTest :
+    StepStmtStar MiniPureExpr stdEvalCmd miniExtendEval
+      (.stmt progBlockScope ρ_x)
+      (.terminal { store := storeWithX, eval := miniEval, hasFailure := false }) := by
+  -- Step 1: step_block — enter the block, saving ρ_x.store as σ_parent.
+  refine .step _ _ _ StepStmt.step_block ?_
+  -- Step 2: step_block_body (step_stmts_cons) — process the singleton list.
+  refine .step _ _ _ (StepStmt.step_block_body StepStmt.step_stmts_cons) ?_
+  -- Step 3: step_block_body (step_seq_inner step_cmd) — evaluate `init y := tt`.
+  refine .step _ _ _
+    (StepStmt.step_block_body
+      (StepStmt.step_seq_inner
+        (StepStmt.step_cmd
+          (EvalCmd.eval_init (P := MiniPureExpr)
+            (show miniEval storeWithX .tt = some .tt from rfl)
+            (InitState.init
+              (show storeWithX "y" = none from rfl)
+              (show storeWithXY "y" = some .tt from rfl)
+              storeWithXY_frame)
+            miniEval_wfVar)))) ?_
+  -- Step 4: step_block_body (step_seq_done) — seq is done, go to stmts [].
+  refine .step _ _ _
+    (StepStmt.step_block_body StepStmt.step_seq_done) ?_
+  -- Step 5: step_block_body (step_stmts_nil) — empty list becomes terminal.
+  refine .step _ _ _
+    (StepStmt.step_block_body StepStmt.step_stmts_nil) ?_
+  -- Step 6: step_block_done — project store.
+  have hproj : projectStore (P := MiniPureExpr) storeWithX storeWithXY = storeWithX := by
+    ext v
+    simp [projectStore, storeWithX, storeWithXY]
+    split <;> simp_all
+  conv => rhs; rw [show Env.mk storeWithX miniEval false =
+    { (Env.mk storeWithXY miniEval false) with store := projectStore storeWithX storeWithXY }
+    from by simp [hproj]]
+  exact .step _ _ _ StepStmt.step_block_done (.refl _)
+
+/-- Directly verify that `projectStore` maps "y" to `none`. -/
+example : projectStore (P := MiniPureExpr) storeWithX storeWithXY "y" = none := by
+  simp [projectStore, storeWithX, Option.isSome]
+
+/-- Directly verify that `projectStore` preserves "x". -/
+example : projectStore (P := MiniPureExpr) storeWithX storeWithXY "x" = some .tt := by
+  simp [projectStore, storeWithX, storeWithXY, Option.isSome]
+
+---------------------------------------------------------------------
+
+/-! ## Loop scoping tests
+
+Verify that variables `init`'d inside a loop body are scoped to each
+iteration. The loop body is wrapped in an anonymous block, so after
+each iteration the init'd variable is projected away. -/
+
+/-- Program: `loop (nondet) { init y := tt }`.
+    The loop enters one iteration, inits y, then exits on the next iteration.
+    The anonymous block wrapper projects "y" away. -/
+def progLoopScope : Stmt MiniPureExpr (Cmd MiniPureExpr) :=
+  .loop .nondet none [] [.cmd (.init "y" .Bool (.det .tt) .empty)] .empty
+
+/-- After stepping the loop through one iteration and exiting, the final
+    store should still be `storeWithX` (the variable "y" is projected away
+    by the per-iteration anonymous block).  With the new semantics, each
+    iteration's body runs in its own block scope. -/
+theorem loopScopeTest :
+    StepStmtStar MiniPureExpr stdEvalCmd miniExtendEval
+      (.stmt progLoopScope ρ_x)
+      (.terminal { store := storeWithX, eval := miniEval, hasFailure := false }) := by
+  -- Step 1: step_loop_nondet_enter — produces:
+  --   .seq (.block .none ρ_x.store (.stmts [init y] ρ_x')) [loop ...]
+  refine .step _ _ _
+    (StepStmt.step_loop_nondet_enter (hasInvFailure := false) ?_ ?_) ?_
+  · intro _ hmem; nomatch hmem
+  · constructor <;> intro h
+    · cases h
+    · rcases h with ⟨_, hmem, _⟩; nomatch hmem
+  -- Step 2: step_seq_inner (step_block_body step_stmts_cons)
+  refine .step _ _ _
+    (StepStmt.step_seq_inner
+      (StepStmt.step_block_body StepStmt.step_stmts_cons)) ?_
+  -- Step 3: step_seq_inner (step_block_body (step_seq_inner step_cmd)) — init y
+  refine .step _ _ _
+    (StepStmt.step_seq_inner
+      (StepStmt.step_block_body
+        (StepStmt.step_seq_inner
+          (StepStmt.step_cmd
+            (EvalCmd.eval_init (P := MiniPureExpr)
+              (show miniEval storeWithX .tt = some .tt from rfl)
+              (InitState.init
+                (show storeWithX "y" = none from rfl)
+                (show storeWithXY "y" = some .tt from rfl)
+                storeWithXY_frame)
+              miniEval_wfVar))))) ?_
+  -- Step 4: step_seq_inner (step_block_body step_seq_done) — inner stmt terminal
+  refine .step _ _ _
+    (StepStmt.step_seq_inner
+      (StepStmt.step_block_body StepStmt.step_seq_done)) ?_
+  -- Step 5: step_seq_inner (step_block_body step_stmts_nil)
+  refine .step _ _ _
+    (StepStmt.step_seq_inner
+      (StepStmt.step_block_body StepStmt.step_stmts_nil)) ?_
+  -- Step 6: step_seq_inner step_block_done — body's block projects, dropping "y"
+  refine .step _ _ _
+    (StepStmt.step_seq_inner StepStmt.step_block_done) ?_
+  -- After projection, env's store is projectStore storeWithX storeWithXY = storeWithX
+  have hproj : projectStore (P := MiniPureExpr) storeWithX storeWithXY = storeWithX := by
+    funext v
+    simp [projectStore, storeWithX, storeWithXY]
+    split <;> simp_all
+  -- Step 7: step_seq_done — seq advances with projected env to [loop ...]
+  refine .step _ _ _ StepStmt.step_seq_done ?_
+  -- Step 8: step_stmts_cons
+  refine .step _ _ _ StepStmt.step_stmts_cons ?_
+  -- Step 9: step_seq_inner step_loop_nondet_exit
+  refine .step _ _ _
+    (StepStmt.step_seq_inner
+      (StepStmt.step_loop_nondet_exit (hasInvFailure := false) ?_ ?_)) ?_
+  · intro _ hmem; nomatch hmem
+  · constructor <;> intro h
+    · cases h
+    · rcases h with ⟨_, hmem, _⟩; nomatch hmem
+  -- Step 10: step_seq_done
+  refine .step _ _ _ StepStmt.step_seq_done ?_
+  -- Step 11: step_stmts_nil — final terminal
+  -- The final env's store should be storeWithX after the projection.
+  -- Need to reconcile the env shape.
+  conv => rhs; rw [show Env.mk storeWithX miniEval false =
+    { Env.mk (projectStore storeWithX storeWithXY) miniEval false with
+      hasFailure := false || false } from by simp [hproj, Bool.or_false]]
+  exact .step _ _ _ StepStmt.step_stmts_nil (.refl _)
+
+---------------------------------------------------------------------
+
+/-! ## Test: re-init inside an if-branch gets stuck
+
+`init x := tt; if tt { init x := ff }` gets stuck at the second `init x`
+because `InitState` requires the variable to be undefined (`σ x = none`),
+but after the first `init`, `x` is already `some .tt`.  This confirms that
+block scoping is necessary to re-use a variable name. -/
+
+def progReinitStuck : List (Stmt MiniPureExpr (Cmd MiniPureExpr)) :=
+  [.cmd (.init "x" .Bool (.det .tt) .empty),
+   .ite (.det .tt) [.cmd (.init "x" .Bool (.det .ff) .empty)] [] .empty]
+
+/-- After executing `init x := tt`, the inner `init x := ff` cannot step
+    because `InitState` requires `σ "x" = none` but `σ "x" = some .tt`.
+    We show no single step is possible from this configuration. -/
+theorem reinit_stuck :
+    ¬ ∃ c₂, StepStmt MiniPureExpr stdEvalCmd miniExtendEval
+      (.stmt (.cmd (.init "x" .Bool (.det .ff) .empty)) ρ_x) c₂ := by
+  intro ⟨c₂, hstep⟩
+  match hstep with
+  | .step_cmd (.eval_init _ (.init h_none _ _) _) =>
+    exact absurd h_none (by simp [ρ_x, storeWithX])
 
 ---------------------------------------------------------------------
 

--- a/StrataTest/DL/SMT/TranslateTests.lean
+++ b/StrataTest/DL/SMT/TranslateTests.lean
@@ -74,3 +74,69 @@ info: ∀ (α : Type → Type → Type) [inst : ∀ (α_1 α_2 : Type), Nonempty
   let inner := .app .ite [c, (.prim (.int 1)), (.prim (.int 2))] (.prim .int)
   let outer := .app .ite [c, inner, (.prim (.int 3))] (.prim .int)
   elabQuery {} [] (.app .eq [outer, (.prim (.int 1))] (.prim .bool))
+
+-- SMT-Lib theory of strings: literals and the operations supported by
+-- `Denote.lean` (`str_length`, `str_concat`).
+
+/-- info: "hi" = "hi" -/
+#guard_msgs in
+#eval
+  elabQuery {} [] (.app .eq [(.prim (.string "hi")), (.prim (.string "hi"))] (.prim .bool))
+
+/-- info: Int.ofNat "hello".length = 5 -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq [(.app .str_length [(.prim (.string "hello"))] (.prim .int)), (.prim (.int 5))]
+      (.prim .bool))
+
+/-- info: "hi" ++ " there" = "hi there" -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq [(.app .str_concat [(.prim (.string "hi")), (.prim (.string " there"))] (.prim .string)),
+               (.prim (.string "hi there"))]
+      (.prim .bool))
+
+/-- info: "a" ++ "b" ++ "c" = "abc" -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_concat
+         [(.prim (.string "a")), (.prim (.string "b")), (.prim (.string "c"))]
+         (.prim .string)),
+       (.prim (.string "abc"))]
+      (.prim .bool))
+
+-- Malformed string terms are rejected up front, matching `Denote.denoteTerm`.
+-- Using `.prim (.bool _)` (which translates to type `Prop`) for the
+-- non-string operand keeps the expected error message stable independent of
+-- how `.prim (.int _)` happens to be typed by the translator.
+
+/-- error: Error: expected String type, got 'Prop' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_length [(.prim (.bool true))] (.prim .int)),
+       (.prim (.int 0))]
+      (.prim .bool))
+
+/-- error: Error: str_concat expects at least two operands, got '1' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_concat [(.prim (.string "hi"))] (.prim .string)),
+       (.prim (.string "hi"))]
+      (.prim .bool))
+
+/-- error: Error: expected String type, got 'Prop' -/
+#guard_msgs in
+#eval
+  elabQuery {} []
+    (.app .eq
+      [(.app .str_concat [(.prim (.bool true)), (.prim (.string "hi"))] (.prim .string)),
+       (.prim (.string "hi"))]
+      (.prim .bool))

--- a/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
+++ b/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
@@ -406,8 +406,7 @@ private def summaryMd (summary : String) : Imperative.MetaData Core.Expression :
 /-- Metadata carrying only a file range (no property summary); used to
     exercise `addLocationInfo`. -/
 private def fileRangeMd (file : String) : Imperative.MetaData Core.Expression :=
-  let fr : Strata.FileRange := ⟨.file file, Strata.SourceRange.none⟩
-  Imperative.MetaData.empty.pushElem Imperative.MetaData.fileRange (.fileRange fr)
+  Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange (.file file) Strata.SourceRange.none)
 
 /-! Embedded double quotes in the property summary must be doubled (`""`). -/
 /--

--- a/StrataTest/Languages/Core/Tests/SarifOutputTests.lean
+++ b/StrataTest/Languages/Core/Tests/SarifOutputTests.lean
@@ -36,15 +36,13 @@ def makeMetadata (file : String) (_line _col : Nat) : MetaData Expression :=
   let uri := Strata.Uri.file file
   -- Create a 1D range (byte offsets). For testing, we use simple offsets.
   let range : Strata.SourceRange := { start := ⟨0⟩, stop := ⟨10⟩ }
-  let fr : Strata.FileRange := { file := uri, range := range }
-  #[{ fld := Imperative.MetaData.fileRange, value := .fileRange fr }]
+  Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange uri range)
 
 /-- Create metadata with a specific byte offset for the file range start. -/
 def makeMetadataAt (file : String) (startByte : Nat) : MetaData Expression :=
   let uri := Strata.Uri.file file
   let range : Strata.SourceRange := { start := ⟨startByte⟩, stop := ⟨startByte + 10⟩ }
-  let fr : Strata.FileRange := { file := uri, range := range }
-  #[{ fld := Imperative.MetaData.fileRange, value := .fileRange fr }]
+  Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange uri range)
 
 /-- Create a simple FileMap for testing -/
 def makeFileMap : Lean.FileMap :=
@@ -122,7 +120,7 @@ def makeVCResult (label : String) (outcome : VCOutcome)
 -- Test location extraction from metadata with wrong value type
 #guard
   let md : MetaData Expression := #[
-    { fld := Imperative.MetaData.fileRange, value := .msg "not a fileRange" }
+    { fld := Imperative.MetaData.provenanceField, value := .msg "not a provenance" }
   ]
   let files := makeFilesMap "/test/file.st"
   (extractLocation files md == none)

--- a/StrataTest/Transform/ProcedureInlining.lean
+++ b/StrataTest/Transform/ProcedureInlining.lean
@@ -151,11 +151,8 @@ def alphaEquivStatement (s1 s2: Core.Statement) (map:IdMap)
       .error "invariant does not match"
     else alphaEquivBlock b1 b2 map
 
-  | .exit lbl1 _, .exit lbl2 _ =>
-    match lbl1, lbl2 with
-    | some l1, some l2 => IdMap.updateLabel map l1 l2
-    | none, none => .ok map
-    | _, _ => mk_err "exit label mismatch"
+  | .exit l1 _, .exit l2 _ =>
+    IdMap.updateLabel map l1 l2
 
   | .cmd c1, .cmd c2 =>
     match c1, c2 with

--- a/docs/verso/LangDefDoc.lean
+++ b/docs/verso/LangDefDoc.lean
@@ -242,8 +242,7 @@ arrangements, including sequencing, alternation, and iteration. Sequencing
 statements occurs by grouping them into blocks. Loops can be annotated with
 optional invariants and decreasing measures, which can be used for deductive
 verification. An `exit` statement transfers control out of the nearest
-enclosing block with a matching label, or, if no label is provided, the nearest
-enclosing block. In addition, statements include
+enclosing block with a matching label. In addition, statements include
 `funcDecl` for local function declarations (which extend the expression
 evaluator within a scope) and `typeDecl` for local type declarations.
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -27,7 +27,12 @@ globs = ["StrataTest.+"]
 [[lean_exe]]
 name = "StrataTestMain"
 root = "Scripts.StrataTestMain"
-needs = ["StrataTest"]
+# `Strata` is listed explicitly because the driver spawns `lean` on files
+# under `StrataTestExtra/` (which is not a `lean_lib`). Those files import
+# modules from the `Strata` library that are not in `StrataTest`'s transitive
+# closure (e.g., `Strata.DDM.Integration.Java`), so without this the oleans
+# would be missing when running `lake test` from a clean `.lake`.
+needs = ["Strata", "StrataTest"]
 
 [[lean_exe]]
 name = "StrataToCBMC"


### PR DESCRIPTION
Fixes #1241

## Problem

`Solver.spawn` passed `stderr := .piped` but never stored the read end of the pipe in the `Solver` struct. When the process handle was dropped, the pipe's reading end closed. Any subsequent solver write to stderr (fatal error, OOM, unsupported logic) would receive EPIPE, and the default SIGPIPE disposition would kill the solver — producing a spurious `unknown` or hang.

## Fix

Switch `stderr := .piped` to `stderr := .inherit`, so solver errors are forwarded to the verifier's stderr. This avoids creating a closeable pipe while making solver diagnostics visible.

## Testing

All library and test modules compile successfully.
