### PR TITLE
SMT counter-example decoder: handle sc_decimal_neg

### DIFF
--- a/Strata/DL/SMT/DDMTransform/Translate.lean
+++ b/Strata/DL/SMT/DDMTransform/Translate.lean
@@ -329,8 +329,8 @@ partial def translateFromDDMTermToUntyped (t : Strata.SMTResponseDDM.Term Strata
     | .sc_numeral _ n     => return .prim (.int n)
     | .sc_numeral_neg _ n => return .prim (.int (-(n : Int)))
     | .sc_decimal _ d     => return .prim (.real d)
+    | .sc_decimal_neg _ d => return .prim (.real { d with mantissa := -d.mantissa })
     | .sc_str _ s         => return .prim (.string s)
-    | _  => throw s!"translateFromDDMTermToUntyped: don't know how to convert {repr t}"
   | .qual_identifier _ qi =>
     match resolveQI qi with
     | some ("true", _)  => return .prim (.bool true)

--- a/Strata/DL/SMT/DDMTransform/Translate.lean
+++ b/Strata/DL/SMT/DDMTransform/Translate.lean
@@ -325,6 +325,7 @@ partial def translateFromDDMTermToUntyped (t : Strata.SMTResponseDDM.Term Strata
     : Except String Strata.SMT.Term := do
   match t with
   | .spec_constant_term _ sc =>
+    -- Exhaustive match over all SpecConstant variants; Lean will flag any missing case.
     match sc with
     | .sc_numeral _ n     => return .prim (.int n)
     | .sc_numeral_neg _ n => return .prim (.int (-(n : Int)))


### PR DESCRIPTION
Fixes #1236

`translateFromDDMTermToUntyped` was missing a case for `sc_decimal_neg`, causing negative real-valued counter-examples (e.g. `-2.0`) to fall through to the catch-all error and be silently dropped from the parsed model.

Added the missing case that negates the mantissa, mirroring the existing `sc_numeral_neg` pattern. Since all `SpecConstant` constructors are now exhaustively matched, the catch-all was removed and a comment documents the deliberate exhaustiveness so future reviewers don't re-add a defensive catch-all.

Tested: all library and test modules compile successfully.
