### PR TITLE
Fix SMT translator to encode Term.none/Term.some instead of throwing

### DIFF
--- a/Strata/DL/SMT/DDMTransform/Translate.lean
+++ b/Strata/DL/SMT/DDMTransform/Translate.lean
@@ -186,7 +186,14 @@ partial def translateFromTerm (t:SMT.Term): Except String (SMTDDM.Term Provenanc
   | .var v =>
     return .qual_identifier smtProv (.qi_ident smtProv (.iden_simple smtProv
       (.symbol smtProv (mkSimpleSymbol v.id))))
-  | .none _ | .some _ => throw "don't know how to translate none and some"
+  | .none ty =>
+    let retSort ← translateFromTermType (.option ty)
+    let qi := QualIdentifier.qi_isort smtProv (mkIdentifier "none") retSort
+    return .qual_identifier smtProv qi
+  | .some inner =>
+    let innerTerm ← translateFromTerm inner
+    let qi := QualIdentifier.qi_ident smtProv (mkIdentifier "some")
+    return .qual_identifier_args smtProv qi (smtAnn #[innerTerm])
   | .app op args retTy =>
     let args' <- args.mapM translateFromTerm
     let args_array := args'.toArray

--- a/StrataTest/DL/SMT/DDMTransform/TranslateTests.lean
+++ b/StrataTest/DL/SMT/DDMTransform/TranslateTests.lean
@@ -48,4 +48,10 @@ namespace Strata.SMTDDM
      let trigger : SMT.Term := .app .triggers [.app .triggers [abv0] .trigger] .trigger
      .quant .all [⟨"a", bv32⟩] trigger body))
 
+/-- info: Except.ok "(as none (Option Bool))" -/
+#guard_msgs in #eval (termToString (.none (.prim .bool)))
+
+/-- info: Except.ok "(some true)" -/
+#guard_msgs in #eval (termToString (.some (.prim (.bool true))))
+
 end Strata.SMTDDM

--- a/StrataTest/DL/SMT/SolverTests.lean
+++ b/StrataTest/DL/SMT/SolverTests.lean
@@ -21,29 +21,23 @@ private def runSolverM (act : SolverM α) : IO α := do
   let (a, _) ← act.run solver
   return a
 
--- termToSMTString throws on Term.none instead of panicking.
+-- termToSMTString succeeds on Term.none producing valid SMT-LIB.
 /--
-info: termToSMTString correctly threw: Solver.termToSMTString failed: don't know how to translate none and some
+info: termToSMTString Term.none: (as none (Option Bool))
 -/
 #guard_msgs in
 #eval do
-  try
-    let _ ← runSolverM (termToSMTString (Term.none .bool))
-    IO.println "ERROR: termToSMTString did not throw"
-  catch e =>
-    IO.println s!"termToSMTString correctly threw: {e}"
+  let s ← runSolverM (termToSMTString (Term.none .bool))
+  IO.println s!"termToSMTString Term.none: {s}"
 
--- termToSMTString throws on Term.some instead of panicking.
+-- termToSMTString succeeds on Term.some producing valid SMT-LIB.
 /--
-info: termToSMTString correctly threw: Solver.termToSMTString failed: don't know how to translate none and some
+info: termToSMTString Term.some: (some true)
 -/
 #guard_msgs in
 #eval do
-  try
-    let _ ← runSolverM (termToSMTString (Term.some (Term.prim (.bool true))))
-    IO.println "ERROR: termToSMTString did not throw"
-  catch e =>
-    IO.println s!"termToSMTString correctly threw: {e}"
+  let s ← runSolverM (termToSMTString (Term.some (Term.prim (.bool true))))
+  IO.println s!"termToSMTString Term.some: {s}"
 
 -- typeToSMTString throws on TermType.trigger instead of panicking.
 /--


### PR DESCRIPTION
Fixes #1231

`translateFromTerm` threw on `Term.none` and `Term.some`, which caused `termToSMTString` to produce an error (or previously, via `panic!`, an empty body that solvers reject).

This PR adds proper SMT-LIB encoding:
- `Term.none ty` → `(as none (Option T))`
- `Term.some inner` → `(some <inner>)`

Tested: existing tests pass, new `#guard_msgs` tests added for both cases at the `termToString` and `termToSMTString` levels.
