### PR TITLE
Rename StrataDDM-internal namespaces from Strata.* to StrataDDM.*

### DIFF
--- a/DiffTestCore.lean
+++ b/DiffTestCore.lean
@@ -32,6 +32,7 @@ import Strata.Languages.Python.Regex.ReToCore
 
 open Strata Strata.Python
 open Core (VerifyOptions)
+open StrataDDM.Elab (elabProgram)
 
 /-- Escape a string for embedding as a double-quoted Core string literal. -/
 def escapeForCore (s : String) : String :=
@@ -95,7 +96,7 @@ def checkMatch (pyRegex testStr : String) (mode : MatchMode)
     let dctx := Elab.LoadedDialects.builtin
     let dctx := dctx.addDialect! Core
     let leanEnv ← Lean.mkEmptyEnvironment 0
-    match Strata.Elab.elabProgram dctx leanEnv inputCtx with
+    match elabProgram dctx leanEnv inputCtx with
     | .error errors =>
       let msgs ← errors.toList.mapM (·.toString)
       let errStr := String.intercalate "; " msgs

--- a/DiffTestCore.lean
+++ b/DiffTestCore.lean
@@ -32,7 +32,7 @@ import Strata.Languages.Python.Regex.ReToCore
 
 open Strata Strata.Python
 open Core (VerifyOptions)
-open StrataDDM.Elab (elabProgram)
+open StrataDDM.Elab (LoadedDialects elabProgram)
 
 /-- Escape a string for embedding as a double-quoted Core string literal. -/
 def escapeForCore (s : String) : String :=
@@ -93,7 +93,7 @@ def checkMatch (pyRegex testStr : String) (mode : MatchMode)
       catch e =>
         IO.eprintln s!"[log] Failed to write {path}: {e}"
     let inputCtx := Lean.Parser.mkInputContext progText "<diff_test>"
-    let dctx := Elab.LoadedDialects.builtin
+    let dctx := LoadedDialects.builtin
     let dctx := dctx.addDialect! Core
     let leanEnv ← Lean.mkEmptyEnvironment 0
     match elabProgram dctx leanEnv inputCtx with

--- a/Examples/Lean/BoogieLite.lean
+++ b/Examples/Lean/BoogieLite.lean
@@ -10,6 +10,8 @@ import StrataDDM.Util.Format
 
 namespace Strata
 
+open StrataDDM hiding Bool
+
 namespace OfAstM
 
 def argAsExpr (arg : Arg) : OfAstM Expr :=

--- a/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
+++ b/Strata/Backends/CBMC/GOTO/CoreToCProverGOTO.lean
@@ -161,6 +161,7 @@ structure CProverGOTO.Json where
   goto   : Lean.Json := .null
 
 open Strata in
+open StrataDDM in
 def CProverGOTO.Context.toJson (programName : String) (ctx : CProverGOTO.Context) :
   Except String CProverGOTO.Json := do
   let fn_symbol : Map String CProverGOTO.CBMCSymbol :=
@@ -249,6 +250,7 @@ def transformToGoto (cprog : Core.Program) : Except Format CProverGOTO.Context :
               GOTO at a time!"
 
 open Strata in
+open StrataDDM in
 def getGotoJson (programName : String) (env : Program) : IO CProverGOTO.Json := do
   let (program, errors) := TransM.run Inhabited.default (translateProgram env)
   if errors.isEmpty then
@@ -262,6 +264,7 @@ def getGotoJson (programName : String) (env : Program) : IO CProverGOTO.Json := 
     throw (IO.userError s!"DDM Transform Error: {repr errors}")
 
 open Strata in
+open StrataDDM in
 def writeToGotoJson (programName symTabFileName gotoFileName : String) (env : Program) : IO Unit := do
   let json ← getGotoJson programName env
   let symtabObj := match json.symtab with | .obj m => m | _ => .empty

--- a/Strata/DL/Imperative/SMTUtils.lean
+++ b/Strata/DL/Imperative/SMTUtils.lean
@@ -146,9 +146,9 @@ dialect. Returns `some .sat`, `some .unsat`, `some .unknown`, or `none`
 on parse/conversion failure.
 -/
 private def parseVerdict (line : String) : IO (Option (Result PUnit)) := do
-  let inputCtx := Strata.Parser.stringInputContext "solver" (line ++ "\n")
+  let inputCtx := StrataDDM.Parser.stringInputContext "solver" (line ++ "\n")
   let prg ←
-    try Strata.Elab.parseStrataProgramFromDialect
+    try StrataDDM.Elab.parseStrataProgramFromDialect
           Strata.SMTResponseDDM.smtResponseDialects "SMTResponse" inputCtx
     catch _ => return none
   if prg.commands.isEmpty then return none
@@ -168,9 +168,9 @@ directly, which avoids the ambiguity that arises when parsing at the
 Returns a list of (key-string, value-Term) pairs on success.
 -/
 def parseModelDDM (modelStr : String) : IO (List (String × Strata.SMT.Term)) := do
-  let inputCtx := Strata.Parser.stringInputContext "solver-model" modelStr
+  let inputCtx := StrataDDM.Parser.stringInputContext "solver-model" modelStr
   let op ←
-    try Strata.Elab.parseCategoryFromDialect
+    try StrataDDM.Elab.parseCategoryFromDialect
           Strata.SMTResponseDDM.smtResponseDialects q`SMTResponse.GetValueResponse inputCtx
     catch _ => return []
   match Strata.SMTResponseDDM.GetValueResponse.ofAst op with

--- a/Strata/DL/SMT/DDMTransform/Parse.lean
+++ b/Strata/DL/SMT/DDMTransform/Parse.lean
@@ -20,6 +20,7 @@ Appendix B. Concrete Syntax.
 
 namespace Strata
 
+open StrataDDM
 open Elab
 
 -- TODO: reservedKeywords should be in the SMTDDM namespace, not Strata

--- a/Strata/DL/SMT/DDMTransform/Translate.lean
+++ b/Strata/DL/SMT/DDMTransform/Translate.lean
@@ -14,6 +14,8 @@ import Strata.Util.Tactics
 
 namespace Strata
 
+open StrataDDM
+
 public section
 
 namespace SMTDDM
@@ -270,7 +272,7 @@ partial def translateFromTerm (t:SMT.Term): Except String (SMTDDM.Term Provenanc
 
 private def dummy_prg_for_toString :=
   let dialect_map := DialectMap.ofList!
-    [Strata.initDialect, Strata.smtReservedKeywordsDialect, Strata.SMTCore,
+    [initDialect, Strata.smtReservedKeywordsDialect, Strata.SMTCore,
      Strata.SMT]
   Program.create dialect_map "SMT" #[]
 
@@ -293,21 +295,21 @@ end SMTDDM
 namespace SMTResponseDDM
 
 /-- The loaded dialects needed to parse SMTResponse commands. -/
-def smtResponseDialects : Strata.Elab.LoadedDialects :=
-  .ofDialects! #[Strata.initDialect, Strata.smtReservedKeywordsDialect,
+def smtResponseDialects : StrataDDM.Elab.LoadedDialects :=
+  .ofDialects! #[initDialect, Strata.smtReservedKeywordsDialect,
                  Strata.SMTCore, Strata.SMTResponse]
 
 /-- Format context for rendering SMTResponse `Arg` values back to strings. -/
-private def smtFormatContext : Strata.FormatContext :=
+private def smtFormatContext : FormatContext :=
   .ofDialects smtResponseDialects.dialects
 
 /-- Format state for rendering SMTResponse `Arg` values back to strings. -/
-private def smtFormatState : Strata.FormatState where
+private def smtFormatState : FormatState where
   openDialects := smtResponseDialects.dialects.toList.foldl (init := {}) fun s d => s.insert d.name
 
 /-- Render a DDM `Arg` to a string using the SMTResponse dialect formatting. -/
-def formatArg (arg : Strata.Arg) : String :=
-  (Strata.mformat arg smtFormatContext smtFormatState).format.pretty
+def formatArg (arg : Arg) : String :=
+  (StrataDDM.mformat arg smtFormatContext smtFormatState).format.pretty
 
 /--
 Convert an `SMTResponseDDM.Term` (parsed from solver output) into a
@@ -322,7 +324,7 @@ the type information does not exist in the Term itself. It is the caller's
 responsibility to correctly fill in the types in .app/.uf, or faithfully
 ignore these.
 -/
-partial def translateFromDDMTermToUntyped (t : Strata.SMTResponseDDM.Term Strata.SourceRange)
+partial def translateFromDDMTermToUntyped (t : Strata.SMTResponseDDM.Term StrataDDM.SourceRange)
     : Except String Strata.SMT.Term := do
   match t with
   | .spec_constant_term _ sc =>
@@ -348,8 +350,8 @@ partial def translateFromDDMTermToUntyped (t : Strata.SMTResponseDDM.Term Strata
 
 where
   /-- Extract the name string from a QualIdentifier. -/
-  resolveQI (qi : Strata.SMTResponseDDM.QualIdentifier Strata.SourceRange)
-      : Option (String × Option (Strata.SMTResponseDDM.SMTSort Strata.SourceRange)) :=
+  resolveQI (qi : Strata.SMTResponseDDM.QualIdentifier StrataDDM.SourceRange)
+      : Option (String × Option (Strata.SMTResponseDDM.SMTSort StrataDDM.SourceRange)) :=
     match qi with
     | .qi_ident _ iden =>
       match iden with
@@ -360,7 +362,7 @@ where
       | .iden_simple _ sym | .iden_indexed _ sym _
       => some (symbolToString sym, some sort)
   /-- Extract the raw string from a Symbol. -/
-  symbolToString (sym : Strata.SMTResponseDDM.Symbol Strata.SourceRange) : String :=
+  symbolToString (sym : Strata.SMTResponseDDM.Symbol StrataDDM.SourceRange) : String :=
     formatArg (.op (Strata.SMTResponseDDM.Symbol.toAst sym))
   /-- Build a `Term.app` with a UF op for a named function/constructor.
       Since the SMTDDM's term does not have any type annotation, the return

--- a/Strata/DL/SMT/IncrementalSolver.lean
+++ b/Strata/DL/SMT/IncrementalSolver.lean
@@ -23,6 +23,8 @@ repeated declarations of the same name. The shadow depth is tracked per name.
 
 namespace Strata.SMT
 
+open StrataDDM (quoteIdent)
+
 public section
 
 /-- State for the incremental SMT-LIB solver backend. Wraps a live solver

--- a/Strata/DL/SMT/Solver.lean
+++ b/Strata/DL/SMT/Solver.lean
@@ -25,6 +25,8 @@ works purely with `Term` values and delegates string rendering to the Solver via
 
 namespace Strata.SMT
 
+open StrataDDM (escapeSMTStringLit quoteIdent)
+
 public section
 
 inductive Decision where
@@ -181,7 +183,7 @@ def setInfo (name value : String) : SolverM Unit :=
     NOT pre-quote or pre-escape the argument — use `setInfo` for already-
     formatted attribute values (integers, s-expressions, etc.). -/
 def setInfoString (name value : String) : SolverM Unit :=
-  emitln s!"(set-info :{name} {Strata.escapeSMTStringLit value})"
+  emitln s!"(set-info :{name} {escapeSMTStringLit value})"
 
 def comment (comment : String) : SolverM Unit :=
   let inline := comment.replace "\n" " "

--- a/Strata/DL/SMT/Term.lean
+++ b/Strata/DL/SMT/Term.lean
@@ -10,6 +10,8 @@ public import Strata.DL.SMT.Op
 public import StrataDDM.Util.Decimal
 import StrataDDM.Util.DecimalRat
 
+open StrataDDM (Decimal)
+
 public section
 /-!
 Based on Cedar's Term language.

--- a/Strata/DL/SMT/Translate.lean
+++ b/Strata/DL/SMT/Translate.lean
@@ -11,7 +11,7 @@ public import Strata.Languages.Core.SMTEncoder
 public section
 
 open Lean
-open Strata hiding Expr
+open Strata
 open SMT
 
 deriving instance Hashable for Core.SMT.Sort

--- a/Strata/Languages/B3/DDMTransform/Conversion.lean
+++ b/Strata/Languages/B3/DDMTransform/Conversion.lean
@@ -9,6 +9,7 @@ public import Strata.Languages.B3.DDMTransform.ParseCST
 public import Strata.Languages.B3.DDMTransform.DefinitionAST
 import Strata.Util.Tactics
 import Std.Tactic.BVDecide.Normalize.Prop
+open StrataDDM
 
 public section
 

--- a/Strata/Languages/B3/DDMTransform/DefinitionAST.lean
+++ b/Strata/Languages/B3/DDMTransform/DefinitionAST.lean
@@ -8,6 +8,7 @@ module
 import Strata.Util.Tactics
 public import StrataDDM.Integration.Lean.OfAstM
 import StrataDDM.Integration.Lean -- shake: keep
+open StrataDDM
 
 public section
 

--- a/Strata/Languages/B3/Transform/FunctionToAxiom.lean
+++ b/Strata/Languages/B3/Transform/FunctionToAxiom.lean
@@ -6,6 +6,7 @@
 module
 
 public import Strata.Languages.B3.DDMTransform.DefinitionAST
+open StrataDDM
 
 public section
 

--- a/Strata/Languages/B3/Verifier.lean
+++ b/Strata/Languages/B3/Verifier.lean
@@ -15,6 +15,7 @@ public meta import Strata.Languages.B3.Verifier.Program
 public meta import Strata.Languages.B3.Verifier.Statements
 
 open Strata
+open StrataDDM (SourceRange)
 open Strata.B3.Verifier
 open Strata.SMT
 
@@ -63,7 +64,7 @@ Use `programToSMTWithoutDiagnosis` for faster verification without diagnosis - r
 -- This is not a test, it only demonstrates the end-to-end API
 public meta def exampleVerification : IO Unit := do
   -- Parse B3 program using DDM syntax
-  let ddmProgram : Strata.Program := #strata program B3CST;
+  let ddmProgram : StrataDDM.Program := #strata program B3CST;
     function f(x : int) : int { x + 1 }
     procedure test() {
       check 8 == 8 && f(5) == 7

--- a/Strata/Languages/B3/Verifier/Diagnosis.lean
+++ b/Strata/Languages/B3/Verifier/Diagnosis.lean
@@ -22,6 +22,7 @@ When a verification fails, these strategies help identify the root cause by:
 
 namespace Strata.B3.Verifier
 
+open StrataDDM (SourceRange)
 open Strata.SMT
 
 ---------------------------------------------------------------------

--- a/Strata/Languages/B3/Verifier/Expression.lean
+++ b/Strata/Languages/B3/Verifier/Expression.lean
@@ -22,6 +22,7 @@ Converts B3 abstract syntax trees to SMT terms for verification.
 namespace Strata.B3.Verifier
 
 open Strata
+open StrataDDM
 open Strata.B3AST
 open Strata.SMT
 open Strata.SMT.Factory

--- a/Strata/Languages/B3/Verifier/Program.lean
+++ b/Strata/Languages/B3/Verifier/Program.lean
@@ -21,6 +21,7 @@ Verifies entire programs with automatic diagnosis.
 namespace Strata.B3.Verifier
 
 open Strata
+open StrataDDM
 open Strata.SMT
 open Strata.B3AST
 

--- a/Strata/Languages/B3/Verifier/State.lean
+++ b/Strata/Languages/B3/Verifier/State.lean
@@ -20,6 +20,7 @@ Manages incremental verification state for interactive debugging.
 namespace Strata.B3.Verifier
 
 open Strata
+open StrataDDM (SourceRange)
 open Strata.SMT
 open Strata.B3AST
 open Strata.B3.Verifier (UF_ARG_PLACEHOLDER)

--- a/Strata/Languages/B3/Verifier/Statements.lean
+++ b/Strata/Languages/B3/Verifier/Statements.lean
@@ -31,6 +31,7 @@ namespace Strata.B3.Verifier
 public section
 
 open Strata
+open StrataDDM
 open Strata.SMT
 
 inductive StatementResult where

--- a/Strata/Languages/C_Simp/DDMTransform/Translate.lean
+++ b/Strata/Languages/C_Simp/DDMTransform/Translate.lean
@@ -8,6 +8,7 @@ module
 public import Strata.Languages.C_Simp.C_Simp
 public import Strata.Languages.Core.CoreOp
 public import StrataDDM.AST
+open StrataDDM
 
 public section
 
@@ -89,13 +90,13 @@ def checkOpArg (arg : Arg) (name : QualifiedIdent) (argc : Nat) : TransM (Array 
 
 ---------------------------------------------------------------------
 
-def translateCommaSep [Inhabited α] (f : Strata.Arg → TransM α) (arg : Strata.Arg) :
+def translateCommaSep [Inhabited α] (f : Arg → TransM α) (arg : Arg) :
   TransM (Array α) := do
   let .seq _ .comma args := arg
     | TransM.error s!"Expected commaSepList: {repr arg}"
   args.mapM f
 
-def translateOption [Inhabited α] (f : Option Strata.Arg → TransM α) (arg : Arg) :
+def translateOption [Inhabited α] (f : Option Arg → TransM α) (arg : Arg) :
   TransM α := do
   let .option _ maybe_arg := arg
     | TransM.error s!"Expected Option: {repr arg}"
@@ -103,7 +104,7 @@ def translateOption [Inhabited α] (f : Option Strata.Arg → TransM α) (arg : 
 
 ---------------------------------------------------------------------
 
-def translateIdent (arg : Strata.Arg) : TransM String := do
+def translateIdent (arg : Arg) : TransM String := do
   let .ident _ name := arg
     | TransM.error s!"Expected ident: {repr arg}"
   pure name
@@ -295,7 +296,7 @@ def translateInvariant (bindings : TransBindings) (arg : Arg) :
 
 ---------------------------------------------------------------------
 
-def translateTypeArgs (op : Strata.Arg) : TransM (Array String) := do
+def translateTypeArgs (op : Arg) : TransM (Array String) := do
   translateOption (fun x => do match x with
                   | none => return Array.empty
                   | some a =>

--- a/Strata/Languages/C_Simp/Verify.lean
+++ b/Strata/Languages/C_Simp/Verify.lean
@@ -179,15 +179,15 @@ def loop_elimination(program : C_Simp.Program) : Core.Program :=
 def to_core(program : C_Simp.Program) : Core.Program :=
   loop_elimination program
 
-def C_Simp.get_program (p : Strata.Program) : C_Simp.Program :=
+def C_Simp.get_program (p : StrataDDM.Program) : C_Simp.Program :=
   (Strata.C_Simp.TransM.run Inhabited.default (Strata.C_Simp.translateProgram (p.commands))).fst
 
-def C_Simp.typeCheck (p : Strata.Program) (options : VerifyOptions := .default):
+def C_Simp.typeCheck (p : StrataDDM.Program) (options : VerifyOptions := .default):
   Except DiagnosticModel Core.Program := do
   let program := C_Simp.get_program p
   Core.typeCheck options (to_core program)
 
-def C_Simp.verify (p : Strata.Program)
+def C_Simp.verify (p : StrataDDM.Program)
     (options : VerifyOptions := .default)
     (tempDir : Option String := .none):
   IO Core.VCResults := do

--- a/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
+++ b/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
@@ -6,6 +6,7 @@
 module
 
 public import Strata.Languages.Core.Program
+open StrataDDM
 
 public section
 

--- a/Strata/Languages/Core/DDMTransform/FormatCore.lean
+++ b/Strata/Languages/Core/DDMTransform/FormatCore.lean
@@ -10,6 +10,7 @@ public import Strata.Languages.Core.Procedure
 public import StrataDDM.Util.DecimalRat
 public import StrataDDM.Format
 import Strata.Languages.Core.Factory
+open StrataDDM
 
 public section
 
@@ -269,7 +270,7 @@ def lconstToExpr {M} [Inhabited M] (c : Lambda.LConst) :
       let ty := CoreType.tvar default unknownTypeVar
       pure (.neg_expr default ty (.natToInt default ⟨default, n.natAbs⟩))
   | .realConst r =>
-    match Strata.Decimal.fromRat r with
+    match StrataDDM.Decimal.fromRat r with
     | some d => pure (.realLit default ⟨default, d⟩)
     | none => do
       ToCSTM.logError "lconstToExpr" "unsupported real" (toString r)

--- a/Strata/Languages/Core/DDMTransform/Translate.lean
+++ b/Strata/Languages/Core/DDMTransform/Translate.lean
@@ -6,6 +6,7 @@
 module
 
 public import Strata.Languages.Core.Env
+open StrataDDM
 
 
 ---------------------------------------------------------------------
@@ -49,10 +50,10 @@ def SourceRange.toMetaData (ictx : InputContext) (sr : SourceRange) : Imperative
   Imperative.MetaData.ofSourceRange (.file ictx.fileName) sr
 
 def getOpMetaData (op : Operation) : TransM (Imperative.MetaData Core.Expression) :=
-  return op.ann.toMetaData (← StateT.get).inputCtx
+  return SourceRange.toMetaData (← StateT.get).inputCtx op.ann
 
 def getArgMetaData (arg : Arg) : TransM (Imperative.MetaData Core.Expression) :=
-  return arg.ann.toMetaData (← StateT.get).inputCtx
+  return SourceRange.toMetaData (← StateT.get).inputCtx arg.ann
 
 ---------------------------------------------------------------------
 
@@ -82,13 +83,13 @@ def checkOpArg (arg : Arg) (name : QualifiedIdent) (argc : Nat) : TransM (Array 
 
 ---------------------------------------------------------------------
 
-def translateCommaSep [Inhabited α] (f : Strata.Arg → TransM α) (arg : Strata.Arg) :
+def translateCommaSep [Inhabited α] (f : Arg → TransM α) (arg : Arg) :
   TransM (Array α) := do
   let .seq _ .comma args := arg
     | TransM.error s!"Expected commaSepList: {repr arg}"
   args.mapM f
 
-def translateOption [Inhabited α] (f : Option Strata.Arg → TransM α) (arg : Arg) :
+def translateOption [Inhabited α] (f : Option Arg → TransM α) (arg : Arg) :
   TransM α := do
   let .option _ maybe_arg := arg
     | TransM.error s!"Expected Option: {repr arg}"
@@ -97,7 +98,7 @@ def translateOption [Inhabited α] (f : Option Strata.Arg → TransM α) (arg : 
 ---------------------------------------------------------------------
 
 def translateIdent (Identifier : Type) [Coe String Identifier] [Inhabited Identifier]
-  (arg : Strata.Arg) : TransM Identifier := do
+  (arg : Arg) : TransM Identifier := do
   let .ident _ name := arg
     | TransM.error s!"Expected ident: {repr arg}"
   pure name
@@ -288,11 +289,11 @@ partial def translateLMonoTys (bindings : TransBindings) (args : Array Arg) :
   args.mapM (fun a => translateLMonoTy bindings a)
 end
 
-def translateTypeVar (op : Strata.Arg) : TransM TyIdentifier := do
+def translateTypeVar (op : Arg) : TransM TyIdentifier := do
   let args ← checkOpArg op q`Core.type_var 1
   translateIdent TyIdentifier args[0]!
 
-def translateTypeArgs (op : Strata.Arg) : TransM (Array TyIdentifier) := do
+def translateTypeArgs (op : Arg) : TransM (Array TyIdentifier) := do
   translateOption (fun x => do match x with
                   | none => return Array.empty
                   | some a =>
@@ -844,7 +845,7 @@ partial def translateExpr (p : Program) (bindings : TransBindings) (arg : Arg) :
     return .strConst () x
   | .fn _ q`Core.realLit, [xa] =>
     let x ← translateReal xa
-    return .realConst () (Strata.Decimal.toRat x)
+    return .realConst () (StrataDDM.Decimal.toRat x)
   -- Equality
   | .fn _ q`Core.equal, [_tpa, xa, ya] =>
     let x ← translateExpr p bindings xa
@@ -1196,7 +1197,7 @@ def translateInvariant (p : Program) (bindings : TransBindings) (arg : Arg) :
     pure [(label, e)]
   | _ => pure []
 
-partial def translateInvariants (p : Strata.Program) (bindings : TransBindings) (arg : Arg) :
+partial def translateInvariants (p : StrataDDM.Program) (bindings : TransBindings) (arg : Arg) :
   TransM (List (String × Core.Expression.Expr)) := do
   let .op op := arg
     | TransM.error s!"translateInvariants expects an op {repr arg}"

--- a/Strata/Languages/Core/SMTEncoder.lean
+++ b/Strata/Languages/Core/SMTEncoder.lean
@@ -263,7 +263,7 @@ partial def toSMTTerm (E : Env) (bvs : BoundVars) (e : LExpr CoreLParams.mono) (
   | .boolConst _ b => .ok (Term.bool b, ctx)
   | .intConst _ i => .ok (Term.int i, ctx)
   | .realConst _ r =>
-    match Strata.Decimal.fromRat r with
+    match StrataDDM.Decimal.fromRat r with
     | some d => .ok (Term.real d, ctx)
     | none => .error f!"Non-decimal real value {e}"
   | .bitvecConst _ n b => .ok (Term.bitvec b, ctx)

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -1727,6 +1727,7 @@ namespace Strata
 
 open Lean.Parser
 open Strata (DiagnosticModel FileRange)
+open StrataDDM (Program)
 
 public section
 
@@ -1740,7 +1741,7 @@ def typeCheck (ictx : InputContext) (env : Program) (options : Core.VerifyOption
     .error <| DiagnosticModel.fromFormat s!"DDM Transform Error: {repr errors}"
 
 def Core.getProgram
-  (p : Strata.Program)
+  (p : StrataDDM.Program)
   (ictx : InputContext := Inhabited.default) : Core.Program × Array String :=
   TransM.run ictx (translateProgram p)
 

--- a/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
+++ b/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
@@ -8,6 +8,7 @@ module
 public import Strata.Languages.Laurel.Laurel
 import StrataDDM.Util.Graph.Tarjan
 import Strata.Util.Tactics
+open StrataDDM
 
 /-!
 ## Grouping and Ordering for Core Translation
@@ -150,8 +151,8 @@ public def computeSccDecls (program : Program) : List (List Procedure × Bool) :
 
   -- Build the OutGraph for Tarjan.
   let n := nonExternalArr.size
-  let graph : Strata.OutGraph n :=
-    nonExternalArr.foldl (fun (acc : Strata.OutGraph n × Nat) proc =>
+  let graph : OutGraph n :=
+    nonExternalArr.foldl (fun (acc : OutGraph n × Nat) proc =>
       let callerIdx := acc.2
       let g := acc.1
       let callees := procCallees proc
@@ -159,11 +160,11 @@ public def computeSccDecls (program : Program) : List (List Procedure × Bool) :
         match nameToIdx.get? callee with
         | some calleeIdx => g.addEdge! calleeIdx callerIdx
         | none => g) g
-      (g', callerIdx + 1)) (Strata.OutGraph.empty n, 0) |>.1
+      (g', callerIdx + 1)) (OutGraph.empty n, 0) |>.1
 
   -- Run Tarjan's SCC algorithm. Results are in reverse topological order
   -- (a node appears after all nodes that have paths to it).
-  let sccs := Strata.OutGraph.tarjan graph
+  let sccs := OutGraph.tarjan graph
 
   sccs.toList.filterMap fun scc =>
     let procs := scc.toList.filterMap fun idx =>

--- a/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
@@ -15,7 +15,8 @@ namespace Laurel
 
 public section
 
-open Strata (SourceRange QualifiedIdent Arg Operation SepFormat)
+open Strata (SourceRange)
+open StrataDDM (QualifiedIdent Arg Operation SepFormat FormatContext FormatState)
 
 private def sr : SourceRange := .none
 
@@ -216,7 +217,7 @@ private def modifiesClausesToArgs (modifies : List StmtExprMd) : Array Arg :=
     else #[laurelOp "modifiesClause" #[commaSep (specific.map stmtExprToArg |>.toArray)]]
   wildcardArgs ++ specificArgs
 
-private def procedureToOp (proc : Procedure) : Strata.Operation :=
+private def procedureToOp (proc : Procedure) : StrataDDM.Operation :=
   let opName := if proc.isFunctional then "function" else "procedure"
   let params := proc.inputs.map parameterToArg |>.toArray
   let returnTypeArg : Arg :=
@@ -264,14 +265,14 @@ private def procedureToOp (proc : Procedure) : Strata.Operation :=
       bodyArg
     ] }
 
-private def compositeToOp (ct : CompositeType) : Strata.Operation :=
+private def compositeToOp (ct : CompositeType) : StrataDDM.Operation :=
   let extendsArg := if ct.extending.isEmpty then
     optionArg none
   else
     optionArg (some (laurelOp "extends" #[commaSep (ct.extending.map (fun e => ident e.text) |>.toArray)]))
   let fields := ct.fields.map fieldToArg |>.toArray
   let procs := ct.instanceProcedures.map (fun p => .op (procedureToOp p)) |>.toArray
-  let compositeOp : Strata.Operation :=
+  let compositeOp : StrataDDM.Operation :=
     { ann := sr
       name := { dialect := "Laurel", name := "composite" }
       args := #[ident ct.name.text, extendsArg, seqArg fields, seqArg procs] }
@@ -289,10 +290,10 @@ private def datatypeConstructorToArg (c : DatatypeConstructor) : Arg :=
     let args := c.args.map datatypeConstructorArgToArg |>.toArray
     laurelOp "datatypeConstructor" #[ident c.name.text, commaSep args]
 
-private def datatypeToOp (dt : DatatypeDefinition) : Strata.Operation :=
+private def datatypeToOp (dt : DatatypeDefinition) : StrataDDM.Operation :=
   let ctors := dt.constructors.map datatypeConstructorToArg |>.toArray
   let ctorList := laurelOp "datatypeConstructorList" #[commaSep ctors]
-  let datatypeOp : Strata.Operation :=
+  let datatypeOp : StrataDDM.Operation :=
     { ann := sr
       name := { dialect := "Laurel", name := "datatype" }
       args := #[ident dt.name.text, ctorList] }
@@ -300,8 +301,8 @@ private def datatypeToOp (dt : DatatypeDefinition) : Strata.Operation :=
     name := { dialect := "Laurel", name := "datatypeCommand" }
     args := #[.op datatypeOp] }
 
-private def constrainedTypeToOp (ct : ConstrainedType) : Strata.Operation :=
-  let ctOp : Strata.Operation :=
+private def constrainedTypeToOp (ct : ConstrainedType) : StrataDDM.Operation :=
+  let ctOp : StrataDDM.Operation :=
     { ann := sr
       name := { dialect := "Laurel", name := "constrainedType" }
       args := #[
@@ -315,27 +316,27 @@ private def constrainedTypeToOp (ct : ConstrainedType) : Strata.Operation :=
     name := { dialect := "Laurel", name := "constrainedTypeCommand" }
     args := #[.op ctOp] }
 
-private def typeDefinitionToOp : TypeDefinition → Strata.Operation
+private def typeDefinitionToOp : TypeDefinition → StrataDDM.Operation
   | .Composite ct => compositeToOp ct
   | .Constrained ct => constrainedTypeToOp ct
   | .Datatype dt => datatypeToOp dt
   -- Placeholder: aliases are eliminated before CST serialization
   | .Alias _ => { ann := sr, name := { dialect := "Laurel", name := "typeAlias" }, args := #[] }
 
-private def procedureCommandOp (proc : Procedure) : Strata.Operation :=
+private def procedureCommandOp (proc : Procedure) : StrataDDM.Operation :=
   { ann := sr
     name := { dialect := "Laurel", name := "procedureCommand" }
     args := #[.op (procedureToOp proc)] }
 
-/-- Convert a Laurel.Program to a Strata.Program (DDM concrete syntax tree).
-    The resulting program can be formatted using `Strata.Program.format` to
+/-- Convert a Laurel.Program to a StrataDDM.Program (DDM concrete syntax tree).
+    The resulting program can be formatted using `StrataDDM.Program.format` to
     produce Laurel source text.
     Note: `staticFields` and `constants` are not emitted because the Laurel
     grammar has no top-level commands for them. -/
-def programToStrata (prog : Laurel.Program) : Strata.Program :=
+def programToStrata (prog : Laurel.Program) : StrataDDM.Program :=
   let typeOps := prog.types.map typeDefinitionToOp |>.toArray
   let procOps := prog.staticProcedures.map procedureCommandOp |>.toArray
-  Strata.Program.create Laurel_map "Laurel" (typeOps ++ procOps)
+  StrataDDM.Program.create Laurel_map "Laurel" (typeOps ++ procOps)
 
 /-- Format a Laurel program by converting to DDM concrete syntax and using the grammar-based formatter.
     This avoids duplicating the grammar in a separate formatter. -/
@@ -343,23 +344,23 @@ def formatProgram (prog : Laurel.Program) : Std.Format :=
   let sp := programToStrata prog
   let c := sp.formatContext {}
   let s := sp.formatState
-  let fmts := sp.commands.map fun cmd => (Strata.mformat cmd c s).format
+  let fmts := sp.commands.map fun cmd => (StrataDDM.mformat cmd c s).format
   Std.Format.joinSep fmts.toList "\n\n"
 
 open Std (Format format)
 open Std.Format
 
-private def laurelFmtCtx : Strata.FormatContext :=
-  Strata.FormatContext.ofDialects Laurel_map
+private def laurelFmtCtx : FormatContext :=
+  FormatContext.ofDialects Laurel_map
 
-private def laurelFmtState : Strata.FormatState where
+private def laurelFmtState : FormatState where
   openDialects := ({} : Std.HashSet String).insert "Laurel"
 
 private def formatArg (a : Arg) : Format :=
-  (Strata.mformat a laurelFmtCtx laurelFmtState).format
+  (StrataDDM.mformat a laurelFmtCtx laurelFmtState).format
 
-private def formatOp (o : Strata.Operation) : Format :=
-  (Strata.mformat o laurelFmtCtx laurelFmtState).format
+private def formatOp (o : StrataDDM.Operation) : Format :=
+  (StrataDDM.mformat o laurelFmtCtx laurelFmtState).format
 
 def formatHighType (t : HighTypeMd) : Format := formatArg (highTypeToArg t)
 def formatHighTypeVal (t : HighType) : Format := formatArg (highTypeValToArg t)

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -14,7 +14,8 @@ namespace Laurel
 public section
 
 open Std (ToFormat Format format)
-open Strata (QualifiedIdent Arg SourceRange Uri FileRange)
+open Strata (Uri FileRange SourceRange)
+open StrataDDM (QualifiedIdent Arg Decimal)
 open Lean.Parser (InputContext)
 open Imperative (MetaData)
 
@@ -45,7 +46,7 @@ def getArgMetaData (arg : Arg) : TransM (Imperative.MetaData Core.Expression) :=
   | some uri => Imperative.MetaData.ofSourceRange uri arg.ann
   | none => Imperative.MetaData.ofProvenance (.synthesized .laurelParse)
 
-def checkOp (op : Strata.Operation) (name : QualifiedIdent) (argc : Nat) :
+def checkOp (op : StrataDDM.Operation) (name : QualifiedIdent) (argc : Nat) :
   TransM Unit := do
   if op.name != name then
     TransM.error s!"Op name mismatch! \n\
@@ -672,7 +673,7 @@ def parseTopLevel (arg : Arg) : TransM (Option Procedure × Option TypeDefinitio
 /--
 Translate concrete Laurel syntax into abstract Laurel syntax
 -/
-def parseProgram (prog : Strata.Program) : TransM Laurel.Program := do
+def parseProgram (prog : StrataDDM.Program) : TransM Laurel.Program := do
   let mut procedures : List Procedure := []
   let mut types : List TypeDefinition := []
   for op in prog.commands do

--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -9,6 +9,7 @@ public import Strata.DL.Imperative.MetaData
 public import Strata.Languages.Core.Expressions
 import Strata.Util.Tactics
 public import StrataDDM.Util.Decimal
+open StrataDDM
 
 /-
 Documentation for Laurel can be found in docs/verso/LaurelDoc.lean

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -148,7 +148,7 @@ def translateExpr (expr : StmtExprMd)
   | .LiteralBool b => return .const () (.boolConst b)
   | .LiteralInt i => return .const () (.intConst i)
   | .LiteralString s => return .const () (.strConst s)
-  | .LiteralDecimal d => return .const () (.realConst (Strata.Decimal.toRat d))
+  | .LiteralDecimal d => return .const () (.realConst (StrataDDM.Decimal.toRat d))
   | .Var (.Local name) =>
       -- First check if this name is bound by an enclosing quantifier
       match boundVars.findIdx? (· == name) with

--- a/Strata/Languages/Python/PythonDialect.lean
+++ b/Strata/Languages/Python/PythonDialect.lean
@@ -10,6 +10,7 @@ public import StrataDDM.Integration.Lean.OfAstM
 public import StrataDDM.Format
 import StrataDDM.Integration.Lean.Gen
 import StrataDDM.Integration.Lean.HashCommands
+open StrataDDM
 
 public section
 namespace Strata.Python

--- a/Strata/Languages/Python/PythonToCore.lean
+++ b/Strata/Languages/Python/PythonToCore.lean
@@ -11,6 +11,7 @@ public import Strata.Languages.Python.PythonDialect
 public import Strata.Languages.Python.FunctionSignatures
 public import Strata.Languages.Core.Program
 import Strata.Languages.Core.Env
+open StrataDDM
 
 namespace Strata
 open Lambda.LTy.Syntax

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -34,6 +34,7 @@ This module translates Python AST to Laurel intermediate representation.
 
 namespace Strata.Python
 
+open StrataDDM
 open Laurel
 
 public section

--- a/Strata/Languages/Python/ReadPython.lean
+++ b/Strata/Languages/Python/ReadPython.lean
@@ -12,10 +12,10 @@ public import Strata.Languages.Python.PythonDialect
 public section
 namespace Strata.Python
 
-def readPythonStrataBytes (strataPath : String) (bytes : ByteArray) : Except String (Array (Strata.Python.stmt Strata.SourceRange)) := do
+def readPythonStrataBytes (strataPath : String) (bytes : ByteArray) : Except String (Array (Strata.Python.stmt StrataDDM.SourceRange)) := do
   if ! Ion.isIonFile bytes then
     throw <| s!"{strataPath} is not an Ion file."
-  match Strata.Program.fromIon Strata.Python.Python_map Strata.Python.Python.name bytes with
+  match StrataDDM.Program.fromIon Strata.Python.Python_map Strata.Python.Python.name bytes with
   | .ok pgm =>
     let pyCmds ← pgm.commands.mapM fun cmd =>
       match Strata.Python.Command.ofAst cmd with
@@ -107,7 +107,7 @@ private def runPyToStrata (pythonCmd : String) (extraPythonArgs : Array String)
     throw <| msg
 
 /-- Reads a pre-compiled Strata file (Ion format) containing Python AST statements. -/
-def readPythonStrata (strataPath : String) : EIO String (Array (Strata.Python.stmt Strata.SourceRange)) := do
+def readPythonStrata (strataPath : String) : EIO String (Array (Strata.Python.stmt StrataDDM.SourceRange)) := do
   let bytes ←
     match ← IO.FS.readBinFile strataPath |>.toBaseIO with
     | .ok b =>
@@ -129,7 +129,7 @@ or the Python file cannot be parsed.
 def pythonToStrata (dialectFile pythonFile : System.FilePath)
     (pythonCmd : String := "python")
     (options : PythonToStrataOptions := {})
-    : EIO String (Array (Strata.Python.stmt Strata.SourceRange)) := do
+    : EIO String (Array (Strata.Python.stmt StrataDDM.SourceRange)) := do
   let (_handle, strataFile) ←
     match ← IO.FS.createTempFile |>.toBaseIO with
     | .ok p => pure p

--- a/Strata/Languages/Python/Specs.lean
+++ b/Strata/Languages/Python/Specs.lean
@@ -74,6 +74,7 @@ def mkIdent (mod : ModuleName) (name : String) : PythonIdent :=
 end Strata.Python.ModuleName
 
 open Strata.Pipeline
+open StrataDDM (SourceRange eformat Ann)
 
 namespace Strata.Python.Specs
 
@@ -274,7 +275,7 @@ def logEvent (event : EventType) (message : String) : PySpecM Unit := do
 
 /-- Check whether a decorator list contains `@overload`. -/
 private def hasOverloadDecorator
-    (decorators : Array (Strata.Python.expr Strata.SourceRange)) : Bool :=
+    (decorators : Array (Strata.Python.expr StrataDDM.SourceRange)) : Bool :=
   decorators.any fun d =>
     match d with
     | .Name _ ⟨_, "overload"⟩ _ => true
@@ -625,7 +626,7 @@ def pyDefaultValue (val : expr SourceRange) (_tp : SpecType) : PySpecM Unit := d
 
 def pySpecArg (usedNames : Std.HashSet String)
               (selfType : Option String)
-              (arg : Strata.Python.arg Strata.SourceRange)
+              (arg : Strata.Python.arg StrataDDM.SourceRange)
               (de : Option (expr SourceRange)) : PySpecM Arg := do
   let .mk_arg loc ⟨_, name⟩ ⟨_typeLoc, type⟩ ⟨_, comment⟩ := arg
   if name ∈ usedNames then
@@ -1182,7 +1183,7 @@ private def resolveBaseClasses (bases : Array (expr SourceRange))
 
 partial def pySpecClassBody (loc : SourceRange) (className : String)
     (bases : Array PythonIdent)
-    (body : Array (Strata.Python.stmt Strata.SourceRange)) : PySpecM ClassDef := do
+    (body : Array (Strata.Python.stmt StrataDDM.SourceRange)) : PySpecM ClassDef := do
   let mut usedNames : Std.HashSet String := {}
   let mut fields : Array ClassField := #[]
   let mut classVars : Array ClassVariable := #[]
@@ -1483,7 +1484,7 @@ partial def translateImportFromStmt (loc : SourceRange)
       let mod ← resolveRelativeModuleName loc relMod lvl
       resolveAndRegisterModule loc mod asname
 
-partial def translate (body : Array (stmt Strata.SourceRange)) : PySpecM Unit := do
+partial def translate (body : Array (stmt StrataDDM.SourceRange)) : PySpecM Unit := do
   for stmt in body do
     match stmt with
     | .Assign loc ⟨_, targets⟩ value _typeAnn =>
@@ -1557,7 +1558,7 @@ partial def translate (body : Array (stmt Strata.SourceRange)) : PySpecM Unit :=
         pushSignature (.classDef d)
     | _ => specError stmt.ann s!"Unknown statement {stmt}"
 
-partial def translateModuleAux (body : Array (Strata.Python.stmt Strata.SourceRange))
+partial def translateModuleAux (body : Array (Strata.Python.stmt StrataDDM.SourceRange))
   : PySpecM (Array Signature) := do
   let ctx ← read
   let start ← IO.monoNanosNow
@@ -1577,7 +1578,7 @@ end
 def translateModule
     (dialectFile searchPath strataDir pythonFile : System.FilePath)
     (fileMap : Lean.FileMap)
-    (body : Array (Strata.Python.stmt Strata.SourceRange))
+    (body : Array (Strata.Python.stmt StrataDDM.SourceRange))
     (currentModule : ModuleName)
     (pythonCmd : String := "python")
     (events : Std.HashSet EventType := {})

--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -10,6 +10,7 @@ public import StrataDDM.AST
 import StrataDDM.Format
 import StrataDDM.Ion
 import StrataDDM.Integration.Lean -- shake: keep
+open StrataDDM
 
 namespace Strata.Python
 
@@ -532,7 +533,7 @@ public def readDDM (path : System.FilePath) : EIO String (Array Signature) := do
   | .error msg => throw msg
 
 /-- Converts Python spec signatures to a DDM program for serialization. -/
-def toDDMProgram (sigs : Array Signature) : Strata.Program :=
+def toDDMProgram (sigs : Array Signature) : StrataDDM.Program :=
   .create DDM.PythonSpecs_map DDM.PythonSpecs.name (sigs.map fun s => s.toDDM.toAst)
 
 /-- Writes Python spec signatures to a DDM Ion file. -/

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -6,6 +6,7 @@
 module
 public import StrataDDM.Util.SourceRange
 public import Strata.Languages.Python.PythonIdent
+open StrataDDM
 
 public section
 namespace Strata.Python

--- a/Strata/MetaVerifier.lean
+++ b/Strata/MetaVerifier.lean
@@ -98,8 +98,10 @@ end C_Simp
 
 namespace Strata
 
+open StrataDDM
+
 /--
-Generate verification conditions for a `Strata.Program` by translating it to the
+Generate verification conditions for a `StrataDDM.Program` by translating it to the
 appropriate frontend verifier and collecting its deferred proof obligations.
 
 Note that this can be extended to new dialects by using
@@ -163,7 +165,7 @@ def toSMTVCs (vcs : Core.coreVCs) : Option SMT.SMTVCs := do
     return (label, ctx, ts, t) :: vcs
 
 /--
-Generate SMT verification conditions for a `Strata.Program`.
+Generate SMT verification conditions for a `StrataDDM.Program`.
 -/
 def genSMTVCs (program : Program) : Option SMT.SMTVCs := do
   let coreVCs ← genCoreVCs program

--- a/Strata/Pipeline/Context.lean
+++ b/Strata/Pipeline/Context.lean
@@ -6,6 +6,7 @@
 module
 public import Strata.Pipeline.Messages
 import all StrataDDM.Util.String
+open StrataDDM
 
 namespace Strata.Pipeline
 

--- a/Strata/Pipeline/Messages.lean
+++ b/Strata/Pipeline/Messages.lean
@@ -7,6 +7,7 @@ module
 
 public import StrataDDM.Util.SourceRange
 import all StrataDDM.Util.String
+open StrataDDM
 
 public section
 namespace Strata.Pipeline

--- a/Strata/SimpleAPI.lean
+++ b/Strata/SimpleAPI.lean
@@ -39,12 +39,12 @@ currently do.
 
 It involves several key types:
 
-* `Strata.Dialect`: The formal description of a Strata dialect. Used only to
+* `StrataDDM.Dialect`: The formal description of a Strata dialect. Used only to
   describe which dialects are available when reading or writing files.
 
-* `Strata.Program`: The generic AST for a Strata program in any dialect.
+* `StrataDDM.Program`: The generic AST for a Strata program in any dialect.
    Generally used just as an interim representation before serializing or after
-   deserializing a program. Before using a `Strata.Program`, it will usually
+   deserializing a program. Before using a `StrataDDM.Program`, it will usually
    make sense to translate it into the custom AST for a specific dialect.
 
 * `Laurel.Program`: A dialect-specific AST for a program in the Laurel dialect.
@@ -64,6 +64,7 @@ public section
 
 namespace Strata
 
+open StrataDDM
 open Strata.Python (ModuleName)
 
 /-! ### File I/O -/
@@ -76,7 +77,7 @@ to be parsed. And the `ByteArray` includes the contents of that file. TODO:
 should it take just a file name and read it directly?
 -/
 def readStrataText :
-  Strata.DialectFileMap →
+  StrataDDM.DialectFileMap →
   System.FilePath →
   ByteArray →
   IO Strata.Util.DialectOrProgram :=
@@ -90,7 +91,7 @@ to be parsed. And the `ByteArray` includes the contents of that file. TODO:
 should it take just a file name and read it directly?
 -/
 def readStrataIon :
-  Strata.DialectFileMap →
+  StrataDDM.DialectFileMap →
   System.FilePath →
   ByteArray →
   IO Strata.Util.DialectOrProgram :=
@@ -103,7 +104,7 @@ where to find the definitions of other dialects. The `FilePath` indicates the
 name of the file to be loaded.
 -/
 def readStrataFile :
-  Strata.DialectFileMap →
+  StrataDDM.DialectFileMap →
   System.FilePath →
   IO Strata.Util.DialectOrProgram :=
   Strata.Util.readFile
@@ -112,14 +113,14 @@ def readStrataFile :
 Serialize a Strata program in textual format. Returns a byte array rather than
 writing directly to a file.
 -/
-def writeStrataText : Strata.Program → ByteArray
+def writeStrataText : StrataDDM.Program → ByteArray
 | pgm => String.toByteArray pgm.toString
 
 /--
 Serialize a Strata program in Ion format. Returns a byte array rather than
 writing directly to a file.
 -/
-def writeStrataIon : Strata.Program → ByteArray
+def writeStrataIon : StrataDDM.Program → ByteArray
 | pgm => pgm.toIon
 
 /--
@@ -129,12 +130,12 @@ AST translation in one step.
 -/
 def parseLaurelText (path : System.FilePath) (content : String)
     : IO Laurel.Program := do
-  let input := Strata.Parser.stringInputContext path content
+  let input := StrataDDM.Parser.stringInputContext path content
   let dialects :=
-    Strata.Elab.LoadedDialects.ofDialects!
-      #[Strata.initDialect, Strata.Laurel.Laurel]
+    StrataDDM.Elab.LoadedDialects.ofDialects!
+      #[initDialect, Strata.Laurel.Laurel]
   let strataProgram ←
-    Strata.Elab.parseStrataProgramFromDialect
+    StrataDDM.Elab.parseStrataProgramFromDialect
       dialects Strata.Laurel.Laurel.name input
   let uri := Strata.Uri.file path.toString
   match Strata.Laurel.TransM.run uri
@@ -154,8 +155,8 @@ into a list of `StrataFile`s. Useful for per-file operations like
 printing.
 -/
 def readLaurelIonFiles (bytes : ByteArray)
-    : IO (List Strata.StrataFile) := do
-  match Strata.Program.filesFromIon Strata.Laurel.Laurel_map bytes with
+    : IO (List StrataFile) := do
+  match StrataDDM.Program.filesFromIon Strata.Laurel.Laurel_map bytes with
   | .ok files => pure files
   | .error msg => throw (IO.userError msg)
 
@@ -196,14 +197,14 @@ AST. Usually useful as a step before serialization. TODO: we can't yet implement
 this, but will be able to once we use DDM-generated translation between the
 generic and Strata-specific ASTs.
 -/
-noncomputable opaque coreToGeneric : Core.Program → Strata.Program
+noncomputable opaque coreToGeneric : Core.Program → StrataDDM.Program
 
 /--
 Translate a program in the generic AST for Strata into the dialect-specific AST
 for Core. This can fail with an error message if the input is not a
 well-structured instance of the Core dialect.
 -/
-def genericToCore (p : Strata.Program) : Except String Core.Program :=
+def genericToCore (p : StrataDDM.Program) : Except String Core.Program :=
   let (program, errors) := Core.getProgram p
   if errors.isEmpty then
     .ok program
@@ -214,7 +215,7 @@ def genericToCore (p : Strata.Program) : Except String Core.Program :=
 Translate a program in the dialect-specific AST for Laurel into the generic Strata
 AST. Usually useful as a step before serialization.
 -/
-def laurelToGeneric (p : Laurel.Program) : Strata.Program :=
+def laurelToGeneric (p : Laurel.Program) : StrataDDM.Program :=
   Laurel.programToStrata p
 
 /--
@@ -224,7 +225,7 @@ well-structured instance of the Laurel dialect.
 
 TODO: possibly add an input context argument
 -/
-def genericToLaurel (p : Strata.Program) : Except String Laurel.Program :=
+def genericToLaurel (p : StrataDDM.Program) : Except String Laurel.Program :=
   Laurel.TransM.run .none (Laurel.parseProgram p)
 
 /-! ### Transformation between dialects -/

--- a/Strata/Util/FileRange.lean
+++ b/Strata/Util/FileRange.lean
@@ -10,6 +10,9 @@ open Std (Format)
 
 public section
 namespace Strata
+export StrataDDM (SourceRange)
+
+abbrev SourceRange.none := StrataDDM.SourceRange.none
 
 inductive Uri where
   | file (path: String)

--- a/Strata/Util/IO.lean
+++ b/Strata/Util/IO.lean
@@ -8,8 +8,10 @@ module
 import StrataDDM.Elab
 public import StrataDDM.Elab.LoadedDialects
 import StrataDDM.Util.Ion
+open StrataDDM
 
 open Lean (Message)
+open StrataDDM.Elab (elabProgramRest)
 
 public section
 namespace Strata.Util
@@ -63,32 +65,32 @@ inductive DialectOrProgram
 needed, when used by the artifact being parsed. The `path` argument specifies
 the location of the file that `bytes` came from, but is used only for error
 messages and metadata. -/
-def readStrataText (fm : Strata.DialectFileMap) (path : System.FilePath) (bytes : ByteArray)
+def readStrataText (fm : StrataDDM.DialectFileMap) (path : System.FilePath) (bytes : ByteArray)
     : IO DialectOrProgram := do
   let leanEnv ← Lean.mkEmptyEnvironment 0
   let contents ← match bytesToText path bytes with
     | Except.ok c => pure c
     | Except.error msg => throw (IO.userError (fileReadErrorMsg path msg))
-  let inputContext := Strata.Parser.stringInputContext path contents
-  let (header, errors, startPos) := Strata.Elab.elabHeader leanEnv inputContext
+  let inputContext := StrataDDM.Parser.stringInputContext path contents
+  let (header, errors, startPos) := StrataDDM.Elab.elabHeader leanEnv inputContext
   if errors.size > 0 then
     throw (IO.userError (← mkErrorReport path errors))
   match header with
   | .program _ dialect =>
-    match ← Strata.Elab.loadDialect fm dialect with
+    match ← StrataDDM.Elab.loadDialect fm dialect with
     | .ok _ => pure ()
     | .error msg => throw (IO.userError msg)
     let dialects ← fm.getLoaded
     let .isTrue mem := (inferInstance : Decidable (dialect ∈ dialects.dialects))
       | panic! "internal: loadDialect failed"
-    match Strata.Elab.elabProgramRest dialects leanEnv inputContext dialect mem startPos with
+    match elabProgramRest dialects leanEnv inputContext dialect mem startPos with
     | .ok program => pure (.program program)
     | .error errors => throw (IO.userError (← mkErrorReport path errors))
   | .dialect stx dialect =>
     if dialect ∈ (←fm.loaded.get).dialects then
       throw <| IO.userError s!"{dialect} already loaded"
     let (d, s) ←
-      Strata.Elab.elabDialectRest fm inputContext stx dialect (startPos := startPos)
+      StrataDDM.Elab.elabDialectRest fm inputContext stx dialect (startPos := startPos)
     if s.errors.size > 0 then
       throw (IO.userError (← mkErrorReport path s.errors))
     fm.modifyLoaded (·.addDialect! d)
@@ -99,11 +101,11 @@ The `DialectFileMap` is used to lazily load dialect definitions as needed, when
 used by the artifact being parsed. The `path` argument specifies the location of
 the file that `bytes` came from, but is used only for error messages and
 metadata. -/
-def readStrataIon (fm : Strata.DialectFileMap)
+def readStrataIon (fm : StrataDDM.DialectFileMap)
     (path : System.FilePath) (bytes : ByteArray)
     : IO DialectOrProgram := do
   let (hdr, frag) ←
-    match Strata.Ion.Header.parse bytes with
+    match StrataDDM.Ion.Header.parse bytes with
     | .error msg =>
       throw (IO.userError (fileReadErrorMsg path msg))
     | .ok p =>
@@ -112,20 +114,20 @@ def readStrataIon (fm : Strata.DialectFileMap)
   | .dialect dialect =>
     if dialect ∈ (←fm.loaded.get).dialects then
       throw <| IO.userError s!"{dialect} already loaded"
-    match ← Strata.Elab.loadDialectFromIonFragment fm #[] dialect frag with
+    match ← StrataDDM.Elab.loadDialectFromIonFragment fm #[] dialect frag with
     | .error msg =>
       throw (IO.userError (fileReadErrorMsg path msg))
     | .ok d =>
       pure (.dialect d)
   | .program dialect => do
-    match ← Strata.Elab.loadDialect fm dialect with
+    match ← StrataDDM.Elab.loadDialect fm dialect with
     | .ok _ => pure ()
     | .error msg => throw (IO.userError (fileReadErrorMsg path msg))
     let dialects ← fm.getLoaded
     let .isTrue mem := (inferInstance : Decidable (dialect ∈ dialects.dialects))
       | panic! "loadDialect failed"
     let dm := dialects.dialects.importedDialects dialect mem
-    match Strata.Program.fromIonFragment frag dm dialect with
+    match StrataDDM.Program.fromIonFragment frag dm dialect with
     | .ok pgm =>
       pure (.program pgm)
     | .error msg =>
@@ -134,7 +136,7 @@ def readStrataIon (fm : Strata.DialectFileMap)
 /-- Parse a Strata artifact from the file at the given `path`.  The
 `DialectFileMap` is used to lazily load dialect definitions as needed, when used
 by the artifact being parsed. -/
-def readFile (fm : Strata.DialectFileMap) (path : System.FilePath) : IO DialectOrProgram := do
+def readFile (fm : StrataDDM.DialectFileMap) (path : System.FilePath) : IO DialectOrProgram := do
   let bytes ← readBinInputSource path.toString
   let displayPath : System.FilePath := displayName path.toString
   if Ion.isIonFile bytes then

--- a/StrataBoole/StrataBoole/Boole.lean
+++ b/StrataBoole/StrataBoole/Boole.lean
@@ -20,6 +20,8 @@ end Strata.BooleDDM
 
 namespace Strata
 
+open StrataDDM (SourceRange)
+
 abbrev Boole.Type := BooleDDM.BooleType SourceRange
 abbrev Boole.Expr := BooleDDM.Expr SourceRange
 abbrev Boole.Program := BooleDDM.Program SourceRange

--- a/StrataBoole/StrataBoole/MetaVerifier.lean
+++ b/StrataBoole/StrataBoole/MetaVerifier.lean
@@ -26,7 +26,9 @@ public section
 
 namespace Strata.Boole
 
-def genVCs (program : Strata.Boole.Program) (gctx : Strata.GlobalContext) (options : Core.VerifyOptions := .default) : Option Core.coreVCs := do
+open StrataDDM (GlobalContext Program)
+
+def genVCs (program : Strata.Boole.Program) (gctx : GlobalContext) (options : Core.VerifyOptions := .default) : Option Core.coreVCs := do
   let program ← (Strata.Boole.toCoreProgram program gctx).toOption
   Core.genVCs program options
 
@@ -34,8 +36,10 @@ end Strata.Boole
 
 namespace Strata
 
+open StrataDDM (Program)
+
 /--
-Generate verification conditions for a `Strata.Program`, with Boole support.
+Generate verification conditions for a `StrataDDM.Program`, with Boole support.
 Extends `Strata.genCoreVCs` to handle the Boole dialect.
 -/
 def genCoreVCsBoole (program : Program) : Option Core.coreVCs := do
@@ -48,7 +52,7 @@ def genCoreVCsBoole (program : Program) : Option Core.coreVCs := do
     genCoreVCs program
 
 /--
-Generate SMT verification conditions for a `Strata.Program`, with Boole support.
+Generate SMT verification conditions for a `StrataDDM.Program`, with Boole support.
 -/
 def genSMTVCsBoole (program : Program) : Option SMT.SMTVCs := do
   let coreVCs ← genCoreVCsBoole program

--- a/StrataBoole/StrataBoole/Verify.lean
+++ b/StrataBoole/StrataBoole/Verify.lean
@@ -14,12 +14,13 @@ public section
 
 namespace Strata.Boole
 
+open StrataDDM
 open Lambda
 
 /--
 Boole verification pipeline:
 
-`Strata.Program` -> `BooleDDM.Program.ofAst` -> `BooleDDM.Program`
+`StrataDDM.Program` -> `BooleDDM.Program.ofAst` -> `BooleDDM.Program`
 -> `toCoreProgram` -> `Core.Program` -> `Core.verify`
 -/
 
@@ -881,7 +882,7 @@ def toCoreDecls (cmd : BooleDDM.Command SourceRange) : TranslateM (List Core.Dec
     return [.type (.data (← decls.toList.mapM toCoreDatatypeDecl)) .empty]
 
 /-- Render a `Boole.Program` to a format object using the provided `GlobalContext` and
-`DialectMap`. These should come from the originating `Strata.Program` (i.e. `env.globalContext`
+`DialectMap`. These should come from the originating `StrataDDM.Program` (i.e. `env.globalContext`
 and `env.dialects`), since fvar indices in `prog` are relative to that context.
 
 This mirrors `Core.formatProgram`: both functions accept an external context rather than
@@ -932,7 +933,7 @@ def toCoreProgram (p : Boole.Program) (gctx : GlobalContext := {}) (fileName : S
 open Lean.Parser in
 
 /-- Parse Boole syntax using generated `BooleDDM.Program.ofAst`. -/
-def getProgram (p : Strata.Program) : Except DiagnosticModel Boole.Program := do
+def getProgram (p : StrataDDM.Program) : Except DiagnosticModel Boole.Program := do
   let cmds : Array Arg := p.commands.map ArgF.op
   let progOp : Operation :=
     { ann := default
@@ -942,14 +943,14 @@ def getProgram (p : Strata.Program) : Except DiagnosticModel Boole.Program := do
   | .ok prog => return prog
   | .error e => throw (.fromMessage e)
 
-def typeCheck (p : Strata.Program) (options : Core.VerifyOptions := .default) : Except DiagnosticModel Core.Program := do
+def typeCheck (p : StrataDDM.Program) (options : Core.VerifyOptions := .default) : Except DiagnosticModel Core.Program := do
   let prog ← getProgram p
   let coreProg ← toCoreProgram prog p.globalContext
   Core.typeCheck options coreProg
 
 open Lean.Parser in
 def verify
-    (smtsolver : String) (env : Strata.Program)
+    (smtsolver : String) (env : StrataDDM.Program)
     (ictx : InputContext := Inhabited.default)
     (proceduresToVerify : Option (List String) := none)
     (options : Core.VerifyOptions := .default)

--- a/StrataBoole/StrataBooleTest/FeatureRequests/abstract_types_and_stubs.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/abstract_types_and_stubs.lean
@@ -24,7 +24,7 @@ Near-upstream anchors from `differential_status.md`:
   pruning
 -/
 
-private def abstractTypesAndStubsSeed : Strata.Program :=
+private def abstractTypesAndStubsSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/bitvector_ops.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/bitvector_ops.lean
@@ -25,7 +25,7 @@ Near-upstream anchors:
 -/
 
 -- Exercises & and | (X25519 scalar clamping).
-private def bitvectorOpsSeed : Strata.Program :=
+private def bitvectorOpsSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -51,7 +51,7 @@ example : Strata.smtVCsCorrectBoole bitvectorOpsSeed := by
   all_goals (first | grind | decide)
 
 -- Exercises ~, ^, >>, << (bit extraction, conditional swap, nibble ops).
-private def bitvectorShiftXorSeed : Strata.Program :=
+private def bitvectorShiftXorSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -87,7 +87,7 @@ example : Strata.smtVCsCorrectBoole bitvectorShiftXorSeed := by
 
 -- Exercises >>s (arithmetic/signed right shift): vacated bits are filled with
 -- the sign bit, unlike >> which fills with 0.
-private def bitvectorSShrSeed : Strata.Program :=
+private def bitvectorSShrSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/bitvector_proof_mode.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/bitvector_proof_mode.lean
@@ -26,7 +26,7 @@ Near-upstream anchors:
   a bitvector decision procedure without explicit axioms.
 -/
 
-private def bitvectorProofModeSeed : Strata.Program :=
+private def bitvectorProofModeSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/choose_operator.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/choose_operator.lean
@@ -19,7 +19,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: direct `choose` surface syntax and faithful lowering
 -/
 
-private def chooseOperatorSeed : Strata.Program :=
+private def chooseOperatorSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -50,7 +50,7 @@ spec {
 
 /--
 info:
-Obligation: choose_seed_ensures_1_1082
+Obligation: choose_seed_ensures_1_1085
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/FeatureRequests/datatypes_and_selectors.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/datatypes_and_selectors.lean
@@ -21,7 +21,7 @@ Near-upstream anchors from `differential_status.md`:
   when Strata emits the expected VC shape
 -/
 
-private def datatypeSelectorsSeed : Strata.Program :=
+private def datatypeSelectorsSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -50,15 +50,15 @@ spec {
 
 /--
 info:
-Obligation: assert_1_1164
+Obligation: assert_1_1167
 Property: assert
 Result: ✅ pass
 
-Obligation: assert_assert_2_1195_calls_OptionInt..val_0
+Obligation: assert_assert_2_1198_calls_OptionInt..val_0
 Property: assert
 Result: ✅ pass
 
-Obligation: assert_2_1195
+Obligation: assert_2_1198
 Property: assert
 Result: ✅ pass
 
@@ -66,7 +66,7 @@ Obligation: set_ok_calls_OptionInt..val_0
 Property: assert
 Result: ✅ pass
 
-Obligation: datatype_selector_seed_ensures_0_1108
+Obligation: datatype_selector_seed_ensures_0_1111
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/FeatureRequests/decreases_metadata.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/decreases_metadata.lean
@@ -22,7 +22,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: function/procedure/spec-function `decreases`
 -/
 
-private def decreasesMetadataSeed : Strata.Program :=
+private def decreasesMetadataSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -75,7 +75,7 @@ Obligation: arbitrary_iter_maintain_invariant_0_1
 Property: assert
 Result: ✅ pass
 
-Obligation: loop_measure_seed_ensures_1_1179
+Obligation: loop_measure_seed_ensures_1_1182
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/FeatureRequests/early_return.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/early_return.lean
@@ -22,7 +22,7 @@ Early return is implemented via `exit functionName;`:
      return style.
 -/
 
-private def earlyReturnSeed : Strata.Program :=
+private def earlyReturnSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -41,7 +41,7 @@ spec {
 
 /--
 info:
-Obligation: abs_seed_ensures_0_802
+Obligation: abs_seed_ensures_0_805
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/FeatureRequests/higher_order_encoding.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/higher_order_encoding.lean
@@ -22,7 +22,7 @@ Near-upstream anchors from `differential_status.md`:
   `FnIntInt`/`apply` workaround
 -/
 
-private def higherOrderSeed : Strata.Program :=
+private def higherOrderSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -44,7 +44,7 @@ spec {
 
 /--
 info:
-Obligation: higher_order_seed_ensures_0_988
+Obligation: higher_order_seed_ensures_0_991
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/FeatureRequests/lambda_closure.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/lambda_closure.lean
@@ -23,7 +23,7 @@ proof fn use_lambda() {
   directly in Boole
 -/
 
-private def lambdaClosureSeed : Strata.Program :=
+private def lambdaClosureSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/map_extensionality.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/map_extensionality.lean
@@ -21,7 +21,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: named map synonyms and non-map extensional equality
 -/
 
-private def mapExtensionalitySeed : Strata.Program :=
+private def mapExtensionalitySeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -68,7 +68,7 @@ lift their de Bruijn indices so they keep referring to the outer map binders
 instead of the new index binder.
 -/
 
-private def quantifiedMapExtensionalityCaptureSeed : Strata.Program :=
+private def quantifiedMapExtensionalityCaptureSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/mutual_recursion.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/mutual_recursion.lean
@@ -32,7 +32,7 @@ Remaining gap:
 -- Working: mutual recursion over a Peano-style datatype.
 -- `even` calls `odd` and vice versa; both terminate by structural recursion
 -- on the `@[cases]` MyNat parameter.
-private def mutualRecursionSeed : Strata.Program :=
+private def mutualRecursionSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/nat_int_boundary.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/nat_int_boundary.lean
@@ -22,7 +22,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: native `nat` support and less burdensome coercion handling
 -/
 
-private def natIntBoundarySeed : Strata.Program :=
+private def natIntBoundarySeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/opaque_reveal_hide.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/opaque_reveal_hide.lean
@@ -25,7 +25,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: direct proof-visibility controls in Boole
 -/
 
-private def opaqueRevealHideSeed : Strata.Program :=
+private def opaqueRevealHideSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/option_matches.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/option_matches.lean
@@ -30,7 +30,7 @@ Near-upstream anchors:
   destructuring in `ensures` and `exists` clauses.
 -/
 
-private def optionMatchesSeed : Strata.Program :=
+private def optionMatchesSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/overflow_guard.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/overflow_guard.lean
@@ -21,7 +21,7 @@ Near-upstream anchors from `differential_status.md`:
   modeled directly
 -/
 
-private def overflowGuardSeed : Strata.Program :=
+private def overflowGuardSeed : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -48,15 +48,15 @@ spec {
 
 /--
 info:
-Obligation: assert_6_1180
+Obligation: assert_6_1183
 Property: assert
 Result: ✅ pass
 
-Obligation: overflow_guard_seed_ensures_4_1117
+Obligation: overflow_guard_seed_ensures_4_1120
 Property: assert
 Result: ✅ pass
 
-Obligation: overflow_guard_seed_ensures_5_1139
+Obligation: overflow_guard_seed_ensures_5_1142
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/FeatureRequests/reveal_with_fuel.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/reveal_with_fuel.lean
@@ -20,7 +20,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: bounded recursive unfolding tied to `reveal_with_fuel`
 -/
 
-private def revealWithFuelSeed : Strata.Program :=
+private def revealWithFuelSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/seq_slicing.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/seq_slicing.lean
@@ -23,7 +23,7 @@ Near-upstream anchors:
   matching the Verus `vstd::prelude::Seq` interface.
 -/
 
-private def seqSlicingSeed : Strata.Program :=
+private def seqSlicingSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/struct_field_access.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/struct_field_access.lean
@@ -31,7 +31,7 @@ Near-upstream anchors:
   (`T { f1: v1, f2: v2 }`), and quantification over fixed-size field arrays.
 -/
 
-private def structFieldAccessSeed : Strata.Program :=
+private def structFieldAccessSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/trait_spec_methods.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/trait_spec_methods.lean
@@ -28,7 +28,7 @@ Near-upstream anchors:
   procedures.
 -/
 
-private def traitSpecMethodsSeed : Strata.Program :=
+private def traitSpecMethodsSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/FeatureRequests/widening_casts.lean
+++ b/StrataBoole/StrataBooleTest/FeatureRequests/widening_casts.lean
@@ -22,7 +22,7 @@ Near-upstream anchors from `differential_status.md`:
 - Remaining gap: centralized insertion/preservation of widening casts
 -/
 
-private def wideningCastsSeed : Strata.Program :=
+private def wideningCastsSeed : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/array_assignment.lean
+++ b/StrataBoole/StrataBooleTest/array_assignment.lean
@@ -8,7 +8,7 @@ import StrataBoole.MetaVerifier
 
 open Strata
 
-def matrix_transpose_example : Strata.Program :=
+def matrix_transpose_example : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/demo.lean
+++ b/StrataBoole/StrataBooleTest/demo.lean
@@ -8,7 +8,7 @@ import StrataBoole.MetaVerifier
 
 open Strata
 
-def loopSimple : Strata.Program :=
+def loopSimple : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/find_max.lean
+++ b/StrataBoole/StrataBooleTest/find_max.lean
@@ -8,7 +8,7 @@ import StrataBoole.MetaVerifier
 
 open Strata
 
-private def find_max_program : Strata.Program :=
+private def find_max_program : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -51,7 +51,7 @@ Obligation: arbitrary_iter_maintain_invariant_0_1
 Property: assert
 Result: ✅ pass
 
-Obligation: FindMax_ensures_1_318
+Obligation: FindMax_ensures_1_321
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/find_max_verus.lean
+++ b/StrataBoole/StrataBooleTest/find_max_verus.lean
@@ -50,7 +50,7 @@ fn find_max(nums: Vec<i32>) -> (ret:i32)
 
 -/
 
-def findMax : Strata.Program :=
+def findMax : StrataDDM.Program :=
 #strata
 program Boole;
 
@@ -95,7 +95,7 @@ spec {
 
 /--
 info:
-Obligation: witnessOccurs_ensures_2_1234
+Obligation: witnessOccurs_ensures_2_1237
 Property: assert
 Result: ✅ pass
 
@@ -123,23 +123,23 @@ Obligation: arbitrary_iter_maintain_invariant_0_2
 Property: assert
 Result: ✅ pass
 
-Obligation: assert_7_1955
+Obligation: assert_7_1958
 Property: assert
 Result: ✅ pass
 
-Obligation: callElimAssert_witnessOccurs_requires_0_1171_4
+Obligation: callElimAssert_witnessOccurs_requires_0_1174_4
 Property: assert
 Result: ✅ pass
 
-Obligation: callElimAssert_witnessOccurs_requires_1_1203_5
+Obligation: callElimAssert_witnessOccurs_requires_1_1206_5
 Property: assert
 Result: ✅ pass
 
-Obligation: findMax_ensures_5_1453
+Obligation: findMax_ensures_5_1456
 Property: assert
 Result: ✅ pass
 
-Obligation: findMax_ensures_6_1513
+Obligation: findMax_ensures_6_1516
 Property: assert
 Result: ✅ pass
 -/

--- a/StrataBoole/StrataBooleTest/format_program.lean
+++ b/StrataBoole/StrataBooleTest/format_program.lean
@@ -11,18 +11,18 @@ import StrataDDM.Elab
 Regression test for `Boole.formatProgram`.
 
 `Boole.Program` stores type references as fvar indices into a `GlobalContext`.
-When a `Boole.Program` is converted back to a `Strata.Program` via `prog.toAst`,
+When a `Boole.Program` is converted back to a `StrataDDM.Program` via `prog.toAst`,
 the resulting program wraps everything in a single `Boole.prog` container op.
 That container has no binding specs, so its `globalContext` is empty, which causes
 fvar indices to be printed as `fvar!N` instead of their real names.
 
 `Boole.formatProgram` fixes this by accepting the `GlobalContext` and `DialectMap`
-from the *original* `Strata.Program` and passing them directly into the `FormatContext`.
+from the *original* `StrataDDM.Program` and passing them directly into the `FormatContext`.
 -/
 
 open Strata
 
-private def vec_program : Strata.Program :=
+private def vec_program : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/global_readonly_call.lean
+++ b/StrataBoole/StrataBooleTest/global_readonly_call.lean
@@ -15,7 +15,7 @@ namespace Strata
 
 /-! ## Header shape: read-only globals appear as inputs -/
 
-private def headerHelper (p : Strata.Program) : Except String (List String) := do
+private def headerHelper (p : StrataDDM.Program) : Except String (List String) := do
   let prog ← (Boole.getProgram p).mapError toString
   let cp ← (Boole.toCoreProgram prog p.globalContext).mapError
     fun e => toString (e.format none)
@@ -59,7 +59,7 @@ private def fmtCallArg : Core.CallArg Core.Expression → String
   | .inoutArg id => s!"inout({id.name})"
   | .outArg id => s!"out({id.name})"
 
-private def callHelper (p : Strata.Program) : Except String (List String) := do
+private def callHelper (p : StrataDDM.Program) : Except String (List String) := do
   let prog ← (Boole.getProgram p).mapError toString
   let cp ← (Boole.toCoreProgram prog p.globalContext).mapError
     fun e => toString (e.format none)
@@ -141,41 +141,41 @@ spec {
 
 
 VCs:
-Label: inc_ensures_1_2423
+Label: inc_ensures_1_2429
 Property: assert
 Assumptions:
-inc_requires_0_2405: z@1 > 0
+inc_requires_0_2411: z@1 > 0
 Obligation:
 true
 
-Label: callElimAssert_inc_requires_0_2405_6
+Label: callElimAssert_inc_requires_0_2411_6
 Property: assert
 Assumptions:
-main_caller_requires_2_2539: z@3 == 10
-main_caller_requires_3_2559: g@3 == 0
+main_caller_requires_2_2545: z@3 == 10
+main_caller_requires_3_2565: g@3 == 0
 Obligation:
 z@3 > 0
 
-Label: main_caller_ensures_4_2578
+Label: main_caller_ensures_4_2584
 Property: assert
 Assumptions:
-main_caller_requires_2_2539: z@3 == 10
-main_caller_requires_3_2559: g@3 == 0
-callElimAssume_inc_ensures_1_2423_7: g@5 == g@3 + 5 + z@5
+main_caller_requires_2_2545: z@3 == 10
+main_caller_requires_3_2565: g@3 == 0
+callElimAssume_inc_ensures_1_2429_7: g@5 == g@3 + 5 + z@5
 Obligation:
 g@5 == 15
 
 ---
 info:
-Obligation: inc_ensures_1_2423
+Obligation: inc_ensures_1_2429
 Property: assert
 Result: ✅ pass
 
-Obligation: callElimAssert_inc_requires_0_2405_6
+Obligation: callElimAssert_inc_requires_0_2411_6
 Property: assert
 Result: ✅ pass
 
-Obligation: main_caller_ensures_4_2578
+Obligation: main_caller_ensures_4_2584
 Property: assert
 Result: ❓ unknown
 Model:

--- a/StrataBoole/StrataBooleTest/grammar_extensions.lean
+++ b/StrataBoole/StrataBooleTest/grammar_extensions.lean
@@ -20,7 +20,7 @@ This covers:
 - quantifiers inside invariants
 -/
 
-private def grammarExtensions : Strata.Program :=
+private def grammarExtensions : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/loop_simple.lean
+++ b/StrataBoole/StrataBooleTest/loop_simple.lean
@@ -8,7 +8,7 @@ import StrataBoole.MetaVerifier
 
 open Strata
 
-def loop_simple_program : Strata.Program :=
+def loop_simple_program : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataBoole/StrataBooleTest/procedure_signatures.lean
+++ b/StrataBoole/StrataBooleTest/procedure_signatures.lean
@@ -19,7 +19,7 @@ when they appear in Boole programs (which parse as `command_procedure`).
 
 open Strata
 
-private def helper (p : Strata.Program) : Except String (List String) := do
+private def helper (p : StrataDDM.Program) : Except String (List String) := do
   let prog ← (Boole.getProgram p).mapError toString
   let cp ← (Boole.toCoreProgram prog p.globalContext).mapError
     fun e => toString (e.format none)

--- a/StrataBoole/StrataBooleTest/top_level_block_selection.lean
+++ b/StrataBoole/StrataBooleTest/top_level_block_selection.lean
@@ -8,7 +8,7 @@ import StrataBoole.MetaVerifier
 
 open Strata
 
-def topLevelBlockSelection : Strata.Program :=
+def topLevelBlockSelection : StrataDDM.Program :=
 #strata
 program Boole;
 

--- a/StrataCoreToGoto.lean
+++ b/StrataCoreToGoto.lean
@@ -9,6 +9,7 @@ import Strata.Languages.Core.Verifier
 import Strata.Util.IO
 
 open Strata
+open StrataDDM.Elab (elabProgram LoadedDialects)
 
 def usageMessage : Std.Format :=
   f!"Usage: StrataCoreToGoto [OPTIONS] <file.core.st>{Std.Format.line}\
@@ -57,10 +58,10 @@ def main (args : List String) : IO UInt32 := do
     IO.FS.createDirAll dir
     let text ← Strata.Util.readInputSource file
     let inputCtx := Lean.Parser.mkInputContext text (Strata.Util.displayName file)
-    let dctx := Elab.LoadedDialects.builtin
+    let dctx := LoadedDialects.builtin
     let dctx := dctx.addDialect! Core
     let leanEnv ← Lean.mkEmptyEnvironment 0
-    match Strata.Elab.elabProgram dctx leanEnv inputCtx with
+    match elabProgram dctx leanEnv inputCtx with
     | .ok pgm =>
       let symTabFile := dir / s!"{programName}.symtab.json"
       let gotoFile := dir / s!"{programName}.goto.json"

--- a/StrataDDM/StrataDDM/AST.lean
+++ b/StrataDDM/StrataDDM/AST.lean
@@ -18,7 +18,7 @@ import all StrataDDM.Util.DecideProp
 set_option autoImplicit false
 
 public section
-namespace Strata
+namespace StrataDDM
 open Std (ToFormat Format format)
 
 abbrev DialectName := String
@@ -46,7 +46,7 @@ def ofString (fullname : String) : Option QualifiedIdent := do
     none
 
 section
-open _root_.Lean
+open Lean
 public protected def quote (i : QualifiedIdent) : Term :=
   Syntax.mkCApp ``QualifiedIdent.mk #[quote i.dialect, quote i.name]
 
@@ -2303,5 +2303,5 @@ macro "sizeOf_op_arg_dec" : tactic =>
 
 macro_rules | `(tactic| decreasing_trivial) => `(tactic| sizeOf_op_arg_dec)
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/AST/Datatype.lean
+++ b/StrataDDM/StrataDDM/AST/Datatype.lean
@@ -25,7 +25,7 @@ declarations. Each template has:
 set_option autoImplicit false
 
 public section
-namespace Strata
+namespace StrataDDM
 
 /-! ## Function Template Types -/
 
@@ -122,5 +122,5 @@ def validateNamePattern (pattern : Array NamePatternPart) (scope : FunctionIterS
     else
       none
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/AST/Lemmas.lean
+++ b/StrataDDM/StrataDDM/AST/Lemmas.lean
@@ -10,7 +10,7 @@ public import StrataDDM.AST
 import all StrataDDM.AST
 
 public section
-namespace Strata.Program
+namespace StrataDDM.Program
 
 @[simp]
 theorem create_dialects (d : DialectMap) (dn : DialectName) (cmds : Array Operation) :
@@ -24,5 +24,5 @@ theorem create_dialect (d : DialectMap) (dn : DialectName) (cmds : Array Operati
 theorem create_commands (d : DialectMap) (dn : DialectName) (cmds : Array Operation) :
     (create d dn cmds).commands = cmds := by dsimp [create]
 
-end Strata.Program
+end StrataDDM.Program
 end

--- a/StrataDDM/StrataDDM/BuiltinDialects.lean
+++ b/StrataDDM/StrataDDM/BuiltinDialects.lean
@@ -10,9 +10,9 @@ public import StrataDDM.BuiltinDialects.StrataDDL
 public import StrataDDM.BuiltinDialects.StrataHeader
 
 public section
-namespace Strata.Elab.LoadedDialects
+namespace StrataDDM.Elab.LoadedDialects
 
 def builtin : LoadedDialects := .ofDialects! #[initDialect, headerDialect, StrataDDL]
 
-end Strata.Elab.LoadedDialects
+end StrataDDM.Elab.LoadedDialects
 end

--- a/StrataDDM/StrataDDM/BuiltinDialects/BuiltinM.lean
+++ b/StrataDDM/StrataDDM/BuiltinDialects/BuiltinM.lean
@@ -9,7 +9,7 @@ public import StrataDDM.Elab.DeclM
 
 
 public section
-namespace Strata.Elab
+namespace StrataDDM.Elab
 
 abbrev BuiltinM := StateT Dialect DeclM
 

--- a/StrataDDM/StrataDDM/BuiltinDialects/Init.lean
+++ b/StrataDDM/StrataDDM/BuiltinDialects/Init.lean
@@ -9,10 +9,10 @@ public import StrataDDM.AST
 
 import StrataDDM.BuiltinDialects.BuiltinM
 
-open Strata.Elab
+open StrataDDM.Elab
 
 public section
-namespace Strata
+namespace StrataDDM
 
 
 def SyntaxCat.mkOpt (c:SyntaxCat) : SyntaxCat := { ann := .none, name := q`Init.Option, args := #[c] }

--- a/StrataDDM/StrataDDM/BuiltinDialects/StrataDDL.lean
+++ b/StrataDDM/StrataDDM/BuiltinDialects/StrataDDL.lean
@@ -9,10 +9,10 @@ public import StrataDDM.AST
 import StrataDDM.BuiltinDialects.BuiltinM
 import StrataDDM.BuiltinDialects.Init
 
-open Strata.Elab
+open StrataDDM.Elab
 
 public section
-namespace Strata
+namespace StrataDDM
 
 def StrataDDL : Dialect := BuiltinM.create! "StrataDDL" #[initDialect] do
   let Ident : ArgDeclKind := .cat <| .atom .none q`Init.Ident
@@ -189,5 +189,5 @@ def StrataDDL : Dialect := BuiltinM.create! "StrataDDL" #[initDialect] do
   declareMetadata { name := "scopeTVar", args := #[.mk "typeParams" .ident] }
   declareMetadata { name := "preRegisterFunctions", args := #[.mk "scope" .ident] }
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/BuiltinDialects/StrataHeader.lean
+++ b/StrataDDM/StrataDDM/BuiltinDialects/StrataHeader.lean
@@ -10,10 +10,10 @@ public import StrataDDM.AST
 import StrataDDM.BuiltinDialects.BuiltinM
 import StrataDDM.BuiltinDialects.Init
 
-open Strata.Elab
+open StrataDDM.Elab
 
 public section
-namespace Strata
+namespace StrataDDM
 
 
 def headerDialect : Dialect := Elab.BuiltinM.create! "StrataHeader" #[initDialect] do
@@ -36,5 +36,5 @@ def headerDialect : Dialect := Elab.BuiltinM.create! "StrataHeader" #[initDialec
      category := Command,
      syntaxDef := .ofList [.str "program", .ident 0 0, .str ";"],
   }
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/Elab.lean
+++ b/StrataDDM/StrataDDM/Elab.lean
@@ -18,10 +18,10 @@ public import StrataDDM.BuiltinDialects.StrataDDL
 public import StrataDDM.Util.Lean
 
 open Lean (Message)
-open Strata.Parser (InputContext)
+open StrataDDM.Parser (InputContext)
 
 public section
-namespace Strata.Elab
+namespace StrataDDM.Elab
 
 namespace DeclState
 
@@ -75,7 +75,7 @@ private def normalizeUnicodeQuantifierSeparators (src : String) : String :=
 
 private def normalizeInputContext (inputContext : InputContext) : InputContext :=
   let inputString := normalizeUnicodeQuantifierSeparators inputContext.inputString
-  Strata.Parser.stringInputContext (System.FilePath.mk inputContext.fileName) inputString
+  Parser.stringInputContext (System.FilePath.mk inputContext.fileName) inputString
 
 private def normalizedQuantifierSepStep (state : QuantifierSepState) (ch : Char) : Nat × QuantifierSepState :=
   match state with
@@ -268,7 +268,7 @@ private def readDialectTextfileHeader
     : BaseIO (Except (Array Message)
         (Parser.InputContext × SourceRange × DialectName
           × String.Pos.Raw)) := do
-  let inputContext := Strata.Parser.stringInputContext input contents
+  let inputContext := Parser.stringInputContext input contents
   let leanEnv ←
     match ← (Lean.mkEmptyEnvironment 0) |>.toBaseIO with
     | .ok e => pure e
@@ -332,7 +332,7 @@ private partial def loadDialectFromPath
   (path : System.FilePath)
   (actualPath : System.FilePath := path)
   (expected : Option DialectName := none) :
-  BaseIO (Except (Array Message) Strata.Dialect) := do
+  BaseIO (Except (Array Message) Dialect) := do
   let bytes ←
     match ← IO.FS.readBinFile actualPath |>.toBaseIO with
     | .error _ =>
@@ -471,8 +471,8 @@ more structure (such as error location information).
 -/
 partial def loadDialect
   (fm : DialectFileMap)
-  (dialect : Strata.DialectName) :
-  BaseIO (Except String Strata.Dialect) := do
+  (dialect : DialectName) :
+  BaseIO (Except String Dialect) := do
   loadDialectRec fm #[] dialect
 
 /--
@@ -484,7 +484,7 @@ partial def loadDialectFromFile
   (fm : DialectFileMap)
   (path : System.FilePath)
   (actualPath : System.FilePath := path) :
-  BaseIO (Except (Array Message) Strata.Dialect) :=
+  BaseIO (Except (Array Message) Dialect) :=
   loadDialectFromPath fm #[] path (actualPath := actualPath)
 
 /- Elaborate a Strata dialect definition. -/
@@ -510,7 +510,7 @@ def elabDialect
   | .dialect loc dialect =>
     elabDialectRest fm inputContext loc dialect (startPos := startPos) (stopPos := stopPos)
 
-def parseStrataProgramFromDialect (dialects : LoadedDialects) (dialect : DialectName) (input : InputContext) : IO Strata.Program := do
+def parseStrataProgramFromDialect (dialects : LoadedDialects) (dialect : DialectName) (input : InputContext) : IO Program := do
   let leanEnv ← Lean.mkEmptyEnvironment 0
   let originalInput := input
   let input := normalizeInputContext input
@@ -541,7 +541,7 @@ def parseCategoryFromDialect
     (dialects : LoadedDialects) (cat : QualifiedIdent) (input : InputContext)
     (startPos : String.Pos.Raw := 0)
     (stopPos : String.Pos.Raw := input.endPos)
-    : IO Strata.Operation := do
+    : IO Operation := do
   let leanEnv ← Lean.mkEmptyEnvironment 0
   let originalInput := input
   let input := normalizeInputContext input
@@ -583,5 +583,5 @@ def parseCategoryFromDialect
   let op := tree.info.asOp!.op
   return op
 
-end Strata.Elab
+end StrataDDM.Elab
 end

--- a/StrataDDM/StrataDDM/Elab/Core.lean
+++ b/StrataDDM/StrataDDM/Elab/Core.lean
@@ -20,10 +20,10 @@ open Lean (
     Syntax
     nullKind
   )
-open Strata.Parser (DeclParser InputContext)
+open StrataDDM.Parser (DeclParser InputContext)
 
 public section
-namespace Strata
+namespace StrataDDM
 
 namespace TypeExprF
 
@@ -1851,5 +1851,5 @@ partial def elabCommand (leanEnv : Lean.Environment) : DeclM (Option Tree) := do
   let glbl := (←get).globalContext
   runElab <| some <$> elabOperation (.empty glbl) stx
 
-end Strata.Elab
+end StrataDDM.Elab
 end

--- a/StrataDDM/StrataDDM/Elab/DeclM.lean
+++ b/StrataDDM/StrataDDM/Elab/DeclM.lean
@@ -14,10 +14,10 @@ set_option autoImplicit false
 
 open Lean (Syntax Message)
 
-open Strata.Parser (DeclParser InputContext Parser ParsingContext)
+open StrataDDM.Parser (DeclParser InputContext Parser ParsingContext)
 
 public section
-namespace Strata
+namespace StrataDDM
 
 def infoSourceRange (info : Lean.SourceInfo) : Option SourceRange :=
   match info with
@@ -382,5 +382,5 @@ def addTypeOrCatDecl (dialect : DialectName) (tpcd : TypeOrCatDecl) : DeclM Unit
     s with typeOrCatDeclMap := s.typeOrCatDeclMap.add dialect tpcd
   }
 
-end Strata.Elab
+end StrataDDM.Elab
 end

--- a/StrataDDM/StrataDDM/Elab/DialectM.lean
+++ b/StrataDDM/StrataDDM/Elab/DialectM.lean
@@ -16,7 +16,7 @@ import all StrataDDM.Util.Fin
 set_option autoImplicit false
 
 public section
-namespace Strata
+namespace StrataDDM
 
 namespace PreType
 

--- a/StrataDDM/StrataDDM/Elab/Env.lean
+++ b/StrataDDM/StrataDDM/Elab/Env.lean
@@ -8,7 +8,7 @@ module
 public import StrataDDM.AST
 public import Lean.Parser.Basic
 
-namespace Strata
+namespace StrataDDM
 
 open Lean
 
@@ -17,4 +17,4 @@ public abbrev PrattParsingTableMap := Std.HashMap QualifiedIdent Parser.PrattPar
 public initialize parserExt : EnvExtension PrattParsingTableMap ←
   registerEnvExtension (pure {})
 
-end Strata
+end StrataDDM

--- a/StrataDDM/StrataDDM/Elab/LoadedDialects.lean
+++ b/StrataDDM/StrataDDM/Elab/LoadedDialects.lean
@@ -7,10 +7,10 @@ module
 public import StrataDDM.Parser
 public import StrataDDM.Elab.SyntaxElab
 
-open Strata.Parser (DeclParser ParsingContext)
+open StrataDDM.Parser (DeclParser ParsingContext)
 
 public section
-namespace Strata.Elab
+namespace StrataDDM.Elab
 
 /--
 Map from dialect names to all the declaration parsers brought into
@@ -191,5 +191,5 @@ def findPath (m : DialectFileMap) (name : DialectName) : Option System.FilePath 
   | some (_, _, path) => pure path
 
 end DialectFileMap
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/Elab/SyntaxElab.lean
+++ b/StrataDDM/StrataDDM/Elab/SyntaxElab.lean
@@ -9,7 +9,7 @@ public import StrataDDM.AST
 import all StrataDDM.Util.DecideProp
 
 public section
-namespace Strata.Elab
+namespace StrataDDM.Elab
 
 /--
 Describes an elaboration relationship between a argument in the bindings and
@@ -179,5 +179,5 @@ private def addDecl (m : SyntaxElabMap) (dialect : String) (d : Decl) : Except S
 def addDialect (m : SyntaxElabMap) (d : Dialect) : Except String SyntaxElabMap :=
   d.declarations.foldlM (·.addDecl d.name) m
 
-end Strata.Elab.SyntaxElabMap
+end StrataDDM.Elab.SyntaxElabMap
 end

--- a/StrataDDM/StrataDDM/Elab/Tree.lean
+++ b/StrataDDM/StrataDDM/Elab/Tree.lean
@@ -11,7 +11,7 @@ set_option autoImplicit false
 open Lean (Syntax)
 
 public section
-namespace Strata.Elab
+namespace StrataDDM.Elab
 
 /--
 Information about the type or category of a bound variable.

--- a/StrataDDM/StrataDDM/Format.lean
+++ b/StrataDDM/StrataDDM/Format.lean
@@ -13,7 +13,7 @@ import all StrataDDM.Util.String
 open Std (Format format)
 
 public section
-namespace Strata
+namespace StrataDDM
 
 /--
 Check if a character is valid for starting a regular identifier.
@@ -618,7 +618,7 @@ instance : ToStrataFormat ArgDecls where
 
 /- Format `fmt` in a context with additional bindings `b`. -/
 private protected def formatIn [ToStrataFormat α] (b : ArgDecls) (fmt : α) : StrataFormat := fun c s =>
-  Strata.mformat fmt c (b.toArray.foldl (init := s) (·.pushBinding ·.ident))
+  StrataDDM.mformat fmt c (b.toArray.foldl (init := s) (·.pushBinding ·.ident))
 
 end ArgDecls
 
@@ -757,5 +757,5 @@ protected def ppDialect! (p : Program) (name : DialectName := p.dialect) (opts :
 
 end Program
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/HNF.lean
+++ b/StrataDDM/StrataDDM/HNF.lean
@@ -9,7 +9,7 @@ public import StrataDDM.AST
 import all StrataDDM.Util.Array
 
 public section
-namespace Strata
+namespace StrataDDM
 
 /--
 Array ofelements whose sizes are bounded by a value.
@@ -36,5 +36,5 @@ protected def hnf {α} (e0 : ExprF α) : HNF e0 :=
   aux e0 #[] (by simp)
 
 end ExprF
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/Integration/Categories.lean
+++ b/StrataDDM/StrataDDM/Integration/Categories.lean
@@ -7,7 +7,7 @@ module
 public import StrataDDM.AST
 
 public section
-namespace Strata.DDM.Integration
+namespace StrataDDM.Integration
 
 /-- Init categories that map to primitive types (no interface/inductive needed) -/
 def primitiveCategories : Std.HashSet QualifiedIdent := Std.HashSet.ofList [
@@ -33,4 +33,4 @@ def abstractCategories : Std.HashSet QualifiedIdent := Std.HashSet.ofList [
   q`Init.TypeP
 ]
 
-end Strata.DDM.Integration
+end StrataDDM.Integration

--- a/StrataDDM/StrataDDM/Integration/Java/Gen.lean
+++ b/StrataDDM/StrataDDM/Integration/Java/Gen.lean
@@ -9,10 +9,10 @@ public import StrataDDM.AST
 import StrataDDM.Ion
 import StrataDDM.Integration.Categories
 
-namespace Strata.Java
+namespace StrataDDM.Java
 
-open Strata (Dialect OpDecl ArgDecl ArgDeclKind QualifiedIdent SyntaxCat)
-open Strata.DDM.Integration (primitiveCategories forbiddenCategories abstractCategories)
+open StrataDDM (Dialect OpDecl ArgDecl ArgDeclKind QualifiedIdent SyntaxCat)
+open StrataDDM.Integration (primitiveCategories forbiddenCategories abstractCategories)
 
 /-! # Java Code Generator for DDM Dialects
 
@@ -448,4 +448,4 @@ public def writeJavaFiles (baseDir : System.FilePath) (package : String) (files 
   for (filename, content) in files.stubs do
     IO.FS.writeFile (dir / filename) content
 
-end Strata.Java
+end StrataDDM.Java

--- a/StrataDDM/StrataDDM/Integration/Lean/Env.lean
+++ b/StrataDDM/StrataDDM/Integration/Lean/Env.lean
@@ -7,7 +7,7 @@ module
 public import StrataDDM.Elab.LoadedDialects
 import StrataDDM.BuiltinDialects
 
-namespace Strata
+namespace StrataDDM
 
 open Lean Parser
 
@@ -81,4 +81,4 @@ public initialize dialectExt : PersistentEnvExtension PersistentDialect (Name ×
     exportEntriesFn := exportEntries
   }
 
-end Strata
+end StrataDDM

--- a/StrataDDM/StrataDDM/Integration/Lean/Gen.lean
+++ b/StrataDDM/StrataDDM/Integration/Lean/Gen.lean
@@ -39,7 +39,7 @@ open Lean.Parser.Termination (terminationBy suffix)
 open Lean.Syntax (mkApp mkCApp mkStrLit)
 
 meta section
-namespace Strata
+namespace StrataDDM
 
 namespace Lean
 
@@ -193,7 +193,7 @@ def resolveDialects (lookup : String → Option Dialect)
 abbrev CategoryName := QualifiedIdent
 
 def forbiddenCategories : Std.HashSet CategoryName :=
-  DDM.Integration.forbiddenCategories
+  Integration.forbiddenCategories
 
 def forbiddenWellDefined : Bool :=
   forbiddenCategories.all fun nm =>
@@ -209,7 +209,7 @@ def forbiddenWellDefined : Bool :=
 /-- Abstract categories (`Init.Expr`, `Init.Type`, `Init.TypeP`)
 extended via `fn`/`type` rather than `op`. -/
 def abstractCategories : Std.HashSet CategoryName :=
-  DDM.Integration.abstractCategories
+  Integration.abstractCategories
 
 /--
 Argument declaration for code generation.
@@ -320,7 +320,7 @@ def declaredCategories : Std.HashMap CategoryName Name := .ofList [
   (q`Init.Bool, ``Bool)
 ]
 #guard declaredCategories.keys.all
-  (DDM.Integration.primitiveCategories.contains ·)
+  (Integration.primitiveCategories.contains ·)
 
 namespace CatOpMap
 
@@ -800,7 +800,7 @@ def genInductiveDef (cat : QualifiedIdent) (ctors : Array DefaultCtor)
     : GenM Command := do
   assert! cat ∉ declaredCategories
   let ident ← mkScopedIdent (← getCategoryScopedName cat)
-  trace[Strata.generator] "Generating {ident}"
+  trace[StrataDDM.generator] "Generating {ident}"
   let annType := localIdent "α"
   let builtinCtors : Array (TSyntax ``ctor) ←
         match cat with
@@ -824,10 +824,10 @@ OperationF) for use in type signatures.
 def categoryToAstTypeIdent (cat : QualifiedIdent) (annType : Term) : Term :=
   let ident :=
     match cat with
-    | q`Init.Expr => ``Strata.ExprF
-    | q`Init.Type => ``Strata.TypeExprF
-    | q`Init.TypeP => ``Strata.ArgF
-    | _ => ``Strata.OperationF
+    | q`Init.Expr => ``ExprF
+    | q`Init.Type => ``TypeExprF
+    | q`Init.TypeP => ``ArgF
+    | _ => ``OperationF
   Lean.Syntax.mkApp (mkRootIdent ident) #[annType]
 
 /-- Returns the identifier for a category's toAst function. -/
@@ -884,7 +884,7 @@ partial def toAstApplyArg (vn : Name) (cat : SyntaxCat)
       ``(ArgF.op $opExpr)
     else
       -- When wrapped, v is already Ann Bool α
-      let boolToAst := mkCApp ``Strata.OfAstM.toAstBool #[v]
+      let boolToAst := mkCApp ``OfAstM.toAstBool #[v]
       return mkCApp ``ArgF.op #[boolToAst]
   | q`Init.Ident =>
     if !addAnn then
@@ -1120,7 +1120,7 @@ def generateToAstFunction (cat : QualifiedIdent)
   let cases ← toAstBuiltinMatches cat
   let cases : Array MatchAlt := cases ++ (← ops.mapM (toAstMatch cat))
   let toAst ← toAstIdentM cat
-  trace[Strata.generator] "Generating {toAst}"
+  trace[StrataDDM.generator] "Generating {toAst}"
   let src := (←read).src
   let v ← genFreshLeanName "v"
   `(partial def $toAst {$annType : Type} [Inhabited $annType]
@@ -1335,7 +1335,7 @@ def createNameIndexMap (cat : QualifiedIdent) (ops : Array DefaultCtor)
     | some name => map.insert name map.size  -- Assign the next available index
   let ofAstNameMap ←
     getCategoryOpIdent cat `ofAst.nameIndexMap
-  let cmd ← `(def $ofAstNameMap : Std.HashMap Strata.QualifiedIdent Nat :=
+  let cmd ← `(def $ofAstNameMap : Std.HashMap QualifiedIdent Nat :=
     Std.HashMap.ofList $(quote nameIndexMap.toList))
   pure (nameIndexMap, ofAstNameMap, cmd)
 
@@ -1362,7 +1362,7 @@ def generateOfAstFunction (cat : QualifiedIdent) (ops : Array DefaultCtor)
     : GenM (Array Command × Command) := do
   let src := (←read).src
   let ofAst ← ofAstIdentM cat
-  trace[Strata.generator] "Generating {ofAst}"
+  trace[StrataDDM.generator] "Generating {ofAst}"
   match cat with
   | q`Init.Expr =>
     let v ← genFreshLeanName "v"
@@ -1399,11 +1399,11 @@ def generateOfAstFunction (cat : QualifiedIdent) (ops : Array DefaultCtor)
         let $(mkCanIdent src argsVar) := vnf.args.val
         let foldArgs := $foldArgs
         match (vnf.fn) with
-        | Strata.ExprF.bvar ann idx => do
+        | ExprF.bvar ann idx => do
           foldArgs ($bvarCtor ann idx)
-        | Strata.ExprF.fvar ann i => do
+        | ExprF.fvar ann i => do
           foldArgs ($fvarCtor ann i)
-        | Strata.ExprF.fn $annC fnId =>
+        | ExprF.fn $annC fnId =>
           (match ($ofAstNameMap[fnId]?) with
           $cases:matchAlt*
           | _ => OfAstM.throwUnknownIdentifier $(quote cat) fnId)
@@ -1583,7 +1583,7 @@ def generateCategoryCode
       declaredCategories.keysArray
   for allCtors in orderedSyncatGroups categories do
     let s ←
-      withTraceNode `Strata.generator (fun _ =>
+      withTraceNode `StrataDDM.generator (fun _ =>
         return m!"Declarations group: {allCtors.map (·.fst)}") do
         -- TODO: Currently all toAst/ofAst functions are declared `partial`.
         -- The commented-out code below detects whether a group is actually
@@ -1678,5 +1678,5 @@ public def genAstImpl : CommandElab := fun stx =>
   | _ =>
     throwUnsupportedSyntax
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/Integration/Lean/GenTrace.lean
+++ b/StrataDDM/StrataDDM/Integration/Lean/GenTrace.lean
@@ -8,4 +8,4 @@ module
 -- This module defines a trace class used for the generator.
 import Lean.Util.Trace
 
-initialize Lean.registerTraceClass `Strata.generator
+initialize Lean.registerTraceClass `StrataDDM.generator

--- a/StrataDDM/StrataDDM/Integration/Lean/HashCommands.lean
+++ b/StrataDDM/StrataDDM/Integration/Lean/HashCommands.lean
@@ -21,9 +21,9 @@ open Lean.Elab.Command (CommandElab CommandElabM liftCoreM)
 open Lean.Elab.Term (TermElab)
 open Lean.Parser (InputContext)
 open System (FilePath)
-open Strata.Lean (arrayToExpr listToExpr)
+open StrataDDM.Lean (arrayToExpr listToExpr)
 
-namespace Strata
+namespace StrataDDM
 
 class HasInputContext (m : Type → Type _) [Functor m] where
   getInputContext : m InputContext
@@ -136,8 +136,8 @@ def strataDialectImpl: CommandElab := fun (stx : Syntax) => do
         | throwError s!"Expected input context"
   let inputCtx ← HasInputContext.getInputContext
   let loaded := (dialectExt.getState (←Lean.getEnv)).loaded
-  let fm ← Strata.DialectFileMap.new loaded
-  let (d, s) ← Strata.Elab.elabDialect fm inputCtx p e
+  let fm ← DialectFileMap.new loaded
+  let (d, s) ← Elab.elabDialect fm inputCtx p e
   if !s.errors.isEmpty then
     for e in s.errors do
       logMessage e
@@ -170,7 +170,7 @@ meta def strataProgramImpl : TermElab := fun stx tp => do
     let some (.str name root) := s.nameMap[pgm.dialect]?
       | throwError s!"Unknown dialect {pgm.dialect}"
     let commandType := mkConst ``Operation
-    let cmdToExpr (cmd : Strata.Operation) : CoreM Lean.Expr := do
+    let cmdToExpr (cmd : Operation) : CoreM Lean.Expr := do
           let n ← mkFreshUserName `command
           addDefn n commandType (toExpr cmd)
           pure <| mkConst n
@@ -224,7 +224,7 @@ def loadDialectImpl : CommandElab := fun (stx : Syntax) => do
     if ! (← absPath.pathExists) then
       throwErrorAt pathStx "Could not find file {dialectPath}"
     let loaded := (dialectExt.getState (←Lean.getEnv)).loaded
-    let fm ← Strata.DialectFileMap.new loaded
+    let fm ← DialectFileMap.new loaded
     let r ← Elab.loadDialectFromFile fm (path := dialectPath) (actualPath := absPath)
     -- Add dialect to command environment
     match r with
@@ -239,4 +239,4 @@ def loadDialectImpl : CommandElab := fun (stx : Syntax) => do
 end
 end
 
-end Strata
+end StrataDDM

--- a/StrataDDM/StrataDDM/Integration/Lean/OfAstM.lean
+++ b/StrataDDM/StrataDDM/Integration/Lean/OfAstM.lean
@@ -13,7 +13,7 @@ the `ofAst` functions that `#strata_gen` emits.
 -/
 
 public section
-namespace Strata
+namespace StrataDDM
 
 class HasEta (α : Type u) (β : outParam (Type v)) where
   bvar : Nat → α
@@ -255,5 +255,5 @@ def matchTypeParamOrType {Ann α} [Repr Ann] (a : ArgF Ann)
   | .type tp => onType tp
   | _ => .throwExpected "Type parameter or type expression" a
 
-end Strata.OfAstM
+end StrataDDM.OfAstM
 end

--- a/StrataDDM/StrataDDM/Integration/Lean/ToExpr.lean
+++ b/StrataDDM/StrataDDM/Integration/Lean/ToExpr.lean
@@ -16,10 +16,10 @@ import Lean.Exception
 
 open Lean
 open Lean.Elab
-open Strata.Lean
+open StrataDDM.Lean
 
 public section
-namespace Strata
+namespace StrataDDM
 
 namespace QualifiedIdent
 
@@ -527,5 +527,5 @@ instance Program.instToExpr : ToExpr Program where
       (toExpr ms.dialect)
       (toExpr ms.commands)
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDM/Ion.lean
+++ b/StrataDDM/StrataDDM/Ion.lean
@@ -108,7 +108,7 @@ private protected def asDecimal? (v : Ion SymbolId) : Option Decimal :=
 
 end Ion.Ion
 
-namespace Strata
+namespace StrataDDM
 
 namespace SepFormat
 
@@ -652,7 +652,7 @@ private protected def OperationF.fromIon {α} [FromIon α] (v : Ion SymbolId) : 
   let name ← QualifiedIdent.fromIon "Operation name" sexp[0]
   let ann ← fromIon (α := α) sexp[1]
   let args ← sexp.attach.mapM_off (start := 2) fun ⟨a, a_in⟩ =>
-    Strata.ArgF.fromIon a
+    StrataDDM.ArgF.fromIon a
   return { ann := ann, name := name, args := args }
 termination_by v
 decreasing_by
@@ -678,8 +678,8 @@ private protected def ExprF.fromIon {α} [FromIon α] (v : Ion SymbolId) : FromI
   | "app" =>
     let ⟨p⟩ ← .checkArgCount "app" sexp 4
     let ann ← fromIon (α := α) sexp[1]
-    let f ← Strata.ExprF.fromIon sexp[2]
-    let x ← Strata.ArgF.fromIon sexp[3]
+    let f ← StrataDDM.ExprF.fromIon sexp[2]
+    let x ← StrataDDM.ArgF.fromIon sexp[3]
     return .app ann f x
   | str =>
     throw s!"Unexpected identifier {str}"
@@ -703,10 +703,10 @@ private protected def ArgF.fromIon {α} [FromIon α] (v : Ion SymbolId) : FromIo
   match argKind with
   | "op" =>
     let ⟨p⟩ ← .checkArgCount "op" sexp 2
-    .op <$> Strata.OperationF.fromIon sexp[1]
+    .op <$> StrataDDM.OperationF.fromIon sexp[1]
   | "expr" =>
     let ⟨p⟩ ← .checkArgCount "expr" sexp 2
-    .expr <$> Strata.ExprF.fromIon sexp[1]
+    .expr <$> StrataDDM.ExprF.fromIon sexp[1]
   | "cat" =>
     let ⟨p⟩ ← .checkArgCount "cat" sexp 2
     .cat <$> fromIon sexp[1]
@@ -743,7 +743,7 @@ private protected def ArgF.fromIon {α} [FromIon α] (v : Ion SymbolId) : FromIo
     let v ←
       match p : sexp.size with
       | 2 => pure none
-      | 3 => some <$> Strata.ArgF.fromIon sexp[2]
+      | 3 => some <$> StrataDDM.ArgF.fromIon sexp[2]
       | _ => throw "Option expects at most one value."
     return .option ann v
   | str =>
@@ -752,7 +752,7 @@ private protected def ArgF.fromIon {α} [FromIon α] (v : Ion SymbolId) : FromIo
       let ⟨p⟩ ← .checkArgMin str sexp 2
       let ann ← fromIon sexp[1]
       let args ← sexp.attach.mapM_off (start := 2) fun ⟨u, _⟩ =>
-        Strata.ArgF.fromIon u
+        StrataDDM.ArgF.fromIon u
       return .seq ann sep args
     | none =>
       throw s!"Unexpected identifier {str}"
@@ -1587,9 +1587,9 @@ def fromIonFragment (f : Ion.Fragment)
 /--
 Decodes bytes in the Ion format into a single Strata program.
 -/
-def fromIon (dialects : DialectMap) (dialect : DialectName) (bytes : ByteArray) : Except String Strata.Program := do
+def fromIon (dialects : DialectMap) (dialect : DialectName) (bytes : ByteArray) : Except String Program := do
   let (hdr, frag) ←
-    match Strata.Ion.Header.parse bytes with
+    match Ion.Header.parse bytes with
     | .error msg =>
       throw msg
     | .ok p =>
@@ -1662,4 +1662,4 @@ def filesFromIon (dialects : DialectMap) (bytes : ByteArray) : Except String (Li
 
     pure { filePath := filePath, program := program }
 
-end Strata.Program
+end StrataDDM.Program

--- a/StrataDDM/StrataDDM/Parser.lean
+++ b/StrataDDM/StrataDDM/Parser.lean
@@ -63,7 +63,7 @@ private instance : Repr SyntaxStack where
 end Lean.Parser.SyntaxStack
 
 
-namespace Strata.Parser
+namespace StrataDDM.Parser
 
 export Lean.Parser (
     InputContext
@@ -1057,4 +1057,4 @@ def runCatParser (tokenTable : TokenTable)
   let f := andthenFn whitespace p.fn
   f.run inputContext pmc tokenTable leanParserState
 
-end Strata.Parser
+end StrataDDM.Parser

--- a/StrataDDM/StrataDDM/TaggedRegions.lean
+++ b/StrataDDM/StrataDDM/TaggedRegions.lean
@@ -20,7 +20,7 @@ open Lean.Syntax.MonadTraverser (getCur goLeft)
 open Lean.PrettyPrinter.Formatter (pushToken withMaybeTag throwBacktrack)
 
 public section
-namespace Strata.ExternParser
+namespace StrataDDM.ExternParser
 
 private def parserFn (endToken : String) : ParserFn := fun c s => Id.run do
   if s.hasError then
@@ -93,7 +93,7 @@ meta def declareTaggedRegionImpl: CommandElab := fun stx => do -- declare and re
   declareParser stx cat cmdStx.getId decl
 
 initialize
-  Lean.registerTraceClass `Strata.DDM.syntax
+  Lean.registerTraceClass `StrataDDM.syntax
 
-end Strata.ExternParser
+end StrataDDM.ExternParser
 end

--- a/StrataDDM/StrataDDM/Util/ByteArray.lean
+++ b/StrataDDM/StrataDDM/Util/ByteArray.lean
@@ -46,7 +46,7 @@ end ByteArray
 #guard let a := ByteArray.empty |>.push 0 |>.push 1; (a |>.push 2 |>.pop) = a
 
 public section
-namespace Strata.ByteArray
+namespace StrataDDM.ByteArray
 
 def ofNatArray (a : Array Nat) : ByteArray := .mk (a.map UInt8.ofNat)
 
@@ -191,5 +191,5 @@ def unescapeBytes (s : String) : Except (s.Pos × s.Pos × String) ByteArray :=
   | .error (f, e, msg) => .error (f, e, msg)
   | .ok (a, _) => .ok a
 
-end Strata.ByteArray
+end StrataDDM.ByteArray
 end

--- a/StrataDDM/StrataDDM/Util/Decimal.lean
+++ b/StrataDDM/StrataDDM/Util/Decimal.lean
@@ -11,7 +11,7 @@ import all StrataDDM.Util.Lean
 import all StrataDDM.Util.String
 
 public section
-namespace Strata
+namespace StrataDDM
 
 structure Decimal where
   mantissa : Int
@@ -68,4 +68,4 @@ end
 
 end Decimal
 
-end Strata
+end StrataDDM

--- a/StrataDDM/StrataDDM/Util/DecimalRat.lean
+++ b/StrataDDM/StrataDDM/Util/DecimalRat.lean
@@ -7,7 +7,7 @@ module
 public import StrataDDM.Util.Decimal
 
 public section
-namespace Strata.Decimal
+namespace StrataDDM.Decimal
 
 def toRat (d: Decimal) : Rat :=
   if d.exponent < 0 then mkRat d.mantissa (10 ^ (d.exponent).natAbs) else
@@ -74,5 +74,5 @@ def fromRat (r : Rat) : Option Decimal :=
       let exponent := -(k : Int)
       some (normalize mantissa exponent)
 
-end Strata.Decimal
+end StrataDDM.Decimal
 end

--- a/StrataDDM/StrataDDM/Util/Fin.lean
+++ b/StrataDDM/StrataDDM/Util/Fin.lean
@@ -41,8 +41,8 @@ def range (n : Nat) : Range n := .mk
 end Fin
 
 public section
-namespace Strata.Fin
+namespace StrataDDM.Fin
 export _root_.Fin(Range range)
-end Strata.Fin
+end StrataDDM.Fin
 
 end

--- a/StrataDDM/StrataDDM/Util/Format.lean
+++ b/StrataDDM/StrataDDM/Util/Format.lean
@@ -7,6 +7,8 @@ module
 
 import all StrataDDM.Util.String
 
+open StrataDDM (escapeStringLit)
+
 namespace Std.Format
 
 def appendSpaces (s : String) (n : Nat) : String :=
@@ -20,7 +22,7 @@ def repr (fmt : Std.Format) (indent : Nat) : String :=
   | .nil => sline "nil" indent
   | .line => sline "line" indent
   | .align n => sline s!"align {n}" indent
-  | .text msg => sline s!"text {Strata.escapeStringLit msg}" indent
+  | .text msg => sline s!"text {escapeStringLit msg}" indent
   | .nest n fmt => sline s!"nest {n}" indent ++ repr fmt (indent + 2)
   | .append x y => repr x indent ++ repr y indent
   | .group f _ => sline "group" indent ++ repr f (indent + 2)

--- a/StrataDDM/StrataDDM/Util/Graph/Tarjan.lean
+++ b/StrataDDM/StrataDDM/Util/Graph/Tarjan.lean
@@ -8,7 +8,7 @@ import all StrataDDM.Util.Fin
 import all StrataDDM.Util.Vector
 
 public section
-namespace Strata
+namespace StrataDDM
 
 structure OutGraph (nodeCount : Nat) where
   edges : Vector (Array (Fin nodeCount)) nodeCount
@@ -101,5 +101,5 @@ def tarjan {n} (g : OutGraph n) : Array (Array (Node n)) :=
       s
   s.components
 
-end Strata.OutGraph
+end StrataDDM.OutGraph
 end

--- a/StrataDDM/StrataDDM/Util/Ion.lean
+++ b/StrataDDM/StrataDDM/Util/Ion.lean
@@ -142,7 +142,7 @@ def intern (values : List (Ion String)) (symbols : SymbolTable := .system) : Arr
 Write values
 -/
 def internAndSerialize (values : List (Ion String)) (symbols : SymbolTable := .system) : ByteArray :=
-  _root_.Ion.serialize <| intern (symbols := symbols) values
+  serialize <| intern (symbols := symbols) values
 
 /--
 Write a list of Ion values to file.

--- a/StrataDDM/StrataDDM/Util/Ion/AST.lean
+++ b/StrataDDM/StrataDDM/Util/Ion/AST.lean
@@ -12,8 +12,8 @@ public section
 
 namespace Ion
 
-export Strata (Decimal)
-open Strata.ByteArray
+export StrataDDM (Decimal)
+open StrataDDM.ByteArray
 
 inductive CoreType
 | null

--- a/StrataDDM/StrataDDM/Util/Ion/JSON.lean
+++ b/StrataDDM/StrataDDM/Util/Ion/JSON.lean
@@ -10,7 +10,7 @@ import Lean.Data.Json.Basic
 import StrataDDM.Util.Ion.AST
 
 
-namespace Strata.Decimal
+namespace StrataDDM.Decimal
 
 def ofJsonNumber (n : Lean.JsonNumber) : Decimal where
   mantissa := n.mantissa
@@ -24,7 +24,7 @@ def toJsonNumber (d : Decimal) : Lean.JsonNumber :=
   else
     { mantissa := m, exponent := e.natAbs }
 
-end Strata.Decimal
+end StrataDDM.Decimal
 
 namespace Ion
 

--- a/StrataDDM/StrataDDM/Util/Ion/Lean.lean
+++ b/StrataDDM/StrataDDM/Util/Ion/Lean.lean
@@ -194,7 +194,7 @@ meta def declareIonSymbolImpl : Elab.Term.TermElab := fun stx _ =>
 
 private def typeOf {α : Type u} (_ : α) : Type u := α
 
-initialize Lean.registerTraceClass `Strata.ionTypeOf
+initialize Lean.registerTraceClass `StrataDDM.ionTypeOf
 
 syntax (name := declareIonTypeOf) "ionTypeOf!" term : term -- declare the syntax
 
@@ -211,7 +211,7 @@ meta def declareIonTypeOfImpl : Elab.Term.TermElab := fun stx _ =>
           | .app (.const ``List [_]) (.const fldName []) => pure fldName
           | _ =>
             throw <| .error fld m!"Expected a named type instead of {repr fldType}"
-    trace[Strata.ionTypeOf] "Type is {fldName}"
+    trace[StrataDDM.ionTypeOf] "Type is {fldName}"
     return toExpr fldName
   | _ =>
     throwUnsupportedSyntax
@@ -301,7 +301,7 @@ public meta def declareIonSymbolTableImpl : Command.CommandElab := fun stx =>
     Command.elabCommand =<< `(
       def $toIon (x : $tp) : ByteArray :=
         let (tbl, v) := $toIonPair x
-        _root_.Ion.serialize #[tbl.localSymbolTableValue, v]
+        serialize #[tbl.localSymbolTableValue, v]
     )
   | _ =>
     throwUnsupportedSyntax

--- a/StrataDDM/StrataDDM/Util/Ion/Serialize.lean
+++ b/StrataDDM/StrataDDM/Util/Ion/Serialize.lean
@@ -8,7 +8,7 @@ module
 public import StrataDDM.Util.Ion.AST
 import all StrataDDM.Util.ByteArray
 
-namespace Strata.ByteArray
+namespace StrataDDM.ByteArray
 
 theorem size_set (a : ByteArray) (i : Nat) (v : UInt8) (p : _) : (a.set i v p).size = a.size := by
   simp only [ByteArray.set, ByteArray.size, Array.set]
@@ -31,7 +31,9 @@ theorem zeros_size (n : Nat) : (zeros n).size = n := by
     simp_all
     exact hyp
 
-end Strata.ByteArray
+end StrataDDM.ByteArray
+
+open StrataDDM.ByteArray (zeros size_set)
 
 namespace Ion
 
@@ -42,7 +44,7 @@ namespace ByteVector
 @[inline]
 def set {n} (bs : ByteVector n) (i : Nat) (b : UInt8) (p : i < n := by get_elem_tactic) : ByteVector n :=
   match bs with
-  | ⟨a, p⟩ => ⟨a.set i b, by simp [Strata.ByteArray.size_set]; exact p⟩
+  | ⟨a, p⟩ => ⟨a.set i b, by simp [size_set]; exact p⟩
 
 def setBytes {n} (v : ByteVector n) (off : Nat) (bs : ByteArray)
      (p : off + bs.size ≤ n) : ByteVector n :=
@@ -73,7 +75,7 @@ def setFoldrBytes {n} {α} (s : Nat) (e : Nat) (ep : e ≤ n) (f : α → UInt8 
       (cur : ByteVector n) : ByteVector n :=
   setFoldrBytes' s e ep f (fun _ bytes => bytes) x cur
 
-open Strata
+open StrataDDM
 
 def zeros (n : Nat) : ByteVector n :=
   ⟨.zeros n, ByteArray.zeros_size n⟩
@@ -156,13 +158,13 @@ def withReserve (cnt : Nat)
     let prev_size := prev_size + (cur.size - next)
     let min := SerializeState.init_cap
     if p : min > cnt then
-      let cur := Strata.ByteArray.zeros min
+      let cur := zeros min
       let next' := min - cnt
       have p : cur.size = min := by simp [cur]
       let ⟨cur, curp⟩ := act ⟨cur, p⟩ next' (by omega)
       { prev, prev_size, cur, next := next', next_valid := by omega }
     else
-      let cur := Strata.ByteArray.zeros cnt
+      let cur := zeros cnt
       have p : cur.size = cnt := by simp [cur]
       let ⟨cur, curp⟩ := act ⟨cur, p⟩ 0 (by omega)
       { prev, prev_size, cur, next := 0, next_valid := by omega }

--- a/StrataDDM/StrataDDM/Util/Lean.lean
+++ b/StrataDDM/StrataDDM/Util/Lean.lean
@@ -76,7 +76,7 @@ def mkRootIdent (name : Name) : Ident :=
 end Lean
 
 public section
-namespace Strata.Lean
+namespace StrataDDM.Lean
 
 @[inline]
 def arrayToExpr (level : Level) (type : Expr) (a : Array Expr) : Expr :=
@@ -96,5 +96,5 @@ def optionToExpr (type : Lean.Expr) (a : Option Lean.Expr) : Lean.Expr :=
   | some a => mkApp2 (mkConst ``Option.some [levelZero]) type a
 
 
-end Strata.Lean
+end StrataDDM.Lean
 end section

--- a/StrataDDM/StrataDDM/Util/SourceRange.lean
+++ b/StrataDDM/StrataDDM/Util/SourceRange.lean
@@ -8,7 +8,7 @@ module
 public import Lean.Data.Position
 
 public section
-namespace Strata
+namespace StrataDDM
 
 /--
 Source location information in the DDM is defined
@@ -50,5 +50,5 @@ def format (loc : SourceRange) (path : System.FilePath) (fm : Lean.FileMap) : St
     else
       s!"{path}:{spos.line}:{spos.column+1}"
 
-end Strata.SourceRange
+end StrataDDM.SourceRange
 end

--- a/StrataDDM/StrataDDM/Util/String.lean
+++ b/StrataDDM/StrataDDM/Util/String.lean
@@ -84,7 +84,7 @@ info: [""]
 end String
 
 public section
-namespace Strata
+namespace StrataDDM
 
 /--
 Return true if this is a non-printable 8-bit character
@@ -135,5 +135,5 @@ private def escapeSMTStringLitAux (acc : String) (c : Char) : String :=
 def escapeSMTStringLit (s : String) : String :=
   s.foldl escapeSMTStringLitAux "\"" ++ "\""
 
-end Strata
+end StrataDDM
 end

--- a/StrataDDM/StrataDDMTest/ASTTests.lean
+++ b/StrataDDM/StrataDDMTest/ASTTests.lean
@@ -7,8 +7,8 @@ module
 
 meta import StrataDDM.AST
 
-namespace Strata.AST.Tests
+namespace StrataDDMTest.AST
 
 #guard q`A.C = { dialect := "A", name := "C" }
 
-end Strata.AST.Tests
+end StrataDDMTest.AST

--- a/StrataDDM/StrataDDMTest/Integration/Lean/Gen.lean
+++ b/StrataDDM/StrataDDMTest/Integration/Lean/Gen.lean
@@ -12,13 +12,13 @@ Tests for `#strata_gen`: exercises empty dialects, a dialect with types,
 expressions, and mutual recursion, and verifies round-trip correctness.
 -/
 
-namespace Strata
+namespace StrataDDM
 
 class IsAST (β : Type → Type) (M : outParam (Type → Type)) where
   toAst {α} [Inhabited α] : β α → M α
   ofAst {α} [Inhabited α] [Repr α] : M α → OfAstM (β α)
 
-end Strata
+end StrataDDM
 
 -- Make sure empty dialect works
 namespace EmptyD
@@ -29,7 +29,7 @@ dialect EmptyDialect;
 
 
 #guard_msgs in
-set_option trace.Strata.generator true in
+set_option trace.StrataDDM.generator true in
 #strata_gen EmptyDialect
 
 end EmptyD
@@ -47,30 +47,30 @@ op cmd (tp : Type, a : tp) : Command => "cmd " a;
 
 
 /--
-trace: [Strata.generator] Generating Expr
+trace: [StrataDDM.generator] Generating Expr
 ---
-trace: [Strata.generator] Generating Expr.toAst
+trace: [StrataDDM.generator] Generating Expr.toAst
 ---
-trace: [Strata.generator] Generating Expr.ofAst
+trace: [StrataDDM.generator] Generating Expr.ofAst
 ---
-trace: [Strata.generator] Generating EmptyExprDialectType
+trace: [StrataDDM.generator] Generating EmptyExprDialectType
 ---
-trace: [Strata.generator] Generating EmptyExprDialectType.toAst
+trace: [StrataDDM.generator] Generating EmptyExprDialectType.toAst
 ---
-trace: [Strata.generator] Generating EmptyExprDialectType.ofAst
+trace: [StrataDDM.generator] Generating EmptyExprDialectType.ofAst
 ---
-trace: [Strata.generator] Generating Command
+trace: [StrataDDM.generator] Generating Command
 ---
-trace: [Strata.generator] Generating Command.toAst
+trace: [StrataDDM.generator] Generating Command.toAst
 ---
-trace: [Strata.generator] Generating Command.ofAst
+trace: [StrataDDM.generator] Generating Command.ofAst
 ---
-trace: [Strata.generator] ✅️ Declarations group: [Init.Expr]
-[Strata.generator] ✅️ Declarations group: [Init.Type]
-[Strata.generator] ✅️ Declarations group: [Init.Command]
+trace: [StrataDDM.generator] ✅️ Declarations group: [Init.Expr]
+[StrataDDM.generator] ✅️ Declarations group: [Init.Type]
+[StrataDDM.generator] ✅️ Declarations group: [Init.Command]
 -/
 #guard_msgs in
-set_option trace.Strata.generator true in
+set_option trace.StrataDDM.generator true in
 #strata_gen EmptyExprDialect
 
 end EmptyExprD
@@ -116,6 +116,7 @@ op mkMutACommaSep (a : CommaSepBy MutA) : MutACommaSep => a;
 #end
 
 namespace TestDialect
+open StrataDDM (Ann ArgF IsAST ExprF SepFormat TypeExprF)
 
 #strata_gen TestDialect
 
@@ -124,9 +125,9 @@ info: private inductive TestDialect.test : Type → Type
 number of parameters: 1
 constructors:
 _private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.foo : {α : Type} → α → Expr α → test α
-_private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.identTest : {α : Type} → α → Strata.Ann String α → test α
-_private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.numTest : {α : Type} → α → Strata.Ann Nat α → test α
-_private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.strTest : {α : Type} → α → Strata.Ann String α → test α
+_private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.identTest : {α : Type} → α → Ann String α → test α
+_private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.numTest : {α : Type} → α → Ann Nat α → test α
+_private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.test.strTest : {α : Type} → α → Ann String α → test α
 
 -/
 #guard_msgs in
@@ -161,13 +162,13 @@ _private.StrataDDMTest.Integration.Lean.Gen.0.TestDialect.TypeP.type : {α : Typ
 #print TypeP
 
 /--
-info: Strata.ExprF.fvar () 1
+info: ExprF.fvar () 1
 -/
 #guard_msgs in
 #eval Expr.fvar () 1 |>.toAst
 
 /--
-info: private opaque TestDialect.Expr.toAst : {α : Type} → [Inhabited α] → Expr α → Strata.ExprF α
+info: private opaque TestDialect.Expr.toAst : {α : Type} → [Inhabited α] → Expr α → ExprF α
 -/
 #guard_msgs in
 #print Expr.toAst
@@ -212,16 +213,16 @@ deriving instance BEq for Binding
 deriving instance BEq for Bindings
 deriving instance BEq for Expr
 
-instance : Strata.IsAST Expr Strata.ExprF where
+instance : IsAST Expr ExprF where
   toAst := Expr.toAst
   ofAst := Expr.ofAst
 
-instance : Strata.IsAST TestDialectType Strata.TypeExprF where
+instance : IsAST TestDialectType TypeExprF where
   toAst := TestDialectType.toAst
   ofAst := TestDialectType.ofAst
 
-def testRoundTrip {β M} [h : Strata.IsAST β M] [BEq (β Unit)] (e : β Unit) : Bool :=
-  match e |> Strata.IsAST.toAst |> Strata.IsAST.ofAst with
+def testRoundTrip {β M} [h : IsAST β M] [BEq (β Unit)] (e : β Unit) : Bool :=
+  match e |> IsAST.toAst |> IsAST.ofAst with
   | .error _ => false
   | .ok g => e == g
 
@@ -235,17 +236,17 @@ def testRoundTrip {β M} [h : Strata.IsAST β M] [BEq (β Unit)] (e : β Unit) :
 #guard testRoundTrip <| Expr.app () (.fvar () 0) (.trueExpr ())
 #guard testRoundTrip <| Expr.app () (.app () (.fvar () 0) (.trueExpr ())) (.fvar () 1)
 
-open Strata (OfAstM)
+open StrataDDM (OfAstM)
 
 /--
-info: Strata.ExprF.app ()
-  (Strata.ExprF.app ()
-    (Strata.ExprF.app () (Strata.ExprF.fn () { dialect := "TestDialect", name := "lambda" })
-      (Strata.ArgF.type (Strata.TypeExprF.ident () { dialect := "TestDialect", name := "bool" } (Array.mkEmpty 0))))
-    (Strata.ArgF.op
+info: ExprF.app ()
+  (ExprF.app ()
+    (ExprF.app () (ExprF.fn () { dialect := "TestDialect", name := "lambda" })
+      (ArgF.type (TypeExprF.ident () { dialect := "TestDialect", name := "bool" } (Array.mkEmpty 0))))
+    (ArgF.op
       { ann := (), name := { dialect := "TestDialect", name := "mkBindings" },
-        args := (Array.mkEmpty 1).push (Strata.ArgF.seq () Strata.SepFormat.comma (Array.mkEmpty 0)) }))
-  (Strata.ArgF.expr (Strata.ExprF.fn () { dialect := "TestDialect", name := "trueExpr" }))
+        args := (Array.mkEmpty 1).push (ArgF.seq () SepFormat.comma (Array.mkEmpty 0)) }))
+  (ArgF.expr (ExprF.fn () { dialect := "TestDialect", name := "trueExpr" }))
 -/
 #guard_msgs in
 #eval Expr.lambda () (.bool ()) (.mkBindings () ⟨(), #[]⟩) (.trueExpr ()) |>.toAst

--- a/StrataDDM/StrataDDMTest/Ion.lean
+++ b/StrataDDM/StrataDDMTest/Ion.lean
@@ -10,9 +10,9 @@ import all StrataDDM.Ion
 import StrataDDM.BuiltinDialects.StrataDDL
 import StrataDDM.Integration.Lean
 
-namespace Strata
+open Ion (SymbolTable Ion SymbolId)
 
-open _root_.Ion (SymbolTable Ion SymbolId)
+namespace StrataDDM
 
 def testRoundTrip {α} [FromIon α] [BEq α] [Inhabited α] (toF : α → ByteArray) (init : α) : Bool :=
   let bs := toF init

--- a/StrataDDM/StrataDDMTest/LoadDialect.lean
+++ b/StrataDDM/StrataDDMTest/LoadDialect.lean
@@ -11,7 +11,9 @@ Test the #load_dialect command and also validate example dialects parse.
 
 import StrataDDM.Integration.Lean
 
-namespace Strata.Test
+open StrataDDM (Ann)
+
+namespace StrataDDMTest
 
 /--
 error: Could not find file INVALID!
@@ -35,7 +37,7 @@ namespace Bool
 
 -- Test that boolLit has the expected signature
 /--
-info: Strata.Test.Bool.Expr.boolLit {α : Type} : α → (b : Ann _root_.Bool α) → Expr α
+info: StrataDDMTest.Bool.Expr.boolLit {α : Type} : α → (b : Ann _root_.Bool α) → Expr α
 -/
 #guard_msgs in
 #check Expr.boolLit

--- a/StrataDDM/StrataDDMTest/PipeIdent.lean
+++ b/StrataDDM/StrataDDMTest/PipeIdent.lean
@@ -7,7 +7,7 @@ module
 
 import StrataDDM.Integration.Lean
 
-open Strata
+open StrataDDM
 
 -- Test dialect for pipe-delimited identifiers (SMT-LIB 2.6 syntax)
 #dialect

--- a/StrataDDM/StrataDDMTest/Prec.lean
+++ b/StrataDDM/StrataDDMTest/Prec.lean
@@ -8,6 +8,8 @@ module
 import StrataDDM.Integration.Lean
 import StrataDDM.Format
 
+open StrataDDM
+
 #dialect
 dialect TestPrec;
 
@@ -22,7 +24,7 @@ fn xor (a : bool, b : bool) : bool => @[prec(12)] a " ^^ " b;
 op assert (b : bool) : Command => "assert " b ";\n";
 #end
 
-def ppParen (pgm : Strata.Program) :=
+def ppParen (pgm : Program) :=
   IO.println <| toString <| pgm |>.format {alwaysParen := true }
 
 /--

--- a/StrataDDM/StrataDDMTest/TestGrammar.lean
+++ b/StrataDDM/StrataDDMTest/TestGrammar.lean
@@ -11,7 +11,7 @@ import StrataDDM.Elab
 /-
 Allows testing whether a DDM dialect can parse and print a given program without losing information.
 -/
-open Strata
+open StrataDDM
 
 namespace StrataDDMTest
 
@@ -65,7 +65,7 @@ structure GrammarTestResult where
 def testGrammarFile (dialect: Dialect) (ctx : Lean.Parser.InputContext) : IO GrammarTestResult := do
   try
     let loaded := .ofDialects! #[initDialect, dialect]
-    let ddmProgram ← Strata.Elab.parseStrataProgramFromDialect loaded dialect.name ctx
+    let ddmProgram ← Elab.parseStrataProgramFromDialect loaded dialect.name ctx
     let formatted := toString ddmProgram
     let normalizedInput := normalizeWhitespace <| stripComments <|
       s!"program {dialect.name}; " ++ ctx.inputString

--- a/StrataDDM/StrataDDMTest/UnwrapSimple.lean
+++ b/StrataDDM/StrataDDMTest/UnwrapSimple.lean
@@ -7,7 +7,7 @@ module
 
 import StrataDDM.Integration.Lean
 
-open Strata
+open StrataDDM
 
 #dialect
 dialect TestUnwrap;

--- a/StrataDDM/StrataDDMTest/Util/DecimalRatTests.lean
+++ b/StrataDDM/StrataDDMTest/Util/DecimalRatTests.lean
@@ -7,9 +7,9 @@ module
 
 meta import StrataDDM.Util.DecimalRat
 
-namespace Strata.Decimal.Tests
+namespace StrataDDM.Decimal.Tests
 
-open Strata.Decimal
+open StrataDDM.Decimal
 
 #guard Decimal.fromRat (5 : Rat) = some (Decimal.mk 5 0)
 #guard Decimal.fromRat (0 : Rat) = some Decimal.zero
@@ -33,4 +33,4 @@ open Strata.Decimal
 #guard (Decimal.fromRat (1/2 : Rat)).get!.toRat = (1/2 : Rat)
 #guard (Decimal.fromRat (22/5 : Rat)).get!.toRat = (22/5 : Rat)
 
-end Strata.Decimal.Tests
+end StrataDDM.Decimal.Tests

--- a/StrataDDM/StrataDDMTest/Util/DecimalTests.lean
+++ b/StrataDDM/StrataDDMTest/Util/DecimalTests.lean
@@ -7,9 +7,9 @@ module
 
 meta import StrataDDM.Util.Decimal
 
-namespace Strata.Decimal.Tests
+namespace StrataDDM.Decimal.Tests
 
-open Strata
+open StrataDDM
 
 #guard s!"{Decimal.mk 0 0}" = "0.0"
 #guard s!"{Decimal.mk 1 0}" = "1.0"
@@ -28,4 +28,4 @@ open Strata
 #guard s!"{Decimal.mk 1 (-3)}"  = "0.001"
 #guard s!"{Decimal.mk (-2) (-2)}" = "-0.02"
 
-end Strata.Decimal.Tests
+end StrataDDM.Decimal.Tests

--- a/StrataDDM/StrataDDMTest/Util/Graph/TarjanTests.lean
+++ b/StrataDDM/StrataDDMTest/Util/Graph/TarjanTests.lean
@@ -7,10 +7,10 @@ module
 
 meta import StrataDDM.Util.Graph.Tarjan
 
-namespace Strata.OutGraph.Tests
+namespace StrataDDM.OutGraph.Tests
 
-open Strata.OutGraph
+open StrataDDM.OutGraph
 
 #guard tarjan (.ofEdges! 5 [(0, 1), (1, 2), (2, 3), (2, 0), (2, 4), (4, 3), (4, 1)]) == #[#[0, 1, 2, 4], #[3]]
 
-end Strata.OutGraph.Tests
+end StrataDDM.OutGraph.Tests

--- a/StrataDDM/StrataDDMTest/Util/Ion.lean
+++ b/StrataDDM/StrataDDMTest/Util/Ion.lean
@@ -10,7 +10,7 @@ meta import StrataDDM.Util.Ion
 import StrataDDM.Util.Ion
 
 open Ion
-open Strata
+open StrataDDM
 
 def example2 : Ion String := .struct #[
   ("foo", .null .null),
@@ -52,7 +52,7 @@ def testRoundtrip (v : List (Ion SymbolId)) : Bool :=
 #guard testRoundtrip [.string "", .string "⟨"]
 #guard testRoundtrip [.string "this_is_a_long_name"]
 
-#guard testRoundtrip [.blob <| Strata.ByteArray.zeros 20000]
+#guard testRoundtrip [.blob <| ByteArray.zeros 20000]
 #guard testRoundtrip [.list #[], .list #[.int 1]]
 #guard testRoundtrip [.list (Array.ofFn (n := 8000) fun i => .int i.val)]
 #guard testRoundtrip [.sexp #[], .sexp #[.int 1]]

--- a/StrataMainLib.lean
+++ b/StrataMainLib.lean
@@ -38,6 +38,7 @@ import Strata.Languages.Python.Specs.DDM
 import Strata.Languages.Python.ReadPython
 
 open Strata
+open StrataDDM.Elab (LoadedDialects elabProgram)
 
 open Core (VerifyOptions VerboseMode VerificationMode CheckLevel EntryPoint)
 open Laurel (LaurelVerifyOptions LaurelTranslateOptions)
@@ -131,8 +132,8 @@ def getRepeated (pf : ParsedFlags) (name : String) : Array String :=
 def insert (pf : ParsedFlags) (name : String) (value : Option String) : ParsedFlags :=
   { pf with entries := pf.entries.push (name, value) }
 
-def buildDialectFileMap (pflags : ParsedFlags) : IO Strata.DialectFileMap := do
-  let preloaded := Strata.Elab.LoadedDialects.builtin
+def buildDialectFileMap (pflags : ParsedFlags) : IO StrataDDM.DialectFileMap := do
+  let preloaded := StrataDDM.Elab.LoadedDialects.builtin
     |>.addDialect! Strata.Python.Python
     |>.addDialect! Strata.Python.Specs.DDM.PythonSpecs
     |>.addDialect! Strata.Core
@@ -141,7 +142,7 @@ def buildDialectFileMap (pflags : ParsedFlags) : IO Strata.DialectFileMap := do
     |>.addDialect! Strata.SMTCore
     |>.addDialect! Strata.SMT
     |>.addDialect! Strata.SMTResponse
-  let mut sp ← Strata.DialectFileMap.new preloaded
+  let mut sp ← StrataDDM.DialectFileMap.new preloaded
   for path in pflags.getRepeated "include" do
     match ← sp.add path |>.toBaseIO with
     | .error msg => exitFailure msg
@@ -310,15 +311,15 @@ def parseLaurelVerifyOptions (pflags : ParsedFlags)
     dialects. Returns the parsed program and the input context (for source
     location resolution), or an array of error messages on failure. -/
 private def readStrataProgram (file : String)
-    : IO (Except (Array Lean.Message) (Strata.Program × Lean.Parser.InputContext)) := do
+    : IO (Except (Array Lean.Message) (StrataDDM.Program × Lean.Parser.InputContext)) := do
   let text ← Strata.Util.readInputSource file
   let inputCtx := Lean.Parser.mkInputContext text (Strata.Util.displayName file)
-  let dctx := Elab.LoadedDialects.builtin
+  let dctx := LoadedDialects.builtin
   let dctx := dctx.addDialect! Core
   let dctx := dctx.addDialect! C_Simp
   let dctx := dctx.addDialect! B3CST
   let leanEnv ← Lean.mkEmptyEnvironment 0
-  match Strata.Elab.elabProgram dctx leanEnv inputCtx with
+  match elabProgram dctx leanEnv inputCtx with
   | .ok pgm => pure (.ok (pgm, inputCtx))
   | .error msgs => pure (.error msgs)
 
@@ -583,12 +584,12 @@ private def reportUserCodeError (range : SourceRange) (msg : String)
       s!" at line {pos.line}, col {pos.column}"
     | none => ""
   let mut lines := #[
-    s!"(set-info :file {Strata.escapeSMTStringLit filePath})"
+    s!"(set-info :file {StrataDDM.escapeSMTStringLit filePath})"
   ]
   unless range.isNone do
     lines := lines.push s!"(set-info :start {range.start})"
     lines := lines.push s!"(set-info :stop {range.stop})"
-  lines := lines.push s!"(set-info :error-message {Strata.escapeSMTStringLit msg})"
+  lines := lines.push s!"(set-info :error-message {StrataDDM.escapeSMTStringLit msg})"
   for line in lines do
     IO.println line
   IO.FS.Handle.mk "user_errors.txt" .write >>= fun h =>
@@ -891,10 +892,10 @@ def javaGenCommand : Command where
       match ← Strata.readStrataFile fm v[0] with
       | .dialect d => pure d
       | .program _ => exitFailure "Expected a dialect file, not a program file."
-    match Strata.Java.generateDialect d v[1] with
+    match StrataDDM.Java.generateDialect d v[1] with
     | .ok files =>
-      Strata.Java.writeJavaFiles v[2] v[1] files
-      IO.println s!"Generated Java files for {d.name} in {v[2]}/{Strata.Java.packageToPath v[1]}"
+      StrataDDM.Java.writeJavaFiles v[2] v[1] files
+      IO.println s!"Generated Java files for {d.name} in {v[2]}/{StrataDDM.Java.packageToPath v[1]}"
     | .error msg =>
       exitFailure s!"Error generating Java: {msg}"
 
@@ -1112,7 +1113,7 @@ def laurelPrintCommand : Command where
       let c := p.formatContext {}
       let s := p.formatState
       let fmt := p.commands.foldl (init := f!"") fun f cmd =>
-        f ++ (Strata.mformat cmd c s).format
+        f ++ (StrataDDM.mformat cmd c s).format
       IO.println (fmt.pretty 100)
       IO.println ""
 

--- a/StrataTest/Backends/CBMC/GOTO/E2E_CoreToGOTO.lean
+++ b/StrataTest/Backends/CBMC/GOTO/E2E_CoreToGOTO.lean
@@ -24,10 +24,10 @@ meta section
 
 open Strata
 
-private def translateCore (p : Strata.Program) : Core.Program :=
+private def translateCore (p : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram p)).fst
 
-private def coreToGotoJson (p : Strata.Program) :
+private def coreToGotoJson (p : StrataDDM.Program) :
     Except Std.Format (Lean.Json × Lean.Json) := do
   let cprog := translateCore p
   let Env := Lambda.TEnv.default
@@ -188,7 +188,7 @@ procedure caller(out y : int) {
 #end
 
 -- Helper: translate a specific procedure by name
-private def coreToGotoJsonByName (p : Strata.Program) (name : String) :
+private def coreToGotoJsonByName (p : StrataDDM.Program) (name : String) :
     Except Std.Format (Lean.Json × Lean.Json) := do
   let cprog := translateCore p
   let Env := Lambda.TEnv.default
@@ -350,7 +350,7 @@ private def injectPropertySummary (stmts : List Core.Statement) (msg : String)
       .cmd (.cmd (.assert label b (md.withPropertySummary msg)))
     | other => other
 
-private def coreToGotoJsonWithSummary (p : Strata.Program) (summary : String) :
+private def coreToGotoJsonWithSummary (p : StrataDDM.Program) (summary : String) :
     Except Std.Format (Lean.Json × Lean.Json) := do
   let cprog := translateCore p
   let Env := Lambda.TEnv.default

--- a/StrataTest/Backends/CBMC/SimpleAdd/SimpleAdd.lean
+++ b/StrataTest/Backends/CBMC/SimpleAdd/SimpleAdd.lean
@@ -9,6 +9,7 @@ import Strata.Backends.CBMC.GOTO.CoreToCProverGOTO
 import StrataDDM.Integration.Lean
 
 open Std (ToFormat Format format)
+open StrataDDM (Program)
 -------------------------------------------------------------------------------
 
 namespace Strata

--- a/StrataTest/DL/Imperative/DDMTranslate.lean
+++ b/StrataTest/DL/Imperative/DDMTranslate.lean
@@ -91,7 +91,7 @@ _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Expr.bvar : {α 
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Expr.app : {α : Type} →
   α → ArithPrograms.Expr✝ α → ArithPrograms.Expr✝ α → ArithPrograms.Expr✝¹ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Expr.numLit : {α : Type} →
-  α → Strata.Ann Nat α → ArithPrograms.Expr✝ α
+  α → StrataDDM.Ann Nat α → ArithPrograms.Expr✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Expr.btrue : {α : Type} → α → ArithPrograms.Expr✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Expr.bfalse : {α : Type} → α → ArithPrograms.Expr✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Expr.add_expr : {α : Type} →
@@ -132,7 +132,7 @@ info: private inductive ArithPrograms.Label : Type → Type
 number of parameters: 1
 constructors:
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Label.label : {α : Type} →
-  α → Strata.Ann String α → ArithPrograms.Label✝ α
+  α → StrataDDM.Ann String α → ArithPrograms.Label✝ α
 -/
 #guard_msgs in
 #print Label
@@ -145,17 +145,17 @@ info: private inductive ArithPrograms.Command : Type → Type
 number of parameters: 1
 constructors:
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Command.init : {α : Type} →
-  α → Strata.Ann String α → ArithPrograms.ArithProgramsType✝ α → ArithPrograms.Expr✝ α → ArithPrograms.Command✝ α
+  α → StrataDDM.Ann String α → ArithPrograms.ArithProgramsType✝ α → ArithPrograms.Expr✝ α → ArithPrograms.Command✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Command.var : {α : Type} →
-  α → Strata.Ann String α → ArithPrograms.ArithProgramsType✝ α → ArithPrograms.Command✝ α
+  α → StrataDDM.Ann String α → ArithPrograms.ArithProgramsType✝ α → ArithPrograms.Command✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Command.assign : {α : Type} →
-  α → Strata.Ann String α → ArithPrograms.Expr✝ α → ArithPrograms.Command✝ α
+  α → StrataDDM.Ann String α → ArithPrograms.Expr✝ α → ArithPrograms.Command✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Command.assume : {α : Type} →
   α → ArithPrograms.Label✝ α → ArithPrograms.Expr✝ α → ArithPrograms.Command✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Command.assert : {α : Type} →
   α → ArithPrograms.Label✝ α → ArithPrograms.Expr✝ α → ArithPrograms.Command✝ α
 _private.StrataTest.DL.Imperative.DDMDefinition.0.ArithPrograms.Command.havoc : {α : Type} →
-  α → Strata.Ann String α → ArithPrograms.Command✝ α
+  α → StrataDDM.Ann String α → ArithPrograms.Command✝ α
 -/
 #guard_msgs in
 #print Command
@@ -193,10 +193,10 @@ def translateCommand (bindings : TransBindings) (c : ArithPrograms.Command α) :
   | .havoc _ name =>
     return ((.set name.val .nondet .empty), bindings)
 
-partial def translateProgram (ops : Array Strata.Operation) : TransM Arith.Commands := do
+partial def translateProgram (ops : Array StrataDDM.Operation) : TransM Arith.Commands := do
   let (cmds, _) ← go 0 ops.size {} ops
   return cmds
-  where go (count max : Nat) (bindings : TransBindings) (ops : Array Strata.Operation)
+  where go (count max : Nat) (bindings : TransBindings) (ops : Array StrataDDM.Operation)
       : TransM (Arith.Commands × TransBindings) := do
   match (max - count) with
   | 0 => return ([], bindings)

--- a/StrataTest/DL/Imperative/Examples.lean
+++ b/StrataTest/DL/Imperative/Examples.lean
@@ -9,6 +9,7 @@ meta import all StrataTest.DL.Imperative.Verify
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/DL/Imperative/Verify.lean
+++ b/StrataTest/DL/Imperative/Verify.lean
@@ -87,6 +87,7 @@ end Arith
 
 namespace Strata
 namespace ArithPrograms
+open StrataDDM (Program)
 
 def verify (pgm : Program)
     (verbose : Bool := false) : IO (Imperative.VCResults Arith.PureExpr) := do

--- a/StrataTest/DL/SMT/DDMTransform/TranslateTests.lean
+++ b/StrataTest/DL/SMT/DDMTransform/TranslateTests.lean
@@ -11,6 +11,8 @@ meta section
 
 /-! ## Tests for SMT DDM Translate -/
 
+open StrataDDM (Decimal)
+
 namespace Strata.SMTDDM
 
 /-- info: Except.ok "(+ 10 20)" -/

--- a/StrataTest/Languages/B3/DDMFormatDeclarationsTests.lean
+++ b/StrataTest/Languages/B3/DDMFormatDeclarationsTests.lean
@@ -20,6 +20,7 @@ Verifies that DDM AST → B3 AST → B3 CST → formatted output preserves struc
 namespace B3
 
 open Std (Format)
+open StrataDDM
 open Strata
 open Strata.B3CST
 

--- a/StrataTest/Languages/B3/DDMFormatExpressionsTests.lean
+++ b/StrataTest/Languages/B3/DDMFormatExpressionsTests.lean
@@ -27,6 +27,7 @@ meta section
 namespace B3
 
 open Std (Format)
+open StrataDDM
 open Strata
 open Strata.B3CST
 

--- a/StrataTest/Languages/B3/DDMFormatProgramsTests.lean
+++ b/StrataTest/Languages/B3/DDMFormatProgramsTests.lean
@@ -21,6 +21,7 @@ Verifies that DDM AST → B3 AST → B3 CST → formatted output preserves struc
 namespace B3
 
 open Std (Format)
+open StrataDDM
 open Strata
 open Strata.B3CST
 

--- a/StrataTest/Languages/B3/DDMFormatStatementsTests.lean
+++ b/StrataTest/Languages/B3/DDMFormatStatementsTests.lean
@@ -20,6 +20,7 @@ Verifies that DDM AST → B3 AST → B3 CST → formatted output preserves struc
 namespace B3
 
 open Std (Format)
+open StrataDDM
 open Strata
 open Strata.B3CST
 

--- a/StrataTest/Languages/B3/DDMFormatTests.lean
+++ b/StrataTest/Languages/B3/DDMFormatTests.lean
@@ -22,6 +22,7 @@ Provides string cleanup functions and shared formatting infrastructure used acro
 namespace B3
 
 open Std (Format)
+open StrataDDM
 open Strata
 open Strata.B3CST
 

--- a/StrataTest/Languages/B3/Verifier/TranslationTests.lean
+++ b/StrataTest/Languages/B3/Verifier/TranslationTests.lean
@@ -21,6 +21,7 @@ These tests verify the generated SMT-LIB output without running solvers.
 
 namespace B3.Verifier.TranslationTests
 
+open StrataDDM
 open Strata
 open Strata.B3.Verifier
 

--- a/StrataTest/Languages/B3/Verifier/VerifierTests.lean
+++ b/StrataTest/Languages/B3/Verifier/VerifierTests.lean
@@ -75,6 +75,7 @@ These tests run the actual solver and test check, assert, reach statements with 
 
 namespace B3.Verifier.Tests
 
+open StrataDDM
 open Strata
 open Strata.B3.Verifier
 open Strata.SMT

--- a/StrataTest/Languages/C_Simp/Examples/LoopElimTests.lean
+++ b/StrataTest/Languages/C_Simp/Examples/LoopElimTests.lean
@@ -86,6 +86,7 @@ through `to_core` to test the nondet loop elimination path.
 -/
 
 open Strata in
+open StrataDDM in
 open Strata.C_Simp in
 private def nondetLoopProgram : C_Simp.Program :=
   let md : Imperative.MetaData Expression := .empty

--- a/StrataTest/Languages/Core/Examples/BinaryTreeSize.lean
+++ b/StrataTest/Languages/Core/Examples/BinaryTreeSize.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Binary Tree Size Test
 

--- a/StrataTest/Languages/Core/Examples/BitVecParse.lean
+++ b/StrataTest/Languages/Core/Examples/BitVecParse.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/CallElim.lean
+++ b/StrataTest/Languages/Core/Examples/CallElim.lean
@@ -10,6 +10,7 @@ meta import Strata.Transform.CallElim
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/DDMAxiomsExtraction.lean
+++ b/StrataTest/Languages/Core/Examples/DDMAxiomsExtraction.lean
@@ -10,6 +10,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/Languages/Core/Examples/DDMTransform.lean
+++ b/StrataTest/Languages/Core/Examples/DDMTransform.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/DatatypeAlias.lean
+++ b/StrataTest/Languages/Core/Examples/DatatypeAlias.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Datatype with Type Alias Test
 

--- a/StrataTest/Languages/Core/Examples/DatatypeEnum.lean
+++ b/StrataTest/Languages/Core/Examples/DatatypeEnum.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Datatype Enum Integration Test
 

--- a/StrataTest/Languages/Core/Examples/DatatypeList.lean
+++ b/StrataTest/Languages/Core/Examples/DatatypeList.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Datatype List Integration Test
 

--- a/StrataTest/Languages/Core/Examples/DatatypeOption.lean
+++ b/StrataTest/Languages/Core/Examples/DatatypeOption.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Datatype Option Integration Test
 

--- a/StrataTest/Languages/Core/Examples/DatatypeTree.lean
+++ b/StrataTest/Languages/Core/Examples/DatatypeTree.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Datatype Tree Integration Test
 

--- a/StrataTest/Languages/Core/Examples/Exit.lean
+++ b/StrataTest/Languages/Core/Examples/Exit.lean
@@ -11,6 +11,7 @@ meta import StrataTest.Languages.Core.Examples.Loops
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/FreeRequireEnsure.lean
+++ b/StrataTest/Languages/Core/Examples/FreeRequireEnsure.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/Functions.lean
+++ b/StrataTest/Languages/Core/Examples/Functions.lean
@@ -10,6 +10,7 @@ meta import Strata.Languages.Core.CallGraph
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/Havoc.lean
+++ b/StrataTest/Languages/Core/Examples/Havoc.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/Loops.lean
+++ b/StrataTest/Languages/Core/Examples/Loops.lean
@@ -19,6 +19,7 @@ import StrataDDM.Integration.Lean.HashCommands
 import Strata.Languages.Core.StatementSemantics
 
 public section
+open StrataDDM (Program)
 namespace Strata
 
 def singleCFG (p : Program) (n : Nat) : Imperative.CFG String

--- a/StrataTest/Languages/Core/Examples/Min.lean
+++ b/StrataTest/Languages/Core/Examples/Min.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/MutualDatatypes.lean
+++ b/StrataTest/Languages/Core/Examples/MutualDatatypes.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Mutual Datatype Integration Tests
 

--- a/StrataTest/Languages/Core/Examples/OldExpressions.lean
+++ b/StrataTest/Languages/Core/Examples/OldExpressions.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/ProcedureCall.lean
+++ b/StrataTest/Languages/Core/Examples/ProcedureCall.lean
@@ -10,6 +10,7 @@ meta import Strata.Languages.Core.CallGraph
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/RealBitVector.lean
+++ b/StrataTest/Languages/Core/Examples/RealBitVector.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/RecursiveProcIte.lean
+++ b/StrataTest/Languages/Core/Examples/RecursiveProcIte.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/RemoveIrrelevantAxioms.lean
+++ b/StrataTest/Languages/Core/Examples/RemoveIrrelevantAxioms.lean
@@ -12,7 +12,7 @@ meta section
 ---------------------------------------------------------------------
 namespace Strata
 
-def irrelevantAxiomsTestPgm : Strata.Program :=
+def irrelevantAxiomsTestPgm : StrataDDM.Program :=
 #strata
 program Core;
 type StrataHeap;

--- a/StrataTest/Languages/Core/Examples/SelectiveVerification.lean
+++ b/StrataTest/Languages/Core/Examples/SelectiveVerification.lean
@@ -10,6 +10,7 @@ meta import Strata.Languages.Core.CallGraph
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/SimpleProc.lean
+++ b/StrataTest/Languages/Core/Examples/SimpleProc.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/SubstFvarsCaptureTests.lean
+++ b/StrataTest/Languages/Core/Examples/SubstFvarsCaptureTests.lean
@@ -11,6 +11,7 @@ import StrataDDM.Integration.Lean.HashCommands
 import Strata.Languages.Core.StatementEval
 
 meta section
+open StrataDDM (Program)
 /-! # Simultaneous substitution tests (Issue 653)
 
 Tests verifying that simultaneous substitution (`substFvars` /

--- a/StrataTest/Languages/Core/Examples/TermFormula.lean
+++ b/StrataTest/Languages/Core/Examples/TermFormula.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 /-!
 # Term/Formula Deep Embedding
 

--- a/StrataTest/Languages/Core/Examples/TypeAlias.lean
+++ b/StrataTest/Languages/Core/Examples/TypeAlias.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/TypeDecl.lean
+++ b/StrataTest/Languages/Core/Examples/TypeDecl.lean
@@ -10,6 +10,7 @@ import Strata.Languages.Core.DDMTransform.Translate
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 ---------------------------------------------------------------------
 namespace Strata
 

--- a/StrataTest/Languages/Core/Examples/TypeDeclStmt.lean
+++ b/StrataTest/Languages/Core/Examples/TypeDeclStmt.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 namespace Strata
 
 /-- Basic uninterpreted type declaration with equality reasoning -/

--- a/StrataTest/Languages/Core/Tests/AtSignDisambiguationTest.lean
+++ b/StrataTest/Languages/Core/Tests/AtSignDisambiguationTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-! ## Test: parameter names containing `@` are disambiguated from `@N` suffixes
 

--- a/StrataTest/Languages/Core/Tests/DatatypeTests.lean
+++ b/StrataTest/Languages/Core/Tests/DatatypeTests.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Datatype Verification Tests

--- a/StrataTest/Languages/Core/Tests/DatatypeTypingTests.lean
+++ b/StrataTest/Languages/Core/Tests/DatatypeTypingTests.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Datatype Typing Tests

--- a/StrataTest/Languages/Core/Tests/DuplicateAssumeLabels.lean
+++ b/StrataTest/Languages/Core/Tests/DuplicateAssumeLabels.lean
@@ -10,6 +10,7 @@ meta import Strata.Transform.CallElim
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/Languages/Core/Tests/FuncDeclStmtTest.lean
+++ b/StrataTest/Languages/Core/Tests/FuncDeclStmtTest.lean
@@ -13,7 +13,7 @@ meta section
 open Core
 open Strata
 
-def translate (t : Strata.Program) : Core.Program :=
+def translate (t : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram t)).fst
 
 def simpleFuncDeclPgm :=

--- a/StrataTest/Languages/Core/Tests/FuncTypeCheckBody.lean
+++ b/StrataTest/Languages/Core/Tests/FuncTypeCheckBody.lean
@@ -10,6 +10,7 @@ meta import Strata.Languages.Core.CallGraph
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/Languages/Core/Tests/FunctionDeclDDMTest.lean
+++ b/StrataTest/Languages/Core/Tests/FunctionDeclDDMTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/Languages/Core/Tests/GeneratedLabels.lean
+++ b/StrataTest/Languages/Core/Tests/GeneratedLabels.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/Languages/Core/Tests/IfElsePrecedenceTest.lean
+++ b/StrataTest/Languages/Core/Tests/IfElsePrecedenceTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # If-Then-Else Precedence Regression Test (Issue #491)

--- a/StrataTest/Languages/Core/Tests/InlineAssertionMetadataTest.lean
+++ b/StrataTest/Languages/Core/Tests/InlineAssertionMetadataTest.lean
@@ -23,7 +23,7 @@ namespace Core.InlineAssertionMetadata.Tests
 
 open Imperative
 
-private def inlineAssertPgm : Strata.Program :=
+private def inlineAssertPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure callee() {

--- a/StrataTest/Languages/Core/Tests/Issue1146Test.lean
+++ b/StrataTest/Languages/Core/Tests/Issue1146Test.lean
@@ -23,7 +23,7 @@ namespace Strata.Issue1146Test
 
 /-! ## Canonical form: datatype + function translates without error -/
 
-private def datatypeAndFunction : Strata.Program :=
+private def datatypeAndFunction : StrataDDM.Program :=
 #strata
 program Core;
 
@@ -45,7 +45,7 @@ function Len (xs : List) : int
 error: unexpected token ';'; expected 'function', Core.Block or expected at least one element
 -/
 #guard_msgs in
-def strayTrailingSemi : Strata.Program :=
+def strayTrailingSemi : StrataDDM.Program :=
 #strata
 program Core;
 

--- a/StrataTest/Languages/Core/Tests/LambdaHigherOrderTests.lean
+++ b/StrataTest/Languages/Core/Tests/LambdaHigherOrderTests.lean
@@ -22,7 +22,7 @@ and interactions with polymorphism, recursive functions, and datatypes.
 open Core
 open Strata
 
-def translate (t : Strata.Program) : Core.Program :=
+def translate (t : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram t)).fst
 
 /-! ## Lambda expression parsing and formatting -/

--- a/StrataTest/Languages/Core/Tests/ModelLiftTest.lean
+++ b/StrataTest/Languages/Core/Tests/ModelLiftTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Model Lifting Tests (SMT → LExpr)

--- a/StrataTest/Languages/Core/Tests/MutualRecursiveFunctionErrorTest.lean
+++ b/StrataTest/Languages/Core/Tests/MutualRecursiveFunctionErrorTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Mutual Recursive Function Error Tests

--- a/StrataTest/Languages/Core/Tests/MutualRecursiveFunctionTests.lean
+++ b/StrataTest/Languages/Core/Tests/MutualRecursiveFunctionTests.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Mutual Recursive Function Verification Tests

--- a/StrataTest/Languages/Core/Tests/NestedVarScopingTest.lean
+++ b/StrataTest/Languages/Core/Tests/NestedVarScopingTest.lean
@@ -15,7 +15,7 @@ namespace Strata
 
 open Core
 
-def translatePgm (p : Strata.Program) : Core.Program :=
+def translatePgm (p : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram p)).fst
 
 ---------------------------------------------------------------------
@@ -24,7 +24,7 @@ def translatePgm (p : Strata.Program) : Core.Program :=
 -- body captured variables from the then-branch instead of the else-branch.
 ---------------------------------------------------------------------
 
-def issue436Pgm : Strata.Program :=
+def issue436Pgm : StrataDDM.Program :=
 #strata
 program Core;
 

--- a/StrataTest/Languages/Core/Tests/PolyUnifTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolyUnifTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Polymorphic Unification Test
@@ -66,7 +67,7 @@ function BadFunc (o: Option(int)) : int {
 #end
 
 /--
-info: error: (1357-1430) Impossible to unify (arrow string int) with (arrow int $__ty4).
+info: error: (1382-1455) Impossible to unify (arrow string int) with (arrow int $__ty4).
 First mismatch: string with int.
 -/
 #guard_msgs in

--- a/StrataTest/Languages/Core/Tests/PolymorphicDatatypeTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolymorphicDatatypeTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Polymorphic Datatype Integration Tests

--- a/StrataTest/Languages/Core/Tests/PolymorphicFunctionTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolymorphicFunctionTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Polymorphic Function Integration Tests
@@ -208,7 +209,7 @@ spec {
 #end
 
 /--
-info: error: (4692-4715) Impossible to unify (arrow int bool) with (arrow bool $__ty5).
+info: error: (4717-4740) Impossible to unify (arrow int bool) with (arrow bool $__ty5).
 First mismatch: int with bool.
 -/
 #guard_msgs in

--- a/StrataTest/Languages/Core/Tests/PolymorphicProcedureTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolymorphicProcedureTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Polymorphic Procedure Test

--- a/StrataTest/Languages/Core/Tests/PrecedenceCheck.lean
+++ b/StrataTest/Languages/Core/Tests/PrecedenceCheck.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 ---------------------------------------------------------------------
 namespace Strata

--- a/StrataTest/Languages/Core/Tests/ProgramEvalTests.lean
+++ b/StrataTest/Languages/Core/Tests/ProgramEvalTests.lean
@@ -432,11 +432,11 @@ section ConcreteInterpretation
 open Lambda Strata
 open Std (ToFormat Format format)
 
-private def parseAndTypeCheck (pgm : Strata.Program) : Except DiagnosticModel Core.Program := do
+private def parseAndTypeCheck (pgm : StrataDDM.Program) : Except DiagnosticModel Core.Program := do
   let (cst, _errs) := TransM.run Inhabited.default (translateProgram pgm)
   Core.typeCheck { VerifyOptions.default with verbose := .quiet } cst
 
-private def runProc (pgm : Strata.Program) (procName : String)
+private def runProc (pgm : StrataDDM.Program) (procName : String)
     (args : List Expression.Expr := [])
     (fuel : Nat := 10000) : IO Unit := do
   match parseAndTypeCheck pgm with
@@ -460,7 +460,7 @@ private def runProc (pgm : Strata.Program) (procName : String)
     | .error diag => IO.println s!"error: {diag}"
 
 -- Simple assignment
-private def simplePgm : Strata.Program :=
+private def simplePgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(out y : int)
@@ -474,7 +474,7 @@ procedure Test(out y : int)
 #eval runProc simplePgm "Test"
 
 -- Arithmetic
-private def arithPgm : Strata.Program :=
+private def arithPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(x : int, out y : int)
@@ -488,7 +488,7 @@ procedure Test(x : int, out y : int)
 #eval runProc arithPgm "Test" [.intConst () 5]
 
 -- If-then-else
-private def itePgm : Strata.Program :=
+private def itePgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(x : int, out y : int)
@@ -510,7 +510,7 @@ procedure Test(x : int, out y : int)
 #eval runProc itePgm "Test" [.intConst () (-3)]
 
 -- Procedure call
-private def callPgm : Strata.Program :=
+private def callPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Double(n : int, out result : int)
@@ -528,7 +528,7 @@ procedure Test(x : int, out y : int)
 #eval runProc callPgm "Test" [.intConst () 10]
 
 -- Chained procedure calls (DoubleTwice)
-private def chainedCallPgm : Strata.Program :=
+private def chainedCallPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Double(n : int, out result : int)
@@ -547,7 +547,7 @@ procedure Test(x : int, out output : int)
 #eval runProc chainedCallPgm "Test" [.intConst () 5]
 
 -- Loop (sum of 0..n-1)
-private def loopPgm : Strata.Program :=
+private def loopPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(n : int, out sum : int)
@@ -568,7 +568,7 @@ procedure Test(n : int, out sum : int)
 #eval runProc loopPgm "Test" [.intConst () 5]
 
 -- Assertion success
-private def assertSuccessPgm : Strata.Program :=
+private def assertSuccessPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(out y : int)
@@ -583,7 +583,7 @@ procedure Test(out y : int)
 #eval runProc assertSuccessPgm "Test"
 
 -- Assertion failure
-private def assertFailPgm : Strata.Program :=
+private def assertFailPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(out y : int)
@@ -600,7 +600,7 @@ false
 #eval runProc assertFailPgm "Test"
 
 -- Nested blocks with scoping
-private def blockPgm : Strata.Program :=
+private def blockPgm : StrataDDM.Program :=
 #strata
 program Core;
 procedure Test(out y : int)

--- a/StrataTest/Languages/Core/Tests/QuantifierBvarIndexTest.lean
+++ b/StrataTest/Languages/Core/Tests/QuantifierBvarIndexTest.lean
@@ -14,7 +14,7 @@ meta section
 open Core
 open Strata
 
-def translate (t : Strata.Program) : Core.Program :=
+def translate (t : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram t)).fst
 
 /-! ## Regression test for #1038 (https://github.com/strata-org/Strata/issues/1038)

--- a/StrataTest/Languages/Core/Tests/RecursiveFunctionDDMTest.lean
+++ b/StrataTest/Languages/Core/Tests/RecursiveFunctionDDMTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-! ## DDM parsing tests for recursive functions
 

--- a/StrataTest/Languages/Core/Tests/RecursiveFunctionErrorTest.lean
+++ b/StrataTest/Languages/Core/Tests/RecursiveFunctionErrorTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Recursive Function Error Tests

--- a/StrataTest/Languages/Core/Tests/RecursiveFunctionTests.lean
+++ b/StrataTest/Languages/Core/Tests/RecursiveFunctionTests.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Recursive Function Integration Tests

--- a/StrataTest/Languages/Core/Tests/RoundtripTest.lean
+++ b/StrataTest/Languages/Core/Tests/RoundtripTest.lean
@@ -12,6 +12,7 @@ meta import StrataDDM.BuiltinDialects.Init
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program initDialect)
 
 /-!
 # Core Roundtrip Tests
@@ -30,13 +31,13 @@ open Lean.Parser (InputContext)
 
 /-- Parse a string as a Core program and translate to AST. -/
 private def parseAndTranslate (input : String) : IO Core.Program := do
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Core]
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Core]
   -- Strip "program Core;\n\n" header if present
   let body := if input.startsWith "program Core;\n\n" then
     (input.drop "program Core;\n\n".length).toString
   else input
-  let inputCtx := Strata.Parser.stringInputContext ⟨"roundtrip-test"⟩ body
-  let strataProgram ← Strata.Elab.parseStrataProgramFromDialect dialects "Core" inputCtx
+  let inputCtx := StrataDDM.Parser.stringInputContext ⟨"roundtrip-test"⟩ body
+  let strataProgram ← StrataDDM.Elab.parseStrataProgramFromDialect dialects "Core" inputCtx
   let (ast, errs) := TransM.run Inhabited.default (translateProgram strataProgram)
   if !errs.isEmpty then
     throw (IO.userError s!"Translation errors: {errs}")
@@ -44,7 +45,7 @@ private def parseAndTranslate (input : String) : IO Core.Program := do
 
 /-- Perform a roundtrip test: parse → format → re-parse → compare.
     Prints OK or FAIL with details. -/
-def roundtrip (program : Strata.Program) : IO Unit := do
+def roundtrip (program : StrataDDM.Program) : IO Unit := do
   -- First pass: translate to AST
   let (ast1, errs1) := TransM.run Inhabited.default (translateProgram program)
   if !errs1.isEmpty then

--- a/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
+++ b/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
@@ -418,7 +418,7 @@ private def summaryMd (summary : String) : Imperative.MetaData Core.Expression :
 /-- Metadata carrying only a file range (no property summary); used to
     exercise `addLocationInfo`. -/
 private def fileRangeMd (file : String) : Imperative.MetaData Core.Expression :=
-  Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange (.file file) Strata.SourceRange.none)
+  Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange (.file file) StrataDDM.SourceRange.none)
 
 /-! Embedded double quotes in the property summary must be doubled (`""`). -/
 /--

--- a/StrataTest/Languages/Core/Tests/SarifOutputTests.lean
+++ b/StrataTest/Languages/Core/Tests/SarifOutputTests.lean
@@ -38,13 +38,13 @@ private def mkOutcome (sat val : Result) : VCOutcome :=
 def makeMetadata (file : String) (_line _col : Nat) : MetaData Expression :=
   let uri := Strata.Uri.file file
   -- Create a 1D range (byte offsets). For testing, we use simple offsets.
-  let range : Strata.SourceRange := { start := ⟨0⟩, stop := ⟨10⟩ }
+  let range : StrataDDM.SourceRange := { start := ⟨0⟩, stop := ⟨10⟩ }
   Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange uri range)
 
 /-- Create metadata with a specific byte offset for the file range start. -/
 def makeMetadataAt (file : String) (startByte : Nat) : MetaData Expression :=
   let uri := Strata.Uri.file file
-  let range : Strata.SourceRange := { start := ⟨startByte⟩, stop := ⟨startByte + 10⟩ }
+  let range : StrataDDM.SourceRange := { start := ⟨startByte⟩, stop := ⟨startByte + 10⟩ }
   Imperative.MetaData.ofProvenance (Strata.Provenance.ofSourceRange uri range)
 
 /-- Create a simple FileMap for testing -/

--- a/StrataTest/Languages/Core/Tests/StatisticsTest.lean
+++ b/StrataTest/Languages/Core/Tests/StatisticsTest.lean
@@ -22,7 +22,7 @@ open Strata
 
 /-! ## Core Statistics: simple procedure -/
 
-def statsPgm : Strata.Program :=
+def statsPgm : StrataDDM.Program :=
 #strata
 program Core;
 
@@ -53,7 +53,7 @@ info: [statistics] Evaluator.factoryOps: 286
 
 /-! ## Core Statistics: two procedures with a function -/
 
-def statsPgm2 : Strata.Program :=
+def statsPgm2 : StrataDDM.Program :=
 #strata
 program Core;
 

--- a/StrataTest/Languages/Core/Tests/TerminationCheckTests.lean
+++ b/StrataTest/Languages/Core/Tests/TerminationCheckTests.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Core.Verifier
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 /-!
 # Termination Checking Tests

--- a/StrataTest/Languages/Core/Tests/TestASTtoCST.lean
+++ b/StrataTest/Languages/Core/Tests/TestASTtoCST.lean
@@ -10,6 +10,7 @@ meta import Strata.Languages.Core.DDMTransform.Translate
 import StrataDDM.Integration.Lean.HashCommands
 
 meta section
+open StrataDDM (Program)
 
 -- Tests for Core.Program → CST Conversion
 -- This file tests one-direction conversion: AST → CST using the old
@@ -21,7 +22,7 @@ open Strata.CoreDDM
 open Strata
 open Core
 
-def ASTtoCST (program : Strata.Program) := do
+def ASTtoCST (program : StrataDDM.Program) := do
   -- Use old translator to get AST
   let (ast, errs) := TransM.run Inhabited.default (translateProgram program)
   if !errs.isEmpty then

--- a/StrataTest/Languages/Core/Tests/VCGPathTests.lean
+++ b/StrataTest/Languages/Core/Tests/VCGPathTests.lean
@@ -14,7 +14,7 @@ meta section
 namespace Strata
 
 /-- Extract evaluator statistics from a program without running the solver. -/
-private def getEvalStats (program : Strata.Program)
+private def getEvalStats (program : StrataDDM.Program)
     (options : Core.VerifyOptions := .quiet) : IO (Statistics × Nat) := do
   let (coreProgram, _) := Core.getProgram program
   let coreProgram ← IO.ofExcept (Core.typeCheck options coreProgram)

--- a/StrataTest/Languages/Laurel/AbstractToConcreteTreeTranslatorTest.lean
+++ b/StrataTest/Languages/Laurel/AbstractToConcreteTreeTranslatorTest.lean
@@ -19,13 +19,14 @@ meta import Strata.Languages.Laurel.Grammar.AbstractToConcreteTreeTranslator
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 private def parseLaurel (input : String) : IO Program := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with
@@ -38,7 +39,7 @@ private def laurelToText (prog : Program) : String :=
   let lines := text.splitOn "\n" |>.map (fun s => (s.trimAsciiEnd).toString)
   "\n".intercalate lines
 
-/-- Roundtrip through the DDM tree: Laurel AST → Strata.Program → Laurel AST → text -/
+/-- Roundtrip through the DDM tree: Laurel AST → StrataDDM.Program → Laurel AST → text -/
 private def roundtripViaDDM (prog : Program) : IO String := do
   let strataProgram := programToStrata prog
   match Laurel.TransM.run .none (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/ConstrainedTypeElimTest.lean
+++ b/StrataTest/Languages/Laurel/ConstrainedTypeElimTest.lean
@@ -19,7 +19,8 @@ meta import Strata.Languages.Laurel.Resolution
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
@@ -33,8 +34,8 @@ procedure test(n: nat) returns (r: nat) {
 "
 
 def parseLaurelAndElim (input : String) : IO Program := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/DuplicateNameTests.lean
+++ b/StrataTest/Languages/Laurel/DuplicateNameTests.lean
@@ -21,13 +21,14 @@ meta section
 
 open StrataTest.Util
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 /-- Run only parsing + resolution and return diagnostics (no SMT verification). -/
 private def processResolution (input : Lean.Parser.InputContext) : IO (Array Diagnostic) := do
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name input
   let uri := Strata.Uri.file input.fileName
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/LiftExpressionAssignmentsTest.lean
+++ b/StrataTest/Languages/Laurel/LiftExpressionAssignmentsTest.lean
@@ -20,7 +20,8 @@ meta import Strata.Languages.Laurel.LiftImperativeExpressions
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
@@ -34,8 +35,8 @@ procedure assertInBlockExpr()
 "
 
 def parseLaurelAndLift (input : String) : IO Program := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/LiftHolesTest.lean
+++ b/StrataTest/Languages/Laurel/LiftHolesTest.lean
@@ -21,14 +21,15 @@ meta import Strata.Languages.Laurel.Grammar.AbstractToConcreteTreeTranslator
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 /-- Parse a Laurel source string, resolve, eliminate holes, and print all procedures. -/
 private def parseElimAndPrint (input : String) : IO Unit := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/LiftImperativeCallsInAssertTest.lean
+++ b/StrataTest/Languages/Laurel/LiftImperativeCallsInAssertTest.lean
@@ -20,13 +20,14 @@ meta import Strata.Languages.Laurel.LiftImperativeExpressions
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 private def parseLaurelAndLift (input : String) : IO Program := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/MapStmtExprTest.lean
+++ b/StrataTest/Languages/Laurel/MapStmtExprTest.lean
@@ -21,13 +21,14 @@ meta import Strata.Languages.Laurel.Resolution
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 private def parseLaurel (input : String) : IO Program := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/ResolutionKindTests.lean
+++ b/StrataTest/Languages/Laurel/ResolutionKindTests.lean
@@ -21,13 +21,14 @@ meta section
 
 open StrataTest.Util
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 /-- Run only parsing + resolution and return diagnostics (no SMT verification). -/
 private def processResolution (input : Lean.Parser.InputContext) : IO (Array Diagnostic) := do
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name input
   let uri := Strata.Uri.file input.fileName
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/StatisticsTest.lean
+++ b/StrataTest/Languages/Laurel/StatisticsTest.lean
@@ -21,15 +21,16 @@ meta import Strata.Util.Statistics
 meta section
 
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 
 namespace Strata.Laurel
 
 /-- Parse a Laurel source string and run it through the full Laurel pipeline,
     returning the merged statistics from all passes. -/
 private def parseLaurelAndGetStats (input : String) : IO Statistics := do
-  let inputCtx := Strata.Parser.stringInputContext "test" input
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
   let uri := Strata.Uri.file "test"
   match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with

--- a/StrataTest/Languages/Laurel/TestExamples.lean
+++ b/StrataTest/Languages/Laurel/TestExamples.lean
@@ -17,13 +17,14 @@ meta section
 
 open StrataTest.Util
 open Strata
-open Strata.Elab (parseStrataProgramFromDialect)
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
 open Lean.Parser (InputContext)
 
 namespace Strata.Laurel
 
 def processLaurelFileWithOptions (options : LaurelVerifyOptions) (input : InputContext) : IO (Array Diagnostic) := do
-  let dialects := Strata.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
   let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name input
 
   let uri := Strata.Uri.file input.fileName

--- a/StrataTest/Languages/Python/CorePreludeTest.lean
+++ b/StrataTest/Languages/Python/CorePreludeTest.lean
@@ -9,6 +9,7 @@ meta import Strata.Languages.Python.CorePrelude
 meta import StrataDDM.Ion
 
 meta section
+open StrataDDM (Program)
 
 namespace Strata.Python
 

--- a/StrataTest/Transform/ANFEncoderTests.lean
+++ b/StrataTest/Transform/ANFEncoderTests.lean
@@ -17,7 +17,7 @@ namespace Core.ANFEncoder.Tests
 
 open Strata Lambda Imperative Core.ANFEncoder
 
-private def translateCore (p : Strata.Program) : Core.Program :=
+private def translateCore (p : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram p)).fst
 
 /-! ## ANFEncoder across ITE branches and condition -/

--- a/StrataTest/Transform/CallElim.lean
+++ b/StrataTest/Transform/CallElim.lean
@@ -189,7 +189,7 @@ procedure h(inout j : bool, k : bool) {
 };
 #end
 
-def translate (t : Strata.Program) : Core.Program := (TransM.run Inhabited.default (translateProgram t)).fst
+def translate (t : StrataDDM.Program) : Core.Program := (TransM.run Inhabited.default (translateProgram t)).fst
 
 def env : Lambda.LContext CoreLParams := .default (functions := Core.Factory)
 

--- a/StrataTest/Transform/PrecondElim.lean
+++ b/StrataTest/Transform/PrecondElim.lean
@@ -26,10 +26,10 @@ see `StrataTest/Languages/Core/Examples/FunctionPreconditions.lean`.
 
 section PrecondElimTests
 
-def translate (t : Strata.Program) : Core.Program :=
+def translate (t : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram t)).fst
 
-def transformProgram (t : Strata.Program) : Core.Program :=
+def transformProgram (t : StrataDDM.Program) : Core.Program :=
   let program := translate t
   match Core.Transform.run program PrecondElim.precondElim { Core.Transform.CoreTransformState.emp with factory := some Core.Factory } with
   | .error e => panic! s!"PrecondElim failed: {e}"

--- a/StrataTest/Transform/ProcBodyVerify.lean
+++ b/StrataTest/Transform/ProcBodyVerify.lean
@@ -23,11 +23,11 @@ namespace ProcBodyVerifyTest
 open Core Core.ProcBodyVerify Lambda Transform Imperative
 open Strata
 
-def translate (t : Strata.Program) : Core.Program :=
+def translate (t : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram t)).fst
 
 /-- Helper to show transformed output for a procedure -/
-def showTransformed (prog : Strata.Program) (procName : String) : Except String Std.Format := do
+def showTransformed (prog : StrataDDM.Program) (procName : String) : Except String Std.Format := do
   let p := translate prog
   let some proc := Program.Procedure.find? p procName
     | throw s!"Procedure {procName} not found"

--- a/StrataTest/Transform/ProcedureInlining.lean
+++ b/StrataTest/Transform/ProcedureInlining.lean
@@ -230,7 +230,7 @@ private def alphaEquiv (p1 p2:Core.Procedure):Except Format Bool := do
 
 
 
-def translate (t : Strata.Program) : Core.Program :=
+def translate (t : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram t)).fst
 
 def runInlineCall (p : Core.Program) : Core.Program :=

--- a/StrataTest/Transform/SymbolicEvalTests.lean
+++ b/StrataTest/Transform/SymbolicEvalTests.lean
@@ -18,10 +18,10 @@ namespace Core.SymbolicEval.Tests
 
 open Strata
 
-private def translateCore (p : Strata.Program) : Core.Program :=
+private def translateCore (p : StrataDDM.Program) : Core.Program :=
   (TransM.run Inhabited.default (translateProgram p)).fst
 
-private def evalAndPrint (p : Strata.Program) : IO Unit := do
+private def evalAndPrint (p : StrataDDM.Program) : IO Unit := do
   match typeCheckAndBuildObligationProgram .quiet (translateCore p) with
   | .ok (oblProg, _) =>
     let s := (Core.formatProgram oblProg).pretty

--- a/StrataTest/Util/TestDiagnostics.lean
+++ b/StrataTest/Util/TestDiagnostics.lean
@@ -10,6 +10,7 @@ public import Strata.Languages.Core.Verifier
 import Lean.Elab.Command
 
 open Strata
+open StrataDDM
 open String
 open Lean Elab
 namespace StrataTest.Util

--- a/StrataTestExtra/Languages/Java/TestGen.lean
+++ b/StrataTestExtra/Languages/Java/TestGen.lean
@@ -13,15 +13,15 @@ meta import StrataDDM.Integration.Lean.HashCommands  -- For #load_dialect
 public meta import StrataDDM.Ion
 import Strata.Languages.Core.DDMTransform.Grammar  -- Loads Strata Core dialect into env
 
-namespace Strata.Java.Test
+namespace StrataDDM.Java.Test
 
-open Strata.Java
+open StrataDDM.Java
 
 meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 1: Basic dialect with 2 operators — nested records in category file
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Test"
     imports := #[]
     declarations := #[
@@ -57,7 +57,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 2: Reserved word escaping for fields
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Reserved"
     imports := #[]
     declarations := #[
@@ -80,7 +80,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 3: Name collision (single-op, operator name matches category name) → uses "Of"
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Collision"
     imports := #[]
     declarations := #[
@@ -101,7 +101,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 4: Duplicate operator names across categories — nested so no global collision
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Dup"
     imports := #[]
     declarations := #[
@@ -123,7 +123,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 5: Category name collides with base class
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Base"
     imports := #[]
     declarations := #[
@@ -139,7 +139,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 6: Snake_case to PascalCase conversion
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Snake"
     imports := #[]
     declarations := #[
@@ -159,7 +159,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 7: All DDM types map correctly
 #eval! do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Types"
     imports := #[]
     declarations := #[
@@ -200,7 +200,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 8: FQN usage (no imports that could conflict)
 #eval! do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "FQN"
     imports := #[]
     declarations := #[
@@ -220,7 +220,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 
 -- Test 9: Stub interfaces for referenced-but-empty categories
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "Stub"
     imports := #[]
     declarations := #[
@@ -243,7 +243,7 @@ meta def check (s sub : String) : Bool := (s.splitOn sub).length > 1
 -- Test 10: Core dialect returns error (has type/function declarations not yet supported)
 elab "#testCoreError" : command => do
   let env ← Lean.getEnv
-  let state := Strata.dialectExt.getState env
+  let state := StrataDDM.dialectExt.getState env
   let some core := state.loaded.dialects["Core"]?
     | Lean.logError "Core dialect not found"; return
   match generateDialect core "com.strata.core" with
@@ -256,7 +256,7 @@ elab "#testCoreError" : command => do
 
 -- Test 11: Cross-dialect name collision (A.Num vs B.Num)
 #eval do
-  let testDialect : Strata.Dialect := {
+  let testDialect : StrataDDM.Dialect := {
     name := "A"
     imports := #[]
     declarations := #[
@@ -291,7 +291,7 @@ elab "#testCompile" : command => do
     return
 
   let env ← Lean.getEnv
-  let state := Strata.dialectExt.getState env
+  let state := StrataDDM.dialectExt.getState env
   let some simple := state.loaded.dialects["Simple"]?
     | Lean.logError "Simple dialect not found"; return
   let files := (generateDialect simple "com.test").toOption.get!
@@ -324,17 +324,17 @@ elab "#testCompile" : command => do
 -- Depends on testdata/comprehensive.ion
 elab "#testRoundtrip" : command => do
   let env ← Lean.getEnv
-  let state := Strata.dialectExt.getState env
+  let state := StrataDDM.dialectExt.getState env
   let some simple := state.loaded.dialects["Simple"]?
     | Lean.logError "Simple dialect not found"; return
-  let dm := Strata.DialectMap.ofList! [Strata.initDialect, simple]
+  let dm := StrataDDM.DialectMap.ofList! [StrataDDM.initDialect, simple]
   let ionBytes ← IO.FS.readBinFile "StrataTestExtra/Languages/Java/testdata/comprehensive.ion"
-  match Strata.Program.fromIon dm "Simple" ionBytes with
+  match StrataDDM.Program.fromIon dm "Simple" ionBytes with
   | .error e => Lean.logError s!"Roundtrip test failed: {e}"
   | .ok prog =>
     if prog.commands.size != 1 then Lean.logError "Expected 1 command"; return
     let cmd := prog.commands[0]!
-    if cmd.name != (⟨"Simple", "block"⟩ : Strata.QualifiedIdent) then Lean.logError "Expected block command"; return
+    if cmd.name != (⟨"Simple", "block"⟩ : StrataDDM.QualifiedIdent) then Lean.logError "Expected block command"; return
     if let .seq _ _ stmts := cmd.args[0]! then
       if stmts.size != 4 then Lean.logError s!"Expected 4 statements, got {stmts.size}"
       -- Verify print's msg arg is strlit (not ident) — catches Init.Str serialization bug
@@ -355,12 +355,12 @@ elab "#testRoundtrip" : command => do
 -- Depends on testdata/comprehensive-files.ion
 elab "#testRoundtripFiles" : command => do
   let env ← Lean.getEnv
-  let state := Strata.dialectExt.getState env
+  let state := StrataDDM.dialectExt.getState env
   let some simple := state.loaded.dialects["Simple"]?
     | Lean.logError "Simple dialect not found"; return
-  let dm := Strata.DialectMap.ofList! [Strata.initDialect, simple]
+  let dm := StrataDDM.DialectMap.ofList! [StrataDDM.initDialect, simple]
   let ionBytes ← IO.FS.readBinFile "StrataTestExtra/Languages/Java/testdata/comprehensive-files.ion"
-  match Strata.Program.filesFromIon dm ionBytes with
+  match StrataDDM.Program.filesFromIon dm ionBytes with
   | .error e => Lean.logError s!"Roundtrip files test failed: {e}"
   | .ok files =>
     if files.length != 2 then
@@ -375,7 +375,7 @@ elab "#testRoundtripFiles" : command => do
       Lean.logError s!"File 1: Expected 1 command, got {file1.program.commands.size}"
       return
     let cmd1 := file1.program.commands[0]!
-    if cmd1.name != (⟨"Simple", "block"⟩ : Strata.QualifiedIdent) then
+    if cmd1.name != (⟨"Simple", "block"⟩ : StrataDDM.QualifiedIdent) then
       Lean.logError "File 1: Expected block command"; return
     if let .seq _ _ stmts := cmd1.args[0]! then
       if stmts.size != 2 then
@@ -392,7 +392,7 @@ elab "#testRoundtripFiles" : command => do
       Lean.logError s!"File 2: Expected 1 command, got {file2.program.commands.size}"
       return
     let cmd2 := file2.program.commands[0]!
-    if cmd2.name != (⟨"Simple", "block"⟩ : Strata.QualifiedIdent) then
+    if cmd2.name != (⟨"Simple", "block"⟩ : StrataDDM.QualifiedIdent) then
       Lean.logError "File 2: Expected block command"; return
     if let .seq _ _ stmts := cmd2.args[0]! then
       if stmts.size != 3 then
@@ -421,4 +421,4 @@ elab "#testJavaGenPreloaded" : command => do
 
 #testJavaGenPreloaded
 
-end Strata.Java.Test
+end StrataDDM.Java.Test

--- a/StrataTestExtra/Languages/Python/DictNoneTest.lean
+++ b/StrataTestExtra/Languages/Python/DictNoneTest.lean
@@ -17,7 +17,7 @@ is correctly detected as a bug, both for direct assignments and dict unpacking.
 namespace Strata.Python.DictNoneTest
 
 open Strata.Python (processPythonFile withPython)
-open Strata.Parser (stringInputContext)
+open StrataDDM.Parser (stringInputContext)
 
 -- Test 1: Using a valid int should succeed (0 diagnostics).
 #guard_msgs in

--- a/StrataTestExtra/Languages/Python/Issue1000Test.lean
+++ b/StrataTestExtra/Languages/Python/Issue1000Test.lean
@@ -10,7 +10,7 @@ import StrataTest.Util.Python
 
 open StrataTest.Util
 open Strata.Python (processPythonFile withPython)
-open Strata.Parser (stringInputContext)
+open StrataDDM.Parser (stringInputContext)
 open Strata
 
 namespace Strata.Python.Issue1000

--- a/StrataTestExtra/Languages/Python/SpecsTest.lean
+++ b/StrataTestExtra/Languages/Python/SpecsTest.lean
@@ -10,6 +10,8 @@ import StrataDDM.Ion
 import Strata.Languages.Python.PythonDialect
 meta import StrataTest.Util.Python
 
+open StrataDDM (SourceRange)
+
 namespace Strata.Python.Specs
 
 private meta def testDir : System.FilePath :=

--- a/StrataTestExtra/Languages/Python/VerifyPythonTest.lean
+++ b/StrataTestExtra/Languages/Python/VerifyPythonTest.lean
@@ -19,7 +19,7 @@ namespace Strata.Python.VerifyPythonTest
 
 open StrataTest.Util
 open Strata.Python (processPythonFile processPythonToLaurel withPython manglePythonMethod)
-open Strata.Parser (stringInputContext)
+open StrataDDM.Parser (stringInputContext)
 
 /-- Run the Python → Laurel pipeline and return the Laurel program together
     with its formatted string representation. -/

--- a/StrataToCBMC.lean
+++ b/StrataToCBMC.lean
@@ -14,6 +14,7 @@ import Strata.Util.IO
 import Std.Internal.Parsec
 
 open Strata
+open StrataDDM.Elab (LoadedDialects)
 
 /-- Parse a flat symbol-table JSON string, add CBMC defaults, and wrap for symtab2gb. -/
 private def wrapOutput (s : String) (moduleName : String) : IO String := do
@@ -26,11 +27,11 @@ def main (args : List String) : IO Unit := do
   | [file] => do
     let text ← Strata.Util.readInputSource file
     let inputCtx := Lean.Parser.mkInputContext text (Strata.Util.displayName file)
-    let dctx := Elab.LoadedDialects.builtin
+    let dctx := LoadedDialects.builtin
     let dctx := dctx.addDialect! Core
     let dctx := dctx.addDialect! C_Simp
     let leanEnv ← Lean.mkEmptyEnvironment 0
-    match Strata.Elab.elabProgram dctx leanEnv inputCtx with
+    match StrataDDM.Elab.elabProgram dctx leanEnv inputCtx with
     | .ok pgm =>
       if pgm.commands.size != 1 then
         IO.println "Error: expected exactly 1 function"

--- a/editors/GenSyntax.lean
+++ b/editors/GenSyntax.lean
@@ -21,7 +21,7 @@ strings, labels, attributes, identifiers, numbers) are hardcoded since
 they come from the DDM parser, not the dialect grammar.
 -/
 
-open Strata CoreDDM Strata.Elab
+open Strata CoreDDM StrataDDM.Elab
 
 /-! ## Extract syntax tokens from the Dialect object -/
 

--- a/editors/GenSyntax.lean
+++ b/editors/GenSyntax.lean
@@ -21,7 +21,7 @@ strings, labels, attributes, identifiers, numbers) are hardcoded since
 they come from the DDM parser, not the dialect grammar.
 -/
 
-open Strata CoreDDM StrataDDM.Elab
+open Strata CoreDDM StrataDDM StrataDDM.Elab
 
 /-! ## Extract syntax tokens from the Dialect object -/
 


### PR DESCRIPTION
Completes the DDM package extraction by renaming all StrataDDM-internal Lean namespaces from `Strata.*` to `StrataDDM.*`, giving the standalone package its own namespace root.

- Definitions that live in the `StrataDDM` package now use the `StrataDDM` namespace (e.g., `StrataDDM.Program`, `StrataDDM.Elab`, `StrataDDM.Parser`). External consumers add `open StrataDDM` or targeted `open StrataDDM (...)` to access them.
- `SourceRange` is re-exported from the `Strata` namespace via `Strata.Util.FileRange` since it is a general utility type not tied to DDM.
- DDM-specific types (`Program`, `Dialect`, `Arg`, `Ann`, etc.) require an explicit `open StrataDDM` rather than being silently available through the `Strata` namespace.
- Trace class names updated to `StrataDDM.*` (breaking change for anyone setting trace options).
- `#guard_msgs` expected output updated where byte offsets shifted or printed names changed.

By submitting this pull request, I confirm that you can use, modify, copy, and
redistribute this contribution, under the terms of your choice.