### PR TITLE
Report arity mismatch error for type aliases

### DIFF
--- a/Strata/DL/Lambda/LExprTypeEnv.lean
+++ b/Strata/DL/Lambda/LExprTypeEnv.lean
@@ -865,12 +865,15 @@ check whether the de-aliased types are registered/known.
 def LMonoTy.tconsAlias [ToFormat IDMeta] (name : String) (args : LMonoTys)
     (Env : TEnv IDMeta) : Except Format (LMonoTy × TEnv IDMeta) := do
   let inputMty := .tcons name args
-  -- Look for a matching alias with same name and arity.
-  let matchingAlias := Env.context.aliases.find?
-                        (fun a => a.name == name && a.typeArgs.length == args.length)
-  match matchingAlias with
+  -- Look for a matching alias by name.
+  let nameMatch := Env.context.aliases.find? (fun a => a.name == name)
+  match nameMatch with
   | none => return (inputMty, Env)
   | some alias =>
+    if alias.typeArgs.length != args.length then
+      .error f!"Arity mismatch for alias '{name}': \
+               expected {alias.typeArgs.length} type argument(s), got {args.length}"
+    else
     -- Create instantiation pair: [alias pattern, alias definition].
     -- The alias pattern and definition share the same type variables here.
     let aliasPattern := .tcons name (alias.typeArgs.map .ftvar)
@@ -901,12 +904,16 @@ def LMonoTy.tconsAlias [ToFormat IDMeta] (name : String) (args : LMonoTys)
     `tconsAlias_eq_simple` which proves the two produce the same result under
     the final substitution for well-formed aliases. -/
 def LMonoTy.tconsAliasSimple (name : String) (args : LMonoTys)
-    (aliases : List TypeAlias) : LMonoTy :=
-  let matchingAlias := aliases.find?
-    (fun a => a.name == name && a.typeArgs.length == args.length)
-  match matchingAlias with
-  | none => .tcons name args
-  | some alias => alias.expand args
+    (aliases : List TypeAlias) : Except Format LMonoTy :=
+  let nameMatch := aliases.find? (fun a => a.name == name)
+  match nameMatch with
+  | none => .ok (.tcons name args)
+  | some alias =>
+    if alias.typeArgs.length == args.length then
+      .ok (alias.expand args)
+    else
+      .error f!"Arity mismatch for alias '{name}': \
+               expected {alias.typeArgs.length} type argument(s), got {args.length}"
 
 /--
 Return the instantiated definition of `mty` if it is a registered
@@ -918,7 +925,9 @@ check whether the de-aliased types are registered/known.
 def LMonoTy.aliasDef? [ToFormat IDMeta] (mty : LMonoTy) (Env : TEnv IDMeta)
     : Except Format (LMonoTy × TEnv IDMeta) := do
   match mty with
-  | .tcons name args => return (LMonoTy.tconsAliasSimple name args Env.context.aliases, Env)
+  | .tcons name args =>
+    let mty' ← LMonoTy.tconsAliasSimple name args Env.context.aliases
+    return (mty', Env)
   | .bitvec _ | .ftvar _ => return (mty, Env)
 
 mutual
@@ -936,7 +945,7 @@ def LMonoTy.resolveAliases [ToFormat IDMeta] (mty : LMonoTy) (Env : TEnv IDMeta)
     return (mty, Env)
   | .tcons name args =>
     let (args', Env) ← LMonoTys.resolveAliases args Env
-    let mty' := LMonoTy.tconsAliasSimple name args' Env.context.aliases
+    let mty' ← LMonoTy.tconsAliasSimple name args' Env.context.aliases
     return (mty', Env)
 
 /--
@@ -1641,22 +1650,25 @@ theorem tconsAlias_tyGen_mono
     (h : LMonoTy.tconsAlias name args Env = .ok (mty, Env')) :
     Env'.genEnv.genState.tyGen ≥ Env.genEnv.genState.tyGen := by
   simp only [LMonoTy.tconsAlias] at h
-  -- Case split on whether a matching alias is found
+  -- Case split on whether a matching alias is found by name
   split at h
   case h_1 =>
     -- No matching alias: Env' = Env
     simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2; omega
   case h_2 alias_val =>
-    -- Matching alias found: calls instantiateEnv then unify + updateSubst
+    -- Matching alias found: check arity
     split at h
-    · simp at h
-    · rename_i instTypes Env1 h_inst
-      -- unify + updateSubst only change stateSubstInfo, not genEnv
+    · simp at h  -- arity mismatch → error, contradicts h
+    · -- Arity matches: calls instantiateEnv then unify + updateSubst
       split at h
       · simp at h
-      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
-        simp [TEnv.updateSubst]
-        exact LMonoTys.instantiateEnv_tyGen_mono _ _ Env instTypes Env1 h_inst
+      · rename_i instTypes Env1 h_inst
+        -- unify + updateSubst only change stateSubstInfo, not genEnv
+        split at h
+        · simp at h
+        · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+          simp [TEnv.updateSubst]
+          exact LMonoTys.instantiateEnv_tyGen_mono _ _ Env instTypes Env1 h_inst
 
 /-- `LMonoTy.aliasDef?` never decreases `tyGen`. -/
 theorem aliasDef_tyGen_mono
@@ -1664,12 +1676,13 @@ theorem aliasDef_tyGen_mono
     (mty' : LMonoTy) (Env' : TEnv T.IDMeta)
     (h : LMonoTy.aliasDef? mty Env = .ok (mty', Env')) :
     Env'.genEnv.genState.tyGen ≥ Env.genEnv.genState.tyGen := by
-  simp only [LMonoTy.aliasDef?] at h
+  simp only [LMonoTy.aliasDef?, Bind.bind, Except.bind] at h
   split at h
-  · -- tconsAliasSimple doesn't change Env
-    simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2; omega
-  · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2; omega
-  · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2; omega
+  · -- .tcons case: split on tconsAliasSimple result
+    split at h
+    · simp at h
+    · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2; omega
+  all_goals (simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2; omega)
 
 mutual
 /-- `LMonoTy.resolveAliases` never decreases `tyGen`. -/
@@ -1691,10 +1704,11 @@ theorem LMonoTy_resolveAliases_tyGen_mono
     · simp at h
     · rename_i v1 h_args
       obtain ⟨args', Env1⟩ := v1; simp at h h_args
-      -- tconsAliasSimple doesn't change Env, so Env' = Env1
-      simp only [LMonoTy.tconsAliasSimple, Pure.pure, Except.pure] at h
-      split at h <;> simp at h <;> obtain ⟨_, h_env⟩ := h <;> subst h_env
-      all_goals exact LMonoTys_resolveAliases_tyGen_mono args Env args' Env1 h_args
+      -- split on tconsAliasSimple result (Except)
+      split at h
+      · simp at h
+      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h_env⟩ := h; subst h_env
+        exact LMonoTys_resolveAliases_tyGen_mono args Env args' Env1 h_args
 
 theorem LMonoTys_resolveAliases_tyGen_mono
     (mtys : LMonoTys) (Env : TEnv T.IDMeta)

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -476,10 +476,11 @@ theorem LMonoTy.resolveAliases_context {IDMeta : Type} [ToFormat IDMeta]
     · simp at h
     · rename_i v1 h_args
       obtain ⟨args', Env1⟩ := v1; simp at h h_args
-      -- tconsAliasSimple doesn't change context (Env' = Env1)
-      simp only [LMonoTy.tconsAliasSimple] at h
-      split at h <;> (obtain ⟨_, h2⟩ := h; rw [← h2])
-      all_goals exact LMonoTys.resolveAliases_context args Env args' Env1 h_args
+      -- tconsAliasSimple returns Except; split on its result
+      split at h
+      · simp at h
+      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; rw [← h2]
+        exact LMonoTys.resolveAliases_context args Env args' Env1 h_args
 theorem LMonoTys.resolveAliases_context {IDMeta : Type} [ToFormat IDMeta]
     (mtys : LMonoTys) (Env : TEnv IDMeta) (mtys' : LMonoTys) (Env' : TEnv IDMeta)
     (h : LMonoTys.resolveAliases mtys Env = .ok (mtys', Env')) :
@@ -1040,12 +1041,11 @@ theorem LMonoTy.resolveAliases_allKeysFresh
     · simp at h
     · rename_i v1 h_args
       obtain ⟨args', Env1⟩ := v1; simp at h h_args
-      -- tconsAliasSimple: split on the alias find? match
-      -- tconsAliasSimple doesn't change Env; proof simplified
-      simp only [LMonoTy.tconsAliasSimple] at h
-      split at h <;> (obtain ⟨_, h2⟩ := h; subst h2)
-      -- Env' = Env1 (tconsAliasSimple doesn't change Env). Delegate to list version.
-      <;> exact LMonoTys.resolveAliases_allKeysFresh args Env args' Env1 h_args
+      -- tconsAliasSimple returns Except; split on its result
+      split at h
+      · simp at h
+      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+        exact LMonoTys.resolveAliases_allKeysFresh args Env args' Env1 h_args
           h_fresh h_vals_fresh h_alias_wf
           (fun tv htv => h_fvs tv (by simp [LMonoTy.freeVars]; exact htv))
 
@@ -1070,12 +1070,11 @@ theorem LMonoTy.resolveAliases_vals_fresh
     · simp at h
     · rename_i v1 h_args
       obtain ⟨args', Env1⟩ := v1; simp at h h_args
-      -- tconsAliasSimple: split on the alias find? match
-      -- tconsAliasSimple doesn't change Env; proof simplified
-      simp only [LMonoTy.tconsAliasSimple] at h
-      split at h <;> (obtain ⟨_, h2⟩ := h; subst h2)
-      -- Env' = Env1 (tconsAliasSimple doesn't change Env). Delegate to list version.
-      <;> exact LMonoTys.resolveAliases_vals_fresh args Env args' Env1 h_args
+      -- tconsAliasSimple returns Except; split on its result
+      split at h
+      · simp at h
+      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+        exact LMonoTys.resolveAliases_vals_fresh args Env args' Env1 h_args
           h_vals_fresh h_alias_wf
           (fun tv htv => h_fvs tv (by simp [LMonoTy.freeVars]; exact htv))
 
@@ -1186,8 +1185,8 @@ theorem LMonoTy.resolveAliases_fvs_fresh
     split at h; · simp at h
     · rename_i v1 h_args_ra
       obtain ⟨args', Env1⟩ := v1; simp at h h_args_ra
-      -- tconsAliasSimple doesn't change Env; proof simplified
-      simp only [LMonoTy.tconsAliasSimple] at h
+      -- tconsAliasSimple returns Except; unfold and split on result
+      simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
       have h_args_fvs : ∀ tv, tv ∈ LMonoTys.freeVars args →
           TContext.isFresh (T := T) tv Env.context := by
         intro tv htv; exact h_fvs tv (by simp [LMonoTy.freeVars]; exact htv)
@@ -1196,26 +1195,34 @@ theorem LMonoTy.resolveAliases_fvs_fresh
           h_vals_fresh h_alias_wf h_args_fvs
       have h_ctx_eq := LMonoTys.resolveAliases_context args Env args' Env1 h_args_ra
       split at h
-      · -- No alias: output = tcons name args', fvs ⊆ args' fvs
-        obtain ⟨h1, _⟩ := h; subst h1
-        intro tv htv; simp [LMonoTy.freeVars] at htv
-        exact h_args'_fresh tv htv
-      · -- Alias: output = expand alias args', fvs ⊆ args' fvs (by alias WF)
-        rename_i alias h_find
-        obtain ⟨h1, _⟩ := h; subst h1
-        intro tv htv
-        -- fvs of (expand alias args') = fvs of (openVars typeArgs args' alias.type) ⊆ fvs of args'
-        -- since alias.WF: all fvs of alias.type are in typeArgs, and openVars maps
-        -- each typeArg to the corresponding element of args'.
-        -- So fvs of the result come from args' elements only.
-        have h_alias_mem : alias ∈ Env1.context.aliases :=
-          List.mem_of_find?_eq_some h_find
-        have h_alias_wf := (h_alias_wf alias (by rw [← h_ctx_eq]; exact h_alias_mem))
-        have h_pred := List.find?_some h_find
-        simp [BEq.beq, decide_eq_true_eq] at h_pred
-        simp only [TypeAlias.expand] at htv
-        exact h_args'_fresh tv (openVars_freeVars_subset alias.typeArgs args' alias.type
-          h_alias_wf.fvs_closed h_pred.2 tv htv)
+      · -- tconsAliasSimple returned error: contradicts h
+        simp at h
+      · -- tconsAliasSimple returned ok: split on internal find?
+        rename_i mty_val heq_val
+        simp [Pure.pure, Except.pure] at h; obtain ⟨h1, _⟩ := h; subst h1
+        -- Now need to determine what mty_val is by splitting heq_val
+        split at heq_val
+        · -- No alias: mty_val = tcons name args'
+          simp at heq_val; subst heq_val
+          intro tv htv; simp [LMonoTy.freeVars] at htv
+          exact h_args'_fresh tv htv
+        · -- Alias found by name: split on arity check
+          rename_i alias h_find
+          split at heq_val
+          · -- Arity matches: mty_val = expand alias args'
+            rename_i h_arity_eq
+            simp at heq_val; subst heq_val
+            intro tv htv
+            have h_alias_mem : alias ∈ Env1.context.aliases :=
+              List.mem_of_find?_eq_some h_find
+            have h_alias_wf := (h_alias_wf alias (by rw [← h_ctx_eq]; exact h_alias_mem))
+            have h_len : alias.typeArgs.length = args'.length := by
+              simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+            simp only [TypeAlias.expand] at htv
+            exact h_args'_fresh tv (openVars_freeVars_subset alias.typeArgs args' alias.type
+              h_alias_wf.fvs_closed h_len tv htv)
+          · -- Arity mismatch: error, contradicts heq_val
+            simp at heq_val
 
 /-- `LMonoTys.resolveAliases` preserves freshness of type free vars. -/
 theorem LMonoTys.resolveAliases_fvs_fresh
@@ -1297,12 +1304,11 @@ private theorem LMonoTy.resolveAliases_absorbs
     · simp at h
     · rename_i v1 h_args
       obtain ⟨args', Env1⟩ := v1; simp at h h_args
-      -- tconsAliasSimple: split on the alias find? match
-      -- tconsAliasSimple doesn't change Env; proof simplified
-      simp only [LMonoTy.tconsAliasSimple] at h
-      split at h <;> (obtain ⟨_, h2⟩ := h; subst h2)
-      -- Env' = Env1 (tconsAliasSimple doesn't change Env)
-      all_goals exact LMonoTys.resolveAliases_absorbs args Env args' Env1 h_args
+      -- tconsAliasSimple returns Except; split on its result
+      split at h
+      · simp at h
+      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+        exact LMonoTys.resolveAliases_absorbs args Env args' Env1 h_args
 
 /-- `LMonoTys.resolveAliases` produces a substitution that absorbs the input. -/
 private theorem LMonoTys.resolveAliases_absorbs
@@ -1825,11 +1831,11 @@ private theorem LMonoTy_resolveAliases_genState_mono
     simp [LMonoTy.resolveAliases, Bind.bind, Except.bind] at h
     split at h; · simp at h
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
-    -- tconsAliasSimple: split on the alias find? match
-    -- tconsAliasSimple doesn't change Env; proof simplified
-    simp only [LMonoTy.tconsAliasSimple] at h
-    split at h <;> (obtain ⟨_, h2⟩ := h; subst h2)
-    all_goals exact LMonoTys_resolveAliases_genState_mono args Env args' Env1 h_args
+    -- tconsAliasSimple returns Except; split on its result
+    split at h
+    · simp at h
+    · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+      exact LMonoTys_resolveAliases_genState_mono args Env args' Env1 h_args
 
 private theorem LMonoTys_resolveAliases_genState_mono
     (mtys : LMonoTys) (Env : TEnv T.IDMeta) (mtys' : LMonoTys) (Env' : TEnv T.IDMeta)
@@ -1873,20 +1879,33 @@ private theorem LMonoTy_resolveAliases_preserves_SubstFreshForGen
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
     have h_args_result := LMonoTys_resolveAliases_preserves_SubstFreshForGen args Env args' Env1 h_args
           h_fresh h_aw (fun v hv => h_input v (by simp [LMonoTy.freeVars]; exact hv))
-    -- tconsAliasSimple: split on the alias find? match
-    simp only [LMonoTy.tconsAliasSimple] at h
-    split at h <;> (obtain ⟨h1, h2⟩ := h; subst h1; subst h2)
-    · -- No alias: mty' = tcons name args', freeVars = LMonoTys.freeVars args'
-      exact ⟨h_args_result.1, h_args_result.2⟩
-    · -- Alias found: mty' = expand alias args'. freeVars ⊆ freeVars args' (by openVars_freeVars_subset)
-      rename_i alias h_find
-      have h_ctx_eq := LMonoTys.resolveAliases_context args Env args' Env1 h_args
-      have h_alias_wf := h_aw alias (by rw [← h_ctx_eq]; exact List.mem_of_find?_eq_some h_find)
-      have h_pred := List.find?_some h_find
-      simp [BEq.beq, decide_eq_true_eq] at h_pred
-      exact ⟨h_args_result.1, fun v hv n hn =>
-        h_args_result.2 v (openVars_freeVars_subset alias.typeArgs args' alias.type
-          h_alias_wf.fvs_closed h_pred.2 v hv) n hn⟩
+    -- tconsAliasSimple returns Except; unfold and split on result
+    simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
+    split at h
+    · -- tconsAliasSimple returned error: contradicts h
+      simp at h
+    · -- tconsAliasSimple returned ok
+      rename_i mty_val heq_val
+      simp [Pure.pure, Except.pure] at h; obtain ⟨h1, h2⟩ := h; subst h1; subst h2
+      split at heq_val
+      · -- No alias: mty_val = tcons name args'
+        simp at heq_val; subst heq_val
+        exact ⟨h_args_result.1, h_args_result.2⟩
+      · -- Alias found by name: split on arity check
+        rename_i alias h_find
+        split at heq_val
+        · -- Arity matches
+          rename_i h_arity_eq
+          simp at heq_val; subst heq_val
+          have h_ctx_eq := LMonoTys.resolveAliases_context args Env args' Env1 h_args
+          have h_alias_wf := h_aw alias (by rw [← h_ctx_eq]; exact List.mem_of_find?_eq_some h_find)
+          have h_len : alias.typeArgs.length = args'.length := by
+            simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+          exact ⟨h_args_result.1, fun v hv n hn =>
+            h_args_result.2 v (openVars_freeVars_subset alias.typeArgs args' alias.type
+              h_alias_wf.fvs_closed h_len v hv) n hn⟩
+        · -- Arity mismatch: error, contradicts heq_val
+          simp at heq_val
 
 /-- `LMonoTys.resolveAliases` preserves `SubstFreshForGen` AND produces output
     whose freeVars satisfy gen-freshness for the output genState.
@@ -2949,24 +2968,36 @@ private theorem LMonoTy_resolveAliases_freeVars_subset
     simp [LMonoTy.resolveAliases, Bind.bind, Except.bind] at h
     split at h; · simp at h
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
-    simp only [LMonoTy.tconsAliasSimple] at h
-    generalize h_alias_find : List.find? _ Env1.context.aliases = alias_opt at h
-    cases alias_opt with
-    | none =>
-      simp at h; obtain ⟨h1, _⟩ := h; subst h1
-      intro v hv; simp [LMonoTy.freeVars] at hv ⊢
-      exact LMonoTys_resolveAliases_freeVars_subset args Env args' Env1 h_args h_aw v hv
-    | some alias =>
-      simp at h; obtain ⟨h1, _⟩ := h; subst h1
-      have h_ctx_eq := LMonoTys.resolveAliases_context args Env args' Env1 h_args
-      have h_aw1 : TContext.AliasesWF Env1.context := h_ctx_eq ▸ h_aw
-      have h_alias_wf := h_aw1 alias (List.mem_of_find?_eq_some h_alias_find)
-      have h_pred := List.find?_some h_alias_find
-      simp [BEq.beq, decide_eq_true_eq] at h_pred
-      intro v hv; simp [LMonoTy.freeVars]
-      exact LMonoTys_resolveAliases_freeVars_subset args Env args' Env1 h_args h_aw v
-        (openVars_freeVars_subset alias.typeArgs args' alias.type
-          h_alias_wf.fvs_closed h_pred.2 v hv)
+    simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
+    split at h
+    · -- tconsAliasSimple returned error: contradicts h
+      simp at h
+    · -- tconsAliasSimple returned ok
+      rename_i mty_val heq_val
+      simp [Pure.pure, Except.pure] at h; obtain ⟨h1, _⟩ := h; subst h1
+      -- Split heq_val on find?
+      split at heq_val
+      · -- No alias found: mty_val = tcons name args'
+        simp at heq_val; subst heq_val
+        intro v hv; simp [LMonoTy.freeVars] at hv ⊢
+        exact LMonoTys_resolveAliases_freeVars_subset args Env args' Env1 h_args h_aw v hv
+      · -- Alias found by name: split on arity check
+        rename_i alias h_alias_find
+        split at heq_val
+        · -- Arity matches
+          rename_i h_arity_eq
+          simp at heq_val; subst heq_val
+          have h_ctx_eq := LMonoTys.resolveAliases_context args Env args' Env1 h_args
+          have h_aw1 : TContext.AliasesWF Env1.context := h_ctx_eq ▸ h_aw
+          have h_alias_wf := h_aw1 alias (List.mem_of_find?_eq_some h_alias_find)
+          have h_len : alias.typeArgs.length = args'.length := by
+            simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+          intro v hv; simp [LMonoTy.freeVars]
+          exact LMonoTys_resolveAliases_freeVars_subset args Env args' Env1 h_args h_aw v
+            (openVars_freeVars_subset alias.typeArgs args' alias.type
+              h_alias_wf.fvs_closed h_len v hv)
+        · -- Arity mismatch: error, contradicts heq_val
+          simp at heq_val
 
 /-- `LMonoTys.resolveAliases` does not grow free variables when aliases are WF. -/
 private theorem LMonoTys_resolveAliases_freeVars_subset
@@ -4311,7 +4342,8 @@ private theorem tconsAlias_expand_eq
     (alias : TypeAlias)
     (h_tcons : LMonoTy.tconsAlias name args Env = .ok (mty', Env'))
     (h_find : Env.context.aliases.find?
-        (fun a => a.name == name && a.typeArgs.length == args.length) = some alias)
+        (fun a => a.name == name) = some alias)
+    (h_arity : alias.typeArgs.length == args.length)
     (h_wf : alias.WF)
     (h_nodup : alias.typeArgs.Nodup) :
     LMonoTy.subst Env'.stateSubstInfo.subst mty' =
@@ -4319,8 +4351,11 @@ private theorem tconsAlias_expand_eq
   -- Unfold tconsAlias and use h_find to match the alias branch
   unfold LMonoTy.tconsAlias at h_tcons
   rw [h_find] at h_tcons
-  -- Now h_tcons is in the `some alias` branch
-  simp at h_tcons
+  -- Now h_tcons is in the `some alias` branch; arity check passes
+  dsimp only at h_tcons
+  have h_ne_false : (alias.typeArgs.length != args.length) = false := by
+    simp [bne, BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity ⊢; exact h_arity
+  simp [h_ne_false] at h_tcons
   -- Decompose: instantiateEnv, then unify
   split at h_tcons
   · simp at h_tcons  -- instantiateEnv failed
@@ -4453,32 +4488,46 @@ private theorem tconsAlias_expand_eq
 
 omit [ToString
   T.IDMeta] [DecidableEq T.IDMeta] [HasGen T.IDMeta] [ToFormat (LFunc T)] [ToFormat T.Metadata] in
-/-- Proof of `tconsAlias_eq_simple` (stated in `LExprTypeEnv.lean`). -/
+/-- Proof of `tconsAlias_eq_simple`: when `tconsAlias` succeeds, `tconsAliasSimple`
+    also succeeds and the two produce the same result under the final substitution. -/
 theorem tconsAlias_eq_simple
     (name : String) (args : LMonoTys) (Env : TEnv T.IDMeta)
     (mty' : LMonoTy) (Env' : TEnv T.IDMeta)
     (h_tcons : LMonoTy.tconsAlias name args Env = .ok (mty', Env'))
     (h_aliases_wf : TContext.AliasesWF Env.context) :
+    ∃ mty_simple, LMonoTy.tconsAliasSimple name args Env.context.aliases = .ok mty_simple ∧
     LMonoTy.subst Env'.stateSubstInfo.subst mty' =
-    LMonoTy.subst Env'.stateSubstInfo.subst
-      (LMonoTy.tconsAliasSimple name args Env.context.aliases) := by
+    LMonoTy.subst Env'.stateSubstInfo.subst mty_simple := by
   unfold LMonoTy.tconsAliasSimple
   generalize h_find : Env.context.aliases.find? _ = ma
   match ma with
   | none =>
     unfold LMonoTy.tconsAlias at h_tcons; rw [h_find] at h_tcons
-    simp at h_tcons
+    simp [Pure.pure, Except.pure] at h_tcons
     obtain ⟨h1, h2⟩ := h_tcons; rw [← h1, ← h2]
+    exact ⟨.tcons name args, rfl, rfl⟩
   | some alias =>
     have h_alias_wf := h_aliases_wf alias (List.mem_of_find?_eq_some h_find)
     have h_pred := List.find?_some h_find
     simp [BEq.beq, decide_eq_true_eq] at h_pred
+    -- tconsAlias succeeded, so arity must match
+    have h_arity : alias.typeArgs.length == args.length := by
+      unfold LMonoTy.tconsAlias at h_tcons; rw [h_find] at h_tcons
+      dsimp only at h_tcons
+      split at h_tcons
+      · simp at h_tcons
+      · rename_i h_ne
+        simp [bne, BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_ne ⊢
+        omega
+    simp [h_arity]
+    have h_len : alias.typeArgs.length = args.length := by
+      simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity; exact h_arity
     have h_bridge := tconsAlias_expand_eq name args Env mty' Env' alias
-      h_tcons h_find h_alias_wf h_alias_wf.typeArgs_nodup
+      h_tcons h_find h_arity h_alias_wf h_alias_wf.typeArgs_nodup
     rw [h_bridge]; simp only [TypeAlias.expand]
     rw [LMonoTys.subst_eq_substLogic]
     exact (subst_openVars_comm Env'.stateSubstInfo.subst alias.typeArgs args alias.type
-      h_alias_wf.fvs_closed h_pred.2).symm
+      h_alias_wf.fvs_closed h_len).symm
 
 mutual
 /-- `AliasEquiv` is preserved under type substitution. -/
@@ -4568,23 +4617,37 @@ private theorem resolveAliases_aliasEquiv
     simp [LMonoTy.resolveAliases, Bind.bind, Except.bind] at h
     split at h; · simp at h
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
-    -- tconsAliasSimple is pure: split on find?
-    simp only [LMonoTy.tconsAliasSimple] at h
+    -- tconsAliasSimple returns Except; unfold and split on result
+    simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
     have h_ctx_pres := LMonoTys.resolveAliases_context args Env args' Env1 h_args
     have h_args_equiv := resolveAliasList_aliasEquiv args Env args' Env1 h_args h_aliases h_aliases_wf
     split at h
-    · -- No alias: mty' = tcons name args'
-      obtain ⟨rfl, _⟩ := h
-      exact .cong_tcons h_args_equiv
-    · -- Alias found: mty' = expand alias args'
-      rename_i alias h_find
-      obtain ⟨rfl, _⟩ := h
-      have h_alias_in : alias ∈ Γ.aliases := by
-        rw [h_aliases, ← h_ctx_pres]; exact List.mem_of_find?_eq_some h_find
-      have h_pred := List.find?_some h_find
-      simp [BEq.beq, decide_eq_true_eq] at h_pred
-      exact .trans (.cong_tcons h_args_equiv)
-        (.expand ⟨alias, h_alias_in, h_pred.1, h_pred.2, rfl⟩)
+    · -- tconsAliasSimple returned error: contradicts h
+      simp at h
+    · -- tconsAliasSimple returned ok
+      rename_i mty_val heq_val
+      simp [Pure.pure, Except.pure] at h; obtain ⟨rfl, _⟩ := h
+      split at heq_val
+      · -- No alias: mty_val = tcons name args'
+        simp at heq_val; subst heq_val
+        exact .cong_tcons h_args_equiv
+      · -- Alias found by name: split on arity check
+        rename_i alias h_find
+        split at heq_val
+        · -- Arity matches: mty_val = expand alias args'
+          rename_i h_arity_eq
+          simp at heq_val; subst heq_val
+          have h_alias_in : alias ∈ Γ.aliases := by
+            rw [h_aliases, ← h_ctx_pres]; exact List.mem_of_find?_eq_some h_find
+          have h_name : alias.name = name := by
+            have h_pred := List.find?_some h_find
+            simp [BEq.beq, decide_eq_true_eq] at h_pred; exact h_pred
+          have h_len : alias.typeArgs.length = args'.length := by
+            simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+          exact .trans (.cong_tcons h_args_equiv)
+            (.expand ⟨alias, h_alias_in, h_name, h_len, rfl⟩)
+        · -- Arity mismatch: error, contradicts heq_val
+          simp at heq_val
 
 /-- `LMonoTys.resolveAliases` produces pointwise alias-equivalent outputs. -/
 private theorem resolveAliasList_aliasEquiv
@@ -4626,9 +4689,11 @@ private theorem LMonoTy_resolveAliases_subst_eq
     simp [LMonoTy.resolveAliases, Bind.bind, Except.bind] at h
     split at h; · simp at h
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
-    simp only [LMonoTy.tconsAliasSimple] at h
-    split at h <;> (obtain ⟨_, h2⟩ := h; rw [← h2])
-    all_goals exact LMonoTys_resolveAliases_subst_eq args Env args' Env1 h_args
+    -- tconsAliasSimple returns Except; split on its result
+    split at h
+    · simp at h
+    · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; rw [← h2]
+      exact LMonoTys_resolveAliases_subst_eq args Env args' Env1 h_args
 
 private theorem LMonoTys_resolveAliases_subst_eq
     (mtys : LMonoTys) (Env : TEnv T.IDMeta) (mtys' : LMonoTys) (Env' : TEnv T.IDMeta)

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -22,6 +22,7 @@ import all Strata.DL.Util.List
 public import Strata.DL.Lambda.LExprT
 import all Strata.DL.Lambda.LExprT
 public import Strata.DL.Lambda.FactoryWF
+public meta import Init.Grind.Cases
 
 /-! ## Typing Relation for Lambda Expressions
 

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -480,7 +480,7 @@ theorem LMonoTy.resolveAliases_context {IDMeta : Type} [ToFormat IDMeta]
       -- tconsAliasSimple returns Except; split on its result
       split at h
       · simp at h
-      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; rw [← h2]
+      · simp at h; obtain ⟨_, h2⟩ := h; rw [← h2]
         exact LMonoTys.resolveAliases_context args Env args' Env1 h_args
 theorem LMonoTys.resolveAliases_context {IDMeta : Type} [ToFormat IDMeta]
     (mtys : LMonoTys) (Env : TEnv IDMeta) (mtys' : LMonoTys) (Env' : TEnv IDMeta)
@@ -1045,7 +1045,7 @@ theorem LMonoTy.resolveAliases_allKeysFresh
       -- tconsAliasSimple returns Except; split on its result
       split at h
       · simp at h
-      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+      · simp at h; obtain ⟨_, h2⟩ := h; subst h2
         exact LMonoTys.resolveAliases_allKeysFresh args Env args' Env1 h_args
           h_fresh h_vals_fresh h_alias_wf
           (fun tv htv => h_fvs tv (by simp [LMonoTy.freeVars]; exact htv))
@@ -1074,7 +1074,7 @@ theorem LMonoTy.resolveAliases_vals_fresh
       -- tconsAliasSimple returns Except; split on its result
       split at h
       · simp at h
-      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+      · simp at h; obtain ⟨_, h2⟩ := h; subst h2
         exact LMonoTys.resolveAliases_vals_fresh args Env args' Env1 h_args
           h_vals_fresh h_alias_wf
           (fun tv htv => h_fvs tv (by simp [LMonoTy.freeVars]; exact htv))
@@ -1187,7 +1187,7 @@ theorem LMonoTy.resolveAliases_fvs_fresh
     · rename_i v1 h_args_ra
       obtain ⟨args', Env1⟩ := v1; simp at h h_args_ra
       -- tconsAliasSimple returns Except; unfold and split on result
-      simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
+      simp only [LMonoTy.tconsAliasSimple] at h
       have h_args_fvs : ∀ tv, tv ∈ LMonoTys.freeVars args →
           TContext.isFresh (T := T) tv Env.context := by
         intro tv htv; exact h_fvs tv (by simp [LMonoTy.freeVars]; exact htv)
@@ -1200,7 +1200,7 @@ theorem LMonoTy.resolveAliases_fvs_fresh
         simp at h
       · -- tconsAliasSimple returned ok: split on internal find?
         rename_i mty_val heq_val
-        simp [Pure.pure, Except.pure] at h; obtain ⟨h1, _⟩ := h; subst h1
+        simp at h; obtain ⟨h1, _⟩ := h; subst h1
         -- Now need to determine what mty_val is by splitting heq_val
         split at heq_val
         · -- No alias: mty_val = tcons name args'
@@ -1218,7 +1218,7 @@ theorem LMonoTy.resolveAliases_fvs_fresh
               List.mem_of_find?_eq_some h_find
             have h_alias_wf := (h_alias_wf alias (by rw [← h_ctx_eq]; exact h_alias_mem))
             have h_len : alias.typeArgs.length = args'.length := by
-              simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+              simp [BEq.beq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
             simp only [TypeAlias.expand] at htv
             exact h_args'_fresh tv (openVars_freeVars_subset alias.typeArgs args' alias.type
               h_alias_wf.fvs_closed h_len tv htv)
@@ -1308,7 +1308,7 @@ private theorem LMonoTy.resolveAliases_absorbs
       -- tconsAliasSimple returns Except; split on its result
       split at h
       · simp at h
-      · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+      · simp at h; obtain ⟨_, h2⟩ := h; subst h2
         exact LMonoTys.resolveAliases_absorbs args Env args' Env1 h_args
 
 /-- `LMonoTys.resolveAliases` produces a substitution that absorbs the input. -/
@@ -1835,7 +1835,7 @@ private theorem LMonoTy_resolveAliases_genState_mono
     -- tconsAliasSimple returns Except; split on its result
     split at h
     · simp at h
-    · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; subst h2
+    · simp at h; obtain ⟨_, h2⟩ := h; subst h2
       exact LMonoTys_resolveAliases_genState_mono args Env args' Env1 h_args
 
 private theorem LMonoTys_resolveAliases_genState_mono
@@ -1881,13 +1881,13 @@ private theorem LMonoTy_resolveAliases_preserves_SubstFreshForGen
     have h_args_result := LMonoTys_resolveAliases_preserves_SubstFreshForGen args Env args' Env1 h_args
           h_fresh h_aw (fun v hv => h_input v (by simp [LMonoTy.freeVars]; exact hv))
     -- tconsAliasSimple returns Except; unfold and split on result
-    simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
+    simp only [LMonoTy.tconsAliasSimple] at h
     split at h
     · -- tconsAliasSimple returned error: contradicts h
       simp at h
     · -- tconsAliasSimple returned ok
       rename_i mty_val heq_val
-      simp [Pure.pure, Except.pure] at h; obtain ⟨h1, h2⟩ := h; subst h1; subst h2
+      simp at h; obtain ⟨h1, h2⟩ := h; subst h1; subst h2
       split at heq_val
       · -- No alias: mty_val = tcons name args'
         simp at heq_val; subst heq_val
@@ -1901,7 +1901,7 @@ private theorem LMonoTy_resolveAliases_preserves_SubstFreshForGen
           have h_ctx_eq := LMonoTys.resolveAliases_context args Env args' Env1 h_args
           have h_alias_wf := h_aw alias (by rw [← h_ctx_eq]; exact List.mem_of_find?_eq_some h_find)
           have h_len : alias.typeArgs.length = args'.length := by
-            simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+            simp [BEq.beq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
           exact ⟨h_args_result.1, fun v hv n hn =>
             h_args_result.2 v (openVars_freeVars_subset alias.typeArgs args' alias.type
               h_alias_wf.fvs_closed h_len v hv) n hn⟩
@@ -2969,13 +2969,13 @@ private theorem LMonoTy_resolveAliases_freeVars_subset
     simp [LMonoTy.resolveAliases, Bind.bind, Except.bind] at h
     split at h; · simp at h
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
-    simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
+    simp only [LMonoTy.tconsAliasSimple] at h
     split at h
     · -- tconsAliasSimple returned error: contradicts h
       simp at h
     · -- tconsAliasSimple returned ok
       rename_i mty_val heq_val
-      simp [Pure.pure, Except.pure] at h; obtain ⟨h1, _⟩ := h; subst h1
+      simp at h; obtain ⟨h1, _⟩ := h; subst h1
       -- Split heq_val on find?
       split at heq_val
       · -- No alias found: mty_val = tcons name args'
@@ -2992,7 +2992,7 @@ private theorem LMonoTy_resolveAliases_freeVars_subset
           have h_aw1 : TContext.AliasesWF Env1.context := h_ctx_eq ▸ h_aw
           have h_alias_wf := h_aw1 alias (List.mem_of_find?_eq_some h_alias_find)
           have h_len : alias.typeArgs.length = args'.length := by
-            simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+            simp [BEq.beq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
           intro v hv; simp [LMonoTy.freeVars]
           exact LMonoTys_resolveAliases_freeVars_subset args Env args' Env1 h_args h_aw v
             (openVars_freeVars_subset alias.typeArgs args' alias.type
@@ -4355,7 +4355,7 @@ private theorem tconsAlias_expand_eq
   -- Now h_tcons is in the `some alias` branch; arity check passes
   dsimp only at h_tcons
   have h_ne_false : (alias.typeArgs.length != args.length) = false := by
-    simp [bne, BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity ⊢; exact h_arity
+    simp [bne, BEq.beq, decide_eq_true_eq] at h_arity ⊢; exact h_arity
   simp [h_ne_false] at h_tcons
   -- Decompose: instantiateEnv, then unify
   split at h_tcons
@@ -4518,11 +4518,11 @@ theorem tconsAlias_eq_simple
       split at h_tcons
       · simp at h_tcons
       · rename_i h_ne
-        simp [bne, BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_ne ⊢
+        simp [bne, BEq.beq, decide_eq_true_eq] at h_ne ⊢
         omega
     simp [h_arity]
     have h_len : alias.typeArgs.length = args.length := by
-      simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity; exact h_arity
+      simp [BEq.beq, decide_eq_true_eq] at h_arity; exact h_arity
     have h_bridge := tconsAlias_expand_eq name args Env mty' Env' alias
       h_tcons h_find h_arity h_alias_wf h_alias_wf.typeArgs_nodup
     rw [h_bridge]; simp only [TypeAlias.expand]
@@ -4619,7 +4619,7 @@ private theorem resolveAliases_aliasEquiv
     split at h; · simp at h
     rename_i v1 h_args; obtain ⟨args', Env1⟩ := v1; simp at h h_args
     -- tconsAliasSimple returns Except; unfold and split on result
-    simp only [LMonoTy.tconsAliasSimple, Bind.bind, Except.bind] at h
+    simp only [LMonoTy.tconsAliasSimple] at h
     have h_ctx_pres := LMonoTys.resolveAliases_context args Env args' Env1 h_args
     have h_args_equiv := resolveAliasList_aliasEquiv args Env args' Env1 h_args h_aliases h_aliases_wf
     split at h
@@ -4627,7 +4627,7 @@ private theorem resolveAliases_aliasEquiv
       simp at h
     · -- tconsAliasSimple returned ok
       rename_i mty_val heq_val
-      simp [Pure.pure, Except.pure] at h; obtain ⟨rfl, _⟩ := h
+      simp at h; obtain ⟨rfl, _⟩ := h
       split at heq_val
       · -- No alias: mty_val = tcons name args'
         simp at heq_val; subst heq_val
@@ -4644,7 +4644,7 @@ private theorem resolveAliases_aliasEquiv
             have h_pred := List.find?_some h_find
             simp [BEq.beq, decide_eq_true_eq] at h_pred; exact h_pred
           have h_len : alias.typeArgs.length = args'.length := by
-            simp [BEq.beq, Nat.beq_eq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
+            simp [BEq.beq, decide_eq_true_eq] at h_arity_eq; exact h_arity_eq
           exact .trans (.cong_tcons h_args_equiv)
             (.expand ⟨alias, h_alias_in, h_name, h_len, rfl⟩)
         · -- Arity mismatch: error, contradicts heq_val
@@ -4693,7 +4693,7 @@ private theorem LMonoTy_resolveAliases_subst_eq
     -- tconsAliasSimple returns Except; split on its result
     split at h
     · simp at h
-    · simp [Pure.pure, Except.pure] at h; obtain ⟨_, h2⟩ := h; rw [← h2]
+    · simp at h; obtain ⟨_, h2⟩ := h; rw [← h2]
       exact LMonoTys_resolveAliases_subst_eq args Env args' Env1 h_args
 
 private theorem LMonoTys_resolveAliases_subst_eq

--- a/Strata/Languages/Boole/Verify.lean
+++ b/Strata/Languages/Boole/Verify.lean
@@ -385,6 +385,13 @@ private partial def toCoreQuantExpr? (e : Boole.Expr) : Option (TranslateM Core.
       some (toCoreQuant false ds body)
   | _ => none
 
+/-- Lower a sequence literal to a left-fold of seq_build over a typed seq_empty. -/
+private partial def seqOfToCore (elemTy : LMonoTy) (vs : Array Boole.Expr) :
+    TranslateM Core.Expression.Expr := do
+  let vals ← vs.toList.mapM toCoreExpr
+  return vals.foldl (fun acc v => mkCoreApp Core.seqBuildOp [acc, v])
+    (Core.seqEmptyOp (some elemTy))
+
 partial def toCoreExpr (e : Boole.Expr) : TranslateM Core.Expression.Expr := do
   if let some q := toCoreQuantExpr? e then
     return ← q
@@ -475,11 +482,12 @@ partial def toCoreExpr (e : Boole.Expr) : TranslateM Core.Expression.Expr := do
   | .seq_empty_bv64 _ => return Core.seqEmptyOp (some (.bitvec 64))
   | .seq_empty_int _  => return Core.seqEmptyOp (some .int)
   -- Sequence literals: Sequence.of_bv32[v0, v1, ..., vn]
-  -- Lowers to a left-fold of seq_build over seq_empty.
-  | .seq_of_bv8  _ ⟨_, vs⟩ | .seq_of_bv16 _ ⟨_, vs⟩ | .seq_of_bv32 _ ⟨_, vs⟩
-  | .seq_of_bv64 _ ⟨_, vs⟩ | .seq_of_int  _ ⟨_, vs⟩ => do
-    let vals ← vs.toList.mapM toCoreExpr
-    return vals.foldl (fun acc v => mkCoreApp Core.seqBuildOp [acc, v]) Core.seqEmptyOp
+  -- Lowers to a left-fold of seq_build over a typed seq_empty.
+  | .seq_of_bv8  _ ⟨_, vs⟩ => seqOfToCore (.bitvec 8)  vs
+  | .seq_of_bv16 _ ⟨_, vs⟩ => seqOfToCore (.bitvec 16) vs
+  | .seq_of_bv32 _ ⟨_, vs⟩ => seqOfToCore (.bitvec 32) vs
+  | .seq_of_bv64 _ ⟨_, vs⟩ => seqOfToCore (.bitvec 64) vs
+  | .seq_of_int  _ ⟨_, vs⟩ => seqOfToCore .int         vs
   -- Lambda abstraction: `fun x : T => body`  →  Core .abs
   | .lambda _ _ decls body => do
       let declsList := declListToList decls
@@ -646,6 +654,9 @@ def toCoreStmt (s : BooleDDM.Statement SourceRange) : TranslateM Core.Statement 
     -- obligation verify as a false positive.
     let .mono_bind_mk _ _ vTy := v
     let vMonoTy ← toCoreMonoType vTy
+    -- Re-translate pred with a de Bruijn bvar as the bound variable so that
+    -- the quantifier body refers to the freshly quantified variable (index 0),
+    -- not the fvar used for the assume statement above.
     let existsBody ← withBVarExprs #[.bvar () 0] (toCoreExpr pred)
     let existsExpr : Core.Expression.Expr :=
       .quant () .exist "" (some vMonoTy) (.bvar () 0) existsBody

--- a/Strata/Languages/Core/CmdType.lean
+++ b/Strata/Languages/Core/CmdType.lean
@@ -59,8 +59,7 @@ bound variables.
 def inferType (C: LContext CoreLParams) (Env: TEnv Unit) (c : Cmd Expression) (e : LExpr CoreLParams.mono) :
     Except DiagnosticModel ((LExpr CoreLParams.mono) × LTy × TEnv Unit) := do
   let _ ← Env.freeVarCheck e f!"[{c}]" |>.mapError DiagnosticModel.fromFormat
-  let T := Env
-  let (ea, T) ← LExpr.resolve C T e |>.mapError DiagnosticModel.fromFormat
+  let (ea, T) ← LExpr.resolve C Env e |>.mapError DiagnosticModel.fromFormat
   let ety := ea.toLMonoTy
   return (ea.unresolved, (.forAll [] ety), T)
 

--- a/Strata/Transform/TerminationCheck.lean
+++ b/Strata/Transform/TerminationCheck.lean
@@ -55,7 +55,11 @@ inductive DecreasesKind where
   | structural (paramIdx : Nat) (dtName : String)
   | intValued (measure : Expression.Expr)
 
-/-- Validate that a parameter index refers to a known ADT type, returning `.structural`. -/
+/-- Validate that a parameter index refers to a known ADT type, returning `.structural`.
+    The `@[cases]` check is defensive: it is always satisfied when called from the
+    `none` branch of `getDecreasesKind` (which already found `@[cases]`), but guards
+    against the `fvar` branch where the user wrote a `decreases` clause pointing to
+    an ADT parameter without marking it `@[cases]`. -/
 private def validateStructuralParam (func : Function) (tf : @TypeFactory Unit)
     (idx : Nat)
     : Except String DecreasesKind := do
@@ -79,6 +83,7 @@ private def getDecreasesKind (func : Function) (tf : @TypeFactory Unit)
   match func.measure with
   | some (.fvar _ id _) =>
     match func.inputs.findWithIdx? id with
+    -- Int-valued measures use the expression directly; the parameter index is not needed.
     | some (_, .int) => .ok (.intValued (.fvar () id (.some .int)))
     | some (idx, _) => validateStructuralParam func tf idx
     | none =>

--- a/StrataTest/DL/Lambda/LExprTypeEnvTests.lean
+++ b/StrataTest/DL/Lambda/LExprTypeEnvTests.lean
@@ -69,15 +69,27 @@ Subst:
                                           type := mty[bool]}]} )
          return format ans
 
-/-- info: ok: myInt -/
+/-- info: ok: int -/
 #guard_msgs in
-#eval do let (ans, _) ← LMonoTy.aliasDef? mty[myInt]
+#eval do let (ans, _) ← LMonoTy.aliasDef? mty[myInt nat]
                         ( (@TEnv.default String).updateContext
                           { aliases := [{
                              typeArgs := ["a"],
                              name := "myInt",
                              type := mty[int]}] })
          return format ans
+
+/-- info: error: Arity mismatch for alias 'myInt': expected 1 type argument(s), got 0 -/
+#guard_msgs in
+#eval do let result := LMonoTy.aliasDef? mty[myInt]
+                        ( (@TEnv.default String).updateContext
+                          { aliases := [{
+                             typeArgs := ["a"],
+                             name := "myInt",
+                             type := mty[int]}] })
+         match result with
+         | .ok (ans, _) => return format s!"ok: {ans}"
+         | .error e => return format s!"error: {e}"
 
 /-- info: ok: (myDef int) -/
 #guard_msgs in


### PR DESCRIPTION
Report arity mismatch error for type aliases instead of silently returning original type.

Previously, `tconsAliasSimple` matched aliases by both name and arity simultaneously. When the name matched but arity didn't, `find?` returned `none` and the function silently returned the unresolved type, leading to confusing downstream type errors.

Now the name-match is split from the arity-check: if the name matches but the number of type arguments is wrong, a clear error message is returned (e.g., "Arity mismatch for alias 'X': expected N type argument(s), got M"). `tconsAliasSimple` returns `Except Format LMonoTy` to support this, and callers (`aliasDef?`, `resolveAliases`) propagate the error.

**Existing test rewritten**: the `LMonoTy.aliasDef? mty[myInt] …` test was previously asserting the buggy silent-fallthrough behaviour (no arity check). It has been rewritten to call with valid arity (`mty[myInt nat]`) and now exercises the success path. A new test was added below it to lock in the arity-mismatch error path that this PR introduces.

All existing tests pass. A new test verifies the arity mismatch error is reported.

---

*Note: `Fixes #1239` keyword removed after merge. This PR was unintentionally auto-merged into #1284's stack branch instead of landing on `main2`; the combined fix tracking #1239 is now in #1284. Issue #1239 has been reopened.*