### PR TITLE
Fix #1229: resolve chained type aliases and preserve user-supplied typeArgs

### DIFF
--- a/Strata/DL/Lambda/LExprTypeEnv.lean
+++ b/Strata/DL/Lambda/LExprTypeEnv.lean
@@ -1240,22 +1240,17 @@ def TEnv.addTypeAlias (alias : TypeAlias) (C: LContext T) (Env : TEnv T.IDMeta) 
               KnownTypes' names:\n\
               {C.knownTypes.keywords}"
   else
-    let (mtys, Env) ← LMonoTys.instantiateEnv alias.typeArgs [alias_lty.toMonoTypeUnsafe, alias.type] Env
-    match mtys with
-    | [lhs, rhs] =>
-      let newTyArgs := lhs.freeVars
-      -- We expect `alias.type` to be a known, legal type, hence the use of
-      -- `instantiateWithCheck` below. Note that we only store type
-      -- declarations -- not synonyms -- as values in the alias table;
-      -- i.e., we don't store a type alias mapped to another type alias.
-      let (rhsmty, _) ← (LTy.forAll [] rhs).instantiateWithCheck C Env
-      let new_aliases := { typeArgs := newTyArgs,
-                           name := alias.name,
-                           type := rhsmty } :: Env.context.aliases
-      let context := { Env.context with aliases := new_aliases }
-      .ok (Env.updateContext context)
-    | _ => .error f!"[TEnv.addTypeAlias] Implementation error! \n\
-                      {alias}"
+    -- De-alias the RHS so that chained aliases are fully resolved.
+    -- This maintains the invariant that stored alias types are never
+    -- themselves aliases.
+    let (rhsResolved, Env) ← LMonoTy.resolveAliases alias.type Env
+    -- Validate that the de-aliased type is a known, legal type.
+    let (_, _) ← (LTy.forAll [] rhsResolved).instantiateWithCheck C Env
+    let new_aliases := { typeArgs := alias.typeArgs,
+                         name := alias.name,
+                         type := rhsResolved } :: Env.context.aliases
+    let context := { Env.context with aliases := new_aliases }
+    .ok (Env.updateContext context)
 
 ---------------------------------------------------------------------
 

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -577,48 +577,9 @@ theorem TEnv.addTypeAlias_preserves_typeArgs
             have h := Except.ok.inj h; rw [← h]
             exact ⟨⟨alias.name, alias.typeArgs, _⟩, rfl, rfl, rfl⟩
 
-/-- The type stored by `addTypeAlias` is fully de-aliased w.r.t. the
-    pre-extension environment: calling `resolveAliases` on it again is
-    the identity.
-
-    The proof requires showing that `LMonoTy.resolveAliases` is idempotent
-    on types that are already resolved — i.e., types whose `tcons` names
-    do not match any alias in the environment. This follows from the
-    invariant that stored alias bodies are themselves alias-free, but
-    formalizing this requires an "alias-free" predicate and mutual
-    induction on the type structure. -/
-theorem TEnv.addTypeAlias_stored_dealiased
-    {T : LExprParams}
-    [DecidableEq T.IDMeta] [ToFormat T.Metadata] [ToFormat T.IDMeta]
-    (alias : TypeAlias) (C : LContext T) (Env Env' : TEnv T.IDMeta)
-    (h : TEnv.addTypeAlias alias C Env = .ok Env')
-    (stored : TypeAlias) (h_head : Env'.context.aliases.head? = some stored) :
-    LMonoTy.resolveAliases stored.type Env = .ok (stored.type, Env) := by
-  -- Extract: stored.type = rhsResolved, the output of resolveAliases alias.type Env
-  unfold TEnv.addTypeAlias at h
-  simp only [Bind.bind, Except.bind] at h
-  split at h
-  · cases h
-  · split at h
-    · cases h
-    · split at h
-      · cases h
-      · split at h
-        · cases h
-        · rename_i v1 h_resolve
-          obtain ⟨rhsResolved, Env1⟩ := v1
-          split at h
-          · cases h
-          · have h_eq := Except.ok.inj h
-            have h_env : Env1 = Env :=
-              LMonoTy.resolveAliases_env alias.type Env rhsResolved Env1 h_resolve
-            subst h_env; subst h_eq
-            simp [TEnv.context, TEnv.updateContext, List.head?] at h_head
-            rw [← h_head]
-            -- Goal: LMonoTy.resolveAliases rhsResolved Env = .ok (rhsResolved, Env)
-            -- This is idempotence of resolveAliases: the output of one pass is a
-            -- fixpoint. Requires mutual induction + alias-free predicate.
-            sorry
+-- TODO (#follow-up): `TEnv.addTypeAlias_stored_dealiased` — the stored type is
+-- a fixpoint of `resolveAliases`. Proof requires showing idempotence of
+-- `resolveAliases` via an "alias-free" predicate and mutual induction.
 
 /-- `LTy.instantiate` preserves the context. -/
 theorem LTy.instantiate_context {IDMeta : Type} [ToFormat IDMeta]

--- a/Strata/DL/Lambda/LExprTypeSpec.lean
+++ b/Strata/DL/Lambda/LExprTypeSpec.lean
@@ -502,6 +502,124 @@ theorem LMonoTys.resolveAliases_context {IDMeta : Type} [ToFormat IDMeta]
             LMonoTy.resolveAliases_context mty Env mty' Env1 h_hd]
 end
 
+---------------------------------------------------------------------
+/-! ### `addTypeAlias` invariants -/
+
+mutual
+/-- `LMonoTy.resolveAliases` preserves the full environment (not just context). -/
+private theorem LMonoTy.resolveAliases_env {IDMeta : Type} [ToFormat IDMeta]
+    (mty : LMonoTy) (Env : TEnv IDMeta) (mty' : LMonoTy) (Env' : TEnv IDMeta)
+    (h : LMonoTy.resolveAliases mty Env = .ok (mty', Env')) :
+    Env' = Env := by
+  match mty with
+  | .ftvar _ =>
+    simp [LMonoTy.resolveAliases] at h
+    obtain ⟨_, h2⟩ := h; exact h2.symm
+  | .bitvec _ =>
+    simp [LMonoTy.resolveAliases] at h
+    obtain ⟨_, h2⟩ := h; exact h2.symm
+  | .tcons name args =>
+    simp [LMonoTy.resolveAliases, Bind.bind, Except.bind] at h
+    split at h
+    · simp at h
+    · rename_i v1 h_args
+      obtain ⟨args', Env1⟩ := v1; simp at h h_args
+      simp only [LMonoTy.tconsAliasSimple] at h
+      split at h <;> (obtain ⟨_, h2⟩ := h; rw [← h2])
+      all_goals exact LMonoTys.resolveAliases_env args Env args' Env1 h_args
+private theorem LMonoTys.resolveAliases_env {IDMeta : Type} [ToFormat IDMeta]
+    (mtys : LMonoTys) (Env : TEnv IDMeta) (mtys' : LMonoTys) (Env' : TEnv IDMeta)
+    (h : LMonoTys.resolveAliases mtys Env = .ok (mtys', Env')) :
+    Env' = Env := by
+  match mtys with
+  | [] =>
+    simp [LMonoTys.resolveAliases] at h
+    obtain ⟨_, h2⟩ := h; exact h2.symm
+  | mty :: mrest =>
+    simp [LMonoTys.resolveAliases, Bind.bind, Except.bind] at h
+    split at h
+    · simp at h
+    · rename_i v1 h_hd
+      obtain ⟨mty', Env1⟩ := v1; simp at h h_hd
+      split at h
+      · simp at h
+      · rename_i v2 h_tl
+        obtain ⟨mrest', Env2⟩ := v2
+        simp at h; obtain ⟨_, h2⟩ := h; rw [← h2]
+        rw [LMonoTys.resolveAliases_env mrest Env1 mrest' Env2 h_tl,
+            LMonoTy.resolveAliases_env mty Env mty' Env1 h_hd]
+end
+
+/-- The alias stored by `addTypeAlias` preserves the user-supplied `typeArgs`. -/
+theorem TEnv.addTypeAlias_preserves_typeArgs
+    {T : LExprParams}
+    [DecidableEq T.IDMeta] [ToFormat T.Metadata] [ToFormat T.IDMeta]
+    (alias : TypeAlias) (C : LContext T) (Env Env' : TEnv T.IDMeta)
+    (h : TEnv.addTypeAlias alias C Env = .ok Env') :
+    ∃ stored, Env'.context.aliases.head? = some stored ∧
+              stored.name = alias.name ∧
+              stored.typeArgs = alias.typeArgs := by
+  unfold TEnv.addTypeAlias at h
+  simp only [Bind.bind, Except.bind] at h
+  split at h
+  · cases h
+  · split at h
+    · cases h
+    · split at h
+      · cases h
+      · -- Now in the success branch: resolveAliases
+        split at h
+        · cases h
+        · -- instantiateWithCheck
+          split at h
+          · cases h
+          · -- h : Except.ok (...) = Except.ok Env'
+            have h := Except.ok.inj h; rw [← h]
+            exact ⟨⟨alias.name, alias.typeArgs, _⟩, rfl, rfl, rfl⟩
+
+/-- The type stored by `addTypeAlias` is fully de-aliased w.r.t. the
+    pre-extension environment: calling `resolveAliases` on it again is
+    the identity.
+
+    The proof requires showing that `LMonoTy.resolveAliases` is idempotent
+    on types that are already resolved — i.e., types whose `tcons` names
+    do not match any alias in the environment. This follows from the
+    invariant that stored alias bodies are themselves alias-free, but
+    formalizing this requires an "alias-free" predicate and mutual
+    induction on the type structure. -/
+theorem TEnv.addTypeAlias_stored_dealiased
+    {T : LExprParams}
+    [DecidableEq T.IDMeta] [ToFormat T.Metadata] [ToFormat T.IDMeta]
+    (alias : TypeAlias) (C : LContext T) (Env Env' : TEnv T.IDMeta)
+    (h : TEnv.addTypeAlias alias C Env = .ok Env')
+    (stored : TypeAlias) (h_head : Env'.context.aliases.head? = some stored) :
+    LMonoTy.resolveAliases stored.type Env = .ok (stored.type, Env) := by
+  -- Extract: stored.type = rhsResolved, the output of resolveAliases alias.type Env
+  unfold TEnv.addTypeAlias at h
+  simp only [Bind.bind, Except.bind] at h
+  split at h
+  · cases h
+  · split at h
+    · cases h
+    · split at h
+      · cases h
+      · split at h
+        · cases h
+        · rename_i v1 h_resolve
+          obtain ⟨rhsResolved, Env1⟩ := v1
+          split at h
+          · cases h
+          · have h_eq := Except.ok.inj h
+            have h_env : Env1 = Env :=
+              LMonoTy.resolveAliases_env alias.type Env rhsResolved Env1 h_resolve
+            subst h_env; subst h_eq
+            simp [TEnv.context, TEnv.updateContext, List.head?] at h_head
+            rw [← h_head]
+            -- Goal: LMonoTy.resolveAliases rhsResolved Env = .ok (rhsResolved, Env)
+            -- This is idempotence of resolveAliases: the output of one pass is a
+            -- fixpoint. Requires mutual induction + alias-free predicate.
+            sorry
+
 /-- `LTy.instantiate` preserves the context. -/
 theorem LTy.instantiate_context {IDMeta : Type} [ToFormat IDMeta]
     (ty : LTy) (Env : TGenEnv IDMeta)

--- a/StrataTest/DL/Lambda/LExprTypeEnvTests.lean
+++ b/StrataTest/DL/Lambda/LExprTypeEnvTests.lean
@@ -162,4 +162,48 @@ info: ok: (x : $__ty0) (y : int) (z : $__ty0)
                     [("x", mty[%a]), ("y", mty[myInt %a %b]), ("z", mty[%a])])
          return Signature.format ans.fst
 
+/-! ### Tests for addTypeAlias: chained resolution and preserved typeArgs -/
+
+section AddTypeAliasTests
+
+open LTy.Syntax in
+private def testContext : LContext TTyDefault :=
+  { LContext.default (T := TTyDefault) with
+    knownTypes := makeKnownTypes
+      ([t[∀a b. %a → %b], t[bool], t[int], t[string], t[∀a. Foo %a]].map
+        (fun k => LTy.toKnownType! k)) }
+
+-- Test (a): Chained aliases are fully resolved.
+-- `FooAlias a := Foo a` and `BarAlias a := FooAlias a` should result in
+-- `resolveAliases (BarAlias int)` returning `Foo int`.
+/-- info: ok: (Foo int) -/
+#guard_msgs in
+#eval do
+  let Env : TEnv TyIdentifier := TEnv.default
+  let Env ← TEnv.addTypeAlias
+    { typeArgs := ["a"], name := "FooAlias", type := mty[Foo %a] } testContext Env
+  let Env ← TEnv.addTypeAlias
+    { typeArgs := ["a"], name := "BarAlias", type := mty[FooAlias %a] } testContext Env
+  let (resolved, _) ← LMonoTy.resolveAliases mty[BarAlias int] Env
+  return format resolved
+
+-- Test (b): Stored alias preserves user-supplied typeArgs.
+-- After `addTypeAlias` with `typeArgs := ["a", "b"]`, the stored alias's
+-- `typeArgs` equals `["a", "b"]`.
+/-- info: ok: [a, b] -/
+#guard_msgs in
+#eval do
+  let C : LContext TTyDefault :=
+    { LContext.default (T := TTyDefault) with
+      knownTypes := makeKnownTypes
+        ([t[∀a b. %a → %b], t[bool], t[int], t[string], t[∀a b. Foo %a %b]].map
+          (fun k => LTy.toKnownType! k)) }
+  let Env : TEnv TyIdentifier := TEnv.default
+  let Env ← TEnv.addTypeAlias
+    { typeArgs := ["a", "b"], name := "MyAlias", type := mty[Foo %a %b] } C Env
+  let stored := Env.context.aliases.head!
+  return format stored.typeArgs
+
+end AddTypeAliasTests
+
 end Lambda


### PR DESCRIPTION
Fixes #1229

## Problem

`TEnv.addTypeAlias` had two defects:
1. **No chain resolution** — the RHS was stored without de-aliasing, so chained aliases (e.g., `BarAlias a := FooAlias a` where `FooAlias` is itself an alias) were never fully resolved.
2. **Internal type argument names** — stored `typeArgs` used `lhs.freeVars` (which produces internal `$__ty0`, `$__ty1` names) instead of the user-supplied names.

## Fix

Replace the `instantiateEnv` + pattern-match logic with a direct call to `LMonoTy.resolveAliases` on the RHS before storing, and use `alias.typeArgs` directly. This maintains the invariant that stored alias types are never themselves aliases, and preserves user-supplied type argument names.

## Invariant theorems

Two theorems in `LExprTypeSpec.lean` lock the invariants this PR establishes:

- `TEnv.addTypeAlias_preserves_typeArgs` — fully proved; the stored alias retains the user-supplied `typeArgs` and `name`.
- `TEnv.addTypeAlias_stored_dealiased` — states that the stored type is a fixpoint of `resolveAliases`. Proof reduced to idempotence of `resolveAliases` (remaining `sorry` to be completed in a follow-up).

A helper `LMonoTy.resolveAliases_env` / `LMonoTys.resolveAliases_env` proves that `resolveAliases` preserves the full `TEnv` (stronger than context-only preservation).

## Testing

- New `#guard_msgs` tests verify chained alias resolution and preserved `typeArgs`.
- All existing tests pass.

## Related issues (separate PRs)

- #1239 (reopened): arity mismatch error reporting
- #1297 (new): typed `seqEmptyOp` in Boole sequence literals
