### PR TITLE
Fix Python for-loop translation: continue now advances the counter

### DIFF
--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -2072,9 +2072,18 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
       | _ =>
           mkStmtExprMd $ .PrimitiveOp .Lt [counterExpr,
                           mkStmtExprMd $ .StaticCall "Any_len" [iterExpr]]
-    let bodyStmts := targetDecls ++ assumeStmts ++ bodyStmts ++ [counterIncrease]
-    let innerBlock := mkStmtExprMd (StmtExpr.Block bodyStmts (some continueLabel))
-    let loopStmt := mkStmtExprMdWithLoc (StmtExpr.While counterLtLen [] none innerBlock) md
+    -- The continue-labeled block contains the body but *not* the counter
+    -- increment: `continue` (translated to `exit continueLabel`) must skip
+    -- the rest of the body and fall through to the increment, otherwise the
+    -- loop counter never advances and the loop is non-terminating. Putting
+    -- the increment outside the labeled block also avoids spurious
+    -- "dead code after 'exit'" diagnostics from `break`/`continue` followed
+    -- by `counterIncrease` in the same block.
+    let bodyInner := targetDecls ++ assumeStmts ++ bodyStmts
+    let continueBlock := mkStmtExprMd (StmtExpr.Block bodyInner (some continueLabel))
+    let bodyStmts := [continueBlock, counterIncrease]
+    let whileBody := mkStmtExprMd (StmtExpr.Block bodyStmts none)
+    let loopStmt := mkStmtExprMdWithLoc (StmtExpr.While counterLtLen [] none whileBody) md
     let loopBlock := mkStmtExprMdWithLoc (StmtExpr.Block [loopStmt] (some breakLabel)) md
     let (preamble, _) := getExceptionCheckPreamble ctx iterExpr s!"$for_iter_{iter.toAst.ann.start.byteIdx}"
     return (finalCtx, iterPreamble ++ preamble ++ [counterDecl] ++ [loopBlock])

--- a/StrataTest/Languages/Python/expected_laurel/test_for_continue_advance.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_for_continue_advance.expected
@@ -1,0 +1,6 @@
+test_for_continue_advance.py(3, 4): ✅ pass - assert(72)
+test_for_continue_advance.py(4, 4): ✅ pass - assume_assume(87)_calls_PIn_0
+test_for_continue_advance.py(1, 35): ✅ pass - (test_for_continue_advance ensures) Return type constraint
+test_for_continue_advance.py(7, 12): ❓ unknown - Check PAdd exception
+DETAIL: 3 passed, 0 failed, 1 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/tests/test_for_continue_advance.py
+++ b/StrataTest/Languages/Python/tests/test_for_continue_advance.py
@@ -1,0 +1,9 @@
+def test_for_continue_advance() -> None:
+    items: Any = [1, 2, 3]
+    s: int = 0
+    for x in items:
+        if x == 2:
+            continue
+        s = s + x
+
+test_for_continue_advance()


### PR DESCRIPTION
## Summary

The Python `for` loop is desugared into a `while` loop with an explicit counter. Before this PR, Python's `continue` skipped the counter increment, making the loop non-terminating. This PR fixes the desugaring so `continue` falls through to the increment, matching Python's semantics.

## The bug, in one Python example

```python
for x in items:
    if some_condition(x):
        continue
    do_work(x)
```

In Python, `continue` skips the rest of the body and proceeds to the next iteration. With the old translation, `continue` skipped the rest of the body **and** the counter increment, so on every iteration where `continue` fired, the counter stayed the same and the loop ran forever on the same index.

## How the desugaring worked before

`for x in iter: body` was translated to:

```
counter := 0
while (counter < len(iter)) {
  block continueLabel: {
    x := iter[counter]
    body
    counter := counter + 1   // ← inside the labeled block
  }
}
```

`continue` in Python compiles to `exit continueLabel`. That exits the **whole labeled block** — past `body`, past `counter := counter + 1`, straight to the next while-condition check.

Result: counter never advances when `continue` fires. Infinite loop.

There was a secondary symptom too: `break` (which compiles to `exit breakLabel`, jumping out of the entire loop) was placed before `counter := counter + 1` in the same block, so `counter := counter + 1` became unreachable code after `break`. Recent stricter resolution passes flag this as a \`dead code after 'exit'\` diagnostic.

## What the fix does

Move the counter increment **outside** the labeled block, so `continue` falls through to it:

```
counter := 0
while (counter < len(iter)) {
  {                               // outer unlabeled block
    block continueLabel: {
      x := iter[counter]
      body
    }
    counter := counter + 1        // ← outside the labeled block
  }
}
```

Now `exit continueLabel` jumps to the end of the *labeled* block but stays inside the *outer* unlabeled block, so the counter increment runs. `break` (`exit breakLabel`) still jumps cleanly out of the whole loop.

This also eliminates the \`dead code after 'exit'\` diagnostic, because nothing follows \`exit\` in the same block anymore.

## File changed

- \`Strata/Languages/Python/PythonToLaurel.lean\`, the \`.For _ target iter body ...\` arm of \`translateStmt\`. 12 lines added, 3 removed.

## Why this matters now

The bug existed on \`main2\` but didn't surface as a test failure because \`pyInterpret\` doesn't execute the loop's body symbolically — the structural translation passed verification, even though it would have hung at runtime.

The PR adding type-checking to Laurel resolution (#1121) introduced a stricter dead-code check that flags the \`exit; counter := counter + 1\` pattern. PR #1121 will reference this fix as the prerequisite that lets its tests pass.

## Tests whose translation changes

These tests use Python `for` loops and therefore go through the changed desugaring code path. **None of them change pass/fail outcome on `main2`** — the bug was previously masked because `pyInterpret` doesn't symbolically execute the loop body. They are listed here for reviewer awareness.

Active tests (in `StrataTest/Languages/Python/tests/`):

- `test_break_continue.py` — exercises both `break` and `continue` directly. The intended target of this fix.
- `test_flag_pattern.py`
- `test_for_else_break.py`
- `test_for_loop.py`
- `test_for_range.py`
- `test_havoc_callee_after_hole_call.py`
- `test_list_empty.py`
- `test_loops.py`

Pending tests (in `StrataTest/Languages/Python/tests/pending/`) — translation also changes; whether any move from pending → passing depends on downstream passes:

- `test_accumulator_pattern.py`, `test_count_pattern.py`, `test_dict_iter_keys.py`, `test_dict_update_loop.py`, `test_dict_empty.py`, `test_flag_found.py`, `test_for_continue.py`, `test_for_count.py`, `test_for_break.py`, `test_for_else.py`, `test_for_range_manual.py`, `test_for_string.py`, `test_for_nested.py`, `test_for_sum.py`, `test_linear_search.py`, `test_list_len.py`, `test_list_of_objects.py`, `test_list_of_strings.py`, `test_list_sum.py`, `test_return_in_loop.py`, `test_scope_for_var.py`, `test_soundness_for_else_ignored.py`

The `while`-loop tests (`test_while_loop.py` and the `while` portion of `test_loops.py`) are unaffected by this change.

## Test plan

- [x] \`bash StrataTest/Languages/Python/run_py_interpret.sh\` — 215 passed, 4 skipped, 0 errors (no regressions)
- [x] \`bash StrataTest/Languages/Python/run_py_analyze.sh\` (from \`StrataTest/Languages/Python/\`) — all tests pass
- [x] \`lake build StrataTest\` — 617 targets, all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)