### PR TITLE
Explicitly `import all` list utilities to avoid naming collisions with Batteries

### DIFF
--- a/Strata/DL/Lambda/Factory.lean
+++ b/Strata/DL/Lambda/Factory.lean
@@ -9,12 +9,12 @@ public import Strata.DL.Lambda.LExprWF
 import all Strata.DL.Lambda.LExprWF
 import all Strata.DL.Lambda.LExpr
 public import Strata.DL.Lambda.LTy
-public import Strata.DL.Lambda.LTyUnify
+import Strata.DL.Lambda.LTyUnify
 import all Strata.DL.Lambda.LTyUnify
 public import Strata.DDM.AST
 public import Strata.DDM.Util.Array
 public import Strata.DL.Util.Func
-public import Strata.DL.Util.List
+import Strata.DL.Util.List
 public import Strata.DL.Util.ListMap
 
 /-!

--- a/Strata/DL/Lambda/FactoryWF.lean
+++ b/Strata/DL/Lambda/FactoryWF.lean
@@ -12,7 +12,7 @@ public import Strata.DL.Lambda.LExprWF
 public import Strata.DL.Lambda.LTy
 public import Strata.DDM.Util.Array
 public import Strata.DL.Util.Func
-public import Strata.DL.Util.List
+import Strata.DL.Util.List
 public import Strata.DL.Util.ListMap
 
 /-!

--- a/Strata/DL/Lambda/Semantics.lean
+++ b/Strata/DL/Lambda/Semantics.lean
@@ -17,6 +17,7 @@ import all Strata.DL.Lambda.Factory
 public import Strata.DL.Lambda.FactoryWF
 import all Strata.DL.Lambda.Scopes
 public import Strata.DL.Util.Relations
+import all Strata.DL.Util.List
 
 /-!
   Small-step semantics for `LExpr` and soundness of `LExpr.eval`.

--- a/Strata/Languages/Core/StatementEval.lean
+++ b/Strata/Languages/Core/StatementEval.lean
@@ -17,6 +17,7 @@ public import Strata.DL.Imperative.StmtEval
 public import Strata.Languages.Core.StatementSemantics
 import all Strata.DL.Imperative.Stmt
 import all Strata.DL.Imperative.CmdEval
+import all Strata.DL.Util.List
 
 ---------------------------------------------------------------------
 


### PR DESCRIPTION
This PR changes files that directly import `Util/List.lean` so that List-related definitions are imported using a regular `import` statement instead of `public import`. (This affects `Factory.lean`, `FactoryWF.lean`, and `LTyUnify.lean`.) 

Downstream clients of these files use `import all Strata.DL.Util.List` directly to access List-definitions. 

The reason for this is that `Util/List.lean` defines a bunch of List-related theorems (e.g. `List.nodup_dedup`), but when an external package imports Strata, these definitions are re-exported into the client's environment via the `public import` chain. If that consumer also depends on Batteries which defines the same `List.*` names), a naming collision occurs. 

By changing `public import` to plain `import`, the definitions remain available inside Strata but are no longer re-exported to downstream packages. This follows the following design principle from #523](https://github.com/strata-org/Strata/pull/523):
  > Namespace extensions kept private. Definitions that extend Lean or library namespaces (e.g. `BitVec.width`, `List.dedup`) stay private by default so Strata does not conflict with Batteries or Mathlib.