### PR TITLE
Fix stack overflow in verify pipeline on large Core programs

### DIFF
--- a/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
+++ b/Strata/Languages/Core/DDMTransform/ASTtoCST.lean
@@ -255,10 +255,15 @@ def declToCST {M} [Inhabited M] (decl : Core.Decl) : ToCSTM M (List (Command M))
 def programToCST {M} [Inhabited M] (prog : Core.Program)
     (initCtx : ToCSTContext M := ToCSTContext.empty) :
     ToCSTContext M × List (Command M) :=
-  let (cmds, finalCtx) := (do
-    let cmdLists ← prog.decls.mapM declToCST
-    pure cmdLists.flatten).run initCtx
-  (finalCtx, cmds)
+  let rec go (decls : List Core.Decl) (acc : List (Command M))
+      (ctx : ToCSTContext M) : List (Command M) × ToCSTContext M :=
+    match decls with
+    | [] => (acc, ctx)
+    | d :: ds =>
+      let (cmds, ctx') := (declToCST d).run ctx
+      go ds (cmds.reverse ++ acc) ctx'
+  let (cmds, finalCtx) := go prog.decls [] initCtx
+  (finalCtx, cmds.reverse)
 
 /-- Render `Core.Program` to a format object.
 

--- a/Strata/Languages/Core/DDMTransform/Translate.lean
+++ b/Strata/Languages/Core/DDMTransform/Translate.lean
@@ -2091,42 +2091,38 @@ def translateDatatypes (p : Program) (bindings : TransBindings) (op : Operation)
 
 partial def translateCoreDecls (p : Program) (bindings : TransBindings) :
   TransM Core.Decls := do
-  let (decls, _) ← go 0 p.commands.size bindings p.commands
-  return decls
-  where go (count max : Nat) bindings ops : TransM (Core.Decls × TransBindings) := do
-  match (max - count) with
-  | 0 => return ([], bindings)
-  | _ + 1 =>
-    let op := ops[count]!
-    let (newDecls, bindings) ← do
-        let (decl, bindings) ←
-          match op.name with
-          | q`Core.command_datatypes =>
-            translateDatatypes p bindings op
-          | q`Core.command_constdecl =>
-            translateConstant bindings op
-          | q`Core.command_typedecl =>
-            translateTypeDecl bindings op
-          | q`Core.command_typesynonym =>
-            translateTypeSynonym bindings op
-          | q`Core.command_axiom =>
-            translateAxiom p bindings op
-          | q`Core.command_distinct =>
-            translateDistinct p bindings op
-          | q`Core.command_procedure =>
-            translateProcedure p bindings op
-          | q`Core.command_fndef =>
-            translateFunction .Definition p bindings op
-          | q`Core.command_fndecl =>
-            translateFunction .Declaration p bindings op
-          | q`Core.command_recfndefs =>
-            translateRecFuncBlock p bindings op
-          | q`Core.command_block =>
-            translateBlockCommand p bindings op
-          | _ => TransM.error s!"translateCoreDecls unimplemented for {repr op}"
-        pure ([decl], bindings)
-    let (decls, bindings) ← go (count + 1) max bindings ops
-    return (newDecls ++ decls, bindings)
+  let mut acc : Array Core.Decl := #[]
+  let mut bindings := bindings
+  for i in [:p.commands.size] do
+    let op := p.commands[i]!
+    let (decl, bindings') ←
+      match op.name with
+      | q`Core.command_datatypes =>
+        translateDatatypes p bindings op
+      | q`Core.command_constdecl =>
+        translateConstant bindings op
+      | q`Core.command_typedecl =>
+        translateTypeDecl bindings op
+      | q`Core.command_typesynonym =>
+        translateTypeSynonym bindings op
+      | q`Core.command_axiom =>
+        translateAxiom p bindings op
+      | q`Core.command_distinct =>
+        translateDistinct p bindings op
+      | q`Core.command_procedure =>
+        translateProcedure p bindings op
+      | q`Core.command_fndef =>
+        translateFunction .Definition p bindings op
+      | q`Core.command_fndecl =>
+        translateFunction .Declaration p bindings op
+      | q`Core.command_recfndefs =>
+        translateRecFuncBlock p bindings op
+      | q`Core.command_block =>
+        translateBlockCommand p bindings op
+      | _ => TransM.error s!"translateCoreDecls unimplemented for {repr op}"
+    acc := acc.push decl
+    bindings := bindings'
+  return acc.toList
 
 def translateProgram (p : Program) : TransM Core.Program := do
   fun s => ((), { s with globalContext := p.globalContext })

--- a/Strata/Transform/PrecondElim.lean
+++ b/Strata/Transform/PrecondElim.lean
@@ -374,30 +374,34 @@ def precondElim (p : Program)
 where
   transformDecls (decls : List Decl)
       : CoreTransformM (Bool × List Decl) := do
-    match decls with
-    | [] => return (false, [])
-    | d :: rest =>
+    let mut acc : Array Decl := #[]
+    let mut changed := false
+    let mut remaining := decls
+    while h : remaining ≠ [] do
+      let d := remaining.head h
+      let rest := remaining.tail
       match d with
       | .proc proc md => do
         if TermCheck.isTermProc proc.header.name.name then
-          let (changed, rest') ← transformDecls rest
-          return (changed, d :: rest')
+          acc := acc.push d
         else
-        let F ← getFactory
-        let (changed, body') ← transformStmts proc.body
-        setFactory F
-        let proc' := { proc with body := body' }
-        let procDecl := Decl.proc proc' md
-        let (changed', rest') ← transformDecls rest
-        match mkContractWFProc F proc md with
-        | some wfDecl => do
-          incrementStat s!"{Stats.wfProceduresGenerated}"
-          incrementStat s!"{Stats.wfProcedureBodyStmtsEmitted}"
-            (match wfDecl with | .proc p _ => p.body.length | _ => 0)
-
-          addWFProcToCallGraph (wfProcName (CoreIdent.toPretty proc.header.name))
-          return (true, wfDecl :: procDecl :: rest')
-        | none => return (changed || changed', procDecl :: rest')
+          let F ← getFactory
+          let (bodyChanged, body') ← transformStmts proc.body
+          setFactory F
+          let proc' := { proc with body := body' }
+          let procDecl := Decl.proc proc' md
+          match mkContractWFProc F proc md with
+          | some wfDecl => do
+            incrementStat s!"{Stats.wfProceduresGenerated}"
+            incrementStat s!"{Stats.wfProcedureBodyStmtsEmitted}"
+              (match wfDecl with | .proc p _ => p.body.length | _ => 0)
+            addWFProcToCallGraph (wfProcName (CoreIdent.toPretty proc.header.name))
+            changed := true
+            acc := acc.push wfDecl
+            acc := acc.push procDecl
+          | none =>
+            changed := changed || bodyChanged
+            acc := acc.push procDecl
       | .func func md => do
         let F ← getFactory
         let .isFalse notMem := Strata.decideProp (func.name.name ∈ F)
@@ -408,16 +412,18 @@ where
         let funcDecl := Decl.func func' md
         let hasPreconds := !func.preconditions.isEmpty
         if hasPreconds then incrementStat s!"{Stats.numFuncsRemovedAfterPrecondStripped}"
-        let (changed, rest') ← transformDecls rest
         match mkFuncWFProc F' func md with
         | some wfDecl => do
           incrementStat s!"{Stats.wfProceduresGenerated}"
           incrementStat s!"{Stats.wfProcedureBodyStmtsEmitted}"
             (match wfDecl with | .proc p _ => p.body.length | _ => 0)
-
           addWFProcToCallGraph (wfProcName (CoreIdent.toPretty func.name))
-          return (true, wfDecl :: funcDecl :: rest')
-        | none => return (changed || hasPreconds, funcDecl :: rest')
+          changed := true
+          acc := acc.push wfDecl
+          acc := acc.push funcDecl
+        | none =>
+          changed := changed || hasPreconds
+          acc := acc.push funcDecl
       | .recFuncBlock funcs md => do
         let F ← getFactory
         let F' ← funcs.foldlM (init := F) fun F func =>  do
@@ -431,30 +437,32 @@ where
         let numStripped := funcs.foldl (fun n f =>
           if !f.preconditions.isEmpty then n + 1 else n) 0
         incrementStat s!"{Stats.numFuncsRemovedAfterPrecondStripped}" numStripped
-
-        let (changed, rest') ← transformDecls rest
         let wfDecls ← funcs.filterMapM fun func => do
           match mkFuncWFProc F' func md with
           | some wfDecl => do
             incrementStat s!"{Stats.wfProceduresGenerated}"
             incrementStat s!"{Stats.wfProcedureBodyStmtsEmitted}"
               (match wfDecl with | .proc p _ => p.body.length | _ => 0)
-
             addWFProcToCallGraph (wfProcName (CoreIdent.toPretty func.name))
             return some wfDecl
           | none => return none
-        if !wfDecls.isEmpty then return (true, funcDecl :: wfDecls ++ rest')
-        else return (changed || hasPreconds, funcDecl :: rest')
+        if !wfDecls.isEmpty then
+          changed := true
+          acc := acc.push funcDecl
+          acc := acc ++ wfDecls.toArray
+        else
+          changed := changed || hasPreconds
+          acc := acc.push funcDecl
       | .type (.data block) _ => do
         let F ← getFactory
         let bf ← liftDiag (Lambda.genBlockFactory (T := CoreLParams) block)
         let F' ← liftDiag (F.addFactory bf)
         setFactory F'
-        let (changed, rest') ← transformDecls rest
-        return (changed, d :: rest')
+        acc := acc.push d
       | _ => do
-        let (changed, rest') ← transformDecls rest
-        return (changed, d :: rest')
+        acc := acc.push d
+      remaining := rest
+    return (changed, acc.toList)
 
 end PrecondElim
 

--- a/Strata/Transform/TerminationCheck.lean
+++ b/Strata/Transform/TerminationCheck.lean
@@ -335,9 +335,14 @@ where
   transformDecls (decls : List Decl) (tf : @TypeFactory Unit)
       (emittedAdtRank : Std.HashSet String)
       : CoreTransformM (Bool × List Decl) := do
-    match decls with
-    | [] => return (false, [])
-    | d :: rest =>
+    let mut acc : Array Decl := #[]
+    let mut changed := false
+    let mut remaining := decls
+    let mut tf := tf
+    let mut emittedAdtRank := emittedAdtRank
+    while h : remaining ≠ [] do
+      let d := remaining.head h
+      let rest := remaining.tail
       match d with
       | .recFuncBlock funcs md => do
         let fileRange := Imperative.getFileRange md |>.getD FileRange.unknown
@@ -369,17 +374,17 @@ where
         let allAdtNames := allAdtNames.eraseDups
         let allAdtRank : AdtRankDecls :=
           let (_, revResults) : Std.HashSet String × List AdtRankDecls :=
-            allAdtNames.foldl (init := ({}, [])) fun (seen, acc) adtName =>
-              if seen.contains adtName then (seen, acc)
+            allAdtNames.foldl (init := ({}, [])) fun (seen, acc') adtName =>
+              if seen.contains adtName then (seen, acc')
               else
                 let r := mkAdtRankDecls adtName tf md
-                (r.namedDecls.foldl (fun s (n, _) => s.insert n) seen, r :: acc)
+                (r.namedDecls.foldl (fun s (n, _) => s.insert n) seen, r :: acc')
           let results := revResults.reverse
           { namedDecls := results.flatMap (·.namedDecls)
             axioms := results.flatMap (·.axioms) }
         let newFuncDecls := allAdtRank.namedDecls.filterMap
-          fun (n, d) => if emittedAdtRank.contains n then none else some d
-        let emittedAdtRank := allAdtRank.namedDecls.foldl (fun s (n, _) => s.insert n) emittedAdtRank
+          fun (n, d') => if emittedAdtRank.contains n then none else some d'
+        emittedAdtRank := allAdtRank.namedDecls.foldl (fun s (n, _) => s.insert n) emittedAdtRank
         incrementStat s!"{Stats.adtRankAxiomsGenerated}" allAdtRank.axioms.length
         -- Step 3: Generate a $$term procedure per function with adtRank
         -- decrease assertions at each recursive call site.
@@ -398,19 +403,21 @@ where
               return some decl
             | .ok none => return none
         -- Step 4: Splice adtRank decls before the rec block, term procs after.
-        let (changed, rest') ← transformDecls rest tf emittedAdtRank
         if newFuncDecls.isEmpty && termDecls.isEmpty then
-          return (changed, d :: rest')
+          acc := acc.push d
         else
-          return (true, newFuncDecls ++ [d] ++ termDecls ++ rest')
+          changed := true
+          acc := acc ++ newFuncDecls.toArray
+          acc := acc.push d
+          acc := acc ++ termDecls.toArray
       | .type (.data block) _md => do
-        let tf' : @TypeFactory Unit := tf.push block
-        let (changed, rest') ← transformDecls rest tf' emittedAdtRank
-        return (changed, d :: rest')
+        tf := tf.push block
+        acc := acc.push d
       | .func _ _ | .proc _ _ | .ax _ _ | .distinct _ _ _
       | .type (.con _) _ | .type (.syn _) _ => do
-        let (changed, rest') ← transformDecls rest tf emittedAdtRank
-        return (changed, d :: rest')
+        acc := acc.push d
+      remaining := rest
+    return (changed, acc.toList)
 
 end TermCheck
 


### PR DESCRIPTION
## Summary

  - Three recursive decl-list traversals (`translateCoreDecls`, `TermCheck.transformDecls`, `PrecondElim.transformDecls`) used cons-style recursion that overflowed the 8MB thread stack at ~30k declarations
  - Replaced with iterative loops (mutable accumulators / `for` over index range) — tail-recursive and stack-constant
  - Also made `programToCST` iterative (not required for correctness but ~6% faster on large inputs)

Core logic is in `Translate.lean`, `TerminationCheck.lean`, `PrecondElim.lean`. `ASTtoCST.lean` is a minor perf improvement.

## Testing

Not directly included in this PR, but the following script creates a very large Strata file:
```
with open('test_stackoverflow.core.st', 'w') as f:
      f.write('program Core;\n\n')
      for i in range(100000):
          f.write(f'function ax_{i}(x: int): int;\n')
          f.write(f'axiom [ax_{i}_pos]: forall x: int :: ax_{i}(x) > 0;\n')
```
Previously, such a file crashed with a stack overflow, now running `strata verify` succeeds in ~5 mins.