### PR TITLE
Add --typed-python: native lowering for annotated Python primitives and containers

### DIFF
--- a/Strata/Languages/Laurel/CoreDefinitionsForLaurel.lean
+++ b/Strata/Languages/Laurel/CoreDefinitionsForLaurel.lean
@@ -39,6 +39,13 @@ function update(map: int, key: int, value: int) : int
 function const(value: int) : int
   external;
 
+// Polymorphic in elem, same as the Map ops above; `int` is a placeholder.
+function Sequence.length(s: int) : int
+  external;
+
+function Sequence.select(s: int, i: int) : int
+  external;
+
 #end
 
 /--

--- a/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
+++ b/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
@@ -31,6 +31,7 @@ open Lambda (LMonoTy LExpr)
 def collectTypeRefs : HighTypeMd → List String
   | ⟨.UserDefined name, _⟩ => [name.text]
   | ⟨.TSet elem, _⟩ => collectTypeRefs elem
+  | ⟨.TSeq elem, _⟩ => collectTypeRefs elem
   | ⟨.TMap k v, _⟩ => collectTypeRefs k ++ collectTypeRefs v
   | ⟨.TTypedField vt, _⟩ => collectTypeRefs vt
   | ⟨.Applied base args, _⟩ =>

--- a/Strata/Languages/Laurel/FilterPrelude.lean
+++ b/Strata/Languages/Laurel/FilterPrelude.lean
@@ -72,6 +72,7 @@ private partial def collectHighTypeNames (ty : HighTypeMd) : CollectM Unit := do
   | .TCore _ => pure ()
   | .TTypedField vt => collectHighTypeNames vt
   | .TSet et => collectHighTypeNames et
+  | .TSeq et => collectHighTypeNames et
   | .TMap kt vt => collectHighTypeNames kt; collectHighTypeNames vt
   | .Applied base args =>
     collectHighTypeNames base; args.forM collectHighTypeNames

--- a/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
@@ -52,6 +52,7 @@ partial def highTypeValToArg : HighType → Arg
   -- Type parameters discarded; the grammar cannot represent Field[T] or Set[T]
   | .TTypedField _vt => laurelOp "compositeType" #[ident "Field"]
   | .TSet _et => laurelOp "compositeType" #[ident "Set"]
+  | .TSeq _et => laurelOp "compositeType" #[ident "Sequence"]
   | .Applied base _args =>
     -- Applied types are not directly representable in the grammar;
     -- emit the base type as a best-effort approximation

--- a/Strata/Languages/Laurel/Laurel.lean
+++ b/Strata/Languages/Laurel/Laurel.lean
@@ -141,6 +141,8 @@ inductive HighType : Type where
   | TTypedField (valueType : AstNode HighType)
   /-- Set type, e.g. `Set int`. -/
   | TSet (elementType : AstNode HighType)
+  /-- Sequence type, e.g. `Sequence int`. Lowers to Core's `Sequence elem`. -/
+  | TSeq (elementType : AstNode HighType)
   /-- Map type. -/
   | TMap (keyType : AstNode HighType) (valueType : AstNode HighType)
   /-- A Identifier to a user-defined composite or constrained type by name. -/
@@ -418,6 +420,7 @@ def highEq (a : HighTypeMd) (b : HighTypeMd) : Bool := match _a: a.val, _b: b.va
   | HighType.TBv n1, HighType.TBv n2 => n1 == n2
   | HighType.TTypedField t1, HighType.TTypedField t2 => highEq t1 t2
   | HighType.TSet t1, HighType.TSet t2 => highEq t1 t2
+  | HighType.TSeq t1, HighType.TSeq t2 => highEq t1 t2
   | HighType.TMap k1 v1, HighType.TMap k2 v2 => highEq k1 k2 && highEq v1 v2
   | HighType.UserDefined r1, HighType.UserDefined r2 => r1.text == r2.text
   | HighType.Applied b1 args1, HighType.Applied b2 args2 =>
@@ -444,6 +447,11 @@ deriving instance BEq for HighType
 def HighType.isBool : HighType → Bool
   | TBool => true
   | _ => false
+
+/-- The class name of a `UserDefined` HighType, if any. -/
+def HighType.className? : HighType → Option String
+  | UserDefined nm => some nm.text
+  | _ => none
 
 /-- Check whether a single modifies entry is the wildcard (`*`). -/
 def StmtExprMd.isWildcard (m : StmtExprMd) : Bool := match m.val with | .All => true | _ => false

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -98,6 +98,7 @@ def translateType (ty : HighTypeMd) : TranslateM LMonoTy := do
   | .THeap => return .tcons "Heap" []
   | .TTypedField _ => return .tcons "Field" []
   | .TSet elementType => return Core.mapTy (← translateType elementType) LMonoTy.bool
+  | .TSeq elementType => return Core.seqTy (← translateType elementType)
   | .TMap keyType valueType => return Core.mapTy (← translateType keyType) (← translateType valueType)
   | .UserDefined name =>
     match model.get? name with

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -350,6 +350,9 @@ def resolveHighType (ty : HighTypeMd) : ResolveM HighTypeMd := do
   | .TSet et =>
     let et' ← resolveHighType et
     pure (.TSet et')
+  | .TSeq et =>
+    let et' ← resolveHighType et
+    pure (.TSeq et')
   | .TMap kt vt =>
     let kt' ← resolveHighType kt
     let vt' ← resolveHighType vt
@@ -711,6 +714,7 @@ private def collectHighType (map : Std.HashMap Nat ResolvedNode) (ty : HighTypeM
   match val with
   | .TTypedField vt => collectHighType map vt
   | .TSet et => collectHighType map et
+  | .TSeq et => collectHighType map et
   | .TMap kt vt =>
     let map := collectHighType map kt
     collectHighType map vt

--- a/Strata/Languages/Laurel/TypeAliasElim.lean
+++ b/Strata/Languages/Laurel/TypeAliasElim.lean
@@ -40,6 +40,7 @@ partial def resolveAliasType (amap : AliasMap) (ty : HighTypeMd)
       | none => ty
   | .TTypedField vt => { val := .TTypedField (resolveAliasType amap vt visited), source := ty.source }
   | .TSet et => { val := .TSet (resolveAliasType amap et visited), source := ty.source }
+  | .TSeq et => { val := .TSeq (resolveAliasType amap et visited), source := ty.source }
   | .TMap kt vt =>
     { val := .TMap (resolveAliasType amap kt visited) (resolveAliasType amap vt visited), source := ty.source }
   | .Applied base args =>

--- a/Strata/Languages/Python/PySpecPipeline.lean
+++ b/Strata/Languages/Python/PySpecPipeline.lean
@@ -134,7 +134,8 @@ private def mergeOverloads (old new : OverloadTable) : OverloadTable :=
     to namespace all generated Laurel names (e.g., `"servicelib_Storage"` for
     module `servicelib.Storage`). -/
 private def buildPySpecLaurelM (pyspecEntries : Array (Python.ModuleName × String))
-    (overloads : OverloadTable) : Pipeline.PipelineM PySpecLaurelResult := do
+    (overloads : OverloadTable) (typedPython : Bool := false)
+    : Pipeline.PipelineM PySpecLaurelResult := do
   let mut combinedProcedures : Array (Laurel.Procedure × String) := #[]
   let mut combinedTypes : Array (Laurel.TypeDefinition × String) := #[]
   let mut allOverloads := overloads
@@ -150,9 +151,15 @@ private def buildPySpecLaurelM (pyspecEntries : Array (Python.ModuleName × Stri
         emitMessageAndAbort .pySpecReadError msg (file := ionFile)
     let { program, errors, overloads, typeAliases, exhaustiveClasses } :=
       Python.Specs.ToLaurel.signaturesToLaurel ionPath sigs moduleName
+        (typedPython := typedPython)
     for msg in errors do
       Pipeline.addMessage msg
       if msg.kind.impact.isFatal then throw ()
+    -- Strict typed-python: any pyspec-side warning must abort the pipeline.
+    if typedPython && !errors.isEmpty then
+      emitMessageAndAbort .typedPythonRefusal
+        s!"--typed-python: pyspec '{ionPath}' produced {errors.size} warning(s); strict mode rejects approximations"
+        (file := ionFile)
     allOverloads := mergeOverloads allOverloads overloads
     allTypeAliases := typeAliases.fold (init := allTypeAliases) fun m k v => m.insert k v
     allExhaustiveClasses := exhaustiveClasses.fold (init := allExhaustiveClasses) fun s name => s.insert name
@@ -207,8 +214,9 @@ private def buildPySpecLaurelM (pyspecEntries : Array (Python.ModuleName × Stri
 public def buildPySpecLaurel
     (ctx : Pipeline.PipelineContext)
     (pyspecEntries : Array (Python.ModuleName × String))
-    (overloads : OverloadTable) : EIO Unit PySpecLaurelResult :=
-  buildPySpecLaurelM pyspecEntries overloads |>.run ctx
+    (overloads : OverloadTable) (typedPython : Bool := false)
+    : EIO Unit PySpecLaurelResult :=
+  buildPySpecLaurelM pyspecEntries overloads typedPython |>.run ctx
 
 /-- Read dispatch Ion files and merge their overload tables. -/
 private def readDispatchOverloadsM
@@ -278,6 +286,7 @@ public def resolveAndBuildLaurelPrelude
     (pyspecModules : Array String)
     (stmts : Array (Python.stmt SourceRange))
     (specDir : System.FilePath := ".")
+    (typedPython : Bool := false)
     : Pipeline.PipelineM PySpecLaurelResult := do
   -- Dispatch modules (fatal on invalid name or missing file)
   let dispatchEntries ← resolveModules dispatchModules specDir
@@ -295,7 +304,7 @@ public def resolveAndBuildLaurelPrelude
     else pure #[]
   -- Explicit pyspec modules (fatal on invalid name or missing file)
   let explicitEntries ← resolveModules pyspecModules specDir
-  buildPySpecLaurelM (autoSpecEntries ++ explicitEntries) dispatchOverloads
+  buildPySpecLaurelM (autoSpecEntries ++ explicitEntries) dispatchOverloads typedPython
 
 /-! ### Pipeline Steps -/
 
@@ -427,6 +436,7 @@ public def pythonAndSpecToLaurel
     (pyspecModules : Array String := #[])
     (sourcePath : Option String := none)
     (specDir : System.FilePath := ".")
+    (typedPython : Bool := false)
     : Pipeline.PipelineM Laurel.Program := do
   let stmts ← Pipeline.withPhase "readPythonIon" do
     match ← Python.readPythonStrata pythonIonPath |>.toBaseIO with
@@ -435,7 +445,7 @@ public def pythonAndSpecToLaurel
       emitMessageAndAbort (file := pythonIonPath) .pySpecParsingError msg
 
   let result ← Pipeline.withPhase "resolveAndBuildPrelude" do
-    resolveAndBuildLaurelPrelude dispatchModules pyspecModules stmts specDir
+    resolveAndBuildLaurelPrelude dispatchModules pyspecModules stmts specDir typedPython
 
   let preludeInfo := buildPreludeInfo result
   let metadataPath := sourcePath.getD pythonIonPath

--- a/Strata/Languages/Python/PySpecPipeline.lean
+++ b/Strata/Languages/Python/PySpecPipeline.lean
@@ -155,7 +155,6 @@ private def buildPySpecLaurelM (pyspecEntries : Array (Python.ModuleName × Stri
     for msg in errors do
       Pipeline.addMessage msg
       if msg.kind.impact.isFatal then throw ()
-    -- Strict typed-python: any pyspec-side warning must abort the pipeline.
     if typedPython && !errors.isEmpty then
       emitMessageAndAbort .typedPythonRefusal
         s!"--typed-python: pyspec '{ionPath}' produced {errors.size} warning(s); strict mode rejects approximations"

--- a/Strata/Languages/Python/PySpecPipeline.lean
+++ b/Strata/Languages/Python/PySpecPipeline.lean
@@ -451,7 +451,8 @@ public def pythonAndSpecToLaurel
   let metadataPath := sourcePath.getD pythonIonPath
 
   let (laurelProgram, _ctx) ←
-    match Python.pythonToLaurel preludeInfo stmts metadataPath result.overloads with
+    match Python.pythonToLaurel preludeInfo stmts metadataPath result.overloads
+                                  (typedPython := typedPython) with
     | .error (.userPythonError range msg) =>
       emitMessageAndAbort (file := sourcePath.getD pythonIonPath) (loc := range)
         .laurelLoweringUserError msg

--- a/Strata/Languages/Python/PythonLaurelTypedExpr.lean
+++ b/Strata/Languages/Python/PythonLaurelTypedExpr.lean
@@ -140,6 +140,26 @@ def reSearchBool (pattern s : TypedStmtExpr .TString)
     (source : Option FileRange := none) : TypedStmtExpr .TBool :=
   .ofStmt (.StaticCall (mkId "re_search_bool") [pattern.stmt, s.stmt]) source
 
+/-- `Sequence.length(s)` over a typed sequence. -/
+def seqLength {elem : HighTypeMd} (s : TypedStmtExpr (.TSeq elem))
+    (source : Option FileRange := s.stmt.source) : TypedStmtExpr .TInt :=
+  .ofStmt (.StaticCall (mkId "Sequence.length") [s.stmt]) source
+
+/-- `Sequence.select(s, i)` over a typed sequence; result has the
+    sequence's element type. -/
+def seqSelect {elem : HighTypeMd}
+    (s : TypedStmtExpr (.TSeq elem)) (i : TypedStmtExpr .TInt)
+    (source : Option FileRange := s.stmt.source) : TypedStmtExpr elem.val :=
+  .ofStmt (.StaticCall (mkId "Sequence.select") [s.stmt, i.stmt]) source
+
+/-- `m[k]` (Map.select) over a typed map; result has the map's
+    value type. -/
+def mapSelect {key val : HighTypeMd}
+    (m : TypedStmtExpr (.TMap key val))
+    (k : TypedStmtExpr key.val)
+    (source : Option FileRange := m.stmt.source) : TypedStmtExpr val.val :=
+  .ofStmt (.StaticCall (mkId "select") [m.stmt, k.stmt]) source
+
 end TypedStmtExpr
 
 /--

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -2639,12 +2639,12 @@ def translateFunction (ctx : TranslationContext) (sourceRange: SourceRange) (fun
           | none => []
         | _ => []
 
-    -- Native return: the signature matches the spec layer; the body
-    -- stays Any-internal and `Return` injects an unwrap to this type.
+    -- Native return: the signature matches the spec layer. Primitives
+    -- need a `fromAny` unwrap at every Return; container/UserDefined
+    -- types are kept as-is so the unwrap is identity.
     let nativeReturnTy : Option HighType := funcDecl.ret.bind fun retInfo =>
-      match retInfo.laurelType.val with
-      | .TInt | .TBool | .TReal | .TString => some retInfo.laurelType.val
-      | _ => none
+      let ty := retInfo.laurelType.val
+      if ty == pyAny then none else some ty
     let outputType : HighTypeMd :=
       nativeReturnTy.map mkHighTypeMd |>.getD AnyTy
     let outputs : List Parameter := [{ name := PyLauFuncReturnVar, type := outputType }]

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -135,7 +135,10 @@ structure TranslationContext where
   loopContinueLabel : Option String := none
   /-- Lower primitives and typed containers natively in user procedures. -/
   typedPython : Bool := false
-deriving Inhabited
+  /-- Static type of `LaurelResult`; `return` unwraps native results. -/
+  resultType : HighType := .TCore "Any"
+
+instance : Inhabited TranslationContext where default := {}
 
 /-! ## Error Handling -/
 
@@ -1426,7 +1429,17 @@ partial def translateCall (ctx : TranslationContext)
     | .Attribute range _ _ _ => range
     | .Name range _ _ => range
     | _ => .none
-  let funcDecl := ctx.functionSignatures.find? fun x => (x.name == funcName || x.name == funcName ++ "@__init__")
+  let nameMatches (x : PythonFunctionDecl) : Bool :=
+    x.name == funcName || x.name == funcName ++ "@__init__"
+  let funcDecl := ctx.functionSignatures.find? nameMatches
+  -- Two declarations can share a name: a Laurel-program entry that
+  -- preserves native types and a Core-prelude entry that stamps
+  -- everything Any. Boundary shim needs the former.
+  let typedFuncDecl :=
+    if ctx.typedPython then
+      ctx.functionSignatures.find? fun x =>
+        nameMatches x && x.args.any (fun a => a.laurelType.val != pyAny)
+    else none
   if funcDecl.isNone && kwords.length > 0 then
     throwUserError f.ann s!"Undeclared function '{funcName}' called with keyword args"
   -- Emit the final call, handling Name vs Attribute dispatch and transparent procedures.
@@ -1515,12 +1528,27 @@ partial def translateCall (ctx : TranslationContext)
   let (args, kwords, funcdecl_hasKwargs) ←
     combinePositionalAndKeywordArgs args kwords funcDecl methodName callRange
   let trans_args ← args.mapM (translateExpr ctx)
+  -- Unwrap each Any-typed argument to its callee-declared native type.
+  let trans_args :=
+    match typedFuncDecl with
+    | some fd =>
+      trans_args.zipIdx.map fun (a, i) =>
+        match fd.args[i]? with
+        | some param => fromAny param.laurelType.val a
+        | none => a
+    | none => trans_args
   let trans_kwords ← translateKwargs ctx kwords
   let trans_kwords_exprs :=
     if kwords.length == 0 then
       if funcdecl_hasKwargs then [DictStrAny_empty] else []
     else [trans_kwords]
-  emitCall (trans_args ++ trans_kwords_exprs)
+  let call ← emitCall (trans_args ++ trans_kwords_exprs)
+  -- Wrap a native return back into Any for the caller.
+  match typedFuncDecl with
+  | some fd => match fd.ret with
+    | some retInfo => return toAny retInfo.laurelType.val call
+    | none => return call
+  | none => return call
 
 
 end
@@ -2051,15 +2079,17 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let whileWrapped := mkStmtExprMdWithLoc (StmtExpr.Block [whileStmt] (some breakLabel)) md
     return (loopCtx, preamble ++ [whileWrapped])
 
-  -- Return statement: assign to the LaurelResult output parameter, then exit $body.
+  -- Return: assign LaurelResult, then exit $body. Native results are
+  -- unwrapped here; the fromAny peephole cancels the wrap from the
+  -- typed expression-translation paths.
   | .Return _ value => do
     let stmts ← match value.val with
       | some expr => do
         let e ← translateExpr ctx expr
         let (preamble, eRef) := getExceptionCheckPreamble ctx e s!"$ret_exc_{expr.toAst.ann.start.byteIdx}"
-        -- Coerce Composite return values to Any for LaurelResult : Any
         let eRef ← coerceToAny ctx expr eRef
-        let assign := mkStmtExprMdWithLoc (StmtExpr.Assign [mkVariableMd (.Local PyLauFuncReturnVar)] eRef) md
+        let coerced := fromAny ctx.resultType eRef
+        let assign := mkStmtExprMdWithLoc (StmtExpr.Assign [mkVariableMd (.Local PyLauFuncReturnVar)] coerced) md
         .ok $ preamble ++ [assign, mkStmtExprMdWithLoc (StmtExpr.Exit "$body") md]
       | none => .ok [mkStmtExprMdWithLoc (StmtExpr.Exit "$body") md]
     return (ctx, stmts)
@@ -2564,8 +2594,12 @@ def translateFunctionBody (ctx : TranslationContext) (kwargsName : Option String
     let nonSelfParams := inputs.filter (fun p => p.name.text != "self")
     let (_, paramCopies) := renameInputParams nonSelfParams
       (match kwargsName with | some kw => (· == kw) | none => fun _ => false)
-    let noneReturn := mkStmtExprMd (.Assign [mkVariableMd (.Local PyLauFuncReturnVar)] AnyNone)
-    let bodyStmts := noneReturn::paramCopies ++ bodyStmts
+    -- The from_None initializer is type-incorrect against a native return.
+    let bodyStmts :=
+      if ctx.resultType == pyAny then
+        mkStmtExprMd (.Assign [mkVariableMd (.Local PyLauFuncReturnVar)] AnyNone) :: paramCopies ++ bodyStmts
+      else
+        paramCopies ++ bodyStmts
     let bodyStmts := (mkStmtExprMd (.Assign [mkVariableMd $ .Declare ⟨ "nullcall_ret", AnyTy⟩] AnyNone)) :: bodyStmts
     return (mkStmtExprMd (StmtExpr.Block bodyStmts none), newctx)
 
@@ -2605,14 +2639,22 @@ def translateFunction (ctx : TranslationContext) (sourceRange: SourceRange) (fun
           | none => []
         | _ => []
 
-    -- Translate return type
-    -- All methods return Any (void methods return Any via from_None)
-    let outputs : List Parameter := [{ name := PyLauFuncReturnVar, type := AnyTy }]
+    -- Native return: the signature matches the spec layer; the body
+    -- stays Any-internal and `Return` injects an unwrap to this type.
+    let nativeReturnTy : Option HighType := funcDecl.ret.bind fun retInfo =>
+      match retInfo.laurelType.val with
+      | .TInt | .TBool | .TReal | .TString => some retInfo.laurelType.val
+      | _ => none
+    let outputType : HighTypeMd :=
+      nativeReturnTy.map mkHighTypeMd |>.getD AnyTy
+    let outputs : List Parameter := [{ name := PyLauFuncReturnVar, type := outputType }]
 
     -- Translate function body
     let inputTypes : List (String × HighType) := funcDecl.args.map fun arg =>
       (arg.name, arg.laurelType.val)
-    let ctx := {ctx with variableTypes:= ("nullcall_ret", pyAny)::inputTypes}
+    let ctx := {ctx with
+      variableTypes := ("nullcall_ret", pyAny)::inputTypes,
+      resultType := outputType.val}
     let ctx := match ctx.currentClassName with
       | some cn => {ctx with variableTypes :=
           ("self", HighType.UserDefined { text := cn }) :: ctx.variableTypes}

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -1793,20 +1793,47 @@ partial def translateAssign  (ctx : TranslationContext)
               newctx.variableTypes ++ [(n.val, .UserDefined className)]}
         | _=> newctx
         if n.val ∈ newctx.variableTypes.unzip.1 then
+          -- The hoisting pass declared the local; if its tracked type
+          -- is native, unwrap the RHS so the assignment typechecks
+          -- against the declared sort.
+          let trackedTy := (newctx.variableTypes.find? (·.fst == n.val)).map (·.snd) |>.getD pyAny
+          let assignStmts :=
+            if trackedTy != pyAny && ctx.typedPython then
+              [mkStmtExprMdWithLoc
+                (StmtExpr.Assign [target] (fromAny trackedTy rhs_trans)) source]
+            else assignStmts
           return (newctx, moExtracts ++ assignStmts, true)
         else
           let inferType ← inferExprType ctx rhs
-          let type ← match annotation with
-          | none => pure inferType
-          | some annotation => do
-               let annStr := pyExprToString annotation
-               -- If the annotation isn't a recognized type, prefer the
-               -- inferred type from the RHS (e.g., overload dispatch).
-               if isKnownType ctx annStr then
-                 let ty ← translateType ctx annStr
-                 pure ty.val
-               else pure inferType
-          let initStmt := mkVarDeclInit n.val AnyTy AnyNone
+          let nativeFromAst : Option HighType :=
+            if ctx.typedPython then
+              annotation.bind pythonTypeExprToHighType
+            else none
+          let type ← match nativeFromAst with
+          | some t => pure t
+          | none => match annotation with
+            | none => pure inferType
+            | some annotation => do
+                 let annStr := pyExprToString annotation
+                 if isKnownType ctx annStr then
+                   let ty ← translateType ctx annStr
+                   pure ty.val
+                 else pure inferType
+          -- A native annotation under `--typed-python` produces a
+          -- native local (matching the spec layer's parameter shape);
+          -- otherwise the local stays Any for compatibility.
+          let useNative := nativeFromAst.isSome
+          let varTy : HighTypeMd := if useNative then mkHighTypeMd type else AnyTy
+          let initExpr := if useNative then mkStmtExprMd .Hole else AnyNone
+          let initStmt := mkVarDeclInit n.val varTy initExpr
+          -- Re-emit the assign so the RHS is unwrapped to the native
+          -- sort when the declaration is native; the fromAny peephole
+          -- cancels the wrap from typed callees.
+          let assignStmts :=
+            if useNative then
+              [mkStmtExprMdWithLoc
+                (StmtExpr.Assign [target] (fromAny type rhs_trans)) source]
+            else assignStmts
           newctx := {ctx with variableTypes:=(n.val, type)::ctx.variableTypes}
           return (newctx, moExtracts ++ (initStmt :: assignStmts), true)
     | .Subscript _ _ _ _ =>
@@ -1885,13 +1912,20 @@ partial def collectDeclaredNamesAndTypes (ctx : TranslationContext) (stmts : Lis
       let names := (lhs.val.toList.filter (λ e => match e with |.Name _ _ _ => true | _=> false)).map pyExprToString
       names.map (λ n => (n, ty))
     | .AnnAssign _ lhs annoTy value _ =>
+      -- Under `--typed-python`, recover native primitives and
+      -- containers from the annotation AST; otherwise fall back to
+      -- the string-keyed lookup.
+      let nativeFromAst : Option HighType :=
+        if ctx.typedPython then pythonTypeExprToHighType annoTy else none
       let ty :=
-        match value.val with
-        | some value =>
-          match inferClassTypeFromLaurelExpr ctx value with
-          | some cn => toCls cn
-          | none => pyTypeStringToHighType (pyExprToString annoTy)
-        | _ => pyTypeStringToHighType (pyExprToString annoTy)
+        match nativeFromAst with
+        | some t => t
+        | none => match value.val with
+          | some value =>
+            match inferClassTypeFromLaurelExpr ctx value with
+            | some cn => toCls cn
+            | none => pyTypeStringToHighType (pyExprToString annoTy)
+          | _ => pyTypeStringToHighType (pyExprToString annoTy)
       [(pyExprToString lhs, ty)]
     | .If _ _ body elsebody => body.val.toList.flatMap go ++ elsebody.val.toList.flatMap go
     | .For _ targetIter _ body _ _
@@ -1918,17 +1952,20 @@ def createVarDeclStmtsAndCtx (ctx : TranslationContext) (newDecls : List (String
   let newDecls := newDecls.foldl (fun acc (n, ty) =>
       if acc.any (fun (an, _) => an == n) || ctx.variableTypes.any (fun (vn, _) => vn == n)
       then acc else acc ++ [(n, ty)]) []
-  let declType (ty : HighType) : HighTypeMd :=
+  -- A type is "native" if its declaration sort matches the values that
+  -- the typed lowering produces (composite class, primitive, container).
+  let isNative (ty : HighType) : Bool :=
     match ty with
-    | .UserDefined nm => if isCompositeType ctx nm.text then mkHighTypeMd ty else AnyTy
-    | _ => AnyTy
+    | .UserDefined nm => isCompositeType ctx nm.text
+    | .TInt | .TBool | .TReal | .TString
+    | .TSeq _ | .TMap _ _ | .TSet _ => ctx.typedPython
+    | _ => false
+  let declType (ty : HighType) : HighTypeMd :=
+    if isNative ty then mkHighTypeMd ty else AnyTy
   let hoistedDecls : List StmtExprMd := newDecls.map fun (name, ty) =>
     mkVarDeclInit name (declType ty) (mkStmtExprMd .Hole)
   let hoistedCtx := { ctx with variableTypes := ctx.variableTypes ++
-      (newDecls.map fun (n, ty) =>
-        match ty with
-        | .UserDefined nm => if isCompositeType ctx nm.text then (n, ty) else (n, pyAny)
-        | _ => (n, pyAny)) }
+      (newDecls.map fun (n, ty) => if isNative ty then (n, ty) else (n, pyAny)) }
   return (hoistedDecls, hoistedCtx)
 
 --Check if a prelude function returns a value of Any type, which may be an exception (such as PAdd, PMul, ...)

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -364,13 +364,19 @@ def translateType (ctx : TranslationContext) (typeStr : String) : Except Transla
           -- Map it to a core PyAnyType
           .ok (mkCoreType PyLauType.Any)
 
-/-- Translate a field type annotation: builtins become Any, composites stay Composite.
-    This matches the two-kind system where method signatures use Any for builtins. -/
+/-- Translate a field type annotation. Composite types resolve to
+    `UserDefined`; primitives resolve to native HighTypes under
+    `--typed-python`; everything else collapses to `Any`. -/
 def translateFieldType (ctx : TranslationContext) (typeStr : String) : Except TranslationError HighTypeMd :=
   match ctx.importedSymbols[typeStr]? with
   | some (ImportedSymbol.compositeType laurelName) =>
     .ok (mkHighTypeMd (.UserDefined laurelName))
-  | _ => .ok (mkCoreType PyLauType.Any)
+  | _ =>
+    if ctx.typedPython then
+      match pythonPrimToHighType typeStr with
+      | some t => .ok (mkHighTypeMd t)
+      | none => .ok (mkCoreType PyLauType.Any)
+    else .ok (mkCoreType PyLauType.Any)
 
 def AnyTy := mkCoreType PyLauType.Any
 def compositeToStringName (typeName : String) : String := "$composite_to_string_" ++ typeName
@@ -1041,7 +1047,8 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
             return mkStmtExprMd .Hole
           else
             return fieldExpr
-        | _ =>
+        | some ty => wrapFieldInAny ty fieldExpr
+        | none =>
           return fieldExpr
       else if isPackage ctx obj then
         -- FIXME: Module attribute (e.g., sys.argv): modules are not modeled as
@@ -1434,11 +1441,20 @@ partial def translateCall (ctx : TranslationContext)
   let funcDecl := ctx.functionSignatures.find? nameMatches
   -- Two declarations can share a name: a Laurel-program entry that
   -- preserves native types and a Core-prelude entry that stamps
-  -- everything Any. Boundary shim needs the former.
+  -- everything Any. Boundary shim needs the former. Class receivers
+  -- (`self : UserDefined`) are non-Any in both, so the discriminator
+  -- looks for at least one primitive/container parameter or return.
+  let isTypedSig (x : PythonFunctionDecl) : Bool :=
+    let isNative (t : HighType) : Bool :=
+      match t with
+      | .TInt | .TBool | .TReal | .TString
+      | .TSeq _ | .TMap _ _ | .TSet _ => true
+      | _ => false
+    x.args.any (fun a => isNative a.laurelType.val) ||
+    (match x.ret with | some r => isNative r.laurelType.val | none => false)
   let typedFuncDecl :=
     if ctx.typedPython then
-      ctx.functionSignatures.find? fun x =>
-        nameMatches x && x.args.any (fun a => a.laurelType.val != pyAny)
+      ctx.functionSignatures.find? fun x => nameMatches x && isTypedSig x
     else none
   if funcDecl.isNone && kwords.length > 0 then
     throwUserError f.ann s!"Undeclared function '{funcName}' called with keyword args"

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -279,9 +279,22 @@ def AnyConstructor.None := "from_None"
 def isOfAnyType (ty: String): Bool := ty ∈ [PyLauType.None, PyLauType.Bool, PyLauType.Int, PyLauType.Float,
                            PyLauType.Str, PyLauType.Datetime, PyLauType.Bytes, PyLauType.ListAny, PyLauType.DictStrAny, PyLauType.Any]
 
-def pyLauTypeTesters (tys : List String) : Array String :=
+/-- Map a Python primitive type string to its native Laurel `HighType`. -/
+def pythonPrimToHighType (ty : String) : Option HighType :=
+  if      ty == PyLauType.Int   then some .TInt
+  else if ty == PyLauType.Bool  then some .TBool
+  else if ty == PyLauType.Float then some .TReal
+  else if ty == PyLauType.Str   then some .TString
+  else none
+
+/-- Any-tag testers for declared parameter types. Native params skip:
+    `Any..isfrom_X` against a native sort would be ill-typed. -/
+def pyLauTypeTesters (typedPython : Bool) (tys : List String) : Array String :=
   tys.foldl (init := #[]) fun acc ty =>
-    if isOfAnyType ty && ty ≠ "Any" then acc.push ("Any..isfrom_" ++ ty) else acc
+    if typedPython && (pythonPrimToHighType ty).isSome then acc
+    else if typedPython && ty ∈ [PyLauType.ListAny, PyLauType.DictStrAny] then acc
+    else if isOfAnyType ty && ty ≠ "Any" then acc.push ("Any..isfrom_" ++ ty)
+    else acc
 
 def PyLauFuncReturnVar := "LaurelResult"
 
@@ -299,10 +312,10 @@ def highTypeToPyLauType : HighType → String
 /-- Sentinel HighType for Python's universal `Any`. -/
 def pyAny : HighType := .TCore "Any"
 
-instance : Inhabited HighType where default := pyAny
-
 /-- Class name for a `UserDefined` type, or `""` otherwise. -/
 def objectClassName (ty : HighType) : String := ty.className?.getD ""
+
+instance : Inhabited HighType where default := pyAny
 
 /-- Convert a Python type-string identifier to its `HighType`.
     `"Any"` / `"None"` / unknown collapse to `pyAny`; everything else
@@ -366,8 +379,39 @@ def isCompositeType (ctx : TranslationContext) (typeName : String) : Bool :=
 
 def pyArgLaurelType (ctx : TranslationContext) (tys : List String) : HighTypeMd :=
   match tys with
-  | [ty] => if isCompositeType ctx ty then mkHighTypeMd (.UserDefined { text := ty }) else AnyTy
+  | [ty] =>
+    if isCompositeType ctx ty then mkHighTypeMd (.UserDefined { text := ty })
+    else if ctx.typedPython then
+      match pythonPrimToHighType ty with
+      | some t => mkHighTypeMd t
+      | none => AnyTy
+    else AnyTy
   | _ => AnyTy
+
+/-- Recover a native HighType from a Python type-annotation AST,
+    preserving inner types of `list[T]` / `dict[K, V]`. -/
+partial def pythonTypeExprToHighType (e : Python.expr SourceRange) : Option HighType :=
+  match e with
+  | .Name _ n _ => pythonPrimToHighType n.val
+  | .Subscript _ baseExpr slice _ =>
+    let baseName : String :=
+      match baseExpr with
+      | .Name _ n _ => n.val
+      | .Attribute _ _ ⟨_, attr⟩ _ => attr
+      | _ => ""
+    let elems : List (Python.expr SourceRange) :=
+      match slice with
+      | .Tuple _ elts _ => elts.val.toList
+      | _ => [slice]
+    match baseName, elems with
+    | "List", [t] | "list", [t] | "Sequence", [t] =>
+      pythonTypeExprToHighType t |>.map fun inner => .TSeq ⟨inner, none⟩
+    | "Dict", [k, v] | "dict", [k, v] | "Mapping", [k, v] =>
+      match pythonTypeExprToHighType k, pythonTypeExprToHighType v with
+      | some kt, some vt => some (.TMap ⟨kt, none⟩ ⟨vt, none⟩)
+      | _, _ => none
+    | _, _ => none
+  | _ => none
 def strToAny (s: String) := mkStmtExprMd (.StaticCall "from_str" [mkStmtExprMd (StmtExpr.LiteralString s)])
 def intToAny (i: Int) := mkStmtExprMd (.StaticCall "from_int" [mkStmtExprMd (StmtExpr.LiteralInt i)])
 def boolToAny (b: Bool) := mkStmtExprMd (.StaticCall "from_bool" [mkStmtExprMd (StmtExpr.LiteralBool b)])
@@ -2261,11 +2305,23 @@ def unpackPyArguments (ctx : TranslationContext) (args: Python.arguments SourceR
             | _ =>
               pure ()
             tys ← checkValidInputTypeList ctx tys
+            -- Structural lowering keeps `list[int]` etc. inner type;
+            -- the String pipeline would collapse it to ListAny.
+            let nativeTy : Option HighType :=
+              if ctx.typedPython then
+                match oty.val with
+                | .some ty => pythonTypeExprToHighType ty
+                | _ => none
+              else none
+            let laurelType : HighTypeMd :=
+              match nativeTy with
+              | some t => mkHighTypeMd t
+              | none => pyArgLaurelType ctx tys
             argtypes := argtypes.push {
               name:= name.val,
               source := md,
-              laurelType := pyArgLaurelType ctx tys,
-              typeTesters := pyLauTypeTesters tys,
+              laurelType,
+              typeTesters := pyLauTypeTesters ctx.typedPython tys,
               default:= default
             }
       let kwargsName := kwargs.val.map (λ kwarg => match kwarg with | .mk_arg _ name _ _ => name.val)
@@ -2291,10 +2347,16 @@ def pyFuncDefToPythonFunctionDecl  (ctx : TranslationContext) (f : Python.stmt S
               let retSource := sourceRangeToSource ctx.filePath retTy.ann
               match checkValidInputTypeList ctx (← getArgumentTypes retTy) with
               | .ok tys =>
+                let nativeTy : Option HighType :=
+                  if ctx.typedPython then pythonTypeExprToHighType retTy else none
+                let laurelType : HighTypeMd :=
+                  match nativeTy with
+                  | some t => mkHighTypeMd t
+                  | none => pyArgLaurelType ctx tys
                 pure $ some {
                   source := retSource,
-                  laurelType := pyArgLaurelType ctx tys,
-                  typeTesters := pyLauTypeTesters tys
+                  laurelType,
+                  typeTesters := pyLauTypeTesters ctx.typedPython tys
                 }
               | _ => pure none
           | none => pure none
@@ -2462,7 +2524,7 @@ def preludeSignatureToPythonFunctionDecl (prelude : Core.Program) : List PythonF
         let tys := [getTypeName tp]
         { source := none,
           laurelType := mkHighTypeMd (.UserDefined (mkId (getTypeName tp))),
-          typeTesters := pyLauTypeTesters tys : PyRetInfo }
+          typeTesters := pyLauTypeTesters false tys : PyRetInfo }
       some {
         name:= proc.header.name.name
         args:=  proc.header.inputs |>.map λ(nm,tp) =>
@@ -2470,7 +2532,7 @@ def preludeSignatureToPythonFunctionDecl (prelude : Core.Program) : List PythonF
           name:= nm.name,
           source := none,
           laurelType := AnyTy,
-          typeTesters := pyLauTypeTesters [getTypeName tp],
+          typeTesters := pyLauTypeTesters false [getTypeName tp],
           default:= noneexpr
         }
         kwargsName := none
@@ -2810,11 +2872,13 @@ def PreludeInfo.ofLaurelProgram (prog : Laurel.Program) : PreludeInfo where
           let argName := if param.name.text.startsWith paramInputPrefix then
             (param.name.text.drop paramInputPrefix.length).toString
           else param.name.text
-          {name:= argName, source := none, laurelType := param.type, typeTesters := pyLauTypeTesters [getHighTypeName param.type.val], default:= some noneexpr}
+          {name:= argName, source := none, laurelType := param.type,
+           typeTesters := pyLauTypeTesters false [getHighTypeName param.type.val],
+           default:= some noneexpr}
         let ret := p.outputs.head?.map fun param =>
           let tys := [getHighTypeName param.type.val]
           { source := none, laurelType := param.type,
-            typeTesters := pyLauTypeTesters tys : PyRetInfo }
+            typeTesters := pyLauTypeTesters false tys : PyRetInfo }
         some { name := p.name.text, args := args, kwargsName := none, ret := ret }
   functions :=
     let funcNames := prog.staticProcedures.filterMap fun p =>

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -87,7 +87,11 @@ inductive ImportedSymbol where
 deriving Inhabited
 
 structure TranslationContext where
-  variableTypes : List (String × String) := []
+  /-- Local-name → declared `HighType`. Native primitives appear as
+      `TInt` / `TBool` / `TReal` / `TString`, native containers as
+      `TSeq` / `TMap`, classes as `UserDefined`, otherwise the
+      `TCore "Any"` sentinel. -/
+  variableTypes : List (String × HighType) := []
   /-- List of function signatures -/
   functionSignatures : List PythonFunctionDecl := []
   /-- Names of user-defined functions -/
@@ -129,6 +133,8 @@ structure TranslationContext where
   classesInHierarchy : Std.HashSet String := {}
   loopBreakLabel : Option String := none
   loopContinueLabel : Option String := none
+  /-- Lower primitives and typed containers natively in user procedures. -/
+  typedPython : Bool := false
 deriving Inhabited
 
 /-! ## Error Handling -/
@@ -286,8 +292,27 @@ def highTypeToPyLauType : HighType → String
   | .TString => PyLauType.Str
   | .TFloat64 => PyLauType.Any
   | .TReal => PyLauType.Any
+  | .TCore s => s
   | .UserDefined name => name.text
   | _ => PyLauType.Any
+
+/-- Sentinel HighType for Python's universal `Any`. -/
+def pyAny : HighType := .TCore "Any"
+
+instance : Inhabited HighType where default := pyAny
+
+/-- Class name for a `UserDefined` type, or `""` otherwise. -/
+def objectClassName (ty : HighType) : String := ty.className?.getD ""
+
+/-- Convert a Python type-string identifier to its `HighType`.
+    `"Any"` / `"None"` / unknown collapse to `pyAny`; everything else
+    becomes a `UserDefined` reference. -/
+def pyTypeStringToHighType (s : String) : HighType :=
+  if s == PyLauType.Any || s == PyLauType.None || s == PyLauType.Package
+     || s == PyLauType.ListAny || s == PyLauType.ListStr
+     || s == PyLauType.DictStrAny || s == PyLauType.Datetime
+     || s == PyLauType.Bytes then pyAny
+  else .UserDefined { text := s }
 
 /-- Map Python type strings to Core type names -/
 def pythonTypeToCoreType (typeStr : String) : Option String :=
@@ -739,15 +764,16 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
   | .FormattedValue _ value _ _ =>
     let ty ← inferExprType ctx value
     let inner ← translateExpr ctx value
-    let asAny ← if isCompositeType ctx ty then
-        let fields := (ctx.classFieldHighType[ty]?.getD {}).toList
+    let cls := objectClassName ty
+    let asAny ← if isCompositeType ctx cls then
+        let fields := (ctx.classFieldHighType[cls]?.getD {}).toList
         let dict ← fields.foldlM (fun acc (fname, fty) =>
           return mkStmtExprMd (.StaticCall "DictStrAny_cons"
             [mkStmtExprMd (.LiteralString fname),
              ← wrapFieldInAny fty (mkStmtExprMd (.Var (.Field inner fname))), acc]))
           (mkStmtExprMd (.StaticCall "DictStrAny_empty" []))
         pure <| mkStmtExprMd (.StaticCall "from_ClassInstance"
-          [mkStmtExprMd (.LiteralString ty), dict])
+          [mkStmtExprMd (.LiteralString cls), dict])
       else pure inner
     return mkStmtExprMd (.StaticCall "to_string_any" [asAny])
 
@@ -794,8 +820,8 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
           -- Skip for dicts, where negative integer keys are valid dict lookups.
           -- Note: Python's AST represents `-1` as UnaryOp(USub, Constant(1)),
           -- not Constant(-1), so we must match both forms.
-          let valType := (inferExprType ctx val).toOption.getD PyLauType.Any
-          let isDictType := valType == PyLauType.DictStrAny
+          let valType := (inferExprType ctx val).toOption.getD (pyAny)
+          let isDictType := valType.className? == some PyLauType.DictStrAny
           let negLitVal? := match slice with
             | .Constant _ (.ConNeg _ n) _ => some n.val
             | .UnaryOp _ (.USub _) (.Constant _ (.ConPos _ n) _) => some n.val
@@ -847,7 +873,8 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
         let objExpr ← translateExpr ctx obj
         let fieldExpr := mkStmtExprMd (StmtExpr.Var (.Field objExpr attr.val))
         let objType ← inferExprType ctx obj
-        match tryLookupFieldHighType ctx objType attr.val with
+        let cls := objectClassName objType
+        match tryLookupFieldHighType ctx cls attr.val with
           | some ty => wrapFieldInAny ty fieldExpr
           | none => return fieldExpr
     | _ =>
@@ -855,7 +882,8 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
       let objExpr ← translateExpr ctx obj
       let fieldExpr := mkStmtExprMd (StmtExpr.Var (.Field objExpr attr.val))
       let objType ← inferExprType ctx obj
-      match tryLookupFieldHighType ctx objType attr.val with
+      let cls := objectClassName objType
+      match tryLookupFieldHighType ctx cls attr.val with
         | some ty => wrapFieldInAny ty fieldExpr
         | none => return fieldExpr
 
@@ -911,59 +939,50 @@ partial def isPackage (ctx : TranslationContext) (expr: Python.expr SourceRange)
   | .Name _ n _ => n.val ∉ ctx.variableTypes.unzip.fst
   | _ => false
 
-partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange) : Except TranslationError String := do
+partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange) : Except TranslationError HighType := do
   match e with
-  -- Integer literals
   | .Constant _ (.ConPos _ _) _
-  | .Constant _ (.ConNeg _ _) _ => return PyLauType.Int
-  -- String literals
-  | .Constant _ (.ConString _ _) _ => return PyLauType.Str
-  -- Boolean literals
+  | .Constant _ (.ConNeg _ _) _ => return .TInt
+  | .Constant _ (.ConString _ _) _ => return .TString
   | .Constant _ (.ConTrue _) _
   | .Constant _ (.ConFalse _) _
   | .BoolOp _ _ _
-  | .Compare _ _ _ _=> return PyLauType.Bool
-  | .Constant _ (.ConNone _) _ => return PyLauType.None
-  -- Variable references
+  | .Compare _ _ _ _ => return .TBool
+  -- Distinct sentinel for `None` so default-value handling can
+  -- detect `Union[T, None] = None`.
+  | .Constant _ (.ConNone _) _ => return .TCore PyLauType.None
   | .Name _ n _ =>
       match ctx.variableTypes.find? (λ v => v.fst == n.val) with
       | some (_, ty) => return ty
-      | _ => return PyLauType.Package
+      | _ => return pyAny
   | .Attribute _ v attr _ =>
     let vty ← inferExprType ctx v
-    match tryLookupFieldHighType ctx vty attr.val with
-      | some ty => return (highTypeToPyLauType ty)
-      | none => return PyLauType.Any
-  -- Binary operations
-  | .BinOp _ _ _ _ => return PyLauType.Any
-
-  -- Unary operations
-  | .UnaryOp _ _ _ => return PyLauType.Any
-
-  -- JoinedStr (f-strings) produce strings
-  | .JoinedStr _ _ => return PyLauType.Str
-  -- FormattedValue produces string-typed Any
-  | .FormattedValue _ _ _ _ => return PyLauType.Str
-
+    let cls := objectClassName vty
+    match tryLookupFieldHighType ctx cls attr.val with
+      | some ty => return ty
+      | none => return pyAny
+  | .BinOp _ _ _ _ => return pyAny
+  | .UnaryOp _ _ _ => return pyAny
+  | .JoinedStr _ _ => return .TString
+  | .FormattedValue _ _ _ _ => return .TString
   | .Call _ f args kwargs =>
     getFunctionReturnType ctx f args.val kwargs.val.toList
-
-  | _ => return PyLauType.Any
+  | _ => return pyAny
 
 partial def getFunctionReturnType (ctx : TranslationContext) (func: Python.expr SourceRange) (args : Array (Python.expr SourceRange))
     (kwords : List (Python.keyword SourceRange) := [])
-    : Except TranslationError String := do
+    : Except TranslationError HighType := do
   match resolveDispatch ctx func args kwords with
-  | .ok (some classname) => return classname
+  | .ok (some classname) => return .UserDefined { text := classname }
   | .error e => throw e
   | .ok none =>
     let (fname, _) ← refineFunctionCallExpr ctx func
     match ctx.functionSignatures.find? (λ f => f.name == fname) with
       | some funcDecl =>
         match funcDecl.ret with
-        | some retInfo => return highTypeToPyLauType retInfo.laurelType.val
-        | none => return PyLauType.Any
-      | _ => return PyLauType.Any
+        | some retInfo => return retInfo.laurelType.val
+        | none => return pyAny
+      | _ => return pyAny
 
 
 /-
@@ -982,7 +1001,7 @@ The following function return a tuple (translated function name, first argument,
 partial def coerceToAny (ctx : TranslationContext) (expr : Python.expr SourceRange)
     (translated : StmtExprMd) : Except TranslationError StmtExprMd := do
   let ty ← inferExprType ctx expr
-  if isCompositeType ctx ty then
+  if isCompositeType ctx (objectClassName ty) then
     pure <| mkStmtExprMd (.Hole)
   else pure translated
 
@@ -992,11 +1011,12 @@ partial def refineFunctionCallExpr (ctx : TranslationContext) (func: Python.expr
     | .Name _ n _ => return (reMapFunctionName ctx n.val, none , false)
     | .Attribute _ v attr _ =>
         let callerTy ←  inferExprType ctx v
+        let callerName := callerTy.className?.getD PyLauType.Any
         let callname := attr.val
         if isPackage ctx v then
           return (pyExprToString func, none, false)
         else
-        if callerTy == PyLauType.Any then
+        if callerName == PyLauType.Any then
           -- Check if this is self.field where the field was initialized via
           -- dispatch (e.g. self.client = boto3.client('s3')).
           let dispatchTy : Option String := match v with
@@ -1029,9 +1049,9 @@ partial def refineFunctionCallExpr (ctx : TranslationContext) (func: Python.expr
             return (manglePythonMethod "AnyTyInstance" callname, some v, true)
         else
           let resolvedTy :=
-            match ctx.importedSymbols[callerTy]? with
+            match ctx.importedSymbols[callerName]? with
             | some (ImportedSymbol.compositeType laurelName) => laurelName
-            | _ => callerTy
+            | _ => callerName
           return (manglePythonMethod resolvedTy callname, some v, false)
     | _ => throw (.internalError s!"{repr func} is not a function")
 
@@ -1134,7 +1154,8 @@ partial def translateExprAsReceiver (ctx : TranslationContext)
   match e with
   | .Attribute _ obj fieldAttr _ =>
     let objType ← inferExprType ctx obj
-    match tryLookupFieldHighType ctx objType fieldAttr.val with
+    let cls := objectClassName objType
+    match tryLookupFieldHighType ctx cls fieldAttr.val with
     | some (.UserDefined _) =>
       let objExpr ← translateExprAsReceiver ctx obj
       pure <| mkStmtExprMd (StmtExpr.Var (.Field objExpr fieldAttr.val))
@@ -1189,7 +1210,7 @@ partial def translateCall (ctx : TranslationContext)
       if let .Name _ n _ := arg then
         match ctx.variableTypes.find? (λ v => Prod.fst v == n.val) with
         | some (varName, ty) =>
-          if ty == PyLauType.Any then
+          if ty == pyAny then
             [mkStmtExprMd (StmtExpr.Assign
               [mkVariableMd (.Local varName)]
               (mkStmtExprMd (.Hole false none)))]
@@ -1219,10 +1240,10 @@ partial def translateCall (ctx : TranslationContext)
     -- Check for len() on Composite types (class instances without __len__)
     if funcName == "Any_len_to_Any" && args.length == 1 then
       match inferExprType ctx args[0]! with
-      | .ok argType =>
-        if isCompositeType ctx argType then
-          throwUserError f.ann s!"len() is not supported on '{argType}' (no __len__ method)"
-      | .error _ => pure ()
+      | .ok (.UserDefined nm) =>
+        if isCompositeType ctx nm.text then
+          throwUserError f.ann s!"len() is not supported on '{nm.text}' (no __len__ method)"
+      | _ => pure ()
     match f with
     | .Name  _ _ _ =>
         -- If calling str() on a composite-typed variable, use $composite_to_string_any_<type>
@@ -1230,11 +1251,11 @@ partial def translateCall (ctx : TranslationContext)
         let funcName' :=
           if funcName == "to_string_any" && args.length == 1 then
             match inferExprType ctx args[0]! with
-            | .ok argType =>
-              if isCompositeType ctx argType then
-                compositeToStringAnyName argType
+            | .ok (.UserDefined nm) =>
+              if isCompositeType ctx nm.text then
+                compositeToStringAnyName nm.text
               else funcName
-            | .error _ => funcName
+            | _ => funcName
           else funcName
         return mkCall funcName'
     | .Attribute _ val _attr _ =>
@@ -1469,10 +1490,11 @@ partial def translateAssign  (ctx : TranslationContext)
         let annType := annotation.map (fun a => pyExprToString a) |>.getD "Any"
         let (varTy, trackType) ← match ctx.importedSymbols[annType]? with
           | some (ImportedSymbol.compositeType laurelName) =>
-            pure (mkHighTypeMd (.UserDefined (mkId laurelName)), laurelName)
+            pure (mkHighTypeMd (.UserDefined (mkId laurelName)),
+                  HighType.UserDefined (mkId laurelName))
           | some _ =>
             throw (.userPythonError lhs.ann s!"'{annType}' is not a type")
-          | _ => pure (AnyTy, "Any")
+          | _ => pure (AnyTy, pyAny)
         let initStmt := mkVarDeclInit n.val varTy (mkStmtExprMd .Hole)
         let newctx := {ctx with variableTypes:=(n.val, trackType)::ctx.variableTypes}
         return (newctx, [initStmt] ++ exceptHavoc, true)
@@ -1511,22 +1533,27 @@ partial def translateAssign  (ctx : TranslationContext)
         newctx := match rhs_trans.val with
         | .StaticCall fnname _ =>
             if let some (ImportedSymbol.compositeType laurelName) := ctx.importedSymbols[fnname.text]? then
-              {newctx with variableTypes:= newctx.variableTypes ++ [(n.val, laurelName)]}
+              {newctx with variableTypes:=
+                newctx.variableTypes ++ [(n.val, .UserDefined (mkId laurelName))]}
             else newctx
         | .New className =>
-            {newctx with variableTypes:= newctx.variableTypes ++ [(n.val, className.text)]}
+            {newctx with variableTypes:=
+              newctx.variableTypes ++ [(n.val, .UserDefined className)]}
         | _=> newctx
         if n.val ∈ newctx.variableTypes.unzip.1 then
           return (newctx, moExtracts ++ assignStmts, true)
         else
           let inferType ← inferExprType ctx rhs
-          let type := match annotation with
-          | none => inferType
-          | some annotation =>
+          let type ← match annotation with
+          | none => pure inferType
+          | some annotation => do
                let annStr := pyExprToString annotation
                -- If the annotation isn't a recognized type, prefer the
                -- inferred type from the RHS (e.g., overload dispatch).
-               if isKnownType ctx annStr then annStr else inferType
+               if isKnownType ctx annStr then
+                 let ty ← translateType ctx annStr
+                 pure ty.val
+               else pure inferType
           let initStmt := mkVarDeclInit n.val AnyTy AnyNone
           newctx := {ctx with variableTypes:=(n.val, type)::ctx.variableTypes}
           return (newctx, moExtracts ++ (initStmt :: assignStmts), true)
@@ -1570,20 +1597,19 @@ partial def translateAssign  (ctx : TranslationContext)
     Returns a list of (variable name, type) pairs, where type defaults to `Any`.
     Items without an `as` clause (e.g. `with open(...)`) are ignored. -/
 partial def getWithItemsVars (withItems: List (Python.withitem SourceRange))
-    :List (String × String) :=
+    : List (String × HighType) :=
   withItems.filterMap fun item => match item with
     | .mk_withitem _ _ var =>
       match var.val with
-        | some var => some (pyExprToString var, PyLauType.Any)
+        | some var => some (pyExprToString var, pyAny)
         | _ => none
 
-/-- Extracts loop variables from a `for` loop target expression.
-    Handles single var or tuple/list unpacking targets. -/
-partial def getForLoopVars (targetIter: Python.expr SourceRange) :List (String × String) :=
+/-- Extracts loop variables from a `for` loop target expression. -/
+partial def getForLoopVars (targetIter: Python.expr SourceRange) : List (String × HighType) :=
   match targetIter with
-    | .Name _ n _ => [(n.val, PyLauType.Any)]  -- `for x in ...`
+    | .Name _ n _ => [(n.val, pyAny)]
     | .Tuple _ tup _ | .List _ tup _ =>
-        tup.val.toList.flatMap fun n => getForLoopVars n -- `for x, y in ...` or `for [x, y] in ...`
+        tup.val.toList.flatMap fun n => getForLoopVars n
     | _ => []
 
 def inferClassTypeFromLaurelExpr (ctx : TranslationContext) (value : Python.expr SourceRange) : Option String :=
@@ -1593,17 +1619,27 @@ def inferClassTypeFromLaurelExpr (ctx : TranslationContext) (value : Python.expr
       if isCompositeType ctx funcname.text then funcname.text else none
   | _ => none
 
-partial def collectDeclaredNamesAndTypes (ctx : TranslationContext) (stmts : List (Python.stmt SourceRange)) : List (String × String) :=
-  let rec go (s : Python.stmt SourceRange) : List (String × String) :=
+partial def collectDeclaredNamesAndTypes (ctx : TranslationContext) (stmts : List (Python.stmt SourceRange))
+    : List (String × HighType) :=
+  let toCls (n : String) : HighType :=
+    if isCompositeType ctx n then .UserDefined { text := n } else pyAny
+  let rec go (s : Python.stmt SourceRange) : List (String × HighType) :=
     match s with
     | .Assign _ lhs value _ =>
-      let ty := (inferClassTypeFromLaurelExpr ctx value).getD PyLauType.Any
+      let ty :=
+        match inferClassTypeFromLaurelExpr ctx value with
+        | some cn => toCls cn
+        | none => pyAny
       let names := (lhs.val.toList.filter (λ e => match e with |.Name _ _ _ => true | _=> false)).map pyExprToString
       names.map (λ n => (n, ty))
     | .AnnAssign _ lhs annoTy value _ =>
-      let ty := match value.val with
-        | some value => (inferClassTypeFromLaurelExpr ctx value).getD $ pyExprToString annoTy
-        | _ => pyExprToString annoTy
+      let ty :=
+        match value.val with
+        | some value =>
+          match inferClassTypeFromLaurelExpr ctx value with
+          | some cn => toCls cn
+          | none => pyTypeStringToHighType (pyExprToString annoTy)
+        | _ => pyTypeStringToHighType (pyExprToString annoTy)
       [(pyExprToString lhs, ty)]
     | .If _ _ body elsebody => body.val.toList.flatMap go ++ elsebody.val.toList.flatMap go
     | .For _ targetIter _ body _ _
@@ -1614,7 +1650,8 @@ partial def collectDeclaredNamesAndTypes (ctx : TranslationContext) (stmts : Lis
         let handlers_bodies := handlers.val.toList.map (λ h => match h with
           | .ExceptHandler _ _ _ body => body.val.toList)
         let error_var := (handlers.val.toList.filterMap (λ h => match h with
-          | .ExceptHandler _ _ errname _ => errname.val)).map (λ h => (h.val, "PythonError"))
+          | .ExceptHandler _ _ errname _ => errname.val)).map
+            (λ h => (h.val, HighType.UserDefined { text := "PythonError" }))
         error_var ++ (body.val.toList.flatMap go) ++ (handlers_bodies.flatten.flatMap go)
           ++ (finalbody.val.toList.flatMap go) ++ (orelse.val.toList.flatMap go)
     | .With _ items body _
@@ -1624,17 +1661,22 @@ partial def collectDeclaredNamesAndTypes (ctx : TranslationContext) (stmts : Lis
     | _ => []
   stmts.flatMap go
 
-def createVarDeclStmtsAndCtx (ctx : TranslationContext) (newDecls : List (String × String))
+def createVarDeclStmtsAndCtx (ctx : TranslationContext) (newDecls : List (String × HighType))
     : Except TranslationError (List StmtExprMd × TranslationContext) := do
   let newDecls := newDecls.foldl (fun acc (n, ty) =>
       if acc.any (fun (an, _) => an == n) || ctx.variableTypes.any (fun (vn, _) => vn == n)
       then acc else acc ++ [(n, ty)]) []
-  let hoistedDecls : List StmtExprMd ←  newDecls.mapM fun (name, tyStr) => do
-      let ty ← translateType ctx tyStr
-      pure $ mkVarDeclInit (name : String) ty (mkStmtExprMd .Hole)
+  let declType (ty : HighType) : HighTypeMd :=
+    match ty with
+    | .UserDefined nm => if isCompositeType ctx nm.text then mkHighTypeMd ty else AnyTy
+    | _ => AnyTy
+  let hoistedDecls : List StmtExprMd := newDecls.map fun (name, ty) =>
+    mkVarDeclInit name (declType ty) (mkStmtExprMd .Hole)
   let hoistedCtx := { ctx with variableTypes := ctx.variableTypes ++
       (newDecls.map fun (n, ty) =>
-        if isCompositeType ctx ty then (n, ty) else (n, PyLauType.Any)) }
+        match ty with
+        | .UserDefined nm => if isCompositeType ctx nm.text then (n, ty) else (n, pyAny)
+        | _ => (n, pyAny)) }
   return (hoistedDecls, hoistedCtx)
 
 --Check if a prelude function returns a value of Any type, which may be an exception (such as PAdd, PMul, ...)
@@ -1773,14 +1815,14 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         | _ => []
       return withExceptionChecks ctx (ctx, stmts ++ typeAssert)
     | none =>
-      -- Declaration without initializer (not allowed in pure context, but OK in procedures)
-      let varType := pyExprToString annotation
+      -- Declaration without initializer.
+      let varTypeStr := pyExprToString annotation
       let varName := pyExprToString target
       if varName ∈ ctx.variableTypes.unzip.1 then
           return (ctx, [])
-      let newctx := {ctx with variableTypes:=(varName, varType)::ctx.variableTypes}
-      let varType ← translateType ctx varType
-      let declStmt := mkVarDeclInit varName varType AnyNone
+      let varTypeMd ← translateType ctx varTypeStr
+      let newctx := {ctx with variableTypes:=(varName, varTypeMd.val)::ctx.variableTypes}
+      let declStmt := mkVarDeclInit varName varTypeMd AnyNone
       return (newctx, [declStmt])
 
   -- If statement
@@ -1841,7 +1883,8 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         let varType := mkHighTypeMd .TBool
         let varDecl := mkVarDeclInit freshVar varType condExpr
         let varRef := mkStmtExprMd (StmtExpr.Var (.Local freshVar))
-        ([varDecl], varRef, { ctx with variableTypes := ctx.variableTypes ++ [(freshVar, "bool")] })
+        ([varDecl], varRef, { ctx with variableTypes :=
+          ctx.variableTypes ++ [(freshVar, HighType.TBool)] })
       | _ => ([], condExpr, ctx)
 
     let assertStmt := mkStmtExprMdWithLoc (StmtExpr.Assert { condition := Any_to_bool finalCondExpr, summary }) md
@@ -1965,12 +2008,16 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         let mgrName := s!"with_mgr_{ctxExpr.toAst.ann.start.byteIdx}"
         let mgrExpr ← translateExpr currentCtx ctxExpr
         let mgrTy ← inferExprType currentCtx ctxExpr
-        let mgrLauTy ← translateType currentCtx mgrTy
+        let mgrClass := mgrTy.className?.getD PyLauType.Any
+        let mgrLauTy : HighTypeMd :=
+          match mgrTy with
+          | .UserDefined _ => mkHighTypeMd mgrTy
+          | _ => AnyTy
         let mgrDecl := mkVarDeclInit mgrName mgrLauTy mgrExpr
         let mgrRef := mkStmtExprMd (StmtExpr.Var (.Local mgrName))
         currentCtx := {currentCtx with variableTypes := currentCtx.variableTypes ++ [(mgrName, mgrTy)]}
-        let enterCall := mkInstanceMethodCall mgrTy "__enter__" mgrRef [] md
-        let exitCall := mkInstanceMethodCall mgrTy "__exit__" mgrRef [] md
+        let enterCall := mkInstanceMethodCall mgrClass "__enter__" mgrRef [] md
+        let exitCall := mkInstanceMethodCall mgrClass "__exit__" mgrRef [] md
         match optVars.val with
         | some varExpr =>
           let varName := pyExprToString varExpr
@@ -1981,7 +2028,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
           else
             -- New variable — declare outside the block so it's visible after
             let varDecl := mkVarDeclInit varName AnyTy enterCall
-            currentCtx := {currentCtx with variableTypes := currentCtx.variableTypes ++ [(varName, PyLauType.Any)]}
+            currentCtx := {currentCtx with variableTypes := currentCtx.variableTypes ++ [(varName, pyAny)]}
             setupStmts := setupStmts ++ [mgrDecl, varDecl]
         | none =>
           setupStmts := setupStmts ++ [mgrDecl, enterCall]
@@ -2041,7 +2088,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let bodyCtx := { bodyCtxNoLabels with
       loopBreakLabel := some breakLabel
       loopContinueLabel := some continueLabel
-      variableTypes := bodyCtxNoLabels.variableTypes ++ [(counterName, "int")]}
+      variableTypes := bodyCtxNoLabels.variableTypes ++ [(counterName, .TInt)]}
     let (finalCtx, bodyStmts) ← translateStmtList bodyCtx body.val.toList
     let assumeStmts : List StmtExprMd ← do match target with
       | .Name _ n _ =>
@@ -2196,9 +2243,10 @@ def unpackPyArguments (ctx : TranslationContext) (args: Python.arguments SourceR
         match arg with
           | .mk_arg sr name oty _ =>
             let md := sourceRangeToSource ctx.filePath sr
-            let defaultType := match default.mapM (inferExprType ctx) with
-                  | .ok (some ty) => some ty
-                  | _ => none
+            let defaultType : Option String :=
+              match default.mapM (inferExprType ctx) with
+              | .ok (some ty) => some (highTypeToPyLauType ty)
+              | _ => none
             let mut tys : List String := []
             tys ← match oty.val with
               | .some ty => getArgumentTypes ty
@@ -2348,11 +2396,12 @@ def translateFunction (ctx : TranslationContext) (sourceRange: SourceRange) (fun
     let outputs : List Parameter := [{ name := PyLauFuncReturnVar, type := AnyTy }]
 
     -- Translate function body
-    let inputTypes := funcDecl.args.map fun arg =>
-      (arg.name, highTypeToPyLauType arg.laurelType.val)
-    let ctx := {ctx with variableTypes:= ("nullcall_ret", PyLauType.Any)::inputTypes}
+    let inputTypes : List (String × HighType) := funcDecl.args.map fun arg =>
+      (arg.name, arg.laurelType.val)
+    let ctx := {ctx with variableTypes:= ("nullcall_ret", pyAny)::inputTypes}
     let ctx := match ctx.currentClassName with
-      | some cn => {ctx with variableTypes := ("self", cn) :: ctx.variableTypes}
+      | some cn => {ctx with variableTypes :=
+          ("self", HighType.UserDefined { text := cn }) :: ctx.variableTypes}
       | none => ctx
     let (bodyTrans, newCtx) ← match body with
     | some body =>
@@ -2811,6 +2860,7 @@ def pythonToLaurel (info : PreludeInfo)
     (body : Array (stmt SourceRange))
     (filePath : String := "")
     (overloadTable : OverloadTable := {})
+    (typedPython : Bool := false)
     : Except TranslationError (Laurel.Program × TranslationContext) := do
   -- Collect user function names (top-level and class methods)
   let userFunctions := body.toList.flatMap fun stmt =>
@@ -2878,7 +2928,8 @@ def pythonToLaurel (info : PreludeInfo)
         classFieldHighType := classFieldHighType,
         userFunctions := userFunctions,
         classesInHierarchy := classesInHierarchy,
-        filePath := filePath
+        filePath := filePath,
+        typedPython := typedPython
       }
       let (composite, instanceProcedures, classFuncDecls) ← translateClass initCtx stmt
       allClassFuncDecls := allClassFuncDecls ++ classFuncDecls
@@ -2916,7 +2967,8 @@ def pythonToLaurel (info : PreludeInfo)
     compositeTypeReverse := compositeTypeReverse,
     exhaustiveClasses := exhaustiveClasses,
     classesInHierarchy := classesInHierarchy,
-    filePath := filePath
+    filePath := filePath,
+    typedPython := typedPython
   }
 
   -- Separate functions from other statements

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -437,11 +437,19 @@ def fromAny (ty : HighType) (e : StmtExprMd) : StmtExprMd :=
     | _ => mkStmtExprMd (.StaticCall accessor [e])
   | _, _ => e
 
-/-- Recover a native HighType from a Python type-annotation AST,
-    preserving inner types of `list[T]` / `dict[K, V]`. -/
+/-- Recover a native HighType from a Python type-annotation AST.
+    `list`/`Sequence` and `dict`/`Mapping` resolve to `TSeq` / `TMap`
+    over `Any` when the inner types aren't given. -/
 partial def pythonTypeExprToHighType (e : Python.expr SourceRange) : Option HighType :=
+  let pyAnyMd : AstNode HighType := ⟨.TCore "Any", none⟩
+  let isListName (s : String) : Bool := s == "List" || s == "list" || s == "Sequence"
+  let isDictName (s : String) : Bool := s == "Dict" || s == "dict" || s == "Mapping"
   match e with
-  | .Name _ n _ => pythonPrimToHighType n.val
+  | .Name _ n _ =>
+    if let some t := pythonPrimToHighType n.val then some t
+    else if isListName n.val then some (.TSeq pyAnyMd)
+    else if isDictName n.val then some (.TMap pyAnyMd pyAnyMd)
+    else none
   | .Subscript _ baseExpr slice _ =>
     let baseName : String :=
       match baseExpr with
@@ -452,14 +460,18 @@ partial def pythonTypeExprToHighType (e : Python.expr SourceRange) : Option High
       match slice with
       | .Tuple _ elts _ => elts.val.toList
       | _ => [slice]
-    match baseName, elems with
-    | "List", [t] | "list", [t] | "Sequence", [t] =>
-      pythonTypeExprToHighType t |>.map fun inner => .TSeq ⟨inner, none⟩
-    | "Dict", [k, v] | "dict", [k, v] | "Mapping", [k, v] =>
-      match pythonTypeExprToHighType k, pythonTypeExprToHighType v with
-      | some kt, some vt => some (.TMap ⟨kt, none⟩ ⟨vt, none⟩)
-      | _, _ => none
-    | _, _ => none
+    if isListName baseName then
+      match elems with
+      | [t] => pythonTypeExprToHighType t |>.map fun inner => .TSeq ⟨inner, none⟩
+      | _ => none
+    else if isDictName baseName then
+      match elems with
+      | [k, v] =>
+        match pythonTypeExprToHighType k, pythonTypeExprToHighType v with
+        | some kt, some vt => some (.TMap ⟨kt, none⟩ ⟨vt, none⟩)
+        | _, _ => none
+      | _ => none
+    else none
   | _ => none
 def strToAny (s: String) := mkStmtExprMd (.StaticCall "from_str" [mkStmtExprMd (StmtExpr.LiteralString s)])
 def intToAny (i: Int) := mkStmtExprMd (.StaticCall "from_int" [mkStmtExprMd (StmtExpr.LiteralInt i)])
@@ -1000,9 +1012,9 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
               let raw := mkStmtExprMd
                 (.StaticCall "Sequence.select" [dictOrList, fromAny .TInt index])
               return { toAny elem.val raw with source := md }
-            | .TMap _ valNode =>
+            | .TMap keyNode valNode =>
               let raw := mkStmtExprMd
-                (.StaticCall "select" [dictOrList, fromAny .TString index])
+                (.StaticCall "select" [dictOrList, fromAny keyNode.val index])
               return { toAny valNode.val raw with source := md }
             | _ => pure ()
           -- Negative-index rewrite: xs[-n] → xs[len(xs) - n] (lists only).

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -319,7 +319,7 @@ instance : Inhabited HighType where default := pyAny
 
 /-- Convert a Python type-string identifier to its `HighType`.
     `"Any"` / `"None"` / unknown collapse to `pyAny`; everything else
-    becomes a `UserDefined` reference. -/
+    everything else becomes a `UserDefined` reference. -/
 def pyTypeStringToHighType (s : String) : HighType :=
   if s == PyLauType.Any || s == PyLauType.None || s == PyLauType.Package
      || s == PyLauType.ListAny || s == PyLauType.ListStr
@@ -387,6 +387,46 @@ def pyArgLaurelType (ctx : TranslationContext) (tys : List String) : HighTypeMd 
       | none => AnyTy
     else AnyTy
   | _ => AnyTy
+
+/-- TInt and TBool are mutually compatible (Python bool widens to int). -/
+def isIntLikeHighType : HighType → Bool
+  | .TInt | .TBool => true
+  | _ => false
+
+/-- Any-tag constructor name for a primitive HighType. -/
+def toAnyCtor : HighType → Option String
+  | .TInt    => some "from_int"
+  | .TBool   => some "from_bool"
+  | .TReal   => some "from_float"
+  | .TString => some "from_str"
+  | _ => none
+
+/-- Any-tag accessor name for a primitive HighType. -/
+def fromAnyAccessor : HighType → Option String
+  | .TInt    => some "Any..as_int!"
+  | .TBool   => some "Any..as_bool!"
+  | .TReal   => some "Any..as_float!"
+  | .TString => some "Any..as_string!"
+  | _ => none
+
+/-- Wrap a native value into Any; identity for non-primitive types. -/
+def toAny (ty : HighType) (e : StmtExprMd) : StmtExprMd :=
+  match toAnyCtor ty with
+  | some ctor => mkStmtExprMd (.StaticCall ctor [e])
+  | none => e
+
+/-- Unwrap an Any value to a native primitive; identity for
+    non-primitive types. Cancels a directly adjacent `from_X(inner)`
+    so wrap/unwrap pairs around an arithmetic operator collapse. -/
+def fromAny (ty : HighType) (e : StmtExprMd) : StmtExprMd :=
+  match fromAnyAccessor ty, toAnyCtor ty with
+  | some accessor, some ctor =>
+    match e.val with
+    | .StaticCall fn [inner] =>
+      if fn.text == ctor then inner
+      else mkStmtExprMd (.StaticCall accessor [e])
+    | _ => mkStmtExprMd (.StaticCall accessor [e])
+  | _, _ => e
 
 /-- Recover a native HighType from a Python type-annotation AST,
     preserving inner types of `list[T]` / `dict[K, V]`. -/
@@ -657,14 +697,44 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
   | .Constant _ (.ConEllipsis _) _ =>
     return mkStmtExprMd .Hole
 
-  -- Variable references
+  -- Native locals: wrap the read into Any so the surrounding Any-typed
+  -- body stays well-typed. The fromAny peephole cancels this when the
+  -- consumer is itself a typed operator.
   | .Name _ name _ =>
-    return mkStmtExprMd (StmtExpr.Var (.Local name.val))
+    let bare := mkStmtExprMd (StmtExpr.Var (.Local name.val))
+    if ctx.typedPython then
+      let ty := (ctx.variableTypes.find? (·.fst == name.val)).map (·.snd) |>.getD pyAny
+      return toAny ty bare
+    else return bare
 
   -- Binary operations
   | .BinOp _ left op right => do
     let leftExpr ← translateExpr ctx left
     let rightExpr ← translateExpr ctx right
+    if ctx.typedPython then
+      let lty := (inferExprType ctx left).toOption.getD pyAny
+      let rty := (inferExprType ctx right).toOption.getD pyAny
+      let bothInt := isIntLikeHighType lty && isIntLikeHighType rty
+      let bothStr := lty == .TString && rty == .TString
+      let mkIntOp (primOp : Strata.Laurel.Operation) : Option StmtExprMd :=
+        if bothInt then
+          some <| toAny .TInt <| mkStmtExprMd <| .PrimitiveOp primOp
+            [fromAny .TInt leftExpr, fromAny .TInt rightExpr]
+        else none
+      let mkStrConcat : Option StmtExprMd :=
+        if bothStr then
+          some <| toAny .TString <| mkStmtExprMd <| .PrimitiveOp .StrConcat
+            [fromAny .TString leftExpr, fromAny .TString rightExpr]
+        else none
+      let native? : Option StmtExprMd := match op with
+        | .Add _ => mkIntOp .Add <|> mkStrConcat
+        | .Sub _ => mkIntOp .Sub
+        | .Mult _ => mkIntOp .Mul
+        | .FloorDiv _ => mkIntOp .Div
+        | .Mod _ => mkIntOp .Mod
+        | _ => none
+      if let some result := native? then
+        return { result with source := md }
     let preludeOpnames ← match op with
       -- Arithmetic
       | .Add _ => .ok "PAdd"
@@ -712,6 +782,21 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
           | .IsNot _ => match comparators.val[i]'(by omega) with
               | .Constant _ (.ConNone _) _ => .ok "PNEq"
               | _ => throw (.unsupportedConstruct "`is not` is only supported with None" (toString (repr e)))
+      -- Native comparison only fires for `n = 1`; chained comparisons
+      -- (e.g. `a < b < c`) keep the Any path so evaluate-once semantics
+      -- is preserved by the existing temp-variable machinery below.
+      let nativeOp? (cmp : Python.cmpop SourceRange) (lty rty : HighType)
+          : Option Strata.Laurel.Operation :=
+        let bothInt := isIntLikeHighType lty && isIntLikeHighType rty
+        let bothStr := lty == .TString && rty == .TString
+        match cmp with
+        | .Eq _    => if bothInt || bothStr then some .Eq else none
+        | .NotEq _ => if bothInt || bothStr then some .Eq else none
+        | .Lt _    => if bothInt then some .Lt else none
+        | .LtE _   => if bothInt then some .Leq else none
+        | .Gt _    => if bothInt then some .Gt else none
+        | .GtE _   => if bothInt then some .Geq else none
+        | _ => none
       -- Check if a Python expression is simple (no side effects when duplicated).
       -- Only `Name` and `Constant` are treated as simple. `Subscript` (e.g.,
       -- `a[0]`) and `Attribute` (e.g., `self.x`) are intentionally non-simple
@@ -759,10 +844,25 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
         have hi : i < n := Membership.mem.upper h
         have : i < operandRefs.size := by omega
         have : i + 1 < operandRefs.size := by omega
-        let opName ← cmpopName i hi
+        have : i < comparators.val.size := by omega
         let lhs := operandRefs[i]
         let rhs := operandRefs[i+1]
-        pairs := pairs.push (mkStmtExprMd (StmtExpr.StaticCall opName [lhs, rhs]))
+        let cmp := ops.val[i]'hi
+        let lty := (inferExprType ctx left).toOption.getD pyAny
+        let rty := (inferExprType ctx (comparators.val[i])).toOption.getD pyAny
+        let opTy := if lty == .TString then HighType.TString else .TInt
+        match (if ctx.typedPython && n == 1 then nativeOp? cmp lty rty else none) with
+        | some primOp =>
+          let raw := mkStmtExprMd (.PrimitiveOp primOp
+            [fromAny opTy lhs, fromAny opTy rhs])
+          let wrapped := toAny .TBool raw
+          let final := match cmp with
+            | .NotEq _ => toAny .TBool (mkStmtExprMd (.PrimitiveOp .Not [fromAny .TBool wrapped]))
+            | _ => wrapped
+          pairs := pairs.push final
+        | none =>
+          let opName ← cmpopName i hi
+          pairs := pairs.push (mkStmtExprMd (StmtExpr.StaticCall opName [lhs, rhs]))
       let ⟨hPairsSize⟩ ← guardProp (p := pairs.size ≥ 1) "pairs is empty"
       -- Fold pairs with PAnd (pairs has n ≥ 1 elements)
       have : 0 < pairs.size := by omega
@@ -780,15 +880,27 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
   | .BoolOp _ op values => do
     if values.val.size < 2 then
       throw (.internalError "BoolOp must have at least 2 operands")
+    -- All-bool only: mixed types need Any (Python's `bool and int` returns int).
+    if ctx.typedPython then
+      let allBool := values.val.toList.all fun v =>
+        (inferExprType ctx v).toOption.getD pyAny == .TBool
+      if allBool then
+        let primOp : Strata.Laurel.Operation := match op with
+          | .And _ => .And
+          | .Or _ => .Or
+        let mut result : StmtExprMd := default
+        for h : i in [0:values.val.size] do
+          have : i < values.val.size := Membership.mem.upper h
+          let raw := fromAny .TBool (← translateExpr ctx values.val[i])
+          result := if i == 0 then raw else mkStmtExprMd (.PrimitiveOp primOp [result, raw])
+        return { toAny .TBool result with source := md }
     let preludeOpnames ← match op with
       | .And _ => .ok "PAnd"
       | .Or _ => .ok "POr"
-    -- Translate all operands
     let mut exprs : List StmtExprMd := []
     for val in values.val do
       let expr ← translateExpr ctx val
       exprs := exprs ++ [expr]
-    -- Chain binary operations: a && b && c becomes (a && b) && c
     let mut result := exprs[0]!
     for i in [1:exprs.length] do
       result := mkStmtExprMd (StmtExpr.StaticCall preludeOpnames [result, exprs[i]!])
@@ -797,6 +909,18 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
   -- Unary operations
   | .UnaryOp _ op operand => do
     let operandExpr ← translateExpr ctx operand
+    if ctx.typedPython then
+      let oty := (inferExprType ctx operand).toOption.getD pyAny
+      match op with
+      | .Not _ =>
+        if oty == .TBool then
+          let raw := mkStmtExprMd (.PrimitiveOp .Not [fromAny .TBool operandExpr])
+          return { toAny .TBool raw with source := md }
+      | .USub _ =>
+        if oty == .TInt then
+          let raw := mkStmtExprMd (.PrimitiveOp .Neg [fromAny .TInt operandExpr])
+          return { toAny .TInt raw with source := md }
+      | _ => pure ()
     let preludeOpnames ← match op with
       | .Not _ => .ok "PNot"
       | .USub _ => .ok "PNeg"
@@ -859,12 +983,20 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
           return mkStmtExprMdWithLoc (.StaticCall "Any_get_slice" [dictOrList, index]) md
       | _ =>
           let index ← translateExpr ctx slice
-          -- Emit bounds check for negative integer indices on lists (e.g., xs[-1])
-          -- and convert to positive index: xs[-n] becomes xs[len(xs) - n].
-          -- Skip for dicts, where negative integer keys are valid dict lookups.
-          -- Note: Python's AST represents `-1` as UnaryOp(USub, Constant(1)),
-          -- not Constant(-1), so we must match both forms.
-          let valType := (inferExprType ctx val).toOption.getD (pyAny)
+          let valType := (inferExprType ctx val).toOption.getD pyAny
+          -- Native subscript over typed containers; result wraps into Any.
+          if ctx.typedPython then
+            match valType with
+            | .TSeq elem =>
+              let raw := mkStmtExprMd
+                (.StaticCall "Sequence.select" [dictOrList, fromAny .TInt index])
+              return { toAny elem.val raw with source := md }
+            | .TMap _ valNode =>
+              let raw := mkStmtExprMd
+                (.StaticCall "select" [dictOrList, fromAny .TString index])
+              return { toAny valNode.val raw with source := md }
+            | _ => pure ()
+          -- Negative-index rewrite: xs[-n] → xs[len(xs) - n] (lists only).
           let isDictType := valType.className? == some PyLauType.DictStrAny
           let negLitVal? := match slice with
             | .Constant _ (.ConNeg _ n) _ => some n.val
@@ -1005,8 +1137,28 @@ partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange
     match tryLookupFieldHighType ctx cls attr.val with
       | some ty => return ty
       | none => return pyAny
-  | .BinOp _ _ _ _ => return pyAny
-  | .UnaryOp _ _ _ => return pyAny
+  -- Recover BinOp/UnaryOp static types so chains cascade natively.
+  | .BinOp _ left op right =>
+    if !ctx.typedPython then return pyAny else do
+      let lty ← inferExprType ctx left
+      let rty ← inferExprType ctx right
+      let bothInt := isIntLikeHighType lty && isIntLikeHighType rty
+      let bothStr := lty == .TString && rty == .TString
+      match op with
+      | .Add _ =>
+        if bothInt then return .TInt
+        else if bothStr then return .TString
+        else return pyAny
+      | .Sub _ | .Mult _ | .FloorDiv _ | .Mod _ =>
+        if bothInt then return .TInt else return pyAny
+      | _ => return pyAny
+  | .UnaryOp _ op operand =>
+    if !ctx.typedPython then return pyAny else do
+      let oty ← inferExprType ctx operand
+      match op with
+      | .Not _ => if oty == .TBool then return .TBool else return pyAny
+      | .USub _ => if oty == .TInt then return .TInt else return pyAny
+      | _ => return pyAny
   | .JoinedStr _ _ => return .TString
   | .FormattedValue _ _ _ _ => return .TString
   | .Call _ f args kwargs =>

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -535,6 +535,9 @@ def wrapFieldInAny (ty : HighType) (expr : StmtExprMd) : Except TranslationError
   | .TReal => .ok <| mkStmtExprMd (.StaticCall "from_float" [expr])
   | .TString => .ok <| mkStmtExprMd (.StaticCall "from_str" [expr])
   | .TCore "Any" => .ok expr
+  -- Container fields stay as the typed value; the consumer's
+  -- subscript / inferExprType paths see the native sort directly.
+  | .TSeq _ | .TMap _ _ | .TSet _ => .ok expr
   | .UserDefined name => .error (.unsupportedConstruct
     s!"Coercion from user-defined class '{name.text}' to Any is not yet supported" name.text)
   | other => .error (.typeError s!"wrapFieldInAny: no Any constructor for field type '{repr other}'")
@@ -1468,6 +1471,18 @@ partial def translateCall (ctx : TranslationContext)
     if ctx.typedPython then
       ctx.functionSignatures.find? fun x => nameMatches x && isTypedSig x
     else none
+  -- For constructor / method calls, the callee's signature carries
+  -- a `self` parameter that the user-side call doesn't pass; the shim
+  -- needs to index callee.args[i + argOffset] against user-side args[i].
+  let argOffset : Nat :=
+    match typedFuncDecl with
+    | some fd =>
+      -- Class methods and constructors carry an implicit `self` first
+      -- arg that the user-side call doesn't pass.
+      match fd.args with
+      | first :: _ => if first.name == "self" then 1 else 0
+      | [] => 0
+    | none => 0
   if funcDecl.isNone && kwords.length > 0 then
     throwUserError f.ann s!"Undeclared function '{funcName}' called with keyword args"
   -- Emit the final call, handling Name vs Attribute dispatch and transparent procedures.
@@ -1557,11 +1572,12 @@ partial def translateCall (ctx : TranslationContext)
     combinePositionalAndKeywordArgs args kwords funcDecl methodName callRange
   let trans_args ← args.mapM (translateExpr ctx)
   -- Unwrap each Any-typed argument to its callee-declared native type.
+  -- argOffset accounts for the implicit `self` on methods/__init__.
   let trans_args :=
     match typedFuncDecl with
     | some fd =>
       trans_args.zipIdx.map fun (a, i) =>
-        match fd.args[i]? with
+        match fd.args[i + argOffset]? with
         | some param => fromAny param.laurelType.val a
         | none => a
     | none => trans_args
@@ -1793,12 +1809,17 @@ partial def translateAssign  (ctx : TranslationContext)
               newctx.variableTypes ++ [(n.val, .UserDefined className)]}
         | _=> newctx
         if n.val ∈ newctx.variableTypes.unzip.1 then
-          -- The hoisting pass declared the local; if its tracked type
-          -- is native, unwrap the RHS so the assignment typechecks
-          -- against the declared sort.
+          -- The hoisting pass declared the local with a primitive
+          -- native type; unwrap the RHS so the assignment typechecks.
+          -- UserDefined / container locals keep the existing
+          -- `assignStmts` (which carries the correct `New` / multi-stmt
+          -- expansion for class instantiation).
           let trackedTy := (newctx.variableTypes.find? (·.fst == n.val)).map (·.snd) |>.getD pyAny
+          let isPrimitive : Bool := match trackedTy with
+            | .TInt | .TBool | .TReal | .TString => true
+            | _ => false
           let assignStmts :=
-            if trackedTy != pyAny && ctx.typedPython then
+            if isPrimitive && ctx.typedPython then
               [mkStmtExprMdWithLoc
                 (StmtExpr.Assign [target] (fromAny trackedTy rhs_trans)) source]
             else assignStmts
@@ -1863,6 +1884,15 @@ partial def translateAssign  (ctx : TranslationContext)
                 pure (mkStmtExprMd (StmtExpr.New (mkId laurelName)))
               else pure rhs_trans
             | none => pure rhs_trans
+          -- Native field assignments: unwrap the Any-wrapped RHS so
+          -- the assignment matches the field's declared sort.
+          let className := ctx.currentClassName.get!
+          let rhs' :=
+            if ctx.typedPython then
+              match tryLookupFieldHighType ctx className attr.val with
+              | some ty => if ty == pyAny then rhs' else fromAny ty rhs'
+              | none => rhs'
+            else rhs'
           let assignStmt := mkStmtExprMdWithLoc (StmtExpr.Assign [fieldAccess] rhs') source
           return (ctx, moExtracts ++ [assignStmt], true)
         else
@@ -2705,11 +2735,13 @@ def translateFunction (ctx : TranslationContext) (sourceRange: SourceRange) (fun
         | _ => []
 
     -- Native return: the signature matches the spec layer. Primitives
-    -- need a `fromAny` unwrap at every Return; container/UserDefined
-    -- types are kept as-is so the unwrap is identity.
+    -- need a `fromAny` unwrap at every Return; container types are
+    -- kept as-is so the unwrap is identity. `__init__` is excluded —
+    -- Python's implicit `None` return shouldn't widen to the class type.
+    let isInit := funcDecl.name.endsWith "@__init__"
     let nativeReturnTy : Option HighType := funcDecl.ret.bind fun retInfo =>
       let ty := retInfo.laurelType.val
-      if ty == pyAny then none else some ty
+      if isInit || ty == pyAny then none else some ty
     let outputType : HighTypeMd :=
       nativeReturnTy.map mkHighTypeMd |>.getD AnyTy
     let outputs : List Parameter := [{ name := PyLauFuncReturnVar, type := outputType }]
@@ -2798,6 +2830,21 @@ def preludeSignatureToPythonFunctionDecl (prelude : Core.Program) : List PythonF
         ret
       }
     | none => none
+/-- Translate a field type from its annotation AST. Under
+    `--typed-python`, `pythonTypeExprToHighType` recovers native
+    primitive shapes that the string-based path collapses to `Any`.
+    Container fields (`list`/`dict`) stay `Any` because the
+    heap-parameterization pass doesn't yet box them; the typed
+    container paths are reserved for parameters and locals. -/
+def translateFieldTypeFromExpr (ctx : TranslationContext)
+    (annotation : Python.expr SourceRange) : Except TranslationError HighTypeMd :=
+  if ctx.typedPython then
+    match pythonTypeExprToHighType annotation with
+    | some (.TInt) | some (.TBool) | some (.TReal) | some (.TString) =>
+      .ok (mkHighTypeMd (pythonTypeExprToHighType annotation).get!)
+    | _ => translateFieldType ctx (pyExprToString annotation)
+  else translateFieldType ctx (pyExprToString annotation)
+
 /-- Extract field declarations from class body (annotated assignments at class level) -/
 def extractClassFields (ctx : TranslationContext) (classBody : Array (Python.stmt SourceRange))
     : Except TranslationError (List Field) := do
@@ -2811,7 +2858,7 @@ def extractClassFields (ctx : TranslationContext) (classBody : Array (Python.stm
         | .Name _ name _ => .ok name.val
         | _ => continue  -- Skip non-simple targets, consistent with extractFieldsFromInit
 
-      let fieldType ← translateFieldType ctx (pyExprToString annotation)
+      let fieldType ← translateFieldTypeFromExpr ctx annotation
 
       fields := fields ++ [{
         name := fieldName
@@ -2830,7 +2877,7 @@ def extractFieldsFromInit (ctx : TranslationContext) (initBody : Array (Python.s
     match stmt with
     | .AnnAssign _ (.Attribute _ (.Name _ selfName _) attr _) annotation _ _ =>
       if selfName.val == "self" then
-        let fieldType ← translateFieldType ctx (pyExprToString annotation)
+        let fieldType ← translateFieldTypeFromExpr ctx annotation
         fields := fields ++ [{
           name := attr.val
           type := fieldType

--- a/Strata/Languages/Python/PythonToLaurel.lean
+++ b/Strata/Languages/Python/PythonToLaurel.lean
@@ -290,8 +290,6 @@ def pythonPrimToHighType (ty : String) : Option HighType :=
   else if ty == PyLauType.Str   then some .TString
   else none
 
-/-- Any-tag testers for declared parameter types. Native params skip:
-    `Any..isfrom_X` against a native sort would be ill-typed. -/
 def pyLauTypeTesters (typedPython : Bool) (tys : List String) : Array String :=
   tys.foldl (init := #[]) fun acc ty =>
     if typedPython && (pythonPrimToHighType ty).isSome then acc
@@ -320,9 +318,7 @@ def objectClassName (ty : HighType) : String := ty.className?.getD ""
 
 instance : Inhabited HighType where default := pyAny
 
-/-- Convert a Python type-string identifier to its `HighType`.
-    `"Any"` / `"None"` / unknown collapse to `pyAny`; everything else
-    everything else becomes a `UserDefined` reference. -/
+/-- Convert a Python type-string identifier to its `HighType`. -/
 def pyTypeStringToHighType (s : String) : HighType :=
   if s == PyLauType.Any || s == PyLauType.None || s == PyLauType.Package
      || s == PyLauType.ListAny || s == PyLauType.ListStr
@@ -364,9 +360,9 @@ def translateType (ctx : TranslationContext) (typeStr : String) : Except Transla
           -- Map it to a core PyAnyType
           .ok (mkCoreType PyLauType.Any)
 
-/-- Translate a field type annotation. Composite types resolve to
-    `UserDefined`; primitives resolve to native HighTypes under
-    `--typed-python`; everything else collapses to `Any`. -/
+/-- Translate a field type annotation: composite types stay
+    Composite, primitives lower natively under `--typed-python`,
+    everything else collapses to Any. -/
 def translateFieldType (ctx : TranslationContext) (typeStr : String) : Except TranslationError HighTypeMd :=
   match ctx.importedSymbols[typeStr]? with
   | some (ImportedSymbol.compositeType laurelName) =>
@@ -424,9 +420,8 @@ def toAny (ty : HighType) (e : StmtExprMd) : StmtExprMd :=
   | some ctor => mkStmtExprMd (.StaticCall ctor [e])
   | none => e
 
-/-- Unwrap an Any value to a native primitive; identity for
-    non-primitive types. Cancels a directly adjacent `from_X(inner)`
-    so wrap/unwrap pairs around an arithmetic operator collapse. -/
+/-- Unwrap an Any value, cancelling an adjacent `from_X(inner)` so
+    wrap/unwrap pairs around an operator collapse. -/
 def fromAny (ty : HighType) (e : StmtExprMd) : StmtExprMd :=
   match fromAnyAccessor ty, toAnyCtor ty with
   | some accessor, some ctor =>
@@ -437,9 +432,7 @@ def fromAny (ty : HighType) (e : StmtExprMd) : StmtExprMd :=
     | _ => mkStmtExprMd (.StaticCall accessor [e])
   | _, _ => e
 
-/-- Recover a native HighType from a Python type-annotation AST.
-    `list`/`Sequence` and `dict`/`Mapping` resolve to `TSeq` / `TMap`
-    over `Any` when the inner types aren't given. -/
+/-- Recover a native HighType from a Python type-annotation AST. -/
 partial def pythonTypeExprToHighType (e : Python.expr SourceRange) : Option HighType :=
   let pyAnyMd : AstNode HighType := ⟨.TCore "Any", none⟩
   let isListName (s : String) : Bool := s == "List" || s == "list" || s == "Sequence"
@@ -535,8 +528,6 @@ def wrapFieldInAny (ty : HighType) (expr : StmtExprMd) : Except TranslationError
   | .TReal => .ok <| mkStmtExprMd (.StaticCall "from_float" [expr])
   | .TString => .ok <| mkStmtExprMd (.StaticCall "from_str" [expr])
   | .TCore "Any" => .ok expr
-  -- Container fields stay as the typed value; the consumer's
-  -- subscript / inferExprType paths see the native sort directly.
   | .TSeq _ | .TMap _ _ | .TSet _ => .ok expr
   | .UserDefined name => .error (.unsupportedConstruct
     s!"Coercion from user-defined class '{name.text}' to Any is not yet supported" name.text)
@@ -721,9 +712,6 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
   | .Constant _ (.ConEllipsis _) _ =>
     return mkStmtExprMd .Hole
 
-  -- Native locals: wrap the read into Any so the surrounding Any-typed
-  -- body stays well-typed. The fromAny peephole cancels this when the
-  -- consumer is itself a typed operator.
   | .Name _ name _ =>
     let bare := mkStmtExprMd (StmtExpr.Var (.Local name.val))
     if ctx.typedPython then
@@ -740,10 +728,16 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
       let rty := (inferExprType ctx right).toOption.getD pyAny
       let bothInt := isIntLikeHighType lty && isIntLikeHighType rty
       let bothStr := lty == .TString && rty == .TString
+      let bothReal := lty == .TReal && rty == .TReal
       let mkIntOp (primOp : Strata.Laurel.Operation) : Option StmtExprMd :=
         if bothInt then
           some <| toAny .TInt <| mkStmtExprMd <| .PrimitiveOp primOp
             [fromAny .TInt leftExpr, fromAny .TInt rightExpr]
+        else none
+      let mkRealOp (primOp : Strata.Laurel.Operation) : Option StmtExprMd :=
+        if bothReal then
+          some <| toAny .TReal <| mkStmtExprMd <| .PrimitiveOp primOp
+            [fromAny .TReal leftExpr, fromAny .TReal rightExpr]
         else none
       let mkStrConcat : Option StmtExprMd :=
         if bothStr then
@@ -751,9 +745,9 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
             [fromAny .TString leftExpr, fromAny .TString rightExpr]
         else none
       let native? : Option StmtExprMd := match op with
-        | .Add _ => mkIntOp .Add <|> mkStrConcat
-        | .Sub _ => mkIntOp .Sub
-        | .Mult _ => mkIntOp .Mul
+        | .Add _ => mkIntOp .Add <|> mkRealOp .Add <|> mkStrConcat
+        | .Sub _ => mkIntOp .Sub <|> mkRealOp .Sub
+        | .Mult _ => mkIntOp .Mul <|> mkRealOp .Mul
         | .FloorDiv _ => mkIntOp .Div
         | .Mod _ => mkIntOp .Mod
         | _ => none
@@ -806,20 +800,19 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
           | .IsNot _ => match comparators.val[i]'(by omega) with
               | .Constant _ (.ConNone _) _ => .ok "PNEq"
               | _ => throw (.unsupportedConstruct "`is not` is only supported with None" (toString (repr e)))
-      -- Native comparison only fires for `n = 1`; chained comparisons
-      -- (e.g. `a < b < c`) keep the Any path so evaluate-once semantics
-      -- is preserved by the existing temp-variable machinery below.
+      -- Chained `a < b < c` keeps the Any path; only n = 1 is native.
       let nativeOp? (cmp : Python.cmpop SourceRange) (lty rty : HighType)
           : Option Strata.Laurel.Operation :=
         let bothInt := isIntLikeHighType lty && isIntLikeHighType rty
         let bothStr := lty == .TString && rty == .TString
+        let bothReal := lty == .TReal && rty == .TReal
         match cmp with
-        | .Eq _    => if bothInt || bothStr then some .Eq else none
-        | .NotEq _ => if bothInt || bothStr then some .Eq else none
-        | .Lt _    => if bothInt then some .Lt else none
-        | .LtE _   => if bothInt then some .Leq else none
-        | .Gt _    => if bothInt then some .Gt else none
-        | .GtE _   => if bothInt then some .Geq else none
+        | .Eq _    => if bothInt || bothStr || bothReal then some .Eq else none
+        | .NotEq _ => if bothInt || bothStr || bothReal then some .Eq else none
+        | .Lt _    => if bothInt || bothReal then some .Lt else none
+        | .LtE _   => if bothInt || bothReal then some .Leq else none
+        | .Gt _    => if bothInt || bothReal then some .Gt else none
+        | .GtE _   => if bothInt || bothReal then some .Geq else none
         | _ => none
       -- Check if a Python expression is simple (no side effects when duplicated).
       -- Only `Name` and `Constant` are treated as simple. `Subscript` (e.g.,
@@ -874,7 +867,10 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
         let cmp := ops.val[i]'hi
         let lty := (inferExprType ctx left).toOption.getD pyAny
         let rty := (inferExprType ctx (comparators.val[i])).toOption.getD pyAny
-        let opTy := if lty == .TString then HighType.TString else .TInt
+        let opTy : HighType :=
+          if lty == .TString then .TString
+          else if lty == .TReal then .TReal
+          else .TInt
         match (if ctx.typedPython && n == 1 then nativeOp? cmp lty rty else none) with
         | some primOp =>
           let raw := mkStmtExprMd (.PrimitiveOp primOp
@@ -944,6 +940,9 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
         if oty == .TInt then
           let raw := mkStmtExprMd (.PrimitiveOp .Neg [fromAny .TInt operandExpr])
           return { toAny .TInt raw with source := md }
+        else if oty == .TReal then
+          let raw := mkStmtExprMd (.PrimitiveOp .Neg [fromAny .TReal operandExpr])
+          return { toAny .TReal raw with source := md }
       | _ => pure ()
     let preludeOpnames ← match op with
       | .Not _ => .ok "PNot"
@@ -1008,7 +1007,6 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
       | _ =>
           let index ← translateExpr ctx slice
           let valType := (inferExprType ctx val).toOption.getD pyAny
-          -- Native subscript over typed containers; result wraps into Any.
           if ctx.typedPython then
             match valType with
             | .TSeq elem =>
@@ -1020,7 +1018,11 @@ partial def translateExpr (ctx : TranslationContext) (e : Python.expr SourceRang
                 (.StaticCall "select" [dictOrList, fromAny keyNode.val index])
               return { toAny valNode.val raw with source := md }
             | _ => pure ()
-          -- Negative-index rewrite: xs[-n] → xs[len(xs) - n] (lists only).
+          -- Emit bounds check for negative integer indices on lists (e.g., xs[-1])
+          -- and convert to positive index: xs[-n] becomes xs[len(xs) - n].
+          -- Skip for dicts, where negative integer keys are valid dict lookups.
+          -- Note: Python's AST represents `-1` as UnaryOp(USub, Constant(1)),
+          -- not Constant(-1), so we must match both forms.
           let isDictType := valType.className? == some PyLauType.DictStrAny
           let negLitVal? := match slice with
             | .Constant _ (.ConNeg _ n) _ => some n.val
@@ -1144,13 +1146,12 @@ partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange
   match e with
   | .Constant _ (.ConPos _ _) _
   | .Constant _ (.ConNeg _ _) _ => return .TInt
+  | .Constant _ (.ConFloat _ _) _ => return .TReal
   | .Constant _ (.ConString _ _) _ => return .TString
   | .Constant _ (.ConTrue _) _
   | .Constant _ (.ConFalse _) _
   | .BoolOp _ _ _
   | .Compare _ _ _ _ => return .TBool
-  -- Distinct sentinel for `None` so default-value handling can
-  -- detect `Union[T, None] = None`.
   | .Constant _ (.ConNone _) _ => return .TCore PyLauType.None
   | .Name _ n _ =>
       match ctx.variableTypes.find? (λ v => v.fst == n.val) with
@@ -1162,19 +1163,24 @@ partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange
     match tryLookupFieldHighType ctx cls attr.val with
       | some ty => return ty
       | none => return pyAny
-  -- Recover BinOp/UnaryOp static types so chains cascade natively.
   | .BinOp _ left op right =>
     if !ctx.typedPython then return pyAny else do
       let lty ← inferExprType ctx left
       let rty ← inferExprType ctx right
       let bothInt := isIntLikeHighType lty && isIntLikeHighType rty
       let bothStr := lty == .TString && rty == .TString
+      let bothReal := lty == .TReal && rty == .TReal
       match op with
       | .Add _ =>
         if bothInt then return .TInt
+        else if bothReal then return .TReal
         else if bothStr then return .TString
         else return pyAny
-      | .Sub _ | .Mult _ | .FloorDiv _ | .Mod _ =>
+      | .Sub _ | .Mult _ =>
+        if bothInt then return .TInt
+        else if bothReal then return .TReal
+        else return pyAny
+      | .FloorDiv _ | .Mod _ =>
         if bothInt then return .TInt else return pyAny
       | _ => return pyAny
   | .UnaryOp _ op operand =>
@@ -1182,7 +1188,10 @@ partial def inferExprType (ctx : TranslationContext) (e: Python.expr SourceRange
       let oty ← inferExprType ctx operand
       match op with
       | .Not _ => if oty == .TBool then return .TBool else return pyAny
-      | .USub _ => if oty == .TInt then return .TInt else return pyAny
+      | .USub _ =>
+        if oty == .TInt then return .TInt
+        else if oty == .TReal then return .TReal
+        else return pyAny
       | _ => return pyAny
   | .JoinedStr _ _ => return .TString
   | .FormattedValue _ _ _ _ => return .TString
@@ -1454,11 +1463,9 @@ partial def translateCall (ctx : TranslationContext)
   let nameMatches (x : PythonFunctionDecl) : Bool :=
     x.name == funcName || x.name == funcName ++ "@__init__"
   let funcDecl := ctx.functionSignatures.find? nameMatches
-  -- Two declarations can share a name: a Laurel-program entry that
-  -- preserves native types and a Core-prelude entry that stamps
-  -- everything Any. Boundary shim needs the former. Class receivers
-  -- (`self : UserDefined`) are non-Any in both, so the discriminator
-  -- looks for at least one primitive/container parameter or return.
+  -- Find the typed declaration when the same name has both a Laurel
+  -- and a Core-prelude entry. `self : UserDefined` is non-Any in both,
+  -- so we require at least one primitive or container.
   let isTypedSig (x : PythonFunctionDecl) : Bool :=
     let isNative (t : HighType) : Bool :=
       match t with
@@ -1471,14 +1478,10 @@ partial def translateCall (ctx : TranslationContext)
     if ctx.typedPython then
       ctx.functionSignatures.find? fun x => nameMatches x && isTypedSig x
     else none
-  -- For constructor / method calls, the callee's signature carries
-  -- a `self` parameter that the user-side call doesn't pass; the shim
-  -- needs to index callee.args[i + argOffset] against user-side args[i].
+  -- Methods and `__init__` carry an implicit `self`; user-side calls don't.
   let argOffset : Nat :=
     match typedFuncDecl with
     | some fd =>
-      -- Class methods and constructors carry an implicit `self` first
-      -- arg that the user-side call doesn't pass.
       match fd.args with
       | first :: _ => if first.name == "self" then 1 else 0
       | [] => 0
@@ -1495,6 +1498,18 @@ partial def translateCall (ctx : TranslationContext)
       | .ok (.UserDefined nm) =>
         if isCompositeType ctx nm.text then
           throwUserError f.ann s!"len() is not supported on '{nm.text}' (no __len__ method)"
+      | _ => pure ()
+    if ctx.typedPython && funcName == "Any_len_to_Any" && args.length == 1 then
+      match inferExprType ctx args[0]! with
+      | .ok (.TSeq _) =>
+        let arg := callArgs[0]!
+        let raw := mkStmtExprMdWithLoc
+          (.StaticCall "Sequence.length" [arg]) callMd
+        return toAny .TInt raw
+      | .ok .TString =>
+        let arg := fromAny .TString callArgs[0]!
+        let raw := mkStmtExprMdWithLoc (.StaticCall "Str.Length" [arg]) callMd
+        return toAny .TInt raw
       | _ => pure ()
     match f with
     | .Name  _ _ _ =>
@@ -1571,8 +1586,6 @@ partial def translateCall (ctx : TranslationContext)
   let (args, kwords, funcdecl_hasKwargs) ←
     combinePositionalAndKeywordArgs args kwords funcDecl methodName callRange
   let trans_args ← args.mapM (translateExpr ctx)
-  -- Unwrap each Any-typed argument to its callee-declared native type.
-  -- argOffset accounts for the implicit `self` on methods/__init__.
   let trans_args :=
     match typedFuncDecl with
     | some fd =>
@@ -1587,7 +1600,6 @@ partial def translateCall (ctx : TranslationContext)
       if funcdecl_hasKwargs then [DictStrAny_empty] else []
     else [trans_kwords]
   let call ← emitCall (trans_args ++ trans_kwords_exprs)
-  -- Wrap a native return back into Any for the caller.
   match typedFuncDecl with
   | some fd => match fd.ret with
     | some retInfo => return toAny retInfo.laurelType.val call
@@ -1809,11 +1821,6 @@ partial def translateAssign  (ctx : TranslationContext)
               newctx.variableTypes ++ [(n.val, .UserDefined className)]}
         | _=> newctx
         if n.val ∈ newctx.variableTypes.unzip.1 then
-          -- The hoisting pass declared the local with a primitive
-          -- native type; unwrap the RHS so the assignment typechecks.
-          -- UserDefined / container locals keep the existing
-          -- `assignStmts` (which carries the correct `New` / multi-stmt
-          -- expansion for class instantiation).
           let trackedTy := (newctx.variableTypes.find? (·.fst == n.val)).map (·.snd) |>.getD pyAny
           let isPrimitive : Bool := match trackedTy with
             | .TInt | .TBool | .TReal | .TString => true
@@ -1840,16 +1847,10 @@ partial def translateAssign  (ctx : TranslationContext)
                    let ty ← translateType ctx annStr
                    pure ty.val
                  else pure inferType
-          -- A native annotation under `--typed-python` produces a
-          -- native local (matching the spec layer's parameter shape);
-          -- otherwise the local stays Any for compatibility.
           let useNative := nativeFromAst.isSome
           let varTy : HighTypeMd := if useNative then mkHighTypeMd type else AnyTy
           let initExpr := if useNative then mkStmtExprMd .Hole else AnyNone
           let initStmt := mkVarDeclInit n.val varTy initExpr
-          -- Re-emit the assign so the RHS is unwrapped to the native
-          -- sort when the declaration is native; the fromAny peephole
-          -- cancels the wrap from typed callees.
           let assignStmts :=
             if useNative then
               [mkStmtExprMdWithLoc
@@ -1884,8 +1885,6 @@ partial def translateAssign  (ctx : TranslationContext)
                 pure (mkStmtExprMd (StmtExpr.New (mkId laurelName)))
               else pure rhs_trans
             | none => pure rhs_trans
-          -- Native field assignments: unwrap the Any-wrapped RHS so
-          -- the assignment matches the field's declared sort.
           let className := ctx.currentClassName.get!
           let rhs' :=
             if ctx.typedPython then
@@ -1942,9 +1941,6 @@ partial def collectDeclaredNamesAndTypes (ctx : TranslationContext) (stmts : Lis
       let names := (lhs.val.toList.filter (λ e => match e with |.Name _ _ _ => true | _=> false)).map pyExprToString
       names.map (λ n => (n, ty))
     | .AnnAssign _ lhs annoTy value _ =>
-      -- Under `--typed-python`, recover native primitives and
-      -- containers from the annotation AST; otherwise fall back to
-      -- the string-keyed lookup.
       let nativeFromAst : Option HighType :=
         if ctx.typedPython then pythonTypeExprToHighType annoTy else none
       let ty :=
@@ -1982,8 +1978,6 @@ def createVarDeclStmtsAndCtx (ctx : TranslationContext) (newDecls : List (String
   let newDecls := newDecls.foldl (fun acc (n, ty) =>
       if acc.any (fun (an, _) => an == n) || ctx.variableTypes.any (fun (vn, _) => vn == n)
       then acc else acc ++ [(n, ty)]) []
-  -- A type is "native" if its declaration sort matches the values that
-  -- the typed lowering produces (composite class, primitive, container).
   let isNative (ty : HighType) : Bool :=
     match ty with
     | .UserDefined nm => isCompositeType ctx nm.text
@@ -2123,6 +2117,8 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
         | .Name _ n _ =>
           if !typeAssertSafe then []
           else if s.toAst.ann == default then [] -- compiler-generated statement, no source location
+          else if ctx.typedPython
+                  && (pythonPrimToHighType (pyExprToString annotation)).isSome then []
           else
           let annStr := pyExprToString annotation
           match typeTester? annStr with
@@ -2174,9 +2170,7 @@ partial def translateStmt (ctx : TranslationContext) (s : Python.stmt SourceRang
     let whileWrapped := mkStmtExprMdWithLoc (StmtExpr.Block [whileStmt] (some breakLabel)) md
     return (loopCtx, preamble ++ [whileWrapped])
 
-  -- Return: assign LaurelResult, then exit $body. Native results are
-  -- unwrapped here; the fromAny peephole cancels the wrap from the
-  -- typed expression-translation paths.
+  -- Return statement: assign to the LaurelResult output parameter, then exit $body.
   | .Return _ value => do
     let stmts ← match value.val with
       | some expr => do
@@ -2582,8 +2576,6 @@ def unpackPyArguments (ctx : TranslationContext) (args: Python.arguments SourceR
             | _ =>
               pure ()
             tys ← checkValidInputTypeList ctx tys
-            -- Structural lowering keeps `list[int]` etc. inner type;
-            -- the String pipeline would collapse it to ListAny.
             let nativeTy : Option HighType :=
               if ctx.typedPython then
                 match oty.val with
@@ -2689,7 +2681,6 @@ def translateFunctionBody (ctx : TranslationContext) (kwargsName : Option String
     let nonSelfParams := inputs.filter (fun p => p.name.text != "self")
     let (_, paramCopies) := renameInputParams nonSelfParams
       (match kwargsName with | some kw => (· == kw) | none => fun _ => false)
-    -- The from_None initializer is type-incorrect against a native return.
     let bodyStmts :=
       if ctx.resultType == pyAny then
         mkStmtExprMd (.Assign [mkVariableMd (.Local PyLauFuncReturnVar)] AnyNone) :: paramCopies ++ bodyStmts
@@ -2734,10 +2725,7 @@ def translateFunction (ctx : TranslationContext) (sourceRange: SourceRange) (fun
           | none => []
         | _ => []
 
-    -- Native return: the signature matches the spec layer. Primitives
-    -- need a `fromAny` unwrap at every Return; container types are
-    -- kept as-is so the unwrap is identity. `__init__` is excluded —
-    -- Python's implicit `None` return shouldn't widen to the class type.
+    -- `__init__` returns implicit None, not the class type.
     let isInit := funcDecl.name.endsWith "@__init__"
     let nativeReturnTy : Option HighType := funcDecl.ret.bind fun retInfo =>
       let ty := retInfo.laurelType.val
@@ -2830,12 +2818,8 @@ def preludeSignatureToPythonFunctionDecl (prelude : Core.Program) : List PythonF
         ret
       }
     | none => none
-/-- Translate a field type from its annotation AST. Under
-    `--typed-python`, `pythonTypeExprToHighType` recovers native
-    primitive shapes that the string-based path collapses to `Any`.
-    Container fields (`list`/`dict`) stay `Any` because the
-    heap-parameterization pass doesn't yet box them; the typed
-    container paths are reserved for parameters and locals. -/
+/-- Translate a field type from its annotation AST. Container fields
+    stay `Any` (heap parameterization can't box them yet). -/
 def translateFieldTypeFromExpr (ctx : TranslationContext)
     (annotation : Python.expr SourceRange) : Except TranslationError HighTypeMd :=
   if ctx.typedPython then
@@ -3344,12 +3328,19 @@ def pythonToLaurel (info : PreludeInfo)
   -- Separate functions from other statements
   let mut otherStmts : Array (Python.stmt SourceRange) := #[]
 
+  -- Pre-collect signatures so recursive and forward calls see the callee.
+  let mut topFuncDecls : List PythonFunctionDecl := []
+  for stmt in body do
+    if let .FunctionDef _ _ _ _ _ _ _ _ := stmt then
+      let fd ← pyFuncDefToPythonFunctionDecl ctx stmt
+      topFuncDecls := topFuncDecls ++ [fd]
+  ctx := {ctx with functionSignatures := ctx.functionSignatures ++ topFuncDecls}
+
   for stmt in body do
     match stmt with
     | .FunctionDef _ _ _ fbody _ _ _ _ =>
       let funcDecl ←  pyFuncDefToPythonFunctionDecl ctx stmt
       let proc ← translateFunction ctx stmt.ann funcDecl fbody.val.toList
-      ctx := {ctx with functionSignatures:= ctx.functionSignatures ++ [funcDecl]}
       procedures := procedures.push proc.fst
     | .ClassDef _ _ _ _ _ _ _ =>
       pure ()  -- Already processed in first pass

--- a/Strata/Languages/Python/Specs/DDM.lean
+++ b/Strata/Languages/Python/Specs/DDM.lean
@@ -102,6 +102,8 @@ op forallListExpr(list : SpecExprDecl, varName : Ident, body : SpecExprDecl) : S
 op forallDictExpr(dict : SpecExprDecl, keyVar : Ident,
     valVar : Ident, body : SpecExprDecl) : SpecExprDecl =>
   "forallDict" "(" dict ", " keyVar ", " valVar ", " body ")";
+op seqIndexExpr(subject : SpecExprDecl, idx : SpecExprDecl) : SpecExprDecl =>
+  "seqIndex" "(" subject ", " idx ")";
 
 category MessagePart;
 op strMessagePart(s : Str) : MessagePart => s;
@@ -287,6 +289,7 @@ protected def SpecExpr.toDDM (e : SpecExpr) : DDM.SpecExprDecl SourceRange :=
     .forallListExpr loc list.toDDM ⟨loc, varName⟩ body.toDDM
   | .forallDict dict keyVar valVar body loc =>
     .forallDictExpr loc dict.toDDM ⟨loc, keyVar⟩ ⟨loc, valVar⟩ body.toDDM
+  | .seqIndex subj idx loc => .seqIndexExpr loc subj.toDDM idx.toDDM
 
 def specExprFormatContext : FormatContext :=
   .ofDialects DDM.PythonSpecs_map
@@ -439,6 +442,7 @@ def DDM.SpecExprDecl.fromDDM (d : DDM.SpecExprDecl SourceRange) : Specs.SpecExpr
     .forallList list.fromDDM varName body.fromDDM loc
   | .forallDictExpr loc dict ⟨_, keyVar⟩ ⟨_, valVar⟩ body =>
     .forallDict dict.fromDDM keyVar valVar body.fromDDM loc
+  | .seqIndexExpr loc subj idx => .seqIndex subj.fromDDM idx.fromDDM loc
 
 def DDM.MessagePart.fromDDM (d : DDM.MessagePart SourceRange) : Specs.MessagePart :=
   match d with

--- a/Strata/Languages/Python/Specs/Decls.lean
+++ b/Strata/Languages/Python/Specs/Decls.lean
@@ -513,6 +513,10 @@ inductive SpecExpr where
     key-value pair in `dict`. Both `keyVar` and `valVar` are bound in `body`.
     Corresponds to `for keyVar, valVar in dict.items(): assert body`. -/
 | forallDict (dict : SpecExpr) (keyVar : String) (valVar : String) (body : SpecExpr) (loc : SourceRange)
+/-- `seqIndex subject idx` represents `subject[idx]` over a sequence.
+    Lowers to `Sequence.select` under typed-python; falls back to
+    `Any_get` over Any-typed subjects. -/
+| seqIndex (subject : SpecExpr) (idx : SpecExpr) (loc : SourceRange)
 deriving Inhabited
 
 /-- Structural equality ignoring source locations. -/
@@ -537,6 +541,7 @@ def SpecExpr.softBEq : SpecExpr → SpecExpr → Bool
     l₁.softBEq l₂ && v₁ == v₂ && b₁.softBEq b₂
   | .forallDict d₁ k₁ v₁ b₁ _, .forallDict d₂ k₂ v₂ b₂ _ =>
     d₁.softBEq d₂ && k₁ == k₂ && v₁ == v₂ && b₁.softBEq b₂
+  | .seqIndex s₁ i₁ _, .seqIndex s₂ i₂ _ => s₁.softBEq s₂ && i₁.softBEq i₂
   | _, _ => false
 
 inductive MessagePart where

--- a/Strata/Languages/Python/Specs/MessageKind.lean
+++ b/Strata/Languages/Python/Specs/MessageKind.lean
@@ -69,5 +69,9 @@ def invalidModuleName : MessageKind :=
 def missingPySpecModule : MessageKind :=
   { category := "missingPySpecModule", impact := .configurationError }
 
+-- Strict typed-python mode: any pyspec-side warning must be a hard error.
+def typedPythonRefusal : MessageKind :=
+  { category := "typedPythonRefusal", impact := .configurationError }
+
 end Strata.Pipeline.MessageKind
 end

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -204,6 +204,45 @@ def specTypeToLaurelType (ty : SpecType) : ToLaurelM HighTypeMd := do
     return mkTy (.UserDefined { text := nm.toLaurelName })
   | none => return tyAny
 
+/-- Lower a Python primitive ident to its native Laurel `HighType`. -/
+private def pythonPrimToHighType (nm : PythonIdent) : Option HighType :=
+  if      nm == .builtinsInt   then some .TInt
+  else if nm == .builtinsBool  then some .TBool
+  else if nm == .builtinsFloat then some .TReal
+  else if nm == .builtinsStr   then some .TString
+  else none
+
+/-- Lower a SpecType to a native Laurel HighType. Recurses into
+    list[T] / dict[K, V]; rejects unions, literals, typed-dicts. -/
+private partial def specTypeToNative (ty : SpecType) : Option HighType :=
+  match ty.asIdent with
+  | some nm => pythonPrimToHighType nm
+  | none =>
+    if ty.intLits.size != 0 || ty.stringLits.size != 0
+       || ty.typedDicts.size != 0 || ty.idents.size != 1 then
+      none
+    else
+      let si := ty.idents[0]!
+      if (si.name == .typingList || si.name == .typingSequence) && si.args.size == 1 then
+        (specTypeToNative si.args[0]!).map fun inner => .TSeq ⟨inner, none⟩
+      else if (si.name == .typingDict || si.name == .typingMapping) && si.args.size == 2 then
+        match specTypeToNative si.args[0]!, specTypeToNative si.args[1]! with
+        | some k, some v => some (.TMap ⟨k, none⟩ ⟨v, none⟩)
+        | _, _ => none
+      else none
+
+/-- `specTypeToLaurelType` for argument position; refuses non-native
+    types under `--typed-python`. -/
+def specArgumentType (ty : SpecType) (procName : String) : ToLaurelM HighTypeMd := do
+  if !(← read).typedPython then return ← specTypeToLaurelType ty
+  match specTypeToNative ty with
+  | some t => return mkTy t
+  | none =>
+    reportError .typeError ty.loc
+      s!"--typed-python: '{ty}' is not a supported native type in '{procName}'. \
+         Supported: int, bool, float, str, list[T], dict[K, V] over native types."
+    return tyAny
+
 /-- Build the assertion for a single atom: type tester for idents,
     `isfrom_X(v) && as_X!(v) == literal` for literals.
     When `isUnion` is true, warns on ident atoms that lack testers.
@@ -308,9 +347,50 @@ private def asBool (loc : SourceRange) (act : ToLaurelExprM SomeTypedStmtExpr) :
     return ⟨se.2.stmt⟩
   match se with
   | ⟨.TBool, e⟩ => pure e
+  | ⟨.UserDefined "Any", e⟩ =>
+    pure ⟨.StaticCall (mkId "Any..as_bool!") [e.stmt], e.stmt.source⟩
   | ⟨tp, e⟩ =>
     let pn := (← read).procName
     reportError .typeError loc s!"Expected Bool-typed expression but got {repr tp} in '{pn}'"
+    pure ⟨e.stmt⟩
+
+private def asInt (loc : SourceRange) (act : ToLaurelExprM SomeTypedStmtExpr)
+    : ToLaurelExprM (TypedStmtExpr .TInt) := do
+  let ctx ← read
+  let (se, success) ← runChecked <| act ctx
+  if !success then return ⟨se.2.stmt⟩
+  match se with
+  | ⟨.TInt, e⟩ => pure e
+  | ⟨.UserDefined "Any", e⟩ => pure (.anyAsInt e)
+  | ⟨tp, e⟩ =>
+    let pn := (← read).procName
+    reportError .typeError loc s!"Expected Int-typed expression but got {repr tp} in '{pn}'"
+    pure ⟨e.stmt⟩
+
+private def asReal (loc : SourceRange) (act : ToLaurelExprM SomeTypedStmtExpr)
+    : ToLaurelExprM (TypedStmtExpr .TReal) := do
+  let ctx ← read
+  let (se, success) ← runChecked <| act ctx
+  if !success then return ⟨se.2.stmt⟩
+  match se with
+  | ⟨.TReal, e⟩ => pure e
+  | ⟨.UserDefined "Any", e⟩ => pure (.anyAsFloat e)
+  | ⟨tp, e⟩ =>
+    let pn := (← read).procName
+    reportError .typeError loc s!"Expected Real-typed expression but got {repr tp} in '{pn}'"
+    pure ⟨e.stmt⟩
+
+private def asString (loc : SourceRange) (act : ToLaurelExprM SomeTypedStmtExpr)
+    : ToLaurelExprM (TypedStmtExpr .TString) := do
+  let ctx ← read
+  let (se, success) ← runChecked <| act ctx
+  if !success then return ⟨se.2.stmt⟩
+  match se with
+  | ⟨.TString, e⟩ => pure e
+  | ⟨.UserDefined "Any", e⟩ => pure (.anyAsString e)
+  | ⟨tp, e⟩ =>
+    let pn := (← read).procName
+    reportError .typeError loc s!"Expected String-typed expression but got {repr tp} in '{pn}'"
     pure ⟨e.stmt⟩
 
 /-- Look up an identifier's type from the SpecExprContext and create a typed identifier.
@@ -350,7 +430,7 @@ def specExprToLaurel (e : SpecExpr) (source : Option FileRange)
     lookupIdentifier name loc src
   | .intLit v loc => do
     let src ← nodeSource loc
-    return .mkSome <| .fromInt (.literalInt v src)
+    return .mkSome <| .literalInt v src
   | .floatLit _ loc => do
     reportError .floatLiteral loc "Float literals not yet supported in preconditions"
     return default
@@ -361,36 +441,55 @@ def specExprToLaurel (e : SpecExpr) (source : Option FileRange)
       lookupIdentifier field loc src
     | _ => do
       let src ← nodeSource loc
-      let s ← asAny loc <| specExprToLaurel subject src
-      let from_str := .fromStr (.literalString field src) src
-      return .mkSome <| .anyGet s from_str src
+      let subjExpr : SomeTypedStmtExpr ← specExprToLaurel subject src
+      let anyFallback : ToLaurelExprM SomeTypedStmtExpr := do
+        let s ← asAny loc <| pure subjExpr
+        return .mkSome <| .anyGet s (.fromStr (.literalString field src) src) src
+      match h : subjExpr.1 with
+      | .TMap keyNode valNode =>
+        match h2 : keyNode.val with
+        | .TString =>
+          let key : TypedStmtExpr keyNode.val := h2 ▸ (.literalString field src)
+          let m : TypedStmtExpr (.TMap keyNode valNode) := h ▸ subjExpr.2
+          return ⟨valNode.val, .mapSelect m key src⟩
+        | _ => anyFallback
+      | _ => anyFallback
   | .isInstanceOf _ typeName loc => do
     reportError .isinstanceUnsupported loc s!"isinstance check for '{typeName}' not yet supported in preconditions"
     return default
   | .stringLen subject loc => do
     let src ← nodeSource loc
-    let s ← asAny loc <| specExprToLaurel subject src
-    return .mkSome <| .fromInt (.strLength (.anyAsString s))
+    let subjExpr : SomeTypedStmtExpr ← specExprToLaurel subject src
+    match h : subjExpr.1 with
+    | .TSeq elemNode =>
+      let s : TypedStmtExpr (.TSeq elemNode) := h ▸ subjExpr.2
+      return .mkSome <| .seqLength s src
+    | .TString =>
+      let s : TypedStmtExpr .TString := h ▸ subjExpr.2
+      return .mkSome <| .strLength s
+    | _ =>
+      let s ← asString loc <| pure subjExpr
+      return .mkSome <| .strLength s
   | .intGe subject bound loc => do
     let src ← nodeSource loc
-    let s ← asAny loc <| specExprToLaurel subject src
-    let b ← asAny loc <| specExprToLaurel bound src
-    return .mkSome <| .intGeq (.anyAsInt s) (.anyAsInt b)
+    let s ← asInt loc <| specExprToLaurel subject src
+    let b ← asInt loc <| specExprToLaurel bound src
+    return .mkSome <| .intGeq s b
   | .intLe subject bound loc => do
     let src ← nodeSource loc
-    let s ← asAny loc <| specExprToLaurel subject src
-    let b ← asAny loc <| specExprToLaurel bound src
-    return .mkSome <| .intLeq (.anyAsInt s) (.anyAsInt b)
+    let s ← asInt loc <| specExprToLaurel subject src
+    let b ← asInt loc <| specExprToLaurel bound src
+    return .mkSome <| .intLeq s b
   | .floatGe subject bound loc => do
     let src ← nodeSource loc
-    let s ← asAny loc <| specExprToLaurel subject src
-    let b ← asAny loc <| specExprToLaurel bound src
-    return .mkSome <| .realGeq (.anyAsFloat s) (.anyAsFloat b)
+    let s ← asReal loc <| specExprToLaurel subject src
+    let b ← asReal loc <| specExprToLaurel bound src
+    return .mkSome <| .realGeq s b
   | .floatLe subject bound loc => do
     let src ← nodeSource loc
-    let s ← asAny loc <| specExprToLaurel subject src
-    let b ← asAny loc <| specExprToLaurel bound src
-    return .mkSome <| .realLeq (.anyAsFloat s) (.anyAsFloat b)
+    let s ← asReal loc <| specExprToLaurel subject src
+    let b ← asReal loc <| specExprToLaurel bound src
+    return .mkSome <| .realLeq s b
   | .not inner loc => do
     let src ← nodeSource loc
     let i ← asBool loc <| specExprToLaurel inner src
@@ -427,6 +526,17 @@ def specExprToLaurel (e : SpecExpr) (source : Option FileRange)
   | .forallDict _ _ _ _ loc => do
     reportError .forallDictUnsupported loc "forallDict quantifier not yet supported in preconditions"
     return default
+  | .seqIndex subject idx loc => do
+    let src ← nodeSource loc
+    let subjExpr : SomeTypedStmtExpr ← specExprToLaurel subject src
+    let i ← asInt loc <| specExprToLaurel idx src
+    match h : subjExpr.1 with
+    | .TSeq elemNode =>
+      let s : TypedStmtExpr (.TSeq elemNode) := h ▸ subjExpr.2
+      return ⟨elemNode.val, .seqSelect s i src⟩
+    | _ =>
+      let s ← asAny loc <| pure subjExpr
+      return .mkSome <| .anyGet s (.fromInt i src) src
 
 private def formatAssertionMessage (msg : Array MessagePart) : String :=
   let parts := msg.map fun
@@ -463,8 +573,14 @@ def buildSpecBody (allArgs : Array Arg)
   let resultId : AstNode Variable := { val := Variable.Local (mkId "result"), source := source }
   let assignStmt ← mkStmtWithLoc (.Assign [resultId] holeExpr) default
   stmts := stmts.push assignStmt
-  -- 2. Assert type / required-param preconditions
+  -- 2. Type / required-param preconditions; native params skip
+  -- the Any-shape testers (declaration carries the guarantee).
   for arg in allArgs do
+    let isNative :=
+      match ctx.argTypes[arg.name]? with
+      | some t => t != Laurel.tyAny
+      | none => false
+    if isNative then continue
     let paramId : StmtExprMd := { val := .Var $ Variable.Local (mkId arg.name), source := source }
     match ← typeAssertion? arg.type paramId source with
     | some assertion =>
@@ -508,10 +624,14 @@ def buildSpecBody (allArgs : Array Arg)
       else
         reportError .typeError default
           s!"Postcondition expression is not Bool in '{ctx.procName}' (skipping)"
-  -- 5. Assume return type postcondition
-  -- NOTE. Skip NoneType: generated stubs currently declare `-> None` even for methods
-  -- that return values. Assuming isfrom_None would make callers unreachable.
-  if returnType.asIdent != some .noneType then
+  -- 5. Return-type postcondition. Skip NoneType (`-> None` stubs are
+  -- declared even on methods that return values) and native results
+  -- (declaration carries the type).
+  let resultIsNative :=
+    match ctx.argTypes["result"]? with
+    | some t => t != Laurel.tyAny
+    | none => false
+  if returnType.asIdent != some .noneType && !resultIsNative then
     let resultRef : StmtExprMd := { val := .Var $ Variable.Local (mkId "result"), source := source }
     if let some retAssertion ← typeAssertion? returnType resultRef source then
       let assumeStmt ← mkStmtWithLoc (.Assume retAssertion) default
@@ -553,12 +673,16 @@ def funcDeclToLaurel (procName : String) (func : FunctionDecl)
     | .error msg => do reportError .kwargsExpansionError default msg; pure #[]
   let allArgs := posArgs ++ func.args.kwonly ++ kwargsArgs
   let inputs ← allArgs.mapM fun a => do
-    let ty ← specTypeToLaurelType a.type
+    let ty ← specArgumentType a.type procName
     return ({ name := a.name, type := ty } : Parameter)
-  let outputs : List Parameter := [{ name := "result", type := tyAny }]
+  let resultType ←
+    if (← read).typedPython then specArgumentType func.returnType procName
+    else pure tyAny
+  let outputs : List Parameter := [{ name := "result", type := resultType }]
   let argTypes : Std.HashMap String HighType :=
-    inputs.foldl (init := ({} : Std.HashMap String HighType).insert "result" Laurel.tyAny) fun m p =>
-      m.insert p.name.text p.type.val
+    inputs.foldl
+      (init := ({} : Std.HashMap String HighType).insert "result" resultType.val)
+      fun m p => m.insert p.name.text p.type.val
   let specCtx : SpecExprContext := { procName, argTypes }
   let body ← buildSpecBody allArgs func.preconditions func.postconditions
     func.returnType none specCtx

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -76,6 +76,8 @@ structure ToLaurelContext where
   /-- Module prefix prepended to generated type and procedure names
       to avoid collisions when multiple PySpec files are combined. -/
   modulePrefix : String
+  /-- Lower primitives and typed containers to native Laurel sorts. -/
+  typedPython : Bool := false
 
 /-- State for PySpec to Laurel translation. -/
 structure ToLaurelState where
@@ -640,11 +642,12 @@ public structure TranslationResult where
 /-- Run the translation and return a Laurel Program, dispatch table,
     and any errors. -/
 public def signaturesToLaurel (filepath : System.FilePath) (sigs : Array Signature)
-    (moduleName : ModuleName)
+    (moduleName : ModuleName) (typedPython : Bool := false)
     : TranslationResult :=
   let ctx : ToLaurelContext := {
     filepath,
-    modulePrefix := moduleName.toString (sep := "_")
+    modulePrefix := moduleName.toString (sep := "_"),
+    typedPython
   }
   let ((), state) := (sigs.forM signatureToLaurel).run ctx |>.run {}
   let pgm : Laurel.Program := {

--- a/Strata/Languages/Python/Specs/ToLaurel.lean
+++ b/Strata/Languages/Python/Specs/ToLaurel.lean
@@ -573,8 +573,7 @@ def buildSpecBody (allArgs : Array Arg)
   let resultId : AstNode Variable := { val := Variable.Local (mkId "result"), source := source }
   let assignStmt ← mkStmtWithLoc (.Assign [resultId] holeExpr) default
   stmts := stmts.push assignStmt
-  -- 2. Type / required-param preconditions; native params skip
-  -- the Any-shape testers (declaration carries the guarantee).
+  -- 2. Assert type / required-param preconditions
   for arg in allArgs do
     let isNative :=
       match ctx.argTypes[arg.name]? with
@@ -624,9 +623,10 @@ def buildSpecBody (allArgs : Array Arg)
       else
         reportError .typeError default
           s!"Postcondition expression is not Bool in '{ctx.procName}' (skipping)"
-  -- 5. Return-type postcondition. Skip NoneType (`-> None` stubs are
-  -- declared even on methods that return values) and native results
-  -- (declaration carries the type).
+  -- 5. Assume return type postcondition
+  -- NOTE. Skip NoneType: generated stubs currently declare `-> None` even for methods
+  -- that return values. Assuming isfrom_None would make callers unreachable.
+  -- Native results carry the type at the declaration, no postcondition needed.
   let resultIsNative :=
     match ctx.argTypes["result"]? with
     | some t => t != Laurel.tyAny

--- a/Strata/Pipeline/PyAnalyzeLaurel.lean
+++ b/Strata/Pipeline/PyAnalyzeLaurel.lean
@@ -37,6 +37,7 @@ public structure PyAnalyzeConfig where
   isBugFinding : Bool := true
   outputMode : OutputMode := .default
   skipVerification : Bool := false
+  typedPython : Bool := false
   profilePipeline : Bool := true
   metricsHandle : Option IO.FS.Handle := none
 
@@ -44,7 +45,7 @@ private def runPipeline (config : PyAnalyzeConfig)
     : PipelineM (PyAnalyzeOutcome × Statistics) := do
   let combinedLaurel ← withPhase "pythonAndSpecToLaurel" do
     Strata.pythonAndSpecToLaurel
-      (specDir := config.specDir)
+      (specDir := config.specDir) (typedPython := config.typedPython)
       config.filePath config.dispatchModules config.pyspecModules config.sourcePath
 
   if config.outputMode == .verbose then

--- a/StrataMainLib.lean
+++ b/StrataMainLib.lean
@@ -623,6 +623,9 @@ def pyAnalyzeLaurelCommand : Command where
               takesArg := .arg "file" },
             { name := "skip-verification",
               help := "Run Python-to-Laurel and Laurel-to-Core translation only (skip SMT verification).",
+              takesArg := .none },
+            { name := "typed-python",
+              help := "Lower icontract-decorated procedures' primitive scalars (int, bool, float, str) and typed homogeneous containers (list[T], dict[str, V]) to native Laurel sorts instead of the universal Any encoding. Refuses anything outside the supported subset. Off by default.",
               takesArg := .none }]
   help := "Verify a Python Ion program via the Laurel pipeline. Translates Python to Laurel to Core, then runs SMT verification."
   callback := fun v pflags => do
@@ -685,6 +688,7 @@ def pyAnalyzeLaurelCommand : Command where
       else if quiet then .quiet
       else .default
     let skipVerification := pflags.getBool "skip-verification"
+    let typedPython := pflags.getBool "typed-python"
 
     -- Run the pipeline
     let (outcome, laurelPassStats, pctx) ← Strata.Pipeline.runPyAnalyzePipeline {
@@ -693,7 +697,7 @@ def pyAnalyzeLaurelCommand : Command where
       keepAllFilesPrefix := keepPrefix
       verifyOptions := options
       entryPoint, isBugFinding
-      outputMode, skipVerification
+      outputMode, skipVerification, typedPython
       metricsHandle
     }
 

--- a/StrataTest/Languages/Python/ToLaurelTest.lean
+++ b/StrataTest/Languages/Python/ToLaurelTest.lean
@@ -62,6 +62,7 @@ private def fmtHighType : HighType → String
   | .THeap => "THeap"
   | .TTypedField _ => "TTypedField"
   | .TSet _ => "TSet"
+  | .TSeq _ => "TSeq"
   | .TMap _ _ => "TMap"
   | .UserDefined name => s!"UserDefined({name})"
   | .Applied _ _ => "Applied"

--- a/StrataTest/Languages/Python/TypedPythonTest.lean
+++ b/StrataTest/Languages/Python/TypedPythonTest.lean
@@ -1,0 +1,231 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import Strata.Languages.Python.PySpecPipeline
+import Strata.Languages.Python.Specs.DDM
+
+/-! # `--typed-python` Spec-Layer Tests
+
+End-to-end coverage of the user-code lowering lives in the
+`tests/test_typed_python_*.py` snapshot pairs. This file unit-tests
+the spec-layer pieces those snapshots can't easily inspect: native
+  lowering of primitives and containers, refusal of unsupported types,
+  and emission of preconditions/postconditions in their native form.
+-/
+
+namespace Strata.Python.TypedPythonTest
+
+open Strata.Python.Specs
+open Strata.Laurel (Procedure formatProcedure)
+
+private def loc : SourceRange := default
+
+private def identType (nm : PythonIdent) : SpecType := SpecType.ident loc nm
+
+private def listOf (inner : PythonIdent) : SpecType :=
+  SpecType.ident loc .typingList #[identType inner]
+
+private def dictOf (k v : PythonIdent) : SpecType :=
+  SpecType.ident loc .typingDict #[identType k, identType v]
+
+private def mkArg (name : String) (type : SpecType) : Specs.Arg :=
+  { name, type }
+
+private def mkFunc (name : String) (args : Array Specs.Arg) (ret : SpecType)
+    (preconds : Array Specs.Assertion := #[]) : Signature :=
+  .functionDecl {
+    loc, nameLoc := loc, name
+    args := { args, kwonly := #[] }
+    returnType := ret
+    isOverload := false
+    preconditions := preconds, postconditions := #[]
+  }
+
+private def assertionOf (formula : SpecExpr) : Specs.Assertion :=
+  { message := #[], formula }
+
+private def testModule : String := "t"
+private def prefix_ : String := testModule ++ "_"
+
+/-- Build the Laurel program from a list of pyspec signatures. -/
+private def buildSpecs (sigs : Array Signature) (typedPython : Bool)
+    : IO Strata.PySpecLaurelResult := do
+  IO.FS.withTempDir fun dir => do
+    let ionFile := dir / "test.pyspec.ion"
+    writeDDM ionFile sigs
+    let some mod := Python.ModuleName.ofString? testModule
+      | throw <| IO.userError "ModuleName parse failed"
+    let pctx ← Strata.Pipeline.PipelineContext.create (outputMode := .quiet)
+    let result ←
+      Strata.buildPySpecLaurel pctx #[(mod, ionFile.toString)] {}
+        (typedPython := typedPython) |>.toBaseIO
+    match result with
+    | .ok r => pure r
+    | .error _ =>
+      let msgs ← pctx.getMessages
+      throw <| IO.userError <| String.intercalate "\n" <|
+        msgs.toList.map fun m => s!"{m.kind.category}: {m.message}"
+
+/-- Run typed-python lowering and expect a refusal; return the joined
+    pipeline messages (`category: message` per line). -/
+private def expectRefusal (sigs : Array Signature) : IO String :=
+  IO.FS.withTempDir fun dir => do
+    let ionFile := dir / "test.pyspec.ion"
+    writeDDM ionFile sigs
+    let some mod := Python.ModuleName.ofString? testModule
+      | throw <| IO.userError "ModuleName parse failed"
+    let pctx ← Strata.Pipeline.PipelineContext.create (outputMode := .quiet)
+    let result ←
+      Strata.buildPySpecLaurel pctx #[(mod, ionFile.toString)] {}
+        (typedPython := true) |>.toBaseIO
+    match result with
+    | .ok _ => throw <| IO.userError "expected refusal, got success"
+    | .error _ =>
+      let msgs ← pctx.getMessages
+      pure <| String.intercalate "\n" <|
+        msgs.toList.map fun m => s!"{m.kind.category}: {m.message}"
+
+/-- Find a procedure by source-level name (the lowering prefixes the
+    module name). -/
+private def findProc (result : Strata.PySpecLaurelResult) (name : String)
+    : IO Procedure := do
+  let target := prefix_ ++ name
+  match result.laurelProgram.staticProcedures.find? (·.name.text == target) with
+  | some p => pure p
+  | none => throw <| IO.userError s!"{name} not found"
+
+/-- Short tag for a `HighType`'s outermost constructor. -/
+private partial def shape : Strata.Laurel.HighType → String
+  | .TInt => "Int"
+  | .TBool => "Bool"
+  | .TReal => "Real"
+  | .TString => "String"
+  | .TSeq inner => s!"TSeq ({shape inner.val})"
+  | .TMap k v => s!"TMap ({shape k.val}) ({shape v.val})"
+  | .UserDefined nm => s!"UserDefined({nm.text})"
+  | .TCore "Any" => "Any"
+  | .TCore s => s!"TCore({s})"
+  | _ => "Other"
+
+/-! ## Pyspec native lowering -/
+
+-- Primitives lower to native sorts under `--typed-python`.
+/-- info: Int / Bool / String / Real -/
+#guard_msgs in
+#eval do
+  let result ← buildSpecs #[
+    mkFunc "scalars"
+      #[mkArg "a" (identType .builtinsInt),
+        mkArg "b" (identType .builtinsBool),
+        mkArg "c" (identType .builtinsStr),
+        mkArg "d" (identType .builtinsFloat)]
+      (identType .builtinsInt)
+  ] (typedPython := true)
+  let proc ← findProc result "scalars"
+  let names := proc.inputs.map (fun (p : Strata.Laurel.Parameter) => shape p.type.val)
+  IO.println (String.intercalate " / " names)
+
+-- Default mode keeps every primitive as `Any` (UserDefined sentinel).
+/-- info: UserDefined(Any) / UserDefined(Any) / UserDefined(Any) / UserDefined(Any) -/
+#guard_msgs in
+#eval do
+  let result ← buildSpecs #[
+    mkFunc "scalars"
+      #[mkArg "a" (identType .builtinsInt),
+        mkArg "b" (identType .builtinsBool),
+        mkArg "c" (identType .builtinsStr),
+        mkArg "d" (identType .builtinsFloat)]
+      (identType .noneType)
+  ] (typedPython := false)
+  let proc ← findProc result "scalars"
+  let names := proc.inputs.map (fun (p : Strata.Laurel.Parameter) => shape p.type.val)
+  IO.println (String.intercalate " / " names)
+
+-- `list[int]` and `dict[str, int]` lower to typed containers.
+/-- info: TSeq (Int) / TMap (String) (Int) -/
+#guard_msgs in
+#eval do
+  let result ← buildSpecs #[
+    mkFunc "containers"
+      #[mkArg "xs" (listOf .builtinsInt),
+        mkArg "m" (dictOf .builtinsStr .builtinsInt)]
+      (identType .builtinsInt)
+  ] (typedPython := true)
+  let proc ← findProc result "containers"
+  let parts := proc.inputs.map (fun (p : Strata.Laurel.Parameter) => shape p.type.val)
+  IO.println (String.intercalate " / " parts)
+
+-- Nested `list[list[int]]` recurses through `specTypeToNative`.
+/-- info: TSeq (TSeq (Int)) -/
+#guard_msgs in
+#eval do
+  let result ← buildSpecs #[
+    mkFunc "matrix"
+      #[mkArg "m" (SpecType.ident loc .typingList #[listOf .builtinsInt])]
+      (identType .builtinsInt)
+  ] (typedPython := true)
+  let proc ← findProc result "matrix"
+  let some m := proc.inputs.find? (fun (p : Strata.Laurel.Parameter) => p.name.text == "m")
+    | throw <| IO.userError "m not found"
+  IO.println (shape m.type.val)
+
+/-! ## Pyspec refusals under `--typed-python` -/
+
+-- `bytes` is not in the supported set.
+#guard_msgs(drop info) in
+#eval do
+  let msg ← expectRefusal #[
+    mkFunc "raw" #[mkArg "b" (identType .builtinsBytes)] (identType .builtinsInt)
+  ]
+  unless msg.length > 0 do throw <| IO.userError "no diagnostic"
+
+-- `Optional[int]` (Union[int, None]) is refused.
+#guard_msgs(drop info) in
+#eval do
+  let msg ← expectRefusal #[
+    mkFunc "uses_optional"
+      #[mkArg "x" (SpecType.unionArray loc
+          #[identType .builtinsInt, identType .noneType])]
+      (identType .builtinsInt)
+  ]
+  unless msg.length > 0 do throw <| IO.userError "no diagnostic"
+
+/-! ## Native preconditions emit native operators -/
+
+-- `assert x >= 0` over a typed `int` parameter does NOT contain
+-- `Any..isfrom_int` or `Any..as_int!` — the comparison is direct.
+/-- info: native: 0 isfrom_int / 0 as_int! -/
+#guard_msgs in
+#eval do
+  let result ← buildSpecs #[
+    mkFunc "check_nonneg"
+      #[mkArg "x" (identType .builtinsInt)]
+      (identType .builtinsInt)
+      #[assertionOf (.intGe (.var "x" loc) (.intLit 0 loc) loc)]
+  ] (typedPython := true)
+  let proc ← findProc result "check_nonneg"
+  let body := toString (formatProcedure proc)
+  let count (needle : String) : Nat :=
+    (body.splitOn needle).length - 1
+  IO.println s!"native: {count "Any..isfrom_int"} isfrom_int / {count "Any..as_int!"} as_int!"
+
+-- Default mode contains the Any-tag obligations.
+/-- info: any: 2 isfrom_int / 1 as_int! -/
+#guard_msgs in
+#eval do
+  let result ← buildSpecs #[
+    mkFunc "check_nonneg"
+      #[mkArg "x" (identType .builtinsInt)]
+      (identType .builtinsInt)
+      #[assertionOf (.intGe (.var "x" loc) (.intLit 0 loc) loc)]
+  ] (typedPython := false)
+  let proc ← findProc result "check_nonneg"
+  let body := toString (formatProcedure proc)
+  let count (needle : String) : Nat :=
+    (body.splitOn needle).length - 1
+  IO.println s!"any: {count "Any..isfrom_int"} isfrom_int / {count "Any..as_int!"} as_int!"
+
+end Strata.Python.TypedPythonTest

--- a/StrataTest/Languages/Python/TypedPythonTest.lean
+++ b/StrataTest/Languages/Python/TypedPythonTest.lean
@@ -5,15 +5,21 @@
 -/
 
 import Strata.Languages.Python.PySpecPipeline
+import Strata.Languages.Python.PythonToLaurel
 import Strata.Languages.Python.Specs.DDM
 
-/-! # `--typed-python` Spec-Layer Tests
+/-! # `--typed-python` Spec-Layer + Peephole Tests
 
 End-to-end coverage of the user-code lowering lives in the
 `tests/test_typed_python_*.py` snapshot pairs. This file unit-tests
-the spec-layer pieces those snapshots can't easily inspect: native
-  lowering of primitives and containers, refusal of unsupported types,
-  and emission of preconditions/postconditions in their native form.
+the two pieces those snapshots can't easily inspect:
+
+- The pyspec-layer translator: native lowering of primitives and
+  containers, refusal of unsupported types, and emission of
+  preconditions/postconditions in their native form.
+- The `toAny` / `fromAny` peephole: a directly adjacent
+  `from_X` / `Any..as_X!` pair around a typed operator must collapse
+  to the bare expression, with no soundness leaks across types.
 -/
 
 namespace Strata.Python.TypedPythonTest
@@ -227,5 +233,65 @@ private partial def shape : Strata.Laurel.HighType → String
   let count (needle : String) : Nat :=
     (body.splitOn needle).length - 1
   IO.println s!"any: {count "Any..isfrom_int"} isfrom_int / {count "Any..as_int!"} as_int!"
+
+/-! ## `toAny` / `fromAny` peephole
+
+These are the invariants the user-code lowering relies on for clean
+output. Snapshot tests verify the end-to-end Laurel; these tests pin
+the algebra directly. -/
+
+private def mkLocal (name : String) : Strata.Laurel.StmtExprMd :=
+  Strata.Python.mkStmtExprMd <| .Var (.Local name)
+
+-- A matching wrap/unwrap collapses to the bare expression.
+/-- info: collapsed: x -/
+#guard_msgs in
+#eval do
+  let x := mkLocal "x"
+  let unwrapped := Strata.Python.fromAny .TInt (Strata.Python.toAny .TInt x)
+  match unwrapped.val with
+  | .Var (.Local "x") => IO.println "collapsed: x"
+  | other => throw <| IO.userError s!"expected bare Local, got {repr other}"
+
+-- A type-mismatched wrap/unwrap does NOT collapse — wrong-type
+-- silent collapse would be a soundness bug.
+/-- info: did not cross-collapse -/
+#guard_msgs in
+#eval do
+  let x := mkLocal "x"
+  let unwrapped := Strata.Python.fromAny .TBool (Strata.Python.toAny .TInt x)
+  match unwrapped.val with
+  | .Var (.Local "x") =>
+    throw <| IO.userError "ERROR: peephole crossed types (TInt -> TBool)"
+  | _ => IO.println "did not cross-collapse"
+
+-- `toAny` and `fromAny` are identity on non-primitive types
+-- (containers, UserDefined).
+/-- info: TSeq identity / UserDefined identity -/
+#guard_msgs in
+#eval do
+  let x := mkLocal "x"
+  let seqIdent := Strata.Python.toAny (.TSeq ⟨.TInt, none⟩) x
+  let usrIdent := Strata.Python.fromAny (.UserDefined (Strata.Laurel.mkId "Foo")) x
+  let isBare (e : Strata.Laurel.StmtExprMd) : Bool :=
+    match e.val with | .Var (.Local "x") => true | _ => false
+  unless isBare seqIdent && isBare usrIdent do
+    throw <| IO.userError "expected identity"
+  IO.println "TSeq identity / UserDefined identity"
+
+-- An unrelated `StaticCall` does not match the peephole — only the
+-- matching `from_X(inner)` shape is the target.
+/-- info: emitted as_int! -/
+#guard_msgs in
+#eval do
+  let other := Strata.Python.mkStmtExprMd <|
+    .StaticCall (Strata.Laurel.mkId "some_func") [mkLocal "x"]
+  let unwrapped := Strata.Python.fromAny .TInt other
+  match unwrapped.val with
+  | .StaticCall fn _ =>
+    if fn.text == "Any..as_int!" then IO.println "emitted as_int!"
+    else throw <| IO.userError s!"expected Any..as_int!, got {fn.text}"
+  | other => throw <| IO.userError s!"expected StaticCall, got {repr other}"
+
 
 end Strata.Python.TypedPythonTest

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_class_fields_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_class_fields_off.expected
@@ -1,0 +1,9 @@
+test_typed_python_class_fields_off.py(9, 11): ❓ unknown - Check PGe exception
+test_typed_python_class_fields_off.py(9, 4): ❓ unknown - assert(215)
+test_typed_python_class_fields_off.py(10, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_class_fields_off.py(10, 4): ❓ unknown - assert(241)
+test_typed_python_class_fields_off.py(11, 11): ❓ unknown - Check PAdd exception
+test_typed_python_class_fields_off.py(8, 40): ❓ unknown - (deposit ensures) Return type constraint
+test_typed_python_class_fields_off.py(14, 26): ❓ unknown - (status ensures) Return type constraint
+DETAIL: 1 passed, 0 failed, 6 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_class_fields_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_class_fields_on.expected
@@ -1,0 +1,4 @@
+test_typed_python_class_fields_on.py(13, 4): ❓ unknown - assert(488)
+test_typed_python_class_fields_on.py(14, 4): ❓ unknown - assert(514)
+DETAIL: 0 passed, 0 failed, 2 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_compose_calls_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_compose_calls_off.expected
@@ -1,0 +1,9 @@
+test_typed_python_compose_calls_off.py(8, 13): ✔️ always true if reached - Check PAdd exception
+test_typed_python_compose_calls_off.py(8, 4): ✔️ always true if reached - Check PAdd exception
+test_typed_python_compose_calls_off.py(7, 18): ✔️ always true if reached - (f2 ensures) Return type constraint
+test_typed_python_compose_calls_off.py(12, 15): ✔️ always true if reached - Check PAdd exception
+test_typed_python_compose_calls_off.py(12, 13): ✔️ always true if reached - Check PAdd exception
+test_typed_python_compose_calls_off.py(12, 4): ✔️ always true if reached - Check PAdd exception
+test_typed_python_compose_calls_off.py(11, 18): ✔️ always true if reached - (f3 ensures) Return type constraint
+DETAIL: 7 passed, 0 failed, 0 inconclusive
+RESULT: Analysis success

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_compose_calls_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_compose_calls_on.expected
@@ -1,0 +1,2 @@
+DETAIL: 0 passed, 0 failed, 0 inconclusive
+RESULT: Analysis success

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_loops_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_loops_off.expected
@@ -1,0 +1,28 @@
+test_typed_python_loops_off.py(4, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_loops_off.py(4, 4): ❓ unknown - assert(135)
+test_typed_python_loops_off.py(5, 4): ✔️ always true if reached - assert(153)
+test_typed_python_loops_off.py(6, 10): ✔️ always true if reached - Check PLt exception
+test_typed_python_loops_off.py(7, 12): ❓ unknown - Check PAdd exception
+test_typed_python_loops_off.py(3, 24): ❓ unknown - (count_up ensures) Return type constraint
+test_typed_python_loops_off.py(12, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_loops_off.py(12, 4): ❓ unknown - assert(245)
+test_typed_python_loops_off.py(13, 11): ✔️ always true if reached - Check PLe exception
+test_typed_python_loops_off.py(13, 4): ❓ unknown - assert(263)
+test_typed_python_loops_off.py(14, 4): ✔️ always true if reached - assert(283)
+test_typed_python_loops_off.py(15, 4): ✔️ always true if reached - assert(302)
+test_typed_python_loops_off.py(16, 10): ✔️ always true if reached - Check PLe exception
+test_typed_python_loops_off.py(17, 16): ❓ unknown - Check PAdd exception
+test_typed_python_loops_off.py(18, 12): ❓ unknown - Check PAdd exception
+test_typed_python_loops_off.py(11, 22): ❓ unknown - (sum_to ensures) Return type constraint
+test_typed_python_loops_off.py(23, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_loops_off.py(23, 4): ❓ unknown - assert(426)
+test_typed_python_loops_off.py(24, 11): ✔️ always true if reached - Check PLe exception
+test_typed_python_loops_off.py(24, 4): ❓ unknown - assert(444)
+test_typed_python_loops_off.py(25, 4): ✔️ always true if reached - assert(463)
+test_typed_python_loops_off.py(26, 4): ✔️ always true if reached - assert(478)
+test_typed_python_loops_off.py(27, 10): ✔️ always true if reached - Check PLe exception
+test_typed_python_loops_off.py(28, 12): ❓ unknown - Check PMul exception
+test_typed_python_loops_off.py(29, 12): ❓ unknown - Check PAdd exception
+test_typed_python_loops_off.py(22, 23): ❓ unknown - (product ensures) Return type constraint
+DETAIL: 13 passed, 0 failed, 13 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_loops_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_loops_on.expected
@@ -1,0 +1,7 @@
+test_typed_python_loops_on.py(5, 4): ❓ unknown - assert(235)
+test_typed_python_loops_on.py(13, 4): ❓ unknown - assert(345)
+test_typed_python_loops_on.py(14, 4): ❓ unknown - assert(363)
+test_typed_python_loops_on.py(24, 4): ❓ unknown - assert(526)
+test_typed_python_loops_on.py(25, 4): ❓ unknown - assert(544)
+DETAIL: 0 passed, 0 failed, 5 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_methods_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_methods_off.expected
@@ -1,0 +1,14 @@
+test_typed_python_methods_off.py(13, 8): ❓ unknown - assert(362)
+test_typed_python_methods_off.py(14, 8): ❓ unknown - assert(389)
+test_typed_python_methods_off.py(12, 39): ❓ unknown - (Wallet@withdraw ensures) Return type constraint
+test_typed_python_methods_off.py(19, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_methods_off.py(19, 4): ❓ unknown - assert(506)
+test_typed_python_methods_off.py(20, 11): ✔️ always true if reached - Check PLe exception
+test_typed_python_methods_off.py(20, 4): ❓ unknown - assert(526)
+test_typed_python_methods_off.py(21, 11): ❓ unknown - Check PGe exception
+test_typed_python_methods_off.py(21, 4): ❓ unknown - assert(548)
+test_typed_python_methods_off.py(22, 4): ❓ unknown - Wallet@deposit_assert(220)_8
+test_typed_python_methods_off.py(22, 4): ❓ unknown - Wallet@deposit_assert(247)_9
+test_typed_python_methods_off.py(18, 39): ❓ unknown - (use_wallet ensures) Return type constraint
+DETAIL: 2 passed, 0 failed, 10 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_methods_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_methods_on.expected
@@ -1,0 +1,9 @@
+test_typed_python_methods_on.py(15, 8): ❓ unknown - assert(537)
+test_typed_python_methods_on.py(16, 8): ❓ unknown - assert(564)
+test_typed_python_methods_on.py(21, 4): ❓ unknown - assert(681)
+test_typed_python_methods_on.py(22, 4): ❓ unknown - assert(701)
+test_typed_python_methods_on.py(23, 4): ❓ unknown - assert(723)
+test_typed_python_methods_on.py(24, 4): ❓ unknown - Wallet@deposit_assert(395)_8
+test_typed_python_methods_on.py(24, 4): ❓ unknown - Wallet@deposit_assert(422)_9
+DETAIL: 0 passed, 0 failed, 7 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_mixed_arith_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_mixed_arith_off.expected
@@ -1,0 +1,16 @@
+test_typed_python_mixed_arith_off.py(4, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_mixed_arith_off.py(4, 4): ❓ unknown - assert(166)
+test_typed_python_mixed_arith_off.py(5, 11): ❓ unknown - Check PAdd exception
+test_typed_python_mixed_arith_off.py(3, 36): ❓ unknown - (typed_and_any_add ensures) Return type constraint
+test_typed_python_mixed_arith_off.py(9, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_mixed_arith_off.py(9, 4): ❓ unknown - assert(244)
+test_typed_python_mixed_arith_off.py(10, 11): ❓ unknown - Check PMul exception
+test_typed_python_mixed_arith_off.py(8, 36): ❓ unknown - (typed_and_any_mul ensures) Return type constraint
+test_typed_python_mixed_arith_off.py(14, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_mixed_arith_off.py(14, 4): ❓ unknown - assert(325)
+test_typed_python_mixed_arith_off.py(15, 11): ❓ unknown - Check PAdd exception
+test_typed_python_mixed_arith_off.py(13, 39): ❓ unknown - (any_first_then_typed ensures) Return type constraint
+test_typed_python_mixed_arith_off.py(19, 11): ✔️ always true if reached - Check PAdd exception
+test_typed_python_mixed_arith_off.py(18, 47): ✔️ always true if reached - (typed_int_and_typed_str ensures) Return type constraint
+DETAIL: 5 passed, 0 failed, 9 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_mixed_arith_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_mixed_arith_on.expected
@@ -1,0 +1,8 @@
+test_typed_python_mixed_arith_on.py(6, 4): ❓ unknown - assert(319)
+test_typed_python_mixed_arith_on.py(7, 11): ❓ unknown - Check PAdd exception
+test_typed_python_mixed_arith_on.py(11, 4): ❓ unknown - assert(397)
+test_typed_python_mixed_arith_on.py(12, 11): ❓ unknown - Check PMul exception
+test_typed_python_mixed_arith_on.py(16, 4): ❓ unknown - assert(478)
+test_typed_python_mixed_arith_on.py(17, 11): ❓ unknown - Check PAdd exception
+DETAIL: 0 passed, 0 failed, 6 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_arith_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_arith_off.expected
@@ -1,0 +1,6 @@
+test_typed_python_nested_arith_off.py(4, 11): ✔️ always true if reached - Check PAdd exception
+test_typed_python_nested_arith_off.py(3, 36): ✔️ always true if reached - (add3 ensures) Return type constraint
+test_typed_python_nested_arith_off.py(8, 11): ✔️ always true if reached - Check PAdd exception
+test_typed_python_nested_arith_off.py(7, 44): ✔️ always true if reached - (add4 ensures) Return type constraint
+DETAIL: 4 passed, 0 failed, 0 inconclusive
+RESULT: Analysis success

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_arith_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_arith_on.expected
@@ -1,0 +1,2 @@
+DETAIL: 0 passed, 0 failed, 0 inconclusive
+RESULT: Analysis success

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_scope_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_scope_off.expected
@@ -1,0 +1,32 @@
+test_typed_python_nested_scope_off.py(4, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_nested_scope_off.py(4, 4): ❓ unknown - assert(165)
+test_typed_python_nested_scope_off.py(5, 7): ✔️ always true if reached - Check PGt exception
+test_typed_python_nested_scope_off.py(6, 17): ✔️ always true if reached - Check PMul exception
+test_typed_python_nested_scope_off.py(6, 8): ✔️ always true if reached - assert(202)
+test_typed_python_nested_scope_off.py(3, 32): ✔️ always true if reached - (conditional_decl ensures) Return type constraint
+test_typed_python_nested_scope_off.py(8, 13): ✔️ always true if reached - Check PAdd exception
+test_typed_python_nested_scope_off.py(8, 4): ✔️ always true if reached - assert(238)
+test_typed_python_nested_scope_off.py(13, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_nested_scope_off.py(13, 4): ❓ unknown - assert(316)
+test_typed_python_nested_scope_off.py(14, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_nested_scope_off.py(14, 4): ❓ unknown - assert(334)
+test_typed_python_nested_scope_off.py(15, 7): ✔️ always true if reached - Check PGt exception
+test_typed_python_nested_scope_off.py(16, 22): ✔️ always true if reached - Check PSub exception
+test_typed_python_nested_scope_off.py(16, 8): ✔️ always true if reached - assert(370)
+test_typed_python_nested_scope_off.py(18, 22): ✔️ always true if reached - Check PSub exception
+test_typed_python_nested_scope_off.py(18, 8): ✔️ always true if reached - assert(408)
+test_typed_python_nested_scope_off.py(12, 39): ✔️ always true if reached - (shadowed_locals ensures) Return type constraint
+test_typed_python_nested_scope_off.py(23, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_nested_scope_off.py(23, 4): ❓ unknown - assert(483)
+test_typed_python_nested_scope_off.py(24, 11): ✔️ always true if reached - Check PLe exception
+test_typed_python_nested_scope_off.py(24, 4): ❓ unknown - assert(501)
+test_typed_python_nested_scope_off.py(25, 4): ✔️ always true if reached - assert(520)
+test_typed_python_nested_scope_off.py(26, 4): ✔️ always true if reached - assert(537)
+test_typed_python_nested_scope_off.py(27, 10): ✔️ always true if reached - Check PLt exception
+test_typed_python_nested_scope_off.py(28, 21): ❓ unknown - Check PMul exception
+test_typed_python_nested_scope_off.py(28, 8): ❓ unknown - assert(573)
+test_typed_python_nested_scope_off.py(29, 14): ❓ unknown - Check PAdd exception
+test_typed_python_nested_scope_off.py(30, 12): ❓ unknown - Check PAdd exception
+test_typed_python_nested_scope_off.py(22, 26): ❓ unknown - (loop_local ensures) Return type constraint
+DETAIL: 20 passed, 0 failed, 10 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_scope_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_nested_scope_on.expected
@@ -1,0 +1,7 @@
+test_typed_python_nested_scope_on.py(6, 4): ❓ unknown - assert(304)
+test_typed_python_nested_scope_on.py(15, 4): ❓ unknown - assert(455)
+test_typed_python_nested_scope_on.py(16, 4): ❓ unknown - assert(473)
+test_typed_python_nested_scope_on.py(25, 4): ❓ unknown - assert(622)
+test_typed_python_nested_scope_on.py(26, 4): ❓ unknown - assert(640)
+DETAIL: 0 passed, 0 failed, 5 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_subscript_off.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_subscript_off.expected
@@ -1,0 +1,10 @@
+test_typed_python_subscript_off.py(6, 4): ❓ unknown - set_LaurelResult_calls_Any_get_0
+test_typed_python_subscript_off.py(5, 23): ❓ unknown - (first ensures) Return type constraint
+test_typed_python_subscript_off.py(10, 11): ✔️ always true if reached - Check PGe exception
+test_typed_python_subscript_off.py(10, 4): ❓ unknown - assert(295)
+test_typed_python_subscript_off.py(11, 4): ❓ unknown - set_LaurelResult_calls_Any_get_0
+test_typed_python_subscript_off.py(9, 34): ❓ unknown - (at_index ensures) Return type constraint
+test_typed_python_subscript_off.py(15, 4): ❓ unknown - set_LaurelResult_calls_Any_get_0
+test_typed_python_subscript_off.py(14, 31): ❓ unknown - (lookup ensures) Return type constraint
+DETAIL: 1 passed, 0 failed, 7 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/expected_laurel/test_typed_python_subscript_on.expected
+++ b/StrataTest/Languages/Python/expected_laurel/test_typed_python_subscript_on.expected
@@ -1,0 +1,5 @@
+test_typed_python_subscript_on.py(7, 4): ❓ unknown - set_LaurelResult_calls_Sequence.select_0
+test_typed_python_subscript_on.py(11, 4): ❓ unknown - assert(427)
+test_typed_python_subscript_on.py(12, 4): ❓ unknown - set_LaurelResult_calls_Sequence.select_0
+DETAIL: 0 passed, 0 failed, 3 inconclusive
+RESULT: Inconclusive

--- a/StrataTest/Languages/Python/tests/test_typed_python_class_fields_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_class_fields_off.py
@@ -1,0 +1,15 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart. Field reads go through Any.
+class Account:
+    balance: int
+    is_open: bool
+
+
+def deposit(a: Account, amount: int) -> int:
+    assert a.balance >= 0
+    assert amount >= 0
+    return a.balance + amount
+
+
+def status(a: Account) -> bool:
+    return a.is_open

--- a/StrataTest/Languages/Python/tests/test_typed_python_class_fields_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_class_fields_on.py
@@ -1,0 +1,19 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Class fields with native primitive types. Under --typed-python the
+# field type lookup returns TInt/TBool/...; reads of `self.balance`
+# wrap into Any (so the surrounding Any-bodied method stays
+# well-typed), and the fromAny peephole cancels the wrap when the
+# consumer is itself a typed operator (e.g. `>=`).
+class Account:
+    balance: int
+    is_open: bool
+
+
+def deposit(a: Account, amount: int) -> int:
+    assert a.balance >= 0
+    assert amount >= 0
+    return a.balance + amount
+
+
+def status(a: Account) -> bool:
+    return a.is_open

--- a/StrataTest/Languages/Python/tests/test_typed_python_compose_calls_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_compose_calls_off.py
@@ -1,0 +1,12 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart for function composition.
+def f(x: int) -> int:
+    return x + 1
+
+
+def f2(x: int) -> int:
+    return f(f(x))
+
+
+def f3(x: int) -> int:
+    return f(f(f(x)))

--- a/StrataTest/Languages/Python/tests/test_typed_python_compose_calls_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_compose_calls_on.py
@@ -1,0 +1,16 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Function composition — `f(f(f(...)))` chains compound the boundary
+# cost: every call wraps its argument in `from_int` and unwraps the
+# result with `as_int!`, and each layer hides the previous bound from
+# the solver. Under `--typed-python` the calls stay in native sorts
+# and the boundary shim collapses adjacent wrap/unwrap pairs.
+def f(x: int) -> int:
+    return x + 1
+
+
+def f2(x: int) -> int:
+    return f(f(x))
+
+
+def f3(x: int) -> int:
+    return f(f(f(x)))

--- a/StrataTest/Languages/Python/tests/test_typed_python_loops_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_loops_off.py
@@ -1,0 +1,30 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart for typed loops.
+def count_up(n: int) -> int:
+    assert n >= 0
+    i: int = 0
+    while i < n:
+        i = i + 1
+    return i
+
+
+def sum_to(n: int) -> int:
+    assert n >= 0
+    assert n <= 100
+    total: int = 0
+    i: int = 0
+    while i <= n:
+        total = total + i
+        i = i + 1
+    return total
+
+
+def product(n: int) -> int:
+    assert n >= 1
+    assert n <= 10
+    p: int = 1
+    i: int = 1
+    while i <= n:
+        p = p * i
+        i = i + 1
+    return p

--- a/StrataTest/Languages/Python/tests/test_typed_python_loops_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_loops_on.py
@@ -1,0 +1,31 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Loops with typed counters. The while loop's condition is a native
+# int comparison; the loop body mutates a typed int counter.
+def count_up(n: int) -> int:
+    assert n >= 0
+    i: int = 0
+    while i < n:
+        i = i + 1
+    return i
+
+
+def sum_to(n: int) -> int:
+    assert n >= 0
+    assert n <= 100
+    total: int = 0
+    i: int = 0
+    while i <= n:
+        total = total + i
+        i = i + 1
+    return total
+
+
+def product(n: int) -> int:
+    assert n >= 1
+    assert n <= 10
+    p: int = 1
+    i: int = 1
+    while i <= n:
+        p = p * i
+        i = i + 1
+    return p

--- a/StrataTest/Languages/Python/tests/test_typed_python_methods_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_methods_off.py
@@ -1,0 +1,22 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart. Method calls and field reads all go
+# through Any.
+class Wallet:
+    balance: int
+
+    def deposit(self, amount: int) -> int:
+        assert amount >= 0
+        assert self.balance >= 0
+        return self.balance + amount
+
+    def withdraw(self, amount: int) -> int:
+        assert amount >= 0
+        assert self.balance >= amount
+        return self.balance - amount
+
+
+def use_wallet(w: Wallet, amt: int) -> int:
+    assert amt >= 0
+    assert amt <= 100
+    assert w.balance >= 100
+    return w.deposit(amt)

--- a/StrataTest/Languages/Python/tests/test_typed_python_methods_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_methods_on.py
@@ -1,0 +1,24 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Methods on a typed receiver. `self.balance` reads a native int field;
+# calls between methods on the same class use the Any-boundary shim
+# so the method body stays Any-internal but native fields and operators
+# fire when types line up.
+class Wallet:
+    balance: int
+
+    def deposit(self, amount: int) -> int:
+        assert amount >= 0
+        assert self.balance >= 0
+        return self.balance + amount
+
+    def withdraw(self, amount: int) -> int:
+        assert amount >= 0
+        assert self.balance >= amount
+        return self.balance - amount
+
+
+def use_wallet(w: Wallet, amt: int) -> int:
+    assert amt >= 0
+    assert amt <= 100
+    assert w.balance >= 100
+    return w.deposit(amt)

--- a/StrataTest/Languages/Python/tests/test_typed_python_mixed_arith_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_mixed_arith_off.py
@@ -1,0 +1,19 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart for mixed typed/untyped arithmetic.
+def typed_and_any_add(a: int, b) -> int:
+    assert a >= 0
+    return a + b
+
+
+def typed_and_any_mul(a: int, b) -> int:
+    assert a >= 0
+    return a * b
+
+
+def any_first_then_typed(a, b: int) -> int:
+    assert b >= 0
+    return a + b
+
+
+def typed_int_and_typed_str(a: int, s: str) -> str:
+    return s + s

--- a/StrataTest/Languages/Python/tests/test_typed_python_mixed_arith_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_mixed_arith_on.py
@@ -1,0 +1,21 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Mixed arithmetic: typed and untyped operands. The native operator
+# dispatch must NOT fire when only one operand is typed; the Any
+# path takes over and the typed operand is widened at the boundary.
+def typed_and_any_add(a: int, b) -> int:
+    assert a >= 0
+    return a + b
+
+
+def typed_and_any_mul(a: int, b) -> int:
+    assert a >= 0
+    return a * b
+
+
+def any_first_then_typed(a, b: int) -> int:
+    assert b >= 0
+    return a + b
+
+
+def typed_int_and_typed_str(a: int, s: str) -> str:
+    return s + s

--- a/StrataTest/Languages/Python/tests/test_typed_python_nested_arith_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_nested_arith_off.py
@@ -1,0 +1,8 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart for nested arithmetic.
+def add3(a: int, b: int, c: int) -> int:
+    return a + b + c
+
+
+def add4(a: int, b: int, c: int, d: int) -> int:
+    return a + b + c + d

--- a/StrataTest/Languages/Python/tests/test_typed_python_nested_arith_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_nested_arith_on.py
@@ -1,0 +1,12 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Nested arithmetic — long chains of `+` and `*` are where the typed
+# encoding wins most: each `Any` operand wraps a `from_int` and each
+# operator unwraps with `as_int!`, so the solver spends its time
+# peeling tags. Under `--typed-python` the same expression stays in
+# `TInt` end-to-end.
+def add3(a: int, b: int, c: int) -> int:
+    return a + b + c
+
+
+def add4(a: int, b: int, c: int, d: int) -> int:
+    return a + b + c + d

--- a/StrataTest/Languages/Python/tests/test_typed_python_nested_scope_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_nested_scope_off.py
@@ -1,0 +1,31 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart for typed locals across nested scopes.
+def conditional_decl(x: int) -> int:
+    assert x >= 0
+    if x > 10:
+        y: int = x * 2
+        return y
+    z: int = x + 1
+    return z
+
+
+def shadowed_locals(x: int, y: int) -> int:
+    assert x >= 0
+    assert y >= 0
+    if x > y:
+        result: int = x - y
+    else:
+        result: int = y - x
+    return result
+
+
+def loop_local(n: int) -> int:
+    assert n >= 0
+    assert n <= 50
+    sum: int = 0
+    i: int = 0
+    while i < n:
+        delta: int = i * 2
+        sum = sum + delta
+        i = i + 1
+    return sum

--- a/StrataTest/Languages/Python/tests/test_typed_python_nested_scope_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_nested_scope_on.py
@@ -1,0 +1,33 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Variables declared inside if/while blocks. Strata's hoisting pass
+# pulls all locals to the top of the procedure; verify it works
+# correctly with typed locals across control-flow scopes.
+def conditional_decl(x: int) -> int:
+    assert x >= 0
+    if x > 10:
+        y: int = x * 2
+        return y
+    z: int = x + 1
+    return z
+
+
+def shadowed_locals(x: int, y: int) -> int:
+    assert x >= 0
+    assert y >= 0
+    if x > y:
+        result: int = x - y
+    else:
+        result: int = y - x
+    return result
+
+
+def loop_local(n: int) -> int:
+    assert n >= 0
+    assert n <= 50
+    sum: int = 0
+    i: int = 0
+    while i < n:
+        delta: int = i * 2
+        sum = sum + delta
+        i = i + 1
+    return sum

--- a/StrataTest/Languages/Python/tests/test_typed_python_subscript_off.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_subscript_off.py
@@ -1,0 +1,15 @@
+# strata-args: --check-mode bugFinding --check-level full
+# Default-mode counterpart. Subscripts go through `Any_get_slice` /
+# `Any..get` (the universal Any-tag accessor); the result keeps the
+# Any tag.
+def first(xs: list) -> int:
+    return xs[0]
+
+
+def at_index(xs: list, i: int) -> int:
+    assert i >= 0
+    return xs[i]
+
+
+def lookup(m: dict, k: str) -> int:
+    return m[k]

--- a/StrataTest/Languages/Python/tests/test_typed_python_subscript_on.py
+++ b/StrataTest/Languages/Python/tests/test_typed_python_subscript_on.py
@@ -1,0 +1,16 @@
+# strata-args: --typed-python --check-mode bugFinding --check-level full
+# Native subscript dispatch over typed containers. `xs[i]` on a
+# `list[int]` lowers to `Sequence.select`; `m[k]` on `dict[str, int]`
+# lowers to native `select`. The index is unwrapped via fromAny so the
+# peephole cancels with the wrap from the local Name read.
+def first(xs: list) -> int:
+    return xs[0]
+
+
+def at_index(xs: list, i: int) -> int:
+    assert i >= 0
+    return xs[i]
+
+
+def lookup(m: dict, k: str) -> int:
+    return m[k]

--- a/docs/TypedPython.md
+++ b/docs/TypedPython.md
@@ -1,0 +1,109 @@
+# `--typed-python`: Native Lowering for Annotated Python
+
+By default, Strata's Python verifier lowers every value through a
+universal `Any` algebraic datatype. The encoding is sound but loses
+precision — ordinary integer arithmetic over `Any` chains a `from_int`
+on each input and a `from_int` on each output, and the SMT solver
+spends its time peeling those tags instead of doing arithmetic.
+
+`--typed-python` is an opt-in mode that keeps annotated primitives
+and containers in their **native Laurel sort** end-to-end. The result
+is fewer obligations, cleaner counter-examples, and verifications
+that finish in milliseconds where the `Any` encoding times out.
+
+## Quick start
+
+```bash
+strata pyAnalyzeLaurel --typed-python my_program.python.st.ion
+```
+
+Off by default. Add the flag to opt every annotated value into the
+typed encoding for the whole file.
+
+## Supported subset
+
+| Python annotation | Laurel sort |
+|---|---|
+| `int`, `bool`, `float`, `str` | `TInt`, `TBool`, `TReal`, `TString` |
+| `list`, `Sequence`, `List` (no inner type) | `TSeq Any` |
+| `list[T]`, `Sequence[T]`, `List[T]` | `TSeq T` (recursive) |
+| `dict`, `Mapping`, `Dict` (no inner type) | `TMap Any Any` |
+| `dict[K, V]`, `Mapping[K, V]`, `Dict[K, V]` | `TMap K V` (recursive) |
+| User-defined classes | `UserDefined ClassName` |
+| Class fields of primitive type | `TInt` / `TBool` / `TReal` / `TString` |
+| Typed `__init__` parameters | native primitive sorts |
+
+Operators that lower natively when the operand types match:
+
+- Arithmetic: `+`, `-`, `*`, `//`, `%` (integers) and `+` (string concat).
+- Unary: `not` on `bool`, `-` on `int`.
+- Comparison: `==`, `!=`, `<`, `<=`, `>`, `>=` on `int`-like or `str`
+  operands. Single comparisons only — chained `a < b < c` keeps the
+  legacy Any path so evaluate-once semantics is preserved.
+- Boolean: `and`, `or` when **all** operands are `bool` (mixed types
+  fall through to Any since Python's `bool and int` returns `int`).
+- Subscript: `xs[i]` over `list[T]` (→ `Sequence.select`), `m[k]`
+  over `dict[K, V]` (→ map `select`).
+- Function calls: typed callees take native arguments and return
+  native values; the call boundary unwraps and re-wraps once via the
+  `fromAny` / `toAny` peephole, which collapses `from_X(Any..as_X!(...))`
+  pairs to the inner expression.
+
+## Refused under `--typed-python`
+
+The pyspec layer rejects the following, with a fatal
+`typedPythonRefusal` diagnostic:
+
+- `Optional[T]` / `Union[T, None]` and other unions.
+- `Literal[...]` types.
+- `bytes` (no native sort yet).
+- `list[Foo]` where `Foo` is not a recognised primitive or class.
+
+When the flag is off, these collapse silently to `Any` as before.
+
+## Limitations
+
+The following work correctly under `--typed-python` but stay on the
+`Any` path (no precision gain):
+
+- Operators not listed above (`**`, `/`, `<<`, `>>`, `&`, `|`, `^`, `~`).
+- `len(x)` in user-code expressions (the spec layer does dispatch
+  natively over `TSeq` / `TString`).
+- Container mutation: `xs.append(...)`, `m[k] = v`, `xs += y`.
+- Tuples (`tuple[A, B]`), sets, frozensets, generators.
+- Higher-order functions: passing typed functions as arguments.
+- Quantifiers (`forall` / `exists`) in user-code preconditions.
+- **Class fields of container type** (`self.items: list`). Container
+  fields stay `Any` because the heap-parameterization pass can't yet
+  box them; subscript on `self.items` routes through `Any_get`. The
+  primitive-field path (e.g. `self.balance: int`) lowers natively.
+
+Counter-examples on a typed program are reported in terms of native
+Laurel sorts (`TInt`, `TSeq Int`, …) rather than the user's Python
+source positions. Mapping back to source is a follow-up.
+
+## Strict mode
+
+`--typed-python` turns refusal of an unsupported type into a hard
+error — there is no silent widening for the typed surface.
+
+## Benchmarks
+
+Measured on the `test_typed_python_*` demo pairs (`pyAnalyzeLaurel
+--check-mode bugFinding --check-level full`, mean of 3 runs).
+"inconclusive" counts the verification obligations the solver could
+not decide — the lower the better.
+
+| Pair           | off (ms) | on (ms) | speed-up | off ❓ | on ❓ |
+|----------------|---------:|--------:|---------:|------:|-----:|
+| nested_arith   |    1475  |     91  |   16.2×  |     0 |    0 |
+| compose_calls  |    1374  |    117  |   11.7×  |     0 |    0 |
+| nested_scope   |    1318  |    163  |    8.1×  |    10 |    5 |
+| loops          |    1053  |    152  |    6.9×  |    13 |    5 |
+| methods        |     485  |    207  |    2.3×  |    10 |    7 |
+| class_fields   |     278  |    119  |    2.3×  |     6 |    2 |
+| mixed_arith    |     460  |    212  |    2.2×  |     9 |    6 |
+| subscript      |     260  |    163  |    1.6×  |     7 |    3 |
+
+Reproduce: `cd StrataTest/Languages/Python && ./run_py_analyze.sh
+--filter typed_python`.


### PR DESCRIPTION
## Summary

Adds `--typed-python`, an opt-in mode that keeps annotated Python
primitives and containers in their native Laurel sort instead of
routing through the universal `Any` encoding. Fewer verification
obligations and proofs that finish in milliseconds where `Any`
times out. Off by default — no behaviour change without the flag.

Covers: `int`, `bool`, `float`, `str`; `list[T]`, `dict[K, V]` (and
their `Sequence` / `Mapping` aliases); class fields, methods, typed
`__init__`; arithmetic, comparison, boolean, subscript, `len`.

Refused (fatal `typedPythonRefusal`): `Optional[T]`, `Union`,
`Literal`, `bytes`, unrecognised container inner types.

## Benchmarks

`pyAnalyzeLaurel --check-mode bugFinding --check-level full`, mean
of 3 runs on `test_typed_python_*` demo pairs:

| Pair          | off (ms) | on (ms) | speed-up | off ❓ | on ❓ |
|---------------|---------:|--------:|---------:|------:|-----:|
| nested_arith  |    1475  |     91  |   16.2×  |     0 |    0 |
| compose_calls |    1374  |    117  |   11.7×  |     0 |    0 |
| nested_scope  |    1318  |    163  |    8.1×  |    10 |    5 |
| loops         |    1053  |    152  |    6.9×  |    13 |    5 |
| methods       |     485  |    207  |    2.3×  |    10 |    7 |
| class_fields  |     278  |    119  |    2.3×  |     6 |    2 |
| mixed_arith   |     460  |    212  |    2.2×  |     9 |    6 |
| subscript     |     260  |    163  |    1.6×  |     7 |    3 |

## Test plan

- [x] `lake build`
- [x] `lake build StrataTest.Languages.Python.TypedPythonTest`
- [x] `cd StrataTest/Languages/Python && ./run_py_analyze.sh` — 238 pass, 0 fail
- [x] No existing snapshot or test modified — off-mode preserved

Docs: `docs/TypedPython.md` (supported subset, limitations,
benchmark table, reproduction instructions).