### PR TITLE
fix(eval): clear Env.deferred on false branch of CFG condGoto

### DIFF
--- a/Strata/Languages/Core/ProcedureEval.lean
+++ b/Strata/Languages/Core/ProcedureEval.lean
@@ -97,10 +97,17 @@ private def evalCFGStep (cfg : DetCFG) (old_var_subst : SubstMap)
               let env_t := { env' with pathConditions :=
                 (env'.pathConditions.addInNewest
                   [.assumption label_t cond']) }
-              let env_f := { env' with pathConditions :=
-                (env'.pathConditions.addInNewest
-                  [.assumption label_f
-                    (Lambda.LExpr.ite () cond' (LExpr.false ()) (LExpr.true ()))]) }
+              -- Mirror processIteBranches at StatementEval.lean: clear
+              -- `deferred` on the false branch so pre-split obligations
+              -- aren't duplicated across both branches. Without this, every
+              -- symbolic condGoto multiplies the deferred-obligation count
+              -- by 2, producing exponential blowup across procedures.
+              let env_f := { env' with
+                deferred := #[]
+                pathConditions :=
+                  (env'.pathConditions.addInNewest
+                    [.assumption label_f
+                      (Lambda.LExpr.ite () cond' (LExpr.false ()) (LExpr.true ()))]) }
               ((lt, env_t) :: (lf, env_f) :: newActive, finished, stats))
     ([], [], {})
 

--- a/StrataTest/Languages/Core/Tests/ProcedureEvalCFGTests.lean
+++ b/StrataTest/Languages/Core/Tests/ProcedureEvalCFGTests.lean
@@ -253,5 +253,64 @@ Proof Obligation:
                      ("done", { cmds := [], transfer := .finish })
                    ] } })
 
+/-! ## Pre-split assert deduped across symbolic condGoto
+
+An `assert` evaluated *before* a symbolic `condGoto` lands in the parent
+env's `deferred` array. Both branches inherit `env'` by record-update, so
+without dedup the pre-split obligation would appear once per terminal
+path after `mergeResults` concatenates them. Each `ProofObligation`
+captures its assumptions at creation time (see
+`Strata/DL/Imperative/CmdEval.lean`), so duplicates are redundant: the
+fix in `evalCFGStep` clears the false-branch's `deferred`, mirroring
+`Strata/Languages/Core/StatementEval.lean` for the structured `.ite`
+path. This test exercises that dedup — the `pre_assert` obligation must
+appear exactly once in the merged output.
+-/
+
+/--
+info: Error:
+none
+Subst Map:
+
+Expression Env:
+State:
+
+
+Evaluation Config:
+Eval Depth: 200
+Factory Functions:
+
+
+
+Datatypes:
+
+Path Conditions:
+
+
+Warnings:
+[]
+Deferred Proof Obligations:
+Label: pre_assert
+Property: assert
+Assumptions:
+
+Proof Obligation:
+x@1 >= 0
+-/
+#guard_msgs in
+#eval IO.println (cfgEval
+  { header := {name := "PreSplitAssert", typeArgs := [],
+               inputs := [("x", mty[int])],
+               outputs := [] },
+    spec := { preconditions := [],
+              postconditions := [] },
+    body := .cfg { entry := "entry",
+                   blocks := [
+                     ("entry", { cmds := [CmdExt.cmd (Cmd.assert "pre_assert" eb[((~Int.Ge x) #0)] .empty)],
+                                 transfer := .condGoto eb[((~Int.Ge x) #0)] "left" "right" }),
+                     ("left",  { cmds := [], transfer := .finish }),
+                     ("right", { cmds := [], transfer := .finish })
+                   ] } })
+
 end CFGEvalTests
 end Core


### PR DESCRIPTION
Closes #1316.

## Summary

`evalCFGStep`'s symbolic-`condGoto` arm builds `env_t` and `env_f` by record-update on the parent `env'`, so both inherit `env'.deferred` wholesale. `mergeResults` then concatenates the terminal envs' deferred arrays without dedup, propagating duplicates into the next procedure's eval — each symbolic branch doubles the deferred-obligation count.

The structured `.ite` path already handles this in `processIteBranches` (clears `deferred := #[]` on the false branch); this PR adds the symmetric clear to the CFG path.

## Diagnostic data

15-procedure synthetic MWE (see #1316), with a one-line `dbg_trace` on `Strata/Languages/Core/ProgramEval.lean:62` after `Procedure.eval` printing `E.deferred.size`:

| Procedure | Pre-fix | Post-fix |
|---|---:|---:|
| P1  | 2     | 2  |
| P2  | 6     | 4  |
| P3  | 14    | 6  |
| P4  | 30    | 8  |
| P5  | 62    | 10 |
| P10 | 2046  | 20 |
| P15 | 65534 | 30 |

Pre-fix recurrence: `D_{n+1} = 2·D_n + 2`. Strata SIGABRTs in ~60 ms when the post-eval ITE-chain walker tries to traverse the resulting 65534-deep statement tree. Post-fix: strict `+2` per procedure (each procedure's own postcondition firing on each branch arm), all 15 goals pass in ~2 s.

## Soundness

Each `ProofObligation` snapshots its `assumptions` (path conditions) at creation time (`Strata/DL/Imperative/CmdEval.lean:64-83`). The verifier proves `assumptions ⊨ predicate` without consulting the env's current state, so each obligation is self-contained. Dropping a duplicate from one branch loses no proof information — the sibling branch still carries it. The set of distinct obligations is unchanged.

`Env.deferred` is otherwise write-only during eval (verified by grep — only post-eval consumers read it).

Empirically validated on a downstream branch: 94-program SMACK portfolio produces 68 PASS / 15 PASS-? / 11 PARTIAL post-fix, with PARTIAL identities matching the pre-fix v4 baseline exactly (no soundness regressions).

## Regression test

`StrataTest/Languages/Core/Tests/ProcedureEvalCFGTests.lean` gains a `#guard_msgs` test that seeds a pre-split assert before a symbolic `condGoto` and verifies the merged deferred contains the assert exactly once. Test passes post-fix; would fail pre-fix.

## Test plan

- [x] `lake build` succeeds (542+ jobs)
- [x] `lake build StrataTest.Languages.Core.Tests.ProcedureEvalCFGTests` succeeds (new dedup test passes; existing CFG tests unchanged)
- [x] 15-procedure MWE: pre-fix SIGABRT in ~60 ms → post-fix all 15 goals pass in ~2 s
- [x] Downstream 94-program SMACK matrix: PARTIAL identities match pre-fix baseline exactly (soundness)
