### PR TITLE
Remove Python copyright check from shared lint action

### DIFF
--- a/.github/actions/check-copyright-headers/action.yml
+++ b/.github/actions/check-copyright-headers/action.yml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 name: Check copyright headers
 description: >
-  Verify that all .lean and .py files have the expected copyright header.
+  Verify that all .lean files have the expected copyright header.
+  Downstream repos can add their own checks for other file types.
 
 inputs:
   directory:

--- a/.github/actions/check-lean-import/action.yml
+++ b/.github/actions/check-lean-import/action.yml
@@ -16,7 +16,5 @@ runs:
   steps:
     - name: Check for bare import Lean
       shell: bash
-      env:
-        LINT_DIR: ${{ inputs.directory }}
       run: |
-        ! (find "$LINT_DIR" -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Lean$')
+        "${{ github.action_path }}/../../scripts/checkLeanImport.sh" "${{ inputs.directory }}"

--- a/.github/scripts/checkLeanImport.sh
+++ b/.github/scripts/checkLeanImport.sh
@@ -2,4 +2,6 @@
 # Check to identify modules that inadvertently import all of Lean.
 # We want to encourage only importing parts of Lean when needed.
 
-! (find . -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Lean$')
+LINT_DIR="${1:-.}"
+
+! (find "$LINT_DIR" -name "*.lean" -type f -print0 | xargs -0 grep -E -n '^import Lean$')

--- a/.github/scripts/check_copyright_headers.py
+++ b/.github/scripts/check_copyright_headers.py
@@ -78,8 +78,10 @@ def main():
     if not check_all_source_files(directory_path, ext=".lean", header=lean_copyright_header):
         success = False
 
-    if not check_all_source_files(directory_path / 'Tools', ext=".py", header=python_copyright_header):
-        success = False
+    tools_dir = directory_path / 'Tools'
+    if tools_dir.is_dir():
+        if not check_all_source_files(tools_dir, ext=".py", header=python_copyright_header):
+            success = False
 
     # Exit with appropriate code
     sys.exit(0 if success else 1)

--- a/.github/scripts/check_copyright_headers.py
+++ b/.github/scripts/check_copyright_headers.py
@@ -59,12 +59,6 @@ lean_copyright_header = """/-
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/"""
 
-python_copyright_header = """\
-# Copyright Strata Contributors
-#
-#  SPDX-License-Identifier: Apache-2.0 OR MIT
-"""
-
 def main():
     """Main function to handle command line arguments"""
     if len(sys.argv) != 2:
@@ -73,17 +67,7 @@ def main():
         sys.exit(1)
 
     directory_path = Path(sys.argv[1])
-    success = True
-
-    if not check_all_source_files(directory_path, ext=".lean", header=lean_copyright_header):
-        success = False
-
-    tools_dir = directory_path / 'Tools'
-    if tools_dir.is_dir():
-        if not check_all_source_files(tools_dir, ext=".py", header=python_copyright_header):
-            success = False
-
-    # Exit with appropriate code
+    success = check_all_source_files(directory_path, ext=".lean", header=lean_copyright_header)
     sys.exit(0 if success else 1)
 
 if __name__ == "__main__":

--- a/.github/scripts/lintWhitespace.sh
+++ b/.github/scripts/lintWhitespace.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 LINT_DIR="${1:-Strata}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,7 @@ jobs:
         uses: ./.github/actions/lint-whitespace
       - name: Check for import Lean
         uses: ./.github/actions/check-lean-import
-      - name: Check Lean version consistncy
+      - name: Check Lean version consistency
         run: .github/scripts/check_lean_consistency.sh
       - name: Check for new panic! usage
         uses: ./.github/actions/check-no-panic


### PR DESCRIPTION
## Summary

- Remove the Python copyright header check from the shared `check-copyright-headers` action. The `Tools/` directory linting is repo-specific and belongs in downstream repos (e.g., Strata-Python) that have Python code.
- The shared action now only checks `.lean` files — downstream repos can add their own custom lint checks for other file types.
- Also includes cleanup from PR #1322 review: typo fix in ci.yml, `set -e` in lintWhitespace.sh, and parameterizing checkLeanImport.sh.

## Context

The original fix (guarding `Tools/` with `is_dir()`) worked around the cross-repo failure but kept repo-specific logic in the shared action. This approach is cleaner: the shared action provides `.lean` checks only, and repos like Strata-Python add their own Python-specific linting.

## Test plan

- [ ] CI passes on this PR (confirms `.lean` copyright checks still work for the Strata monorepo)
- [ ] After merge, re-run Strata-Boole CI to confirm no failures from missing `Tools/`