### PR TITLE
Preserve sat counterexamples on universal-quantification VCs

### DIFF
--- a/Strata/Languages/Core.lean
+++ b/Strata/Languages/Core.lean
@@ -197,13 +197,14 @@ def Core.coreAbstractedPhases (procs : Option (List String) := none)
     : List Core.AbstractedPhase :=
   _root_.Core.coreAbstractedPhases procs options moreFns
 
-/-- Front-end phase: any translation from a source language to Core may
-    introduce over-approximations. Until front-ends can validate models or
-    determine that an assertion is unaffected, all sat results are converted
-    to unknown. -/
+/-- Front-end phase: source-language translations may over-approximate, so
+    sat models are demoted by default. Universal VCs are exempt
+    (see `obligationLabelIsUniversal`). -/
 def frontEndPhase : Core.AbstractedPhase where
   name := "FrontEnd"
-  getValidation _ := .modelToValidate (fun _ => /- TODO -/ false)
+  getValidation obligation :=
+    if Core.obligationLabelIsUniversal obligation then .modelPreserving
+    else .modelToValidate (fun _ => /- TODO -/ false)
 
 /-! ### Analysis of Core programs -/
 

--- a/Strata/Languages/Core/PipelinePhase.lean
+++ b/Strata/Languages/Core/PipelinePhase.lean
@@ -49,6 +49,28 @@ def obligationHasLabelPrefix (obligation : ProofObligation Expression)
   obligation.assumptions.any fun pc =>
     pc.any fun entry => entry.name.startsWith pfx
 
+/-- Registry of obligation-label families whose VCs are universally
+    quantified over a spec-pinned domain. A sat counterexample to such
+    an obligation is genuine regardless of havoc/inlining/translation,
+    so the abstracting phases need not validate the model. -/
+def universalVCRegistry : List ((String → Bool) × String) :=
+  [ (fun lbl => lbl.startsWith "arbitrary_iter_maintain_invariant",
+      "loop-invariant maintenance — LoopElim havoc-and-assert(I)")
+  , (fun lbl => lbl.startsWith "entry_invariant",
+      "loop-invariant entry — LoopElim assert(I) at loop top")
+  , (fun lbl => lbl.startsWith "measure_lb",
+      "termination measure ≥ 0 — LoopElim")
+  , (fun lbl => lbl.startsWith "measure_decrease",
+      "termination measure decreases — LoopElim, C_Simp")
+  , (fun lbl => (lbl.splitOn ":postcondition").length > 1,
+      "callee postcondition — LaurelToCoreTranslator")
+  , (fun lbl => lbl.startsWith "callElimAssert_",
+      "call-site precondition — CallElim asserts callee.requires")
+  ]
+
+def obligationLabelIsUniversal (obligation : ProofObligation Expression) : Bool :=
+  universalVCRegistry.any fun (m, _) => m obligation.label
+
 /-- A verification pipeline phase that pairs a program transformation with
     its model validation. This coupling ensures that adding a new transform
     also requires specifying its soundness annotation, and vice versa. -/

--- a/Strata/Transform/CallElim.lean
+++ b/Strata/Transform/CallElim.lean
@@ -150,7 +150,8 @@ def callElimPipelinePhase : PipelinePhase where
   transform := CallElim.callElim'
   phase.name := "CallElim"
   phase.getValidation obligation :=
-    if obligationHasLabelPrefix obligation CallElim.callElimAssumePrefix then
+    if obligationLabelIsUniversal obligation then .modelPreserving
+    else if obligationHasLabelPrefix obligation CallElim.callElimAssumePrefix then
       .modelToValidate (fun _ => /- TODO -/ false)
     else .modelPreserving
   phase.getAssertDescription label :=

--- a/Strata/Transform/LoopElim.lean
+++ b/Strata/Transform/LoopElim.lean
@@ -259,7 +259,8 @@ def loopElimPipelinePhase : PipelinePhase where
   transform := loopElim'
   phase.name := "LoopElim"
   phase.getValidation obligation :=
-    if obligationHasLabelPrefix obligation loopElimInvariantPrefix
+    if obligationLabelIsUniversal obligation then .modelPreserving
+    else if obligationHasLabelPrefix obligation loopElimInvariantPrefix
        || obligationHasLabelPrefix obligation loopElimGuardPrefix then
       .modelToValidate (fun _ => /- TODO -/ false)
     else .modelPreserving

--- a/StrataTest/Languages/Core/Examples/Loops.lean
+++ b/StrataTest/Languages/Core/Examples/Loops.lean
@@ -101,7 +101,7 @@ Result: ✅ pass
 
 Obligation: measure_decrease_0
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: countUp_ensures_1
 Property: assert
@@ -592,7 +592,7 @@ Result: ✅ pass
 
 Obligation: measure_lb_0
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: loop_measure_end_calls_Int.SafeDiv_0
 Property: division by zero check
@@ -604,7 +604,7 @@ Result: ✅ pass
 
 Obligation: measure_decrease_0
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: countdownByDBad_ensures_1
 Property: assert
@@ -661,7 +661,7 @@ Result: ✅ pass
 
 Obligation: measure_lb_0
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: loop_measure_end_calls_Int.SafeDiv_0
 Property: division by zero check
@@ -673,7 +673,7 @@ Result: ✅ pass
 
 Obligation: measure_decrease_0
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: countdownMutateD_ensures_2
 Property: assert

--- a/StrataTest/Languages/Core/Examples/SelectiveVerification.lean
+++ b/StrataTest/Languages/Core/Examples/SelectiveVerification.lean
@@ -65,7 +65,7 @@ Result: ❌ fail
 
 Obligation: callElimAssert_n_positive_2
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: output_property
 Property: assert
@@ -90,7 +90,7 @@ Result: ❌ fail
 
 Obligation: callElimAssert_n_positive_2
 Property: assert
-Result: ❓ unknown
+Result: ❌ fail
 
 Obligation: output_property
 Property: assert

--- a/StrataTest/Languages/Core/VCOutcomeTests.lean
+++ b/StrataTest/Languages/Core/VCOutcomeTests.lean
@@ -270,17 +270,25 @@ private def cleanObligation : Imperative.ProofObligation Core.Expression :=
     assumptions := [[.assumption "precond_x_positive" (.true ())]],
     obligation := .true (), metadata := {} }
 
--- Combined Core phases: clean obligation preserves sat
+private def universalLoopMaintainObligation : Imperative.ProofObligation Core.Expression :=
+  { label := "arbitrary_iter_maintain_invariant_0_3", property := .assert,
+    assumptions := [[.assumption "assume_invariant_0_3" (.true ())]],
+    obligation := .true (), metadata := {} }
+
+private def universalPostconditionObligation : Imperative.ProofObligation Core.Expression :=
+  { label := "myProc:postcondition_2", property := .assert,
+    assumptions := [[.assumption "callElimAssume_post" (.true ())]],
+    obligation := .true (), metadata := {} }
+
 #guard (satResult.adjustForPhases [callElimPipelinePhase.phase, loopElimPipelinePhase.phase] cleanObligation).1 == satResult
-
--- Combined Core phases: call-elim obligation becomes unknown
 #guard (satResult.adjustForPhases [callElimPipelinePhase.phase, loopElimPipelinePhase.phase] callElimObligation).1 == unknownResult
+#guard (satResult.adjustForPhases [callElimPipelinePhase.phase, loopElimPipelinePhase.phase] universalLoopMaintainObligation).1 == satResult
+#guard (satResult.adjustForPhases [callElimPipelinePhase.phase, loopElimPipelinePhase.phase] universalPostconditionObligation).1 == satResult
 
--- frontEndPhase: always rejects sat regardless of obligation
 #guard (satResult.adjustForPhases [Strata.frontEndPhase] cleanObligation).1 == unknownResult
 #guard (satResult.adjustForPhases [Strata.frontEndPhase] callElimObligation).1 == unknownResult
-
--- frontEndPhase: unsat is unchanged
+#guard (satResult.adjustForPhases [Strata.frontEndPhase] universalLoopMaintainObligation).1 == satResult
+#guard (satResult.adjustForPhases [Strata.frontEndPhase] universalPostconditionObligation).1 == satResult
 #guard (unsatResult.adjustForPhases [Strata.frontEndPhase] cleanObligation).1 == unsatResult
 
 end Core


### PR DESCRIPTION
LoopElim, CallElim, and frontEndPhase demote every sat counterexample
via a `fun _ => false` validator stub. For universal-quantification
obligations (loop-invariant maintenance/entry, measure bounds, callee
postcondition), any witness in the abstracted domain is already in the
user's stated domain, so the demotion is unnecessary.

Adds `obligationLabelIsUniversal` and wires it as the first branch of
each phase's getValidation. Universal labels preserve the model;
everything else still demotes.

Closes part of #1324.