### PR TITLE
Fix outdated ion-java jar path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ A JDK (11+) providing `javac` must be on your `PATH`. For running the
 Java/Ion integration test, download the ion-java jar:
 
 ```bash
-wget -q -O StrataTestExtra/DDM/Integration/Java/testdata/ion-java-1.11.11.jar \
+wget -q -O StrataTestExtra/Languages/Java/testdata/ion-java-1.11.11.jar \
   https://github.com/amazon-ion/ion-java/releases/download/v1.11.11/ion-java-1.11.11.jar
 ```
 


### PR DESCRIPTION
Fix the `wget` path for the ion-java jar in the README.
The old path `StrataTestExtra/DDM/Integration/Java/testdata/` no longer exists.
The test code expects the jar at `StrataTestExtra/Languages/Java/testdata/`.
