### PR TITLE
fix(laurel): datatype `==`/`!=` mis-lowered to reference comparison in heap-writing procedures

### DIFF
--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -409,20 +409,24 @@ where
     | .PureFieldUpdate t f v => return [⟨ .PureFieldUpdate (← recurseOne t) f (← recurseOne v), source ⟩]
     | .PrimitiveOp op args _ =>
       let args' ← args.mapM (recurseOne ·)
-      -- For == and != on Composite types, compare refs instead
+      -- For == and != on Composite types, compare refs instead. Note
+      -- `.UserDefined` covers BOTH composites (heap references — `ref!` is
+      -- correct) and datatypes (values — `ref!` is wrong and would unify a
+      -- datatype value against `Composite`). Only ref-compare composites;
+      -- datatype equality falls through to structural comparison.
       match op, args with
       | .Eq, [e1, _e2] =>
-        let ty := (computeExprType model e1).val
-        match ty with
-        | .UserDefined _ =>
+        match (computeExprType model e1).val with
+        | .UserDefined name =>
+          if isDatatype model name then return [⟨ .PrimitiveOp op args', source ⟩]
           let ref1 := mkMd (.StaticCall "Composite..ref!" [args'[0]!])
           let ref2 := mkMd (.StaticCall "Composite..ref!" [args'[1]!])
           return [⟨ .PrimitiveOp .Eq [ref1, ref2], source ⟩]
         | _ => return [⟨ .PrimitiveOp op args', source ⟩]
       | .Neq, [e1, _e2] =>
-        let ty := (computeExprType model e1).val
-        match ty with
-        | .UserDefined _ =>
+        match (computeExprType model e1).val with
+        | .UserDefined name =>
+          if isDatatype model name then return [⟨ .PrimitiveOp op args', source ⟩]
           let ref1 := mkMd (.StaticCall "Composite..ref!" [args'[0]!])
           let ref2 := mkMd (.StaticCall "Composite..ref!" [args'[1]!])
           return [⟨ .PrimitiveOp .Neq [ref1, ref2], source ⟩]

--- a/StrataTest/Languages/Laurel/DatatypeEqHeapProcTest.lean
+++ b/StrataTest/Languages/Laurel/DatatypeEqHeapProcTest.lean
@@ -1,0 +1,69 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import StrataTest.Util.TestLaurel
+
+open StrataTest.Util
+open Strata
+
+/-! ## Regression: datatype `==` / `!=` inside a heap-writing procedure
+
+`HeapParameterization` rewrites `==`/`!=` on heap references into a
+`Composite..ref!` reference comparison. The operand-type check used
+`.UserDefined _`, which matches BOTH composites (heap references, where
+`ref!` is correct) AND datatypes (values, where `ref!` is wrong: it would
+unify a datatype value against the `Composite` (= int) type).
+
+The bug only surfaces inside a procedure that writes the heap, because only
+then does the heap-rewriting pass descend into the body and reach the `==`
+arm. Allocating a composite (`new C`) is enough to make the procedure a heap
+writer, so a datatype comparison sitting next to it used to fail Core type
+checking with:
+
+  Impossible to unify (arrow Composite int) with (arrow <Datatype> ...)
+
+The fix guards the `ref!` rewrite on `!isDatatype`, letting datatype
+equality fall through to structural comparison. These programs verify
+cleanly with the fix and fail Core type checking without it.
+
+A datatype compared with `==` inside a heap-writing procedure. The `new C`
+makes `cmp` a heap writer; the datatype values must still compare
+structurally rather than being wrongly reference-compared. -/
+
+#eval testLaurel
+#strata
+program Laurel;
+composite C { var x: int }
+datatype Pair { MkPair(a: int, b: int) }
+
+procedure cmp()
+  opaque
+{
+  var c: C := new C;
+  var p1: Pair := MkPair(1, 2);
+  var p2: Pair := MkPair(1, 2);
+  assert p1 == p2
+};
+#end
+
+/-! Same shape with `!=`: two structurally-distinct datatype values are not
+equal, so the inequality holds. Exercises the `.Neq` arm of the same fix. -/
+
+#eval testLaurel
+#strata
+program Laurel;
+composite C { var x: int }
+datatype Pair { MkPair(a: int, b: int) }
+
+procedure cmp()
+  opaque
+{
+  var c: C := new C;
+  var p1: Pair := MkPair(1, 2);
+  var p2: Pair := MkPair(3, 4);
+  assert p1 != p2
+};
+#end


### PR DESCRIPTION
## Summary

`HeapParameterization` rewrites `==`/`!=` on heap references into a `Composite..ref!` reference comparison, gated on the operand type being `.UserDefined _`. That pattern matches **both** composites (heap references, where `ref!` is correct) **and** datatypes (values, where `ref!` is wrong — it unifies a datatype value against `Composite`, which is an `int` synonym).

## Symptom

The bug only surfaces inside a procedure that **writes the heap**, because only then does the heap-rewriting pass descend into the body and reach the equality arm. A datatype comparison sitting next to any heap write (e.g. a `new C` allocation) fails Core type checking with:

```
Impossible to unify (arrow Composite int) with (arrow <Datatype> ...)
```

This is a latent, general correctness bug — it affects **any** datatype `==`/`!=` in a heap-writing procedure, including a plain `datatype Pair { MkPair(a: int, b: int) }`. It is independent of any particular field type.

## Fix

Guard the `ref!` rewrite on `!isDatatype` (using the existing `isDatatype` helper) in both the `.Eq` and `.Neq` arms, so datatype equality falls through to structural comparison. Composite reference-equality semantics are unchanged.

## Tests

`StrataTest/Languages/Laurel/DatatypeEqHeapProcTest.lean` covers both `==` and `!=` on a datatype inside a heap-writing procedure. Verified both arms **fail Core type checking without the guard** and **verify cleanly with it** (non-vacuous regression guard). Full `Strata` + `StrataTest` build passes (554 jobs), no other regressions.

## Notes

Found while investigating `Array<T>` in datatype constructor arguments (the Seq/Array PR #1073): allocating an `Array<T>` forces `writesHeap`, which made this pre-existing bug reachable. This PR fixes the root cause independently; the array-facing follow-up (lifting the validator gate, flipping that test to positive) is left to #1073.