### PR TITLE
fix(laurel): allow a valueless return in the grammar

### DIFF
--- a/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
@@ -148,8 +148,8 @@ where
     | .While cond invs _decreases body =>
       let invArgs := invs.map (fun i => laurelOp "invariantClause" #[stmtExprToArg i]) |>.toArray
       laurelOp "while" #[stmtExprToArg cond, seqArg invArgs, stmtExprToArg body]
-    | .Return (some value) => laurelOp "return" #[stmtExprToArg value]
-    | .Return none => laurelOp "return" #[laurelOp "block" #[semicolonSep #[]]]
+    | .Return (some value) => laurelOp "return" #[optionArg (some (stmtExprToArg value))]
+    | .Return none => laurelOp "return" #[optionArg none]
     | .Exit label => laurelOp "exit" #[ident label]
     | .Assert cond =>
       let errOpt := optionArg (cond.summary.map fun msg =>

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -295,8 +295,10 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
         | _ => pure []
       return mkStmtExprMd (.StaticCall calleeName argsList) src
     | q`Laurel.return, #[arg0] =>
-      let value ← translateStmtExpr arg0
-      return mkStmtExprMd (.Return (some value)) src
+      let value ← match arg0 with
+        | .option _ (some valArg) => some <$> translateStmtExpr valArg
+        | _ => pure none
+      return mkStmtExprMd (.Return value) src
     | q`Laurel.ifThenElse, #[arg0, arg1, elseArg] =>
       let cond ← translateStmtExpr arg0
       let thenBranch ← translateStmtExpr arg1

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -9,7 +9,7 @@ module
 -- Laurel dialect definition, loaded from LaurelGrammar.st
 -- NOTE: Changes to LaurelGrammar.st are not automatically tracked by the build system.
 -- Update this file (e.g. this comment) to trigger a recompile after modifying LaurelGrammar.st.
--- Last grammar change: block format uses indent(2) with leading spaces for vertical layout.
+-- Last grammar change: `return` value is now Option StmtExpr (supports a valueless return).
 public import StrataDDM.AST
 import StrataDDM.BuiltinDialects.Init
 import StrataDDM.Integration.Lean.HashCommands

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -105,7 +105,7 @@ op ifThenElse (cond: StmtExpr, thenBranch: StmtExpr, elseBranch: Option ElseBran
 
 op assert (cond : StmtExpr, errorMessage: Option ErrorSummary) : StmtExpr => @[prec(0)] "assert " cond:0 errorMessage:0;
 op assume (cond : StmtExpr) : StmtExpr => @[prec(0)] "assume " cond:0;
-op return (value : StmtExpr) : StmtExpr => @[prec(0)] "return " value:0;
+op return (value : Option StmtExpr) : StmtExpr => @[prec(0)] "return " value:0;
 op block (stmts : SemicolonSepBy StmtExpr) : StmtExpr => @[prec(1000)] "{\n  " indent(2, stmts) "\n}";
 op labelledBlock (stmts : SemicolonSepBy StmtExpr, label : Ident) : StmtExpr => @[prec(1000)] "{\n  " indent(2, stmts) "\n}" label;
 op exit (label : Ident) : StmtExpr => @[prec(0)] "exit " label;

--- a/StrataTest/Languages/Laurel/AbstractToConcreteTreeTranslatorTest.lean
+++ b/StrataTest/Languages/Laurel/AbstractToConcreteTreeTranslatorTest.lean
@@ -282,5 +282,22 @@ info: procedure test(): int
   opaque
 { <??> };")
 
+-- Valueless return (issue #1353): a bare `return` round-trips as `.Return none`,
+-- not as the old `return { }` block hack, and re-parses stably.
+/--
+info: procedure earlyExit(b: bool)
+  opaque
+{
+  if b then {
+    return
+  };
+  assert true
+};
+-/
+#guard_msgs in
+#eval do IO.println (← roundtrip r"procedure earlyExit(b: bool)
+  opaque
+{ if b then { return }; assert true };")
+
 end Strata.Laurel
 end

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T3_ControlFlow.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T3_ControlFlow.lean
@@ -89,6 +89,17 @@ procedure dag(a: int) returns (r: int)
 //^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion does not hold
   return b
 };
+
+// Valueless early return (issue #1353): a bare `return` parses to `.Return none`.
+// Must verify cleanly — no value, used as an early exit.
+procedure valuelessEarlyReturn(b: bool)
+  opaque
+{
+  if b then {
+    return
+  };
+  assert true
+};
 "
 
 #guard_msgs (error, drop all) in


### PR DESCRIPTION
Fixes #1353.

The Laurel AST already makes a return's value optional (`Return (value : Option …)`) and `Return none` works downstream, but the grammar declared `return` with a **non-optional** value. So `javaGen` emitted a non-`Optional` Java binding and a generated front-end couldn't construct `Return none` — e.g. Java `if (c) return;` couldn't be lowered. The printer also rendered `Return none` as `return { }`.

## Change
- `LaurelGrammar.st`: `return` value is now `Option StmtExpr`.
- `ConcreteToAbstract`: an absent value maps to `.Return none`.
- `AbstractToConcrete`: `.Return none` prints as a bare `return` (drops the `return { }` hack).

The delimiter-free optional parses unambiguously — verified: `return 3` → `Return (some _)`, bare `return` → `Return none`, and `if b then { return }` → `Return none`.

## Tests
- `T3_ControlFlow`: a valueless early-return procedure (parses, lowers, verifies clean).
- `AbstractToConcrete` round-trip: pins the bare-`return` print form and convergence.

Both fail without the grammar change. Full `StrataTest` green.
