### PR TITLE
feat(laurel): Support bitvector and constrained types as composite fields

### DIFF
--- a/Strata/Languages/Laurel/ConstrainedTypeElim.lean
+++ b/Strata/Languages/Laurel/ConstrainedTypeElim.lean
@@ -37,13 +37,8 @@ def buildConstrainedTypeMap (types : List TypeDefinition) : ConstrainedTypeMap :
   types.foldl (init := {}) fun m td =>
     match td with | .Constrained ct => m.insert ct.name.text ct | _ => m
 
-partial def resolveBaseType (ptMap : ConstrainedTypeMap) (ty : HighType) : HighType :=
-  match ty with
-  | .UserDefined name => match ptMap.get? name.text with
-    | some ct => resolveBaseType ptMap ct.base.val | none => ty
-  | .Applied ctor args =>
-    .Applied ctor (args.map fun a => ⟨resolveBaseType ptMap a.val, a.source⟩)
-  | _ => ty
+def resolveBaseType (ptMap : ConstrainedTypeMap) (ty : HighType) : HighType :=
+  resolveConstrainedTypeWith (fun name => ptMap.get? name.text) ty
 
 def resolveType (ptMap : ConstrainedTypeMap) (ty : HighTypeMd) : HighTypeMd :=
   ⟨resolveBaseType ptMap ty.val, ty.source⟩

--- a/Strata/Languages/Laurel/FilterPrelude.lean
+++ b/Strata/Languages/Laurel/FilterPrelude.lean
@@ -123,7 +123,7 @@ private partial def collectExprNames (expr : StmtExprMd) : CollectM Unit := do
   | .ContractOf _ func => collectExprNames func
   | .ReferenceEquals lhs rhs => collectExprNames lhs; collectExprNames rhs
   | .Hole _ ty => ty.forM collectHighTypeNames
-  | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _
+  | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _ | .LiteralBv _ _
   | .Var (.Local _) | .This | .Abstract | .All => pure ()
 
 /-- Collect names from a procedure body. -/
@@ -182,7 +182,7 @@ private partial def collectInvokeOnTargets (expr : StmtExprMd)
     let rest ← args.flatMapM collectInvokeOnTargets
     return callee.text :: rest
   | .Var (.Local _) | .LiteralInt _ | .LiteralBool _ | .LiteralString _
-  | .LiteralDecimal _ => return []
+  | .LiteralDecimal _ | .LiteralBv _ _ => return []
   | _ =>
     throw s!"FilterPrelude.collectInvokeOnTargets: unexpected node in invokeOn expression"
 

--- a/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
@@ -96,6 +96,7 @@ where
       | .negSucc n => laurelOp "neg" #[laurelOp "int" #[.num sr (n + 1)]]
     | .LiteralDecimal d => laurelOp "real" #[.decimal sr d]
     | .LiteralString s => laurelOp "string" #[.strlit sr s]
+    | .LiteralBv value width => laurelOp "bvLiteral" #[.num sr value, .num sr width]
     | .Hole true _ => laurelOp "hole"
     | .Hole false _ => laurelOp "nondetHole"
     | .Var (.Local name) => laurelOp "identifier" #[ident name.text]

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -223,6 +223,10 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
     | q`Laurel.string, #[arg0] =>
       let s ← translateString arg0
       return mkStmtExprMd (.LiteralString s) src
+    | q`Laurel.bvLiteral, #[valueArg, widthArg] =>
+      let value ← translateNat valueArg
+      let width ← translateNat widthArg
+      return mkStmtExprMd (.LiteralBv value width) src
     | q`Laurel.hole, #[] => return mkStmtExprMd (.Hole true none) src
     | q`Laurel.nondetHole, #[] => return mkStmtExprMd (.Hole false none) src
     | q`Laurel.varDecl, #[arg0, typeArg, assignArg] =>

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -3,7 +3,7 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
--- Grammar updated: renamed Optional* categories (op names updated)
+-- Grammar updated: added bitvector literal support (bvLiteral)
 module
 
 -- Laurel dialect definition, loaded from LaurelGrammar.st

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -20,6 +20,7 @@ op literalBool (b: Bool): StmtExpr => b;
 op int(n : Num) : StmtExpr => n;
 op real(d : Decimal) : StmtExpr => d;
 op string (s: Str): StmtExpr => s;
+op bvLiteral(value: Num, width: Num): StmtExpr => value "bv" width;
 op hole: StmtExpr => "<?>";
 op nondetHole: StmtExpr => "<??>";
 

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -183,6 +183,7 @@ def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   | .UserDefined name =>
       if isDatatype model name then s!"Box..{name.text}Val!"
       else "Box..compositeVal!"
+  | .TBv n => s!"Box..bv{n}Val!"
   | .TCore name => s!"Box..{name}Val!"
   | _ => dbg_trace f!"BUG, boxDestructorName bad type {ty}"; "boxDestructorNameError"
 
@@ -199,6 +200,7 @@ def boxConstructorName (model : SemanticModel) (ty : HighType) : Identifier :=
   | .UserDefined name =>
       if isDatatype model name then s!"Box..{name.text}"
       else "BoxComposite"
+  | .TBv n => s!"BoxBv{n}"
   | .TCore name => s!"Box..{name}"
   | ty => dbg_trace s!"BUG, boxConstructorName bad type: {repr ty}"; "boxConstructorNameError"
 
@@ -215,6 +217,8 @@ private def boxConstructorDef (model : SemanticModel) (ty : HighType) : Option D
         some { name := s!"Box..{name.text}", args := [{ name := s!"{name.text}Val", type := ⟨.UserDefined name, none⟩ }] }
       else
         some { name := "BoxComposite", args := [{ name := "compositeVal", type := ⟨.UserDefined "Composite", none⟩ }] }
+  | .TBv n =>
+        some { name := s!"BoxBv{n}", args := [{ name := s!"bv{n}Val", type := ⟨.TBv n, none⟩ }] }
   | .TCore name =>
         some { name := s!"Box..{name}", args := [{ name := s!"{name}Val", type := ⟨.TCore name, none⟩ }] }
   | ty => dbg_trace s!"BUG, boxConstructorDef bad type: {repr ty}"; none

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -174,18 +174,10 @@ private def isDatatype (model : SemanticModel) (name : Identifier) : Bool :=
     E.g., `UserDefined "nat"` where `nat` is `constrained nat = x: int | x >= 0`
     resolves to `TInt`. Chains through multiple levels of constrained types. -/
 private def resolveConstrainedType (model : SemanticModel) (ty : HighType) : HighType :=
-  go 100 ty
-where
-  go (fuel : Nat) (ty : HighType) : HighType :=
-    match fuel with
-    | 0 => ty
-    | n + 1 =>
-      match ty with
-      | .UserDefined name =>
-        match model.get name with
-        | .constrainedType ct => go n ct.base.val
-        | _ => ty
-      | _ => ty
+  resolveConstrainedTypeWith
+    (fun name => match model.get name with
+      | .constrainedType ct => some ct
+      | _ => none) ty
 
 /-- Get the Box destructor name for a given Laurel HighType.
     For UserDefined datatypes, uses "Box..<datatypeName>Val!";

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -170,11 +170,28 @@ private def isDatatype (model : SemanticModel) (name : Identifier) : Bool :=
   | .datatypeDefinition _ => true
   | _ => false
 
+/-- Resolve a HighType through constrained type aliases to the underlying base type.
+    E.g., `UserDefined "nat"` where `nat` is `constrained nat = x: int | x >= 0`
+    resolves to `TInt`. Chains through multiple levels of constrained types. -/
+private def resolveConstrainedType (model : SemanticModel) (ty : HighType) : HighType :=
+  go 100 ty
+where
+  go (fuel : Nat) (ty : HighType) : HighType :=
+    match fuel with
+    | 0 => ty
+    | n + 1 =>
+      match ty with
+      | .UserDefined name =>
+        match model.get name with
+        | .constrainedType ct => go n ct.base.val
+        | _ => ty
+      | _ => ty
+
 /-- Get the Box destructor name for a given Laurel HighType.
     For UserDefined datatypes, uses "Box..<datatypeName>Val!";
     for Composite types, uses "Box..compositeVal!". -/
 def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
-  match ty with
+  match resolveConstrainedType model ty with
   | .TInt => "Box..intVal!"
   | .TBool => "Box..boolVal!"
   | .TFloat64 => "Box..float64Val!"
@@ -191,7 +208,7 @@ def boxDestructorName (model : SemanticModel) (ty : HighType) : Identifier :=
     For UserDefined datatypes, uses "Box..<datatypeName>";
     for Composite types, uses "BoxComposite". -/
 def boxConstructorName (model : SemanticModel) (ty : HighType) : Identifier :=
-  match ty with
+  match resolveConstrainedType model ty with
   | .TInt => "BoxInt"
   | .TBool => "BoxBool"
   | .TFloat64 => "BoxFloat64"
@@ -206,7 +223,7 @@ def boxConstructorName (model : SemanticModel) (ty : HighType) : Identifier :=
 
 /-- Build the DatatypeConstructor for a Box variant from a HighType, for datatype generation -/
 private def boxConstructorDef (model : SemanticModel) (ty : HighType) : Option DatatypeConstructor :=
-  match ty with
+  match resolveConstrainedType model ty with
   | .TInt => some { name := "BoxInt", args := [{ name := "intVal", type := ⟨.TInt, none⟩ }] }
   | .TBool => some { name := "BoxBool", args := [{ name := "boolVal", type := ⟨.TBool, none⟩ }] }
   | .TReal => some { name := "BoxReal", args := [{ name := "realVal", type := ⟨.TReal, none⟩ }] }

--- a/Strata/Languages/Laurel/LaurelAST.lean
+++ b/Strata/Languages/Laurel/LaurelAST.lean
@@ -516,6 +516,27 @@ structure ConstrainedType where
   /-- A witness value proving the type is inhabited. -/
   witness : StmtExprMd
 
+/-- Resolve a `HighType` through constrained-type aliases to its underlying base type.
+
+    `lookup` maps a type name to its `ConstrainedType` definition (or `none` if the name
+    is not a constrained type). The traversal chases chains of constrained types and
+    recurses into the arguments of type applications.
+
+    This is the single, canonical resolution algorithm. Both `HeapParameterization`
+    (when choosing a `Box` variant) and `ConstrainedTypeElim` (when lowering constrained
+    types) call this with their own `lookup` source, guaranteeing they always agree on the
+    base type chosen for any constrained type. Do not duplicate this logic; supply a new
+    `lookup` instead. -/
+partial def resolveConstrainedTypeWith
+    (lookup : Identifier → Option ConstrainedType) : HighType → HighType
+  | .UserDefined name =>
+    match lookup name with
+    | some ct => resolveConstrainedTypeWith lookup ct.base.val
+    | none => .UserDefined name
+  | .Applied ctor args =>
+    .Applied ctor (args.map fun a => ⟨resolveConstrainedTypeWith lookup a.val, a.source⟩)
+  | ty => ty
+
 /-- A constructor of a Laurel datatype, with a name and typed arguments. -/
 structure DatatypeConstructor where
   name : Identifier

--- a/Strata/Languages/Laurel/LaurelAST.lean
+++ b/Strata/Languages/Laurel/LaurelAST.lean
@@ -282,6 +282,8 @@ inductive StmtExpr : Type where
   | LiteralString (value : String)
   /-- A decimal literal. -/
   | LiteralDecimal (value : Decimal)
+  /-- A bitvector literal with value and width. -/
+  | LiteralBv (value : Nat) (width : Nat)
   /-- A variable reference or declaration. When `var` is `Variable.Local`, this is a reference
       that evaluates to the variable's value. When `var` is `Variable.Declare`, this is a
       declaration without an initializer (used as a standalone statement in a block). -/

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -149,6 +149,7 @@ def translateExpr (expr : StmtExprMd)
   | .LiteralInt i => return .const () (.intConst i)
   | .LiteralString s => return .const () (.strConst s)
   | .LiteralDecimal d => return .const () (.realConst (StrataDDM.Decimal.toRat d))
+  | .LiteralBv value width => return .const () (.bitvecConst width (BitVec.ofNat width value))
   | .Var (.Local name) =>
       -- First check if this name is bound by an enclosing quantifier
       match boundVars.findIdx? (· == name) with

--- a/Strata/Languages/Laurel/LaurelTypes.lean
+++ b/Strata/Languages/Laurel/LaurelTypes.lean
@@ -45,6 +45,7 @@ def computeExprType (model : SemanticModel) (expr : StmtExprMd) : HighTypeMd :=
   | .LiteralBool _ => ⟨ .TBool, source ⟩
   | .LiteralString _ => ⟨ .TString, source ⟩
   | .LiteralDecimal _ => ⟨ .TReal, source ⟩
+  | .LiteralBv _ width => ⟨ .TBv width, source ⟩
   -- Variables
   | .Var (.Local id) => (model.get id).getType
   | .Var (.Declare _) => ⟨ .TVoid, source ⟩

--- a/Strata/Languages/Laurel/MapStmtExpr.lean
+++ b/Strata/Languages/Laurel/MapStmtExpr.lean
@@ -91,7 +91,7 @@ def mapStmtExprM [Monad m] (f : StmtExprMd → m StmtExprMd) (expr : StmtExprMd)
   -- ⚠ If a new StmtExpr constructor with StmtExprMd children is added,
   -- it must get its own arm above; otherwise all passes will silently
   -- skip recursion into those children.
-  | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _
+  | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _ | .LiteralBv _ _
   | .Var (.Local _) | .Var (.Declare _) | .New _ | .This | .Abstract | .All | .Hole .. => pure expr
   f rebuilt
 termination_by sizeOf expr

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -402,6 +402,7 @@ def resolveStmtExpr (exprMd : StmtExprMd) : ResolveM StmtExprMd := do
   | .LiteralBool v => pure (.LiteralBool v)
   | .LiteralString v => pure (.LiteralString v)
   | .LiteralDecimal v => pure (.LiteralDecimal v)
+  | .LiteralBv value width => pure (.LiteralBv value width)
   | .Var (.Local ref) =>
     let ref' ← resolveRef ref source
     pure (.Var (.Local ref'))
@@ -783,7 +784,7 @@ private def collectStmtExpr (map : Std.HashMap Nat ResolvedNode) (expr : StmtExp
     let map := collectStmtExpr map val
     collectStmtExpr map proof
   | .ContractOf _ fn => collectStmtExpr map fn
-  | .New _ | .This | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _
+  | .New _ | .This | .Exit _ | .LiteralInt _ | .LiteralBool _ | .LiteralString _ | .LiteralDecimal _ | .LiteralBv _ _
   | .Abstract | .All | .Hole _ _ => map
 
 private def collectBody (map : Std.HashMap Nat ResolvedNode) (body : Body)

--- a/StrataTest/Languages/Laurel/Examples/Objects/T10_CompositeBvField.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T10_CompositeBvField.lean
@@ -1,0 +1,40 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+/-
+Test: bitvector types as composite fields. Verifies that the heap
+parameterization pass correctly boxes/unboxes bv-typed fields.
+-/
+
+meta import all StrataTest.Util.TestDiagnostics
+meta import all StrataTest.Languages.Laurel.TestExamples
+
+meta section
+
+open StrataTest.Util
+open Strata
+
+namespace Strata.Laurel
+
+def compositeBv32Field := r"
+composite Register {
+  var value: bv 32
+}
+
+procedure writeAndRead(r: Register, x: bv 32)
+  opaque
+  ensures r#value == x
+  modifies r
+{
+  r#value := x
+};
+"
+
+#guard_msgs (drop info, error) in
+#eval testInputWithOffset "CompositeBv32Field" compositeBv32Field 23 processLaurelFile
+
+end Laurel

--- a/StrataTest/Languages/Laurel/Examples/Objects/T10_CompositeBvField.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T10_CompositeBvField.lean
@@ -32,6 +32,14 @@ procedure writeAndRead(r: Register, x: bv 32)
 {
   r#value := x
 };
+
+// Error: postcondition violation — field does not change without assignment
+procedure readWithoutWrite(r: Register, x: bv 32)
+  opaque
+  ensures r#value == x
+//        ^^^^^^^^^^^^ error: assertion does not hold
+{
+};
 "
 
 #guard_msgs (drop info, error) in

--- a/StrataTest/Languages/Laurel/Examples/Objects/T10_CompositeBvField.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T10_CompositeBvField.lean
@@ -22,10 +22,10 @@ namespace Strata.Laurel
 
 def compositeBv32Field := r"
 composite Register {
-  var value: bv 32
+  var value: bv 16
 }
 
-procedure writeAndRead(r: Register, x: bv 32)
+procedure writeValue(r: Register, x: bv 16)
   opaque
   ensures r#value == x
   modifies r
@@ -33,12 +33,23 @@ procedure writeAndRead(r: Register, x: bv 32)
   r#value := x
 };
 
-// Error: postcondition violation — field does not change without assignment
-procedure readWithoutWrite(r: Register, x: bv 32)
+// Test using bv literal directly
+procedure writeLiteral(r: Register)
   opaque
-  ensures r#value == x
-//        ^^^^^^^^^^^^ error: assertion does not hold
+  ensures r#value == 100 bv 16
+  modifies r
 {
+  r#value := 100 bv 16
+};
+
+// Error: postcondition claims field equals wrong literal
+procedure writeWrongLiteral(r: Register)
+  opaque
+  ensures r#value == 100 bv 16
+//        ^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+  modifies r
+{
+  r#value := 200 bv 16
 };
 "
 

--- a/StrataTest/Languages/Laurel/Examples/Objects/T11_ConstrainedField.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T11_ConstrainedField.lean
@@ -7,7 +7,13 @@ module
 
 /-
 Test: constrained types as composite fields. Verifies that heap
-parameterization resolves constrained types to their base type for boxing.
+parameterization resolves constrained types to their base type for boxing,
+and that constraint checks are asserted on field writes.
+
+Also documents a known completeness gap: constraints are NOT recovered when
+*reading* a constrained field (see `readCountCompletenessGap`). To be fixed
+in a follow-up PR by assuming the constraint on field reads and maintaining
+it across havoc/modifies.
 -/
 
 meta import all StrataTest.Util.TestDiagnostics
@@ -41,6 +47,22 @@ procedure setCountInvalid(c: Counter)
   modifies c
 {
   c#count := -1
+//^^^^^^^^^^^^^ error: assertion does not hold
+};
+
+// KNOWN COMPLETENESS GAP (to be fixed in a follow-up PR):
+// Reading a constrained-typed field does NOT recover its constraint. Because
+// HeapParameterization boxes the field as its unconstrained base type (BoxInt),
+// and there is no `assume constraint` inserted on field reads, a legitimately
+// constructed `nat` field cannot be relied upon as `>= 0` after a read through
+// a heap parameter. The assertion below is true in principle but currently
+// unprovable. (Note: the same pattern on a *local* `nat` variable verifies
+// fine, because uninitialized constrained locals get an `assume constraint`.)
+procedure readCountCompletenessGap(c: Counter)
+  opaque
+{
+  var x: int := c#count;
+  assert x >= 0
 //^^^^^^^^^^^^^ error: assertion does not hold
 };
 "

--- a/StrataTest/Languages/Laurel/Examples/Objects/T11_ConstrainedField.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T11_ConstrainedField.lean
@@ -34,6 +34,15 @@ procedure setCount(c: Counter)
 {
   c#count := 1
 };
+
+// Error: assigning -1 to a nat field violates the constraint
+procedure setCountInvalid(c: Counter)
+  opaque
+  modifies c
+{
+  c#count := -1
+//^^^^^^^^^^^^^ error: assertion does not hold
+};
 "
 
 #guard_msgs (drop info, error) in

--- a/StrataTest/Languages/Laurel/Examples/Objects/T11_ConstrainedField.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T11_ConstrainedField.lean
@@ -1,0 +1,42 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+/-
+Test: constrained types as composite fields. Verifies that heap
+parameterization resolves constrained types to their base type for boxing.
+-/
+
+meta import all StrataTest.Util.TestDiagnostics
+meta import all StrataTest.Languages.Laurel.TestExamples
+
+meta section
+
+open StrataTest.Util
+open Strata
+
+namespace Strata.Laurel
+
+def constrainedFieldTest := r"
+constrained nat = x: int where x >= 0 witness 0
+
+composite Counter {
+  var count: nat
+}
+
+procedure setCount(c: Counter)
+  opaque
+  ensures c#count >= 0
+  modifies c
+{
+  c#count := 1
+};
+"
+
+#guard_msgs (drop info, error) in
+#eval testInputWithOffset "ConstrainedField" constrainedFieldTest 23 processLaurelFile
+
+end Laurel


### PR DESCRIPTION
Add support for bitvector types and constrained types (type aliases with constraints) as composite fields in the Laurel heap parameterization.
  
  1. Bitvector fields – Add TBv n cases to boxConstructorName, boxDestructorName, and boxConstructorDef so composites can have bv-typed fields. The Box variant is named BoxBv{n}, generated
  dynamically per width.
 
  2. Constrained type fields – Add resolveConstrainedType helper that chases constrained type chains to their base type before choosing a Box variant.
 
 Tests: T10_CompositeBvField.lean, T11_ConstrainedField.lean