### PR TITLE
feat(laurel): add body-tested do-while loop

### DIFF
--- a/Strata/Languages/Laurel/ConstrainedTypeElim.lean
+++ b/Strata/Languages/Laurel/ConstrainedTypeElim.lean
@@ -169,9 +169,9 @@ def elimStmt (ptMap : ConstrainedTypeMap)
     let thenSs ← inScope (elimStmt ptMap thenBr)
     pure [⟨.IfThenElse cond (wrap thenSs source) none, source⟩]
 
-  | .While cond inv dec body =>
+  | .While cond inv dec body postTest =>
     let bodySs ← inScope (elimStmt ptMap body)
-    pure [⟨.While cond inv dec (wrap bodySs source), source⟩]
+    pure [⟨.While cond inv dec (wrap bodySs source) postTest, source⟩]
 
   | _ => pure [stmt]
 termination_by sizeOf stmt

--- a/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
+++ b/Strata/Languages/Laurel/CoreGroupingAndOrdering.lean
@@ -74,7 +74,7 @@ def collectStaticCallNames (expr : StmtExprMd) : List String :=
       match v with
       | some x => collectStaticCallNames x
       | none => []
-  | .While cond invs dec body =>
+  | .While cond invs dec body _ =>
       collectStaticCallNames cond ++
       invs.flatMap (fun i => collectStaticCallNames i) ++
       (match dec with

--- a/Strata/Languages/Laurel/EliminateDoWhile.lean
+++ b/Strata/Languages/Laurel/EliminateDoWhile.lean
@@ -1,0 +1,91 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+public import Strata.Languages.Laurel.LaurelAST
+public import Strata.Languages.Laurel.LaurelPass
+import Strata.Languages.Laurel.MapStmtExpr
+import Strata.Util.Tactics
+
+/-!
+# Eliminate Do-While
+
+Lowers post-test `While` loops (`postTest = true`, the `do … while` form) into
+the pre-test `while` machinery. Runs early so that no later pass (or the Core
+translator) observes `postTest = true`.
+
+The desugaring of `do BODY while(COND) invariant I` is:
+```
+  { while(true) invariant I { BODY; if (!COND) exit L } } L
+```
+`BODY` runs once per iteration with `COND` re-checked after it; the real guard
+reaches post-loop code via the structured `exit L`, so the encoding is sound,
+complete, and linear (a single body in the IR — no peeling/duplication). The
+invariant `I` is checked at the loop head (before each body), matching `while`.
+
+The fresh exit label `L` is `$dowhile_exit_{n}` for a per-program monotonic
+counter `n`. The leading `$` keeps it out of the user-name space (no source
+identifier can contain `$`), so it can never capture, or be captured by, a user
+`break`/`continue` label, and the counter keeps nested do-whiles distinct.
+
+The traversal is the generic bottom-up `mapStmtExprM`, so inner do-whiles are
+eliminated before their enclosing ones.
+-/
+
+namespace Strata.Laurel
+
+/-- Monotonic counter feeding fresh exit labels (scheme described in the module header). -/
+private structure ElimState where
+  freshCounter : Nat := 0
+
+private abbrev ElimM := StateM ElimState
+
+private def freshExitLabel : ElimM String :=
+  modifyGet fun s => (s!"$dowhile_exit_{s.freshCounter}", { s with freshCounter := s.freshCounter + 1 })
+
+/-- Rewrites a post-test `While` to its pre-test desugaring; all other nodes pass through. -/
+private def rewriteNode (node : StmtExprMd) : ElimM StmtExprMd := do
+  match node.val with
+  | .While cond invs dec body true =>
+    let source := node.source
+    let exitLabel ← freshExitLabel
+    let notCond : StmtExprMd := ⟨.PrimitiveOp .Not [cond], source⟩
+    let exitStmt : StmtExprMd := ⟨.Exit exitLabel, source⟩
+    let guardCheck : StmtExprMd := ⟨.IfThenElse notCond exitStmt none, source⟩
+    let loopBody : StmtExprMd := ⟨.Block [body, guardCheck] none, source⟩
+    let trueCond : StmtExprMd := ⟨.LiteralBool true, source⟩
+    -- Thread `dec` onto the `while(true)` rather than dropping it: each desugared
+    -- iteration is one pass through that loop's head, so the measure decreases
+    -- across exactly those iterations. The emitted loop is pre-test
+    -- (`postTest := false`), so it is not rewritten again.
+    let whileStmt : StmtExprMd := ⟨.While trueCond invs dec loopBody false, source⟩
+    pure ⟨.Block [whileStmt] (some exitLabel), source⟩
+  | _ => pure node
+
+public section
+
+/-- Eliminate every post-test `While` in a Laurel program; afterward every `While` has `postTest = false`. -/
+def eliminateDoWhile (program : Program) : Program :=
+  let rewrite : Procedure → ElimM Procedure := mapProcedureM (mapStmtExprM rewriteNode)
+  let go : ElimM Program := do
+    let staticProcs ← program.staticProcedures.mapM rewrite
+    let types ← program.types.mapM fun td =>
+      match td with
+      | .Composite ct => do
+        let procs ← ct.instanceProcedures.mapM rewrite
+        pure (.Composite { ct with instanceProcedures := procs })
+      | other => pure other
+    pure { program with staticProcedures := staticProcs, types := types }
+  (go.run {}).fst
+
+/-- Pipeline pass: eliminate post-test (`do … while`) loops. -/
+public def eliminateDoWhilePass : LaurelPass where
+  name := "EliminateDoWhile"
+  documentation := "Lowers post-test `While` loops (the `do … while` form) into the pre-test loop `{ while(true) invariant I { BODY; if (!COND) exit L } } L`, with a fresh `$`-prefixed exit label `L`. Runs early so no later pass observes a post-test loop; the invariant is checked at the loop head, matching `while`."
+  run := fun p _m => (eliminateDoWhile p, [], {})
+
+end -- public section
+end Strata.Laurel

--- a/Strata/Languages/Laurel/EliminateDoWhile.lean
+++ b/Strata/Languages/Laurel/EliminateDoWhile.lean
@@ -70,16 +70,7 @@ public section
 /-- Eliminate every post-test `While` in a Laurel program; afterward every `While` has `postTest = false`. -/
 def eliminateDoWhile (program : Program) : Program :=
   let rewrite : Procedure → ElimM Procedure := mapProcedureM (mapStmtExprM rewriteNode)
-  let go : ElimM Program := do
-    let staticProcs ← program.staticProcedures.mapM rewrite
-    let types ← program.types.mapM fun td =>
-      match td with
-      | .Composite ct => do
-        let procs ← ct.instanceProcedures.mapM rewrite
-        pure (.Composite { ct with instanceProcedures := procs })
-      | other => pure other
-    pure { program with staticProcedures := staticProcs, types := types }
-  (go.run {}).fst
+  (mapProgramProceduresM rewrite program |>.run {}).fst
 
 /-- Pipeline pass: eliminate post-test (`do … while`) loops. -/
 public def eliminateDoWhilePass : LaurelPass where

--- a/Strata/Languages/Laurel/EliminateIncrDecr.lean
+++ b/Strata/Languages/Laurel/EliminateIncrDecr.lean
@@ -97,13 +97,7 @@ Eliminate every `.IncrDecr` node in a Laurel program by lowering it to
 existing constructs. After this pass, no `.IncrDecr` node remains.
 -/
 def eliminateIncrDecr (program : Program) : Program :=
-  let staticProcs := program.staticProcedures.map lowerProcedure
-  let types := program.types.map fun td =>
-    match td with
-    | .Composite ct =>
-      .Composite { ct with instanceProcedures := ct.instanceProcedures.map lowerProcedure }
-    | other => other
-  { program with staticProcedures := staticProcs, types := types }
+  mapProgramProcedures lowerProcedure program
 
 /-- Pipeline pass: eliminate increment/decrement operators. -/
 public def eliminateIncrDecrPass : LaurelPass where

--- a/Strata/Languages/Laurel/EliminateValueInReturns.lean
+++ b/Strata/Languages/Laurel/EliminateValueInReturns.lean
@@ -45,7 +45,7 @@ def hasValuedReturn (stmt : StmtExprMd) : Bool :=
   | .IfThenElse _ thenBr (some elseBr) =>
     hasValuedReturn thenBr || hasValuedReturn elseBr
   | .IfThenElse _ thenBr none => hasValuedReturn thenBr
-  | .While _ _ _ body => hasValuedReturn body
+  | .While _ _ _ body _ => hasValuedReturn body
   | _ => false
   termination_by sizeOf stmt
   decreasing_by

--- a/Strata/Languages/Laurel/FilterPrelude.lean
+++ b/Strata/Languages/Laurel/FilterPrelude.lean
@@ -93,7 +93,7 @@ private partial def collectExprNames (expr : StmtExprMd) : CollectM Unit := do
     collectExprNames cond; collectExprNames thenB
     elseB.forM collectExprNames
   | .Block stmts _ => stmts.forM collectExprNames
-  | .While cond invs dec body =>
+  | .While cond invs dec body _ =>
     collectExprNames cond; invs.forM collectExprNames
     dec.forM collectExprNames
     collectExprNames body

--- a/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/AbstractToConcreteTreeTranslator.lean
@@ -158,9 +158,13 @@ where
     | .IfThenElse cond thenBr elseBr =>
       let elseOpt := optionArg (elseBr.map fun e => laurelOp "elseBranch" #[stmtExprToArg e])
       laurelOp "ifThenElse" #[stmtExprToArg cond, stmtExprToArg thenBr, elseOpt]
-    | .While cond invs _decreases body =>
+    | .While cond invs _decreases body postTest =>
       let invArgs := invs.map (fun i => laurelOp "invariantClause" #[stmtExprToArg i]) |>.toArray
-      laurelOp "while" #[stmtExprToArg cond, seqArg invArgs, stmtExprToArg body]
+      if postTest then
+        -- `do … while`; grammar op order is `doWhile(body, cond, invariants)`.
+        laurelOp "doWhile" #[stmtExprToArg body, stmtExprToArg cond, seqArg invArgs]
+      else
+        laurelOp "while" #[stmtExprToArg cond, seqArg invArgs, stmtExprToArg body]
     | .Return (some value) => laurelOp "return" #[optionArg (some (stmtExprToArg value))]
     | .Return none => laurelOp "return" #[optionArg none]
     | .Exit label => laurelOp "exit" #[ident label]

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -22,20 +22,13 @@ open Imperative (MetaData)
 structure TransState where
   uri : Option Uri
   errors : Array String
-  /-- Monotonic counter for generating fresh, collision-free labels during
-      desugaring (e.g. the exit label of a `do-while`). -/
-  freshCounter : Nat := 0
 
 @[expose] abbrev TransM := StateT TransState (Except String)
 
 def TransM.run (uri : Option Uri) (m : TransM α) : Except String α :=
-  match StateT.run m { uri := uri, errors := #[], freshCounter := 0 } with
+  match StateT.run m { uri := uri, errors := #[] } with
   | .ok (v, _) => .ok v
   | .error e => .error e
-
-/-- Generate a fresh label with the given prefix, unique within this translation. -/
-def freshLabel (pfx : String) : TransM String :=
-  modifyGet fun s => let n := s.freshCounter + 1; (s!"${pfx}_{n}", { s with freshCounter := n })
 
 def TransM.error (msg : String) : TransM α :=
   throw msg
@@ -372,24 +365,12 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       let whileStmt := mkStmtExprMd (.While cond invariants none whileBody) src
       return mkStmtExprMd (.Block [init, whileStmt] none) src
     | q`Laurel.doWhile, #[bodyArg, condArg, invSeqArg] =>
-      -- Desugar the body-tested `do S while(G) invariant I` into a head-tested loop:
-      --   `{ while(true) invariant I { S; if (!G) exit L } } L`
-      -- The body runs once per iteration with the guard re-checked after it; the
-      -- real guard reaches post-loop code via the structured `exit L`, keeping the
-      -- encoding complete. `I` is checked at the head (before each body), matching
-      -- `while`. The fresh label `L` keeps nested do-whiles from capturing each
-      -- other's exits.
+      -- A `do … while` is a post-test `While`. The `EliminateDoWhile` pass
+      -- lowers `postTest := true` to the pre-test form later.
       let body ← translateStmtExpr bodyArg
       let cond ← translateStmtExpr condArg
       let invariants ← translateInvariantClauses translateStmtExpr invSeqArg
-      let exitLabel ← freshLabel "dowhile_exit"
-      let notCond := mkStmtExprMd (.PrimitiveOp .Not [cond]) src
-      let exitStmt := mkStmtExprMd (.Exit exitLabel) src
-      let guardCheck := mkStmtExprMd (.IfThenElse notCond exitStmt none) src
-      let loopBody := mkStmtExprMd (.Block [body, guardCheck] none) src
-      let trueCond := mkStmtExprMd (.LiteralBool true) src
-      let whileStmt := mkStmtExprMd (.While trueCond invariants none loopBody) src
-      return mkStmtExprMd (.Block [whileStmt] (some exitLabel)) src
+      return mkStmtExprMd (.While cond invariants none body (postTest := true)) src
     | q`Laurel.forallExpr, #[nameArg, tyArg, triggerArg, bodyArg] =>
       let name ← translateIdent nameArg
       let ty ← translateHighType tyArg

--- a/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
+++ b/Strata/Languages/Laurel/Grammar/ConcreteToAbstractTreeTranslator.lean
@@ -22,13 +22,20 @@ open Imperative (MetaData)
 structure TransState where
   uri : Option Uri
   errors : Array String
+  /-- Monotonic counter for generating fresh, collision-free labels during
+      desugaring (e.g. the exit label of a `do-while`). -/
+  freshCounter : Nat := 0
 
 @[expose] abbrev TransM := StateT TransState (Except String)
 
 def TransM.run (uri : Option Uri) (m : TransM α) : Except String α :=
-  match StateT.run m { uri := uri, errors := #[] } with
+  match StateT.run m { uri := uri, errors := #[], freshCounter := 0 } with
   | .ok (v, _) => .ok v
   | .error e => .error e
+
+/-- Generate a fresh label with the given prefix, unique within this translation. -/
+def freshLabel (pfx : String) : TransM String :=
+  modifyGet fun s => let n := s.freshCounter + 1; (s!"${pfx}_{n}", { s with freshCounter := n })
 
 def TransM.error (msg : String) : TransM α :=
   throw msg
@@ -184,6 +191,20 @@ def getUnaryOp? (name : QualifiedIdent) : Option Operation :=
   | q`Laurel.neg => some Operation.Neg
   | _ => none
 
+/-- Translate a `Seq InvariantClause` into the list of invariant conditions,
+    using `translate` for each clause body. Shared by the `while`, `forLoop`,
+    and `doWhile` arms. Takes `translate` as a parameter so it can stay outside
+    the `translateStmtExpr` mutual block and thus be a total `def`. -/
+def translateInvariantClauses (translate : Arg → TransM StmtExprMd) (arg : Arg) :
+    TransM (List StmtExprMd) := do
+  match arg with
+  | .seq _ _ clauses => clauses.toList.mapM fun clause => match clause with
+      | .op invOp => match invOp.name, invOp.args with
+        | q`Laurel.invariantClause, #[exprArg] => translate exprArg
+        | _, _ => TransM.error "Expected invariantClause"
+      | _ => TransM.error "Expected operation"
+  | _ => pure []
+
 mutual
 
 partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
@@ -315,30 +336,37 @@ partial def translateStmtExpr (arg : Arg) : TransM StmtExprMd := do
       return mkStmtExprMd (.Var (.Field obj field)) fieldSrc
     | q`Laurel.while, #[condArg, invSeqArg, bodyArg] =>
       let cond ← translateStmtExpr condArg
-      let invariants ← match invSeqArg with
-        | .seq _ _ clauses => clauses.toList.mapM fun arg => match arg with
-            | .op invOp => match invOp.name, invOp.args with
-              | q`Laurel.invariantClause, #[exprArg] => translateStmtExpr exprArg
-              | _, _ => TransM.error "Expected invariantClause"
-            | _ => TransM.error "Expected operation"
-        | _ => pure []
+      let invariants ← translateInvariantClauses translateStmtExpr invSeqArg
       let body ← translateStmtExpr bodyArg
       return mkStmtExprMd (.While cond invariants none body) src
     | q`Laurel.forLoop, #[initArg, condArg, stepArg, invSeqArg, bodyArg] =>
       let init ← translateStmtExpr initArg
       let cond ← translateStmtExpr condArg
       let step ← translateStmtExpr stepArg
-      let invariants ← match invSeqArg with
-        | .seq _ _ clauses => clauses.toList.mapM fun arg => match arg with
-            | .op invOp => match invOp.name, invOp.args with
-              | q`Laurel.invariantClause, #[exprArg] => translateStmtExpr exprArg
-              | _, _ => TransM.error "Expected invariantClause"
-            | _ => TransM.error "Expected operation"
-        | _ => pure []
+      let invariants ← translateInvariantClauses translateStmtExpr invSeqArg
       let body ← translateStmtExpr bodyArg
       let whileBody := mkStmtExprMd (.Block [body, step] none) src
       let whileStmt := mkStmtExprMd (.While cond invariants none whileBody) src
       return mkStmtExprMd (.Block [init, whileStmt] none) src
+    | q`Laurel.doWhile, #[bodyArg, condArg, invSeqArg] =>
+      -- Desugar the body-tested `do S while(G) invariant I` into a head-tested loop:
+      --   `{ while(true) invariant I { S; if (!G) exit L } } L`
+      -- The body runs once per iteration with the guard re-checked after it; the
+      -- real guard reaches post-loop code via the structured `exit L`, keeping the
+      -- encoding complete. `I` is checked at the head (before each body), matching
+      -- `while`. The fresh label `L` keeps nested do-whiles from capturing each
+      -- other's exits.
+      let body ← translateStmtExpr bodyArg
+      let cond ← translateStmtExpr condArg
+      let invariants ← translateInvariantClauses translateStmtExpr invSeqArg
+      let exitLabel ← freshLabel "dowhile_exit"
+      let notCond := mkStmtExprMd (.PrimitiveOp .Not [cond]) src
+      let exitStmt := mkStmtExprMd (.Exit exitLabel) src
+      let guardCheck := mkStmtExprMd (.IfThenElse notCond exitStmt none) src
+      let loopBody := mkStmtExprMd (.Block [body, guardCheck] none) src
+      let trueCond := mkStmtExprMd (.LiteralBool true) src
+      let whileStmt := mkStmtExprMd (.While trueCond invariants none loopBody) src
+      return mkStmtExprMd (.Block [whileStmt] (some exitLabel)) src
     | q`Laurel.forallExpr, #[nameArg, tyArg, triggerArg, bodyArg] =>
       let name ← translateIdent nameArg
       let ty ← translateHighType tyArg

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -9,7 +9,7 @@ module
 -- Laurel dialect definition, loaded from LaurelGrammar.st
 -- NOTE: Changes to LaurelGrammar.st are not automatically tracked by the build system.
 -- Update this file (e.g. this comment) to trigger a recompile after modifying LaurelGrammar.st.
--- Last grammar change: `return` value is now Option StmtExpr (supports a valueless return).
+-- Last grammar change: added `doWhile` op (body-tested loop, desugared in ConcreteToAbstract).
 public import StrataDDM.AST
 import StrataDDM.BuiltinDialects.Init
 import StrataDDM.Integration.Lean.HashCommands

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -8,7 +8,7 @@ module
 -- Laurel dialect definition, loaded from LaurelGrammar.st
 -- NOTE: Changes to LaurelGrammar.st are not automatically tracked by the build system.
 -- Update this file (e.g. this comment) to trigger a recompile after modifying LaurelGrammar.st.
--- Last grammar change: added `doWhile` op (body-tested loop, desugared in ConcreteToAbstract).
+-- Last grammar change: added `doWhile` op (post-test loop; parsed to a post-test `While`, lowered by EliminateDoWhile).
 
 public import StrataDDM.AST
 import StrataDDM.BuiltinDialects.Init

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -120,6 +120,9 @@ op while (cond: StmtExpr, invariants: Seq InvariantClause, body: StmtExpr): Stmt
 op forLoop (init: StmtExpr, cond: StmtExpr, step: StmtExpr, invariants: Seq InvariantClause, body: StmtExpr): StmtExpr
   => "for" "(" init ";" cond ";" step ")" invariants " " body:0;
 
+op doWhile (body: StmtExpr, cond: StmtExpr, invariants: Seq InvariantClause): StmtExpr
+  => "do " body:0 " while" "(" cond ")" invariants;
+
 category Parameter;
 op parameter (name: Ident, paramType: LaurelType): Parameter => name ": " paramType;
 

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -68,7 +68,7 @@ def collectExpr (expr : StmtExpr) : StateM AnalysisResult Unit := do
   | .StaticCall callee args => modify fun s => { s with callees := callee :: s.callees }; for a in args do collectExprMd a
   | .IfThenElse c t e => collectExprMd c; collectExprMd t; if let some x := e then collectExprMd x
   | .Block stmts _ => for s in stmts do collectExprMd s
-  | .While c invs d b => collectExprMd c; collectExprMd b; for inv in invs do collectExprMd inv; if let some x := d then collectExprMd x
+  | .While c invs d b _ => collectExprMd c; collectExprMd b; for inv in invs do collectExprMd inv; if let some x := d then collectExprMd x
   | .Return v => if let some x := v then collectExprMd x
   | .Assign assignTargets v =>
       -- Check if any target is a field assignment (heap write)
@@ -336,9 +336,9 @@ where
           termination_by (sizeOf remaining, 0)
         let stmts' ← processStmts 0 stmts
         return [⟨ .Block stmts' label, source ⟩]
-    | .While c invs d b =>
+    | .While c invs d b postTest =>
         let invs' ← invs.mapM (recurseOne ·)
-        return [⟨ .While (← recurseOne c) invs' d (← recurseOne b false), source ⟩]
+        return [⟨ .While (← recurseOne c) invs' d (← recurseOne b false) postTest, source ⟩]
     | .Return v =>
         let v' ← match v with | some x => some <$> recurseOne x | none => pure none
         return [⟨ .Return v', source ⟩]

--- a/Strata/Languages/Laurel/InferHoleTypes.lean
+++ b/Strata/Languages/Laurel/InferHoleTypes.lean
@@ -145,11 +145,11 @@ private def inferExpr (expr : StmtExprMd) (expectedType : HighTypeMd) : InferHol
           | .Declare param => param.type
         | _ => ⟨ .Unknown, source ⟩
       return ⟨.Assign targets (← inferExpr value targetType), source⟩
-  | .While cond invs dec body =>
+  | .While cond invs dec body postTest =>
       let dec' ← match dec with
         | some d => pure (some (← inferExpr d (⟨ .TInt, source ⟩)))
         | none => pure none
-      return ⟨.While (← inferExpr cond ⟨ .TBool, source ⟩) (← invs.mapM (inferExpr · ⟨ .TBool, source ⟩)) dec' (← inferExpr body ⟨ .TVoid, source⟩), source⟩
+      return ⟨.While (← inferExpr cond ⟨ .TBool, source ⟩) (← invs.mapM (inferExpr · ⟨ .TBool, source ⟩)) dec' (← inferExpr body ⟨ .TVoid, source⟩) postTest, source⟩
   | .Assert ⟨condExpr, summary, free⟩ =>
       return ⟨.Assert { condition := ← inferExpr condExpr ⟨ .TBool, source ⟩, summary, free }, source⟩
   | .Assume cond =>

--- a/Strata/Languages/Laurel/LaurelAST.lean
+++ b/Strata/Languages/Laurel/LaurelAST.lean
@@ -303,10 +303,21 @@ inductive StmtExpr : Type where
   | IfThenElse (cond : AstNode StmtExpr) (thenBranch : AstNode StmtExpr) (elseBranch : Option (AstNode StmtExpr))
   /-- A sequence of statements with an optional label for `Exit`. -/
   | Block (statements : List (AstNode StmtExpr)) (label : Option String)
-  /-- A while loop with a condition, invariants, optional termination measure, and body. Only allowed in impure contexts. -/
+  /-- A while loop with a condition, invariants, optional termination measure, and body.
+      Only allowed in impure contexts.
+
+      `postTest` selects when the condition is tested relative to the body:
+      - `false` (default) — a *pre-test* loop (`while`): the condition is checked
+        before the body, so the body may run zero times.
+      - `true` — a *post-test* loop (`do … while`): the body runs once before the
+        condition is first checked, so it always runs at least once.
+
+      Invariants are checked at the loop head (before each body) in both cases.
+      A post-test loop is lowered to the pre-test form by the `EliminateDoWhile` pass. -/
   | While (cond : AstNode StmtExpr) (invariants : List (AstNode StmtExpr))
     (decreases : Option (AstNode StmtExpr))
     (body : AstNode StmtExpr)
+    (postTest : Bool := false)
   /-- Exit a labelled block. Models `break` and `continue` statements. -/
   | Exit (target : String)
   /-- Return from the enclosing procedure with an optional value. -/

--- a/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
+++ b/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
@@ -7,6 +7,7 @@ module
 
 public import Strata.Languages.Laurel.LaurelToCoreTranslator
 import Strata.Languages.Laurel.DesugarShortCircuit
+import Strata.Languages.Laurel.EliminateDoWhile
 import Strata.Languages.Laurel.EliminateIncrDecr
 import Strata.Languages.Laurel.MergeAndLiftReturns
 import Strata.Languages.Laurel.EliminateValueInReturns
@@ -92,6 +93,7 @@ abbrev TranslateResultWithLaurel := (Option Core.Program) × (List DiagnosticMod
 
 /-- The ordered sequence of Laurel-to-Laurel lowering passes. -/
 def laurelPipeline : Array LaurelPass := #[
+  eliminateDoWhilePass,
   eliminateIncrDecrPass,
   typeAliasElimPass,
   filterNonCompositeModifiesPass,

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -257,7 +257,7 @@ def translateExpr (expr : StmtExprMd)
   | .IncrDecr _ _ _ =>
       throwExprDiagnostic $ diagnosticFromSource expr.source
         "IncrDecr should have been eliminated by EliminateIncrDecr pass" DiagnosticType.StrataBug
-  | .While _ _ _ _ =>
+  | .While _ _ _ _ _ =>
       disallowed expr.source "loops are not supported in functions or contracts"
   | .Exit _ => disallowed expr.source "exit is not supported in expression position"
 
@@ -497,7 +497,10 @@ def translateStmt (stmt : StmtExprMd)
           let d := md.toDiagnostic "Return statement with value should have been eliminated by EliminateValueReturns pass" DiagnosticType.StrataBug
           emitCoreDiagnostic d
           return [.exit bodyLabel md]
-  | .While cond invariants decreasesExpr body =>
+  | .While cond invariants decreasesExpr body postTest =>
+      if postTest then
+        return ← throwStmtDiagnostic (diagnosticFromSource cond.source
+          "post-test while (do-while) should have been eliminated by EliminateDoWhile pass" DiagnosticType.StrataBug)
       let condExpr ← translateExpr cond
       let invExprs ← invariants.mapM (fun i => do return ("", ← translateExpr i))
       let decreasingExprCore ← decreasesExpr.mapM (translateExpr)

--- a/Strata/Languages/Laurel/LaurelTypes.lean
+++ b/Strata/Languages/Laurel/LaurelTypes.lean
@@ -79,7 +79,7 @@ def computeExprType (model : SemanticModel) (expr : StmtExprMd) : HighTypeMd :=
         computeExprType model last
     | none => ⟨ .TVoid, source ⟩
   -- Statements
-  | .While _ _ _ _ => ⟨ .TVoid, source ⟩
+  | .While _ _ _ _ _ => ⟨ .TVoid, source ⟩
   | .Exit _ => ⟨ .TVoid, source ⟩
   | .Return _ => ⟨ .TVoid, source ⟩
   | .Assign _ value => computeExprType model value

--- a/Strata/Languages/Laurel/LiftImperativeExpressions.lean
+++ b/Strata/Languages/Laurel/LiftImperativeExpressions.lean
@@ -472,7 +472,7 @@ def transformStmt (stmt : StmtExprMd) : LiftM (List StmtExprMd) := do
         | none => pure none
       return condPrepends ++ [⟨.IfThenElse seqCond seqThen seqElse, source⟩]
 
-  | .While cond invs dec body =>
+  | .While cond invs dec body postTest =>
       let seqCond ← transformExpr cond
       let condPrepends ← takePrepends
       -- Process invariants and decreases through transformExpr for nondet holes
@@ -486,7 +486,7 @@ def transformStmt (stmt : StmtExprMd) : LiftM (List StmtExprMd) := do
         let stmts ← transformStmt body
         pure ⟨.Block stmts none, source⟩
       return condPrepends ++ invPrepends ++ decPrepends ++
-        [⟨.While seqCond seqInvs seqDec seqBody, source⟩]
+        [⟨.While seqCond seqInvs seqDec seqBody postTest, source⟩]
 
   | .StaticCall name args =>
       let seqArgs ← args.mapM transformExpr

--- a/Strata/Languages/Laurel/MapStmtExpr.lean
+++ b/Strata/Languages/Laurel/MapStmtExpr.lean
@@ -38,11 +38,11 @@ def mapStmtExprM [Monad m] (f : StmtExprMd → m StmtExprMd) (expr : StmtExprMd)
       (← el.attach.mapM fun ⟨e, _⟩ => mapStmtExprM f e), source⟩
   | .Block stmts label =>
     pure ⟨.Block (← stmts.attach.mapM fun ⟨e, _⟩ => mapStmtExprM f e) label, source⟩
-  | .While cond invs dec body =>
+  | .While cond invs dec body postTest =>
     pure ⟨.While (← mapStmtExprM f cond)
       (← invs.attach.mapM fun ⟨e, _⟩ => mapStmtExprM f e)
       (← dec.attach.mapM fun ⟨e, _⟩ => mapStmtExprM f e)
-      (← mapStmtExprM f body), source⟩
+      (← mapStmtExprM f body) postTest, source⟩
   | .Return v =>
     pure ⟨.Return (← v.attach.mapM fun ⟨e, _⟩ => mapStmtExprM f e), source⟩
   | .Assign targets value =>

--- a/Strata/Languages/Laurel/MapStmtExpr.lean
+++ b/Strata/Languages/Laurel/MapStmtExpr.lean
@@ -127,6 +127,22 @@ def mapProcedureM [Monad m] (f : StmtExprMd → m StmtExprMd) (proc : Procedure)
     decreases := ← proc.decreases.mapM f
     invokeOn := ← proc.invokeOn.mapM f }
 
+/-- Apply a monadic transformation to every procedure in a program — both
+    top-level static procedures and the instance procedures of composite types.
+    The single place that knows where procedures live in a `Program`, so passes
+    don't each re-enumerate `staticProcedures` and composite `instanceProcedures`. -/
+def mapProgramProceduresM [Monad m] (f : Procedure → m Procedure) (program : Program) : m Program := do
+  let staticProcedures ← program.staticProcedures.mapM f
+  let types ← program.types.mapM fun td =>
+    match td with
+    | .Composite ct => return .Composite { ct with instanceProcedures := ← ct.instanceProcedures.mapM f }
+    | other => pure other
+  return { program with staticProcedures := staticProcedures, types := types }
+
+/-- Pure variant of `mapProgramProceduresM`. -/
+def mapProgramProcedures (f : Procedure → Procedure) (program : Program) : Program :=
+  mapProgramProceduresM (m := Id) f program
+
 /-- Apply a monadic transformation to procedure bodies in a program.
     Does **not** traverse preconditions, decreases, or invokeOn — use
     `mapProcedureM` directly if those are needed. -/

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -641,10 +641,10 @@ namespace Resolution
 set_option linter.unusedVariables false in
 -- The well-founded-recursion termination proofs for every helper in this
 -- large mutual block share a single elaboration heartbeat budget. Each
--- `decreasing_by` is individually cheap (a directed `rw [h]` plus a targeted
--- `simp only [<ctor>.sizeOf_spec]` then `omega`), but their cumulative cost
--- across ~30 functions sits just above the 200k default, so the budget is
--- raised modestly for the block.
+-- `decreasing_by` rewrites the node equation (`rw [h]`) and then discharges
+-- the size goal with `term_by_mem` (which adds `List`/`Array` membership-size
+-- lemmas, then `simp_all` and `omega`). Their cumulative cost across ~30
+-- functions sits above the 200k default, so the budget is raised for the block.
 set_option maxHeartbeats 400000 in
 mutual
 
@@ -905,8 +905,7 @@ def Synth.varField (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Var.sizeOf_spec, Variable.Field.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (Var-Declare)
     ```
@@ -982,10 +981,7 @@ def Check.while (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.While.sizeOf_spec] at hsz
-      try (have := List.sizeOf_lt_of_mem ‹_ ∈ invs›)
-      try (rw [‹dec = some _›, Option.some.sizeOf_spec] at hsz)
-      omega
+      term_by_mem
 
 /-- (Exit)
     ```
@@ -1117,9 +1113,7 @@ def Check.return (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.Return.sizeOf_spec] at hsz
-      rw [Option.mem_def.mp ‹_ ∈ val›, Option.some.sizeOf_spec] at hsz
-      omega
+      term_by_mem
 
 /-- (Empty-Block)
     ```
@@ -1273,9 +1267,7 @@ def Check.block (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.Block.sizeOf_spec] at hsz
-      try (have := List.sizeOf_lt_of_mem ‹_ ∈ stmts›)
-      omega
+      term_by_mem
 
 /-- (If / If-NoElse)
     ```
@@ -1317,9 +1309,7 @@ def Check.ifThenElse (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.IfThenElse.sizeOf_spec] at hsz
-      try (rw [Option.mem_def.mp ‹_ ∈ elseBr›, Option.some.sizeOf_spec] at hsz)
-      omega
+      term_by_mem
 
 /-- (If-Synth)
     ```
@@ -1436,9 +1426,7 @@ def Synth.block (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.Block.sizeOf_spec] at hsz
-      try (have := List.sizeOf_lt_of_mem ‹_ ∈ stmts›)
-      omega
+      term_by_mem
 
 -- ### Verification statements
 
@@ -1463,8 +1451,7 @@ def Check.assert (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Assert.sizeOf_spec, Condition.mk.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (Assume)
     ```
@@ -1486,8 +1473,7 @@ def Check.assume (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Assume.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 -- ### Assignment
 
@@ -1540,10 +1526,7 @@ def Synth.assign (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.Assign.sizeOf_spec] at hsz
-      try (have hmem := List.sizeOf_lt_of_mem ‹_ ∈ targets›
-           simp only [AstNode.mk.sizeOf_spec, Variable.Field.sizeOf_spec] at hmem)
-      omega
+      term_by_mem
 
 /-- Check-mode rule for assignment. Synthesizes the assignment's type
     by inlining the same work as `Synth.assign` (resolving targets,
@@ -1593,10 +1576,7 @@ def Check.assign (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.Assign.sizeOf_spec] at hsz
-      try (have hmem := List.sizeOf_lt_of_mem ‹_ ∈ targets›
-           simp only [AstNode.mk.sizeOf_spec, Variable.Field.sizeOf_spec] at hmem)
-      omega
+      term_by_mem
 
 -- ### Increment / decrement
 
@@ -1646,11 +1626,9 @@ def Synth.incrDecr (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.IncrDecr.sizeOf_spec] at hsz
     have hsz2 := target.sizeOf_val_lt
     rw [h_tgt] at hsz2
-    simp only [Variable.Field.sizeOf_spec] at hsz2
-    omega
+    term_by_mem
 
 -- ### Calls
 
@@ -1724,9 +1702,7 @@ def Synth.staticCall (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.StaticCall.sizeOf_spec] at hsz
-    have := List.sizeOf_lt_of_mem ‹_ ∈ args›
-    omega
+    term_by_mem
 
 /-- Cases on the arity of the callee's declared outputs.
     ```
@@ -1813,9 +1789,7 @@ def Synth.instanceCall (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.InstanceCall.sizeOf_spec] at hsz
-      try (have := List.sizeOf_lt_of_mem ‹_ ∈ args›)
-      omega
+      term_by_mem
 
 -- ### Primitive operations
 
@@ -1991,9 +1965,7 @@ def Synth.primitiveOp (exprMd : StmtExprMd) (expr : StmtExpr)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.PrimitiveOp.sizeOf_spec] at hsz
-      have := List.sizeOf_lt_of_mem ‹_ ∈ args›
-      omega
+      term_by_mem
 
 /-- Cases on the operator family.
     ```
@@ -2055,9 +2027,7 @@ def Check.primitiveOp (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.PrimitiveOp.sizeOf_spec] at hsz
-    have := List.sizeOf_lt_of_mem ‹_ ∈ args›
-    omega
+    term_by_mem
 
 -- ### Object forms
 
@@ -2126,8 +2096,7 @@ def Synth.asType (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.AsType.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (IsType)
     ```
@@ -2156,8 +2125,7 @@ def Synth.isType (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.IsType.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (RefEq)
     ```
@@ -2200,8 +2168,7 @@ def Synth.refEq (exprMd : StmtExprMd) (expr : StmtExpr)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.ReferenceEquals.sizeOf_spec] at hsz
-      omega
+      term_by_mem
 
 /-- (PureFieldUpdate)
     ```
@@ -2230,8 +2197,7 @@ def Synth.pureFieldUpdate (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.PureFieldUpdate.sizeOf_spec] at hsz
-      omega
+      term_by_mem
 
 -- ### Verification expressions
 
@@ -2264,9 +2230,7 @@ def Synth.quantifier (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.Quantifier.sizeOf_spec] at hsz
-      try (rw [Option.mem_def.mp ‹_ ∈ trigger›, Option.some.sizeOf_spec] at hsz)
-      omega
+      term_by_mem
 
 /-- (Assigned)
     ```
@@ -2299,8 +2263,7 @@ def Synth.assigned (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Assigned.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (Old)
     ```
@@ -2332,8 +2295,7 @@ def Check.old (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Old.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (Old-Synth)
     ```
@@ -2361,8 +2323,7 @@ def Synth.old (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Old.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (Fresh)
     ```
@@ -2389,8 +2350,7 @@ def Synth.fresh (exprMd : StmtExprMd) (expr : StmtExpr)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.Fresh.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 /-- (ProveBy)
     ```
@@ -2416,8 +2376,7 @@ def Check.proveBy (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.ProveBy.sizeOf_spec] at hsz
-      omega
+      term_by_mem
 
 /-- (ProveBy-Synth)
     ```
@@ -2444,8 +2403,7 @@ def Synth.proveBy (exprMd : StmtExprMd)
       apply Prod.Lex.left
       have hsz := exprMd.sizeOf_val_lt
       rw [h] at hsz
-      simp only [StmtExpr.ProveBy.sizeOf_spec] at hsz
-      omega
+      term_by_mem
 
 -- ### Self reference
 
@@ -2567,8 +2525,7 @@ def Synth.contractOf (exprMd : StmtExprMd)
     apply Prod.Lex.left
     have hsz := exprMd.sizeOf_val_lt
     rw [h] at hsz
-    simp only [StmtExpr.ContractOf.sizeOf_spec] at hsz
-    omega
+    term_by_mem
 
 -- ### Holes
 

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -780,8 +780,8 @@ def Check.resolveStmtExpr (exprMd : StmtExprMd) (expected : HighTypeMd) : Resolv
   | .Hole det none => pure (Check.holeNone det expected source)
   | .Hole det (some ty) => Check.holeSome det ty expected source
   | .Var (.Declare param) => Check.varDeclare param source
-  | .While cond invs dec body =>
-    Check.while exprMd cond invs dec body source (by rw [h_node])
+  | .While cond invs dec body postTest =>
+    Check.while exprMd cond invs dec body postTest source (by rw [h_node])
   | .Exit target => Check.exit target source
   | .Return val =>
     Check.return exprMd val source (by rw [h_node])
@@ -959,9 +959,9 @@ def Check.varDeclare (param : Parameter) (source : Option FileRange) :
     check mode. -/
 def Check.while (exprMd : StmtExprMd)
     (cond : StmtExprMd) (invs : List StmtExprMd)
-    (dec : Option StmtExprMd) (body : StmtExprMd)
+    (dec : Option StmtExprMd) (body : StmtExprMd) (postTest : Bool)
     (source : Option FileRange)
-    (h : exprMd.val = .While cond invs dec body) :
+    (h : exprMd.val = .While cond invs dec body postTest) :
     ResolveM StmtExprMd := do
   let cond' ← Check.resolveStmtExpr cond { val := .TBool, source := cond.source }
   let invs' ← invs.attach.mapM (fun a => have := a.property; do
@@ -973,7 +973,9 @@ def Check.while (exprMd : StmtExprMd)
       typeMismatch a.val.source none "expected a numeric type" decTy
     pure e')
   let body' ← Check.resolveStmtExpr body { val := .Unknown, source := body.source }
-  pure { val := .While cond' invs' dec' body', source := source }
+  -- `postTest` (the `do … while` variant) resolves identically and is carried
+  -- through unchanged for the `EliminateDoWhile` pass to lower afterwards.
+  pure { val := .While cond' invs' dec' body' postTest, source := source }
   termination_by (exprMd, 0)
   decreasing_by
     all_goals
@@ -2840,7 +2842,7 @@ private def collectStmtExpr (map : Std.HashMap Nat ResolvedNode) (expr : StmtExp
     | some e => collectStmtExpr map e
     | none => map
   | .Block stmts _ => stmts.foldl collectStmtExpr map
-  | .While cond invs dec body =>
+  | .While cond invs dec body _ =>
     let map := collectStmtExpr map cond
     let map := invs.foldl collectStmtExpr map
     let map := match dec with | some d => collectStmtExpr map d | none => map
@@ -3040,7 +3042,7 @@ def validateDiamondFieldAccessesForStmtExpr (model : SemanticModel)
     match e with
     | some eb => errs ++ validateDiamondFieldAccessesForStmtExpr model eb
     | none => errs
-  | .While c invs _ b =>
+  | .While c invs _ b _ =>
     let errs := validateDiamondFieldAccessesForStmtExpr model c ++
                 validateDiamondFieldAccessesForStmtExpr model b
     invs.attach.foldl (fun acc ⟨inv, _⟩ => acc ++ validateDiamondFieldAccessesForStmtExpr model inv) errs

--- a/StrataTest/Languages/Laurel/AbstractToConcreteTreeTranslatorTest.lean
+++ b/StrataTest/Languages/Laurel/AbstractToConcreteTreeTranslatorTest.lean
@@ -347,4 +347,32 @@ procedure earlyExit(b: bool)
 { if b then { return }; assert true };
 #end)
 
+-- Do-while (issue #1358): a `do … while` parses to a post-test `While`
+-- (`postTest := true`) and round-trips through the DDM tree via the `doWhile`
+-- serialization arm (whose `#[body, cond, invariants]` arg order this
+-- exercises), re-parsing stably. The desugaring to a pre-test loop happens
+-- later, in the `EliminateDoWhile` pass, not here.
+/--
+info: procedure loop()
+  opaque
+{
+  var x: int := 0;
+  do {
+    x := x + 1
+  } while(x < 3)
+    invariant 0 <= x && x <= 2
+};
+-/
+#guard_msgs in
+#eval do IO.println (← roundtrip
+#strata
+program Laurel;
+procedure loop()
+  opaque
+{
+  var x: int := 0;
+  do { x := x + 1 } while(x < 3) invariant 0 <= x && x <= 2
+};
+#end)
+
 end Strata.Laurel

--- a/StrataTest/Languages/Laurel/EliminateDoWhileTest.lean
+++ b/StrataTest/Languages/Laurel/EliminateDoWhileTest.lean
@@ -1,0 +1,128 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+/-
+Tests that the `EliminateDoWhile` pass lowers a post-test `do … while` loop
+to the pre-test form (see EliminateDoWhile.lean for the desugaring).
+-/
+
+meta import StrataDDM.Elab
+meta import StrataDDM.BuiltinDialects.Init
+meta import Strata.Languages.Laurel.Grammar
+meta import Strata.Languages.Laurel.EliminateDoWhile
+
+meta section
+
+open Strata
+open StrataDDM (initDialect)
+open StrataDDM.Elab (parseStrataProgramFromDialect)
+
+namespace Strata.Laurel
+
+/-- Run the parser, then the `EliminateDoWhile` pass, so the printed output is
+    the desugared pre-test form fed to the rest of the pipeline. -/
+def parseEliminateDoWhile (input : String) : IO Program := do
+  let inputCtx := StrataDDM.Parser.stringInputContext "test" input
+  let dialects := StrataDDM.Elab.LoadedDialects.ofDialects! #[initDialect, Laurel]
+  let strataProgram ← parseStrataProgramFromDialect dialects Laurel.name inputCtx
+  let uri := Strata.Uri.file "test"
+  match Laurel.TransM.run uri (Laurel.parseProgram strataProgram) with
+  | .error e => throw (IO.userError s!"Translation errors: {e}")
+  | .ok program => pure (eliminateDoWhile program)
+
+/-- A single do-while; lowered form is in the `#guard_msgs` block below. -/
+def basicProgram : String := r"
+procedure basic()
+  opaque
+{
+  var x: int := 0;
+  do {
+    x := x + 1
+  } while(x < 3)
+    invariant 0 <= x && x <= 2;
+  assert x == 3
+};
+"
+
+/--
+info: procedure basic()
+  opaque
+{
+  var x: int := 0;
+  {
+    while(true)
+      invariant 0 <= x && x <= 2 {
+      {
+        x := x + 1
+      };
+      if !(x < 3) then exit $dowhile_exit_0
+    }
+  }$dowhile_exit_0;
+  assert x == 3
+};
+-/
+#guard_msgs in
+#eval! do
+  let program ← parseEliminateDoWhile basicProgram
+  for proc in program.staticProcedures do
+    IO.println (toString (Std.Format.pretty (Std.ToFormat.format proc)))
+
+/-- Nested do-whiles get distinct fresh exit labels (`_0` inner, `_1` outer). -/
+def nestedProgram : String := r"
+procedure nested()
+  opaque
+{
+  var x: int := 0;
+  do {
+    var y: int := 0;
+    do {
+      y := y + 1
+    } while(y < 3)
+      invariant 0 <= y;
+    x := x + 1
+  } while(x < 3)
+    invariant 0 <= x;
+  assert x == 3
+};
+"
+
+/--
+info: procedure nested()
+  opaque
+{
+  var x: int := 0;
+  {
+    while(true)
+      invariant 0 <= x {
+      {
+        var y: int := 0;
+        {
+          while(true)
+            invariant 0 <= y {
+            {
+              y := y + 1
+            };
+            if !(y < 3) then exit $dowhile_exit_0
+          }
+        }$dowhile_exit_0;
+        x := x + 1
+      };
+      if !(x < 3) then exit $dowhile_exit_1
+    }
+  }$dowhile_exit_1;
+  assert x == 3
+};
+-/
+#guard_msgs in
+#eval! do
+  let program ← parseEliminateDoWhile nestedProgram
+  for proc in program.staticProcedures do
+    IO.println (toString (Std.Format.pretty (Std.ToFormat.format proc)))
+
+end Laurel
+end Strata
+end

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T23_DoWhile.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T23_DoWhile.lean
@@ -1,0 +1,110 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+import StrataTest.Util.TestLaurel
+
+open StrataTest.Util
+open Strata
+
+/-! ## Body-tested `do-while`
+
+`do BODY while(COND) invariant I` is a body-tested loop: BODY runs once before
+COND is first tested. It is desugared (in `ConcreteToAbstractTreeTranslator`) to a
+head-tested `while(true)` whose body ends with `if (!COND) exit`, so the invariant
+`I` is checked at the loop HEAD — i.e. *before* each BODY runs (head-tested
+placement, matching `while`). Gotcha: because the guard is re-tested only after
+BODY, an invariant must hold of the *pre-body* state. For `do { x := x+1 } while(x<3)`
+the loop exits at x==3, but the head invariant sees the pre-increment value, so the
+bound is `x <= 2` (not `x <= 3`). -/
+
+#eval testLaurel
+#strata
+program Laurel;
+procedure basic()
+  opaque
+{
+  var x: int := 0;
+  do {
+    x := x + 1
+  } while(x < 3)
+    invariant 0 <= x && x <= 2;
+  assert x == 3
+};
+
+procedure runsAtLeastOnce()
+  opaque
+{
+  var x: int := 5;
+  do {
+    x := x + 1
+  } while(x < 3)
+    invariant x == 5;
+  assert x == 6
+};
+
+procedure nested()
+  opaque
+{
+  var x: int := 0;
+  do {
+    var y: int := 0;
+    do {
+      y := y + 1
+    } while(y < 3)
+      invariant 0 <= y
+      invariant y <= 2;
+    x := x + 1
+  } while(x < 3)
+    invariant 0 <= x
+    invariant x <= 2;
+  assert x == 3
+};
+
+procedure breakOut()
+  opaque
+{
+  var x: int := 0;
+  {
+    do {
+      x := x + 1;
+      if (x >= 2) then { exit early }
+    } while(x < 5)
+      invariant 0 <= x && x <= 2
+  } early;
+  assert 2 <= x && x <= 3
+};
+
+procedure noInvariant()
+  opaque
+{
+  var x: int := 0;
+  do {
+    x := x + 1
+  } while(x < 3);
+  assert x >= 3
+};
+#end
+
+/-! ## A false postcondition is still rejected
+
+Confirms the `while(true)` desugar isn't vacuous: the body's effect reaches the
+assertion, so an unprovable assert is reported (not discharged vacuously). -/
+
+#eval testLaurel
+#strata
+program Laurel;
+procedure falsePostRejected()
+  opaque
+{
+  var x: int := 0;
+  do {
+    x := x + 1
+  } while(x < 3)
+    invariant 0 <= x && x <= 2;
+  assert x == 99
+//^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T23_DoWhile.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T23_DoWhile.lean
@@ -9,16 +9,16 @@ import StrataTest.Util.TestLaurel
 open StrataTest.Util
 open Strata
 
-/-! ## Body-tested `do-while`
+/-! ## Post-test `do-while`
 
-`do BODY while(COND) invariant I` is a body-tested loop: BODY runs once before
-COND is first tested. It is desugared (in `ConcreteToAbstractTreeTranslator`) to a
-head-tested `while(true)` whose body ends with `if (!COND) exit`, so the invariant
-`I` is checked at the loop HEAD — i.e. *before* each BODY runs (head-tested
-placement, matching `while`). Gotcha: because the guard is re-tested only after
-BODY, an invariant must hold of the *pre-body* state. For `do { x := x+1 } while(x<3)`
-the loop exits at x==3, but the head invariant sees the pre-increment value, so the
-bound is `x <= 2` (not `x <= 3`). -/
+`do BODY while(COND) invariant I` is a post-test loop: BODY runs once before
+COND is first tested. It parses to a post-test `While` (`postTest := true`),
+desugared by the `EliminateDoWhile` pass to a pre-test `while(true)` whose body
+ends with `if (!COND) exit`. The invariant `I` is checked at the loop head —
+*before* each BODY runs, matching `while`. Gotcha: because the guard is re-tested
+only after BODY, an invariant must hold of the *pre-body* state. For
+`do { x := x+1 } while(x<3)` the loop exits at x==3, but the head invariant sees
+the pre-increment value, so the bound is `x <= 2` (not `x <= 3`). -/
 
 #eval testLaurel
 #strata


### PR DESCRIPTION
Laurel had only a pre-test `while`. This adds a `doWhile` grammar op and a body-tested `do … while` loop. Rather than a separate AST node, a do-while is represented as a post-test `While` — the existing `While` constructor gains a `postTest : Bool := false` field — and is lowered in a new `EliminateDoWhile` Laurel-to-Laurel pass into the existing pre-test loop:

```
  do S while(G) invariant I
```
becomes
```
  { while(true) invariant I { S; if (!G) { exit L } } } L
```

`L` is a fresh, collision-free label (`$dowhile_exit_{n}`, `$`-prefixed so it can't collide with user identifiers), so nested do-whiles and user `break`/`continue` don't capture each other's exits. The body runs once per iteration with the guard re-checked after it, and the real guard reaches post-loop code via the structured `exit` — so the encoding is sound, complete, and linear (single body in the IR, no peeling/duplication).

Invariant placement is head-tested (checked before each body), matching `while`. **Gotcha (documented in T23):** because the guard is re-tested only after the body, the invariant must hold of the *pre-body* state, so `do { x:=x+1 } while(x<3)` needs the bound `x <= 2`, not `x <= 3`.

**Why a flag + a pass:** `postTest` captures the while/do-while distinction at the type level (per review feedback) rather than duplicating the loop as a second constructor — so most passes match `While` once and carry the flag through, with no `.DoWhile` arms. `postTest := false` (pre-test) is the default, so every existing `.While` construction is unchanged. The desugaring lives in `EliminateDoWhile` rather than in `ConcreteToAbstractTreeTranslator`, so it runs for every program reaching the pipeline — including one supplied directly as abstract AST, bypassing the concrete translator. The parser builds a post-test `While`; the serializer emits `while`/`doWhile` by the flag; the pass (modeled on `EliminateIncrDecr`, with its own fresh-label counter) does the desugar and runs first, so no later pass observes `postTest = true`. No new Core construct or `LoopElim` change — the desugar reuses the existing verified pre-test loop machinery. Resolution handles `postTest` in `Check.while` directly (it runs before the passes, the same arrangement as `IncrDecr`).

The per-program traversal over static and composite-instance procedures, which both `EliminateDoWhile` and `EliminateIncrDecr` had hand-rolled, is now `mapProgramProceduresM` in `MapStmtExpr` (per review feedback) — so neither pass refers to unrelated features like instance procedures.

Tests in `T23_DoWhile` (end-to-end): basic, runs-at-least-once (guard false at entry), nested, break-out via labelled block, no-invariant (zero `invariant` clauses — asserts the negated guard, the only fact provable without an invariant), and `falsePostRejected` (a false postcondition is rejected, confirming the `while(true)` desugar isn't vacuous). Plus `EliminateDoWhileTest` (pass-output shape, incl. distinct fresh labels for nested loops) and a round-trip case in `AbstractToConcreteTreeTranslatorTest` (serialization arg order).

**Earlier label-clash warning, now resolved.** Multi-procedure `T23` used to surface a latent label clash (`⚠️ [addPathCondition] Label clash detected for assume_invariant_0_0, …`) — `do-while` was just the first construct to trip it, because path-condition labels weren't reset between procedures. This branch has merged the base fix #1391 (path-condition isolation at the procedure boundary), so the warning is gone (verified: zero clashes on the T23 build). Not caused by this PR.

**Strata half only.** To use do-while end-to-end, the jverify front-end must emit the new op (regenerate the `laurel/` bindings and add a `JCDoWhileLoop` case to `JavaToLaurelCompiler`, which currently rejects do-while) — a separate follow-up. Implements the front-end desugar from #1350.
