### PR TITLE
Per-invariant source ranges for loop-invariant diagnostics

### DIFF
--- a/Strata/DL/Imperative/MetaData.lean
+++ b/Strata/DL/Imperative/MetaData.lean
@@ -293,6 +293,27 @@ def MetaData.eraseAllElems {P : PureExpr} [BEq P.Ident]
     (md : MetaData P) (fld : MetaDataElem.Field P) : MetaData P :=
   md.filter (fun e => !(e.fld == fld))
 
+/-- Label for a per-loop-invariant source provenance. Loop lowering stores one
+    such element per invariant, in invariant order, so that loop elimination can
+    attribute each invariant's verification condition to the specific invariant's
+    source location rather than to the whole loop. -/
+def MetaData.invariantProvenanceLabel : String := "invariantProvenance"
+
+/-- Append a loop invariant's provenance to metadata. These are appended in
+    invariant order. Note this matches on the `.label` constructor directly, so
+    it needs no `BEq P.Ident` instance. -/
+def MetaData.pushInvariantProvenance {P : PureExpr} (md : MetaData P) (p : Provenance) : MetaData P :=
+  md.push { fld := .label MetaData.invariantProvenanceLabel, value := .provenance p }
+
+/-- Get all per-invariant provenances from metadata, in the order they were
+    pushed (matching the loop's invariant order). -/
+def getInvariantProvenances {P : PureExpr} (md : MetaData P) : Array Provenance :=
+  md.filterMap fun elem =>
+    match elem.fld, elem.value with
+    | .label l, .provenance p =>
+      if l == MetaData.invariantProvenanceLabel then some p else none
+    | _, _ => none
+
 /-- Replace the primary provenance with a new one, shifting existing related
     provenances and prepending the old primary provenance. -/
 def MetaData.setCallSiteFileRange {P : PureExpr} [BEq P.Ident]

--- a/Strata/DL/Imperative/MetaData.lean
+++ b/Strata/DL/Imperative/MetaData.lean
@@ -307,7 +307,7 @@ def MetaData.pushInvariantProvenance {P : PureExpr} (md : MetaData P) (p : Prove
 
 /-- Get all per-invariant provenances from metadata, in the order they were
     pushed (matching the loop's invariant order). -/
-def getInvariantProvenances {P : PureExpr} (md : MetaData P) : Array Provenance :=
+def MetaData.getInvariantProvenances {P : PureExpr} (md : MetaData P) : Array Provenance :=
   md.filterMap fun elem =>
     match elem.fld, elem.value with
     | .label l, .provenance p =>

--- a/Strata/Languages/Laurel/LaurelAST.lean
+++ b/Strata/Languages/Laurel/LaurelAST.lean
@@ -393,6 +393,13 @@ def fileRangeToCoreMd (source : Option FileRange) : Imperative.MetaData Core.Exp
   | some fr => Imperative.MetaData.ofSourceRange fr.file fr.range
   | none => Imperative.MetaData.ofProvenance (.synthesized .laurel)
 
+/-- Build a provenance from an optional source location (mirrors
+    `fileRangeToCoreMd`, but returns the bare `Provenance`). -/
+def fileRangeToProvenance (source : Option FileRange) : Provenance :=
+  match source with
+  | some fr => Provenance.ofSourceRange fr.file fr.range
+  | none => .synthesized .laurel
+
 /-- Build Core metadata from an AstNode's source location. -/
 def astNodeToCoreMd (node : AstNode α) : Imperative.MetaData Core.Expression :=
   fileRangeToCoreMd node.source

--- a/Strata/Languages/Laurel/LaurelAST.lean
+++ b/Strata/Languages/Laurel/LaurelAST.lean
@@ -387,18 +387,15 @@ def Condition.mapM [Monad m] (f : AstNode StmtExpr → m (AstNode StmtExpr)) (c 
 def Condition.mapCondition (f : AstNode StmtExpr → AstNode StmtExpr) (c : Condition) : Condition :=
   { c with condition := f c.condition }
 
-/-- Build Core metadata from an optional source location. -/
-def fileRangeToCoreMd (source : Option FileRange) : Imperative.MetaData Core.Expression :=
-  match source with
-  | some fr => Imperative.MetaData.ofSourceRange fr.file fr.range
-  | none => Imperative.MetaData.ofProvenance (.synthesized .laurel)
-
-/-- Build a provenance from an optional source location (mirrors
-    `fileRangeToCoreMd`, but returns the bare `Provenance`). -/
+/-- Build a provenance from an optional source location. -/
 def fileRangeToProvenance (source : Option FileRange) : Provenance :=
   match source with
   | some fr => Provenance.ofSourceRange fr.file fr.range
   | none => .synthesized .laurel
+
+/-- Build Core metadata from an optional source location. -/
+def fileRangeToCoreMd (source : Option FileRange) : Imperative.MetaData Core.Expression :=
+  Imperative.MetaData.ofProvenance (fileRangeToProvenance source)
 
 /-- Build Core metadata from an AstNode's source location. -/
 def astNodeToCoreMd (node : AstNode α) : Imperative.MetaData Core.Expression :=

--- a/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
+++ b/Strata/Languages/Laurel/LaurelToCoreTranslator.lean
@@ -498,7 +498,15 @@ def translateStmt (stmt : StmtExprMd)
       let invExprs ← invariants.mapM (fun i => do return ("", ← translateExpr i))
       let decreasingExprCore ← decreasesExpr.mapM (translateExpr)
       let bodyStmts ← translateStmt body
-      return [Imperative.Stmt.loop (.det condExpr) decreasingExprCore invExprs bodyStmts md]
+      -- Attach each invariant's source provenance to the loop metadata, in
+      -- invariant order, so loop elimination can point an invariant's
+      -- verification condition at the specific invariant rather than the whole
+      -- loop. (The Core loop IR stores invariants as `(label, expr)` pairs with
+      -- no per-invariant metadata slot, and Core expressions carry no source
+      -- range, so we thread the ranges through the loop metadata instead.)
+      let mdWithInvs := invariants.foldl
+        (fun acc i => acc.pushInvariantProvenance (fileRangeToProvenance i.source)) md
+      return [Imperative.Stmt.loop (.det condExpr) decreasingExprCore invExprs bodyStmts mdWithInvs]
   | .Exit target =>
       return [Imperative.Stmt.exit target md]
   | .Hole _ _ =>

--- a/Strata/Transform/LoopElim.lean
+++ b/Strata/Transform/LoopElim.lean
@@ -145,11 +145,19 @@ def Stmt.removeLoopsM
     -- invariant's generated assert/assume is attributed to that invariant's own
     -- source location instead of the whole loop; otherwise we fall back to the
     -- loop metadata `md` (e.g. for loops not originating from Laurel).
-    let invProvs := getInvariantProvenances md
+    -- Contract: `invProvs` holds one provenance per invariant, in invariant
+    -- order, pushed by the Laurel→Core translation (`pushInvariantProvenance`).
+    -- When the sizes disagree (e.g. a loop not originating from Laurel, or a
+    -- future desync between push and retrieval) we fall back to the loop `md`
+    -- via the index lookup below, so a mismatch degrades gracefully rather than
+    -- mis-attributing ranges.
+    let invProvs := MetaData.getInvariantProvenances md
     let invMd : Nat → MetaData P := fun i =>
+      -- Only real source locations (`.loc`) refine the diagnostic; a synthesized
+      -- provenance carries no usable range, so fall back to the loop `md`
       match invProvs[i]? with
-      | some p => MetaData.ofProvenance p
-      | none => md
+      | some (p@(.loc ..)) => MetaData.ofProvenance p
+      | _ => md
     let entry_invariants := invariants.mapIdx fun i (lbl, inv) =>
       Stmt.cmd (HasPassiveCmds.assert s!"entry_invariant_{loop_num}_{invSuffix i lbl}" inv (invMd i))
     let entry_invariant_assumes := invariants.mapIdx fun i (lbl, inv) =>

--- a/Strata/Transform/LoopElim.lean
+++ b/Strata/Transform/LoopElim.lean
@@ -140,16 +140,26 @@ def Stmt.removeLoopsM
     -- reference to the source invariant.
     let invSuffix : Nat → String → String := fun i lbl =>
       if lbl.isEmpty then toString i else s!"{i}_{lbl}"
+    -- Per-invariant source provenance, threaded through the loop metadata by the
+    -- Laurel→Core translation (in invariant order). When present, each
+    -- invariant's generated assert/assume is attributed to that invariant's own
+    -- source location instead of the whole loop; otherwise we fall back to the
+    -- loop metadata `md` (e.g. for loops not originating from Laurel).
+    let invProvs := getInvariantProvenances md
+    let invMd : Nat → MetaData P := fun i =>
+      match invProvs[i]? with
+      | some p => MetaData.ofProvenance p
+      | none => md
     let entry_invariants := invariants.mapIdx fun i (lbl, inv) =>
-      Stmt.cmd (HasPassiveCmds.assert s!"entry_invariant_{loop_num}_{invSuffix i lbl}" inv md)
+      Stmt.cmd (HasPassiveCmds.assert s!"entry_invariant_{loop_num}_{invSuffix i lbl}" inv (invMd i))
     let entry_invariant_assumes := invariants.mapIdx fun i (lbl, inv) =>
-      Stmt.cmd (HasPassiveCmds.assume s!"assume_entry_invariant_{loop_num}_{invSuffix i lbl}" inv md)
+      Stmt.cmd (HasPassiveCmds.assume s!"assume_entry_invariant_{loop_num}_{invSuffix i lbl}" inv (invMd i))
     let first_iter_facts :=
       .block s!"first_iter_asserts_{loop_num}" (entry_invariants ++ entry_invariant_assumes) {}
     let inv_assumes := invariants.mapIdx fun i (lbl, inv) =>
-      Stmt.cmd (HasPassiveCmds.assume s!"{loopElimInvariantPrefix}{loop_num}_{invSuffix i lbl}" inv md)
+      Stmt.cmd (HasPassiveCmds.assume s!"{loopElimInvariantPrefix}{loop_num}_{invSuffix i lbl}" inv (invMd i))
     let maintain_invariants := invariants.mapIdx fun i (lbl, inv) =>
-      Stmt.cmd (HasPassiveCmds.assert s!"arbitrary_iter_maintain_invariant_{loop_num}_{invSuffix i lbl}" inv md)
+      Stmt.cmd (HasPassiveCmds.assert s!"arbitrary_iter_maintain_invariant_{loop_num}_{invSuffix i lbl}" inv (invMd i))
     -- Guard-specific parts: assume_guard, termination, not_guard
     let (guard_assumes, pre_termination, post_termination, exit_guard) ← match guard with
       | .det g => do
@@ -181,7 +191,7 @@ def Stmt.removeLoopsM
       ([havocd, arbitrary_iter_assumes] ++ pre_termination ++
        body_statements ++ maintain_invariants ++ post_termination) {}
     let invariant_assumes := invariants.mapIdx fun i (lbl, inv) =>
-      Stmt.cmd (HasPassiveCmds.assume s!"invariant_{loop_num}_{invSuffix i lbl}" inv md)
+      Stmt.cmd (HasPassiveCmds.assume s!"invariant_{loop_num}_{invSuffix i lbl}" inv (invMd i))
     let exit_state_assumes := [havocd] ++ exit_guard ++ invariant_assumes
     let loop_passive :=
       .ite guard (arbitrary_iter_facts :: exit_state_assumes) [] {}

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
@@ -1,0 +1,71 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+meta import all StrataTest.Util.TestDiagnostics
+meta import all StrataTest.Languages.Laurel.TestExamples
+
+meta section
+
+open StrataTest.Util
+
+namespace Strata
+namespace Laurel
+
+/-
+  Regression test for per-invariant source ranges in loop-invariant
+  diagnostics (LoopElim threads each invariant's provenance through the loop
+  metadata; see `MetaData.getInvariantProvenances` / `LoopElim.invMd`).
+
+  Before that fix, a failing loop invariant was reported at the whole loop's
+  source range. These tests pin the diagnostic to the specific invariant: the
+  caret must land on the failing `invariant` expression, not the loop or the
+  other (passing) invariant.
+-/
+
+-- A single loop invariant that does not hold on entry. The diagnostic must
+-- point at the invariant expression `i >= 0`, not at the `while` loop.
+def badInitialInvariantProgram := r"
+procedure badInitialInvariant()
+  opaque
+{
+    var i: int := -1;
+    while(i < 10)
+      invariant i >= 0
+//              ^^^^^^ error: assertion does not hold
+    {
+        i := i + 1
+    }
+};
+"
+
+#guard_msgs (drop info, error) in
+#eval testInputWithOffset "BadInitialInvariant" badInitialInvariantProgram 40 processLaurelFile
+
+-- Two invariants where the first holds on entry but the second does not. The
+-- diagnostic must point at the failing second invariant `j >= 0` specifically,
+-- demonstrating per-invariant (not loop-wide) source attribution.
+def secondInvariantFailsProgram := r"
+procedure secondInvariantFails()
+  opaque
+{
+    var i: int := 0;
+    var j: int := -1;
+    while(i < 10)
+      invariant i >= 0
+      invariant j >= 0
+//              ^^^^^^ error: assertion does not hold
+    {
+        i := i + 1;
+        j := j + 1
+    }
+};
+"
+
+#guard_msgs (drop info, error) in
+#eval testInputWithOffset "SecondInvariantFails" secondInvariantFailsProgram 60 processLaurelFile
+
+end Laurel

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
@@ -3,19 +3,21 @@
 
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
-module
 
-meta import all StrataTest.Util.TestDiagnostics
-meta import all StrataTest.Languages.Laurel.TestExamples
-
-meta section
+import StrataTest.Util.TestLaurel
 
 open StrataTest.Util
+open Strata
 
-namespace Strata
-namespace Laurel
+/-! ## Loop-invariant failures point at the specific invariant
 
-def badInitialInvariantProgram := r"
+These negative tests pin each failing loop invariant's diagnostic to that
+invariant's own source range (per-invariant source ranges threaded through
+loop elimination), rather than the whole loop. -/
+
+#eval testLaurel
+#strata
+program Laurel;
 procedure badInitialInvariant()
   opaque
 {
@@ -27,12 +29,11 @@ procedure badInitialInvariant()
         i := i + 1
     }
 };
-"
+#end
 
-#guard_msgs (drop info, error) in
-#eval testInputWithOffset "BadInitialInvariant" badInitialInvariantProgram 40 processLaurelFile
-
-def secondInvariantFailsProgram := r"
+#eval testLaurel
+#strata
+program Laurel;
 procedure secondInvariantFails()
   opaque
 {
@@ -47,12 +48,11 @@ procedure secondInvariantFails()
         j := j + 1
     }
 };
-"
+#end
 
-#guard_msgs (drop info, error) in
-#eval testInputWithOffset "SecondInvariantFails" secondInvariantFailsProgram 60 processLaurelFile
-
-def forSecondInvFailsProgram := r"
+#eval testLaurel
+#strata
+program Laurel;
 procedure forSecondInvFails()
   opaque
 {
@@ -65,9 +65,4 @@ procedure forSecondInvFails()
         j := j + 1
     }
 };
-"
-
-#guard_msgs (drop info, error) in
-#eval testInputWithOffset "ForSecondInvFails" forSecondInvFailsProgram 60 processLaurelFile
-
-end Laurel
+#end

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
@@ -15,19 +15,6 @@ open StrataTest.Util
 namespace Strata
 namespace Laurel
 
-/-
-  Regression test for per-invariant source ranges in loop-invariant
-  diagnostics (LoopElim threads each invariant's provenance through the loop
-  metadata; see `MetaData.getInvariantProvenances` / `LoopElim.invMd`).
-
-  Before that fix, a failing loop invariant was reported at the whole loop's
-  source range. These tests pin the diagnostic to the specific invariant: the
-  caret must land on the failing `invariant` expression, not the loop or the
-  other (passing) invariant.
--/
-
--- A single loop invariant that does not hold on entry. The diagnostic must
--- point at the invariant expression `i >= 0`, not at the `while` loop.
 def badInitialInvariantProgram := r"
 procedure badInitialInvariant()
   opaque
@@ -45,9 +32,6 @@ procedure badInitialInvariant()
 #guard_msgs (drop info, error) in
 #eval testInputWithOffset "BadInitialInvariant" badInitialInvariantProgram 40 processLaurelFile
 
--- Two invariants where the first holds on entry but the second does not. The
--- diagnostic must point at the failing second invariant `j >= 0` specifically,
--- demonstrating per-invariant (not loop-wide) source attribution.
 def secondInvariantFailsProgram := r"
 procedure secondInvariantFails()
   opaque

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T13_WhileLoopsError.lean
@@ -52,4 +52,22 @@ procedure secondInvariantFails()
 #guard_msgs (drop info, error) in
 #eval testInputWithOffset "SecondInvariantFails" secondInvariantFailsProgram 60 processLaurelFile
 
+def forSecondInvFailsProgram := r"
+procedure forSecondInvFails()
+  opaque
+{
+    var j: int := -1;
+    for(var i: int := 0; i < 10; i := i + 1)
+      invariant i >= 0
+      invariant j >= 0
+//              ^^^^^^ error: assertion does not hold
+    {
+        j := j + 1
+    }
+};
+"
+
+#guard_msgs (drop info, error) in
+#eval testInputWithOffset "ForSecondInvFails" forSecondInvFailsProgram 60 processLaurelFile
+
 end Laurel


### PR DESCRIPTION
## Summary

Loop-invariant verification diagnostics (a failing `invariant(...)` in a `while`/`for` loop) previously pointed at the **whole loop** instead of the specific invariant that failed. This change threads each invariant's source range through the loop's metadata so loop elimination can attribute each invariant's verification condition to that invariant's own source location.

This support is required for [JVerify#437](https://github.com/strata-org/jverify/issues/437)

## Problem

In Strata, loop-invariant proof obligations are synthesized by `LoopElim` and were tagged with the loop-wide metadata `md`. The per-invariant source range was lost earlier in the pipeline: Core loop invariants are bare `(label, expr)` pairs and Core expressions are `Unit`-annotated, so they carry no source range.

A front-end-only change does not help: the diagnostic location is driven by the synthesized assert's metadata, not by anything attached to the invariant expression. The fix therefore has to live in Strata.

## Solution

Thread each invariant's source range through the loop's existing `MetaData` array and use it per-invariant in `LoopElim`. When a per-invariant provenance is present, each invariant's generated assert/assume is attributed to that invariant's own source location; otherwise we fall back to the loop metadata `md`, so loops not originating from Laurel (Core `.st`, C_Simp) are unchanged.


## Testing

`StrataTest/.../Fundamentals/T13_WhileLoopsError.lean` adds two caret-annotated regression tests using the existing diagnostic harness (`TestDiagnostics`, `matchesDiagnostic`), which checks the exact start/end line and column of each diagnostic:

1. **`badInitialInvariant`** — a single `invariant i >= 0` that fails on entry. The caret asserts the diagnostic lands on the invariant expression, not the `while` loop.
2. **`secondInvariantFails`** — two invariants where the first holds on entry but the second (`invariant j >= 0`) does not. The caret asserts the diagnostic points specifically at the failing second invariant. This is the case that distinguishes per-invariant attribution from loop-wide attribution: before the fix the range would resolve to the loop, so the carets would not match.

Verification:

- `lake build Strata` — compiles, no proof breakage.
- `lake build StrataTest` — all `#guard_msgs` tests pass, including the new ones.
- The fallback to the loop `md` keeps existing Core `.st` and C_Simp loop diagnostics unchanged.
