### PR TITLE
fix(core): thread LoopElim loop counter across procedures

### DIFF
--- a/Strata/Transform/LoopElim.lean
+++ b/Strata/Transform/LoopElim.lean
@@ -241,20 +241,27 @@ def Stmt.removeLoops
 
 /-- Eliminate loops in all procedures of a Core program by replacing each loop
     with assertions and assumptions about its invariants.
-    Returns the transformed program together with accumulated statistics. -/
+    Returns the transformed program together with accumulated statistics.
+
+    The `LoopElimState` (and so `loopCounter`) is threaded across procedures
+    rather than reset per procedure, so the generated labels
+    (`assume_invariant_{loop_num}_…`, `loop_havoc_{loop_num}`, etc.) are unique
+    program-wide. The downstream verifier accumulates path conditions across all
+    procedures in a single run, so a per-procedure reset would make the first
+    loop of every procedure collide on `…_0_…`. -/
 def loopElim (p : Program) : Program × Statistics :=
-  let (decls, stats) := p.decls.foldl (fun (acc, stats) d =>
+  let (decls, st) := p.decls.foldl (fun (acc, st) d =>
     match d with
     | .proc proc md =>
       match proc.body with
       | .structured ss =>
-        let (body, st) := StateT.run (Block.removeLoopsM ss) {}
-        ((.proc { proc with body := .structured body } md) :: acc, stats.merge st.statistics)
+        let (body, st) := StateT.run (Block.removeLoopsM ss) st
+        ((.proc { proc with body := .structured body } md) :: acc, st)
       -- CFG bodies have no structured loops; pass through unchanged. An
       -- unstructured loop elimination process could be applied here later.
-      | .cfg _ => ((.proc proc md) :: acc, stats)
-    | other => (other :: acc, stats)) ([], {})
-  ({ decls := decls.reverse }, stats)
+      | .cfg _ => ((.proc proc md) :: acc, st)
+    | other => (other :: acc, st)) ([], ({} : LoopElimState))
+  ({ decls := decls.reverse }, st.statistics)
 
 /-- Loop elimination as a `CoreTransformM` pass suitable for the pipeline. -/
 def loopElim' (p : Program) : Transform.CoreTransformM (Bool × Program) := do

--- a/StrataBoole/StrataBooleTest/grammar_extensions.lean
+++ b/StrataBoole/StrataBooleTest/grammar_extensions.lean
@@ -100,7 +100,7 @@ Obligation: arbitrary_iter_maintain_invariant_0_0
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_0
+Obligation: entry_invariant_1_0
 Property: assert
 Result: ✅ pass
 
@@ -108,15 +108,15 @@ Obligation: assert_2_648
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_0
+Obligation: arbitrary_iter_maintain_invariant_1_0
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_0
+Obligation: entry_invariant_2_0
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_1
+Obligation: entry_invariant_2_1
 Property: assert
 Result: ✅ pass
 
@@ -128,23 +128,23 @@ Obligation: assert_5_834
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_0
+Obligation: arbitrary_iter_maintain_invariant_2_0
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_1
+Obligation: arbitrary_iter_maintain_invariant_2_1
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_0
+Obligation: entry_invariant_3_0
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_1
+Obligation: entry_invariant_3_1
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_2
+Obligation: entry_invariant_3_2
 Property: assert
 Result: ✅ pass
 
@@ -152,31 +152,31 @@ Obligation: assert_7_990
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_0
+Obligation: arbitrary_iter_maintain_invariant_3_0
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_1
+Obligation: arbitrary_iter_maintain_invariant_3_1
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_2
+Obligation: arbitrary_iter_maintain_invariant_3_2
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_0
+Obligation: entry_invariant_4_0
 Property: assert
 Result: ✅ pass
 
-Obligation: entry_invariant_0_1
+Obligation: entry_invariant_4_1
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_0
+Obligation: arbitrary_iter_maintain_invariant_4_0
 Property: assert
 Result: ✅ pass
 
-Obligation: arbitrary_iter_maintain_invariant_0_1
+Obligation: arbitrary_iter_maintain_invariant_4_1
 Property: assert
 Result: ✅ pass-/
 #guard_msgs in


### PR DESCRIPTION
## Problem

`loopElim` ran `removeLoopsM` with a fresh `LoopElimState {}` per procedure, so `loopCounter` reset to 0 each time and the first loop of every procedure emitted the same labels (`assume_invariant_0_0`, `loop_havoc_0`, …).

The verifier (`CmdEval.addPathCondition`) accumulates path conditions across all procedures in one run. When collided labels stay live there, it auto-renames and emits a noisy (but harmless) trace:

```
⚠️ [addPathCondition] Label clash detected for assume_invariant_0_0, using unique label assume_invariant_0_0_1.
```

Verification is correct either way; this just removes the noise. It showed up via the desugared `do-while` from #1358.

## Fix

Thread the `LoopElimState` (and so `loopCounter`) through the per-procedure fold instead of resetting it, making loop numbers monotonic program-wide. Statistics accumulate identically (`merge`/`increment` are both per-key sums).

## Blast radius

Only `StrataBooleTest/grammar_extensions` changes — a 5-loop multi-procedure program now numbered `0..4` instead of all-`0`; its expected labels are updated. Every other pinned-label snapshot uses `loop_num = 0`, unchanged.

## Verification

- `lake build StrataTest` — green (529)
- `lake build StrataBooleTest` — green (227)
- `lake test -- --exclude Languages.Python` — loop tests pass; only failure is the pre-existing `Languages.Java.TestGen` (missing optional `ion-java` jar, unrelated)