### PR TITLE
File-relative error reporting

### DIFF
--- a/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
+++ b/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
@@ -232,33 +232,8 @@ def translate (options : LaurelTranslateOptions) (program : Program) : IO Transl
   let (core, diags, _, _) ← translateWithLaurel options program
   return (core, diags)
 
-/-- Run `Core.verify` on a translated Core program, returning the verify-phase
-    failure as a **structured** `DiagnosticModel` value (via `.toBaseIO`) rather
-    than throwing it.
-
-    `Core.verify : EIO DiagnosticModel VCResults` carries its error as a
-    `DiagnosticModel` (with byte-offset `fileRange`). Capturing it as an
-    `Except` here is the single point where that structure is preserved; callers
-    decide whether to re-throw it (production) or render it (tests). Mirrors the
-    pre-existing `removeIrrelevantAxioms := .Precise` and `vcDirectory` handling. -/
-private def runVerify (coreProgram : Core.Program) (options : LaurelVerifyOptions)
-    : IO (Except DiagnosticModel VCResults) := do
-  let verifyOptions := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
-  let runner tempDir : IO (Except DiagnosticModel VCResults) :=
-    (_root_.Core.verify coreProgram tempDir (proceduresToVerify := none) verifyOptions).toBaseIO
-  match verifyOptions.vcDirectory with
-  | .none => IO.FS.withTempDir runner
-  | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
-
 /--
 Verify a Laurel program using an SMT solver.
-
-A verify-phase failure (a type-checking / symbolic-evaluation error) is
-**thrown** as an `IO` exception, exactly as before file-relative reporting was
-introduced: the structured error is intercepted at the `runVerify` boundary and
-re-thrown via `toString`, so the CLI's control flow and exit codes are
-unchanged. Tests that need the structured error as a value (to render it to
-`line:col`) call `verifyToDiagnosticModelsCapturing` instead.
 -/
 def verifyToVcResults (program : Program)
     (options : LaurelVerifyOptions := default)
@@ -267,11 +242,14 @@ def verifyToVcResults (program : Program)
 
   match coreProgramOption with
   | some coreProgram =>
-    match ← runVerify coreProgram options with
-    | .ok ioResult => return (some ioResult, translateDiags)
-    -- Reconstruct the throwing path: stringify the structured error exactly as
-    -- the previous `EIO.toIO (fun f => .userError (toString f))` did.
-    | .error dm => throw (IO.userError (toString dm))
+    let options := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
+    let runner tempDir :=
+      EIO.toIO (fun f => IO.Error.userError (toString f))
+          (_root_.Core.verify coreProgram tempDir .none options)
+    let ioResult ← match options.vcDirectory with
+      | .none => IO.FS.withTempDir runner
+      | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
+    return (some ioResult, translateDiags)
   | none => return (none, translateDiags)
 
 /--
@@ -305,20 +283,29 @@ def verifyToDiagnosticModels (program : Program) (options : LaurelVerifyOptions 
 
 /-- Like `verifyToDiagnosticModels`, but a verify-phase failure is **captured**
     as a structured `DiagnosticModel` (the same value `verifyToVcResults` would
-    have thrown) and returned in the list, rather than thrown.
+    have thrown via `toString`) and returned in the list, rather than thrown.
 
     This is the test-framework entry point: the structured error still carries
     its byte-offset `fileRange`, so the caller can render it to snippet-local /
     file-relative `line:col` like every other diagnostic — instead of the raw
     byte offset that a stringified exception would leave in its message text.
-    Production code keeps using the throwing `verifyTo*` functions above. -/
+    Production code keeps using the throwing `verifyTo*` functions above.
+
+    The verify call mirrors `verifyToVcResults` exactly, except it intercepts the
+    `EIO DiagnosticModel` error via `.toBaseIO` instead of stringifying it. -/
 def verifyToDiagnosticModelsCapturing (program : Program)
     (options : LaurelVerifyOptions := default) : IO (Array DiagnosticModel) := do
   let (coreProgramOption, translateDiags) ← translate options.translateOptions program
   match coreProgramOption with
   | none => return translateDiags.toArray
   | some coreProgram =>
-    match ← runVerify coreProgram options with
+    let options := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
+    let runner tempDir : IO (Except DiagnosticModel VCResults) :=
+      (_root_.Core.verify coreProgram tempDir .none options).toBaseIO
+    let result ← match options.vcDirectory with
+      | .none => IO.FS.withTempDir runner
+      | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
+    match result with
     | .error dm => return (translateDiags ++ [dm]).toArray
     | .ok results =>
       let phases := Core.coreAbstractedPhases

--- a/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
+++ b/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
@@ -243,13 +243,20 @@ def verifyToVcResults (program : Program)
   match coreProgramOption with
   | some coreProgram =>
     let options := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
-    let runner tempDir :=
-      EIO.toIO (fun f => IO.Error.userError (toString f))
-          (_root_.Core.verify coreProgram tempDir .none options)
-    let ioResult ← match options.vcDirectory with
+    -- Preserve the structured `DiagnosticModel` error (it carries a `fileRange`)
+    -- via `.toBaseIO` instead of stringifying it. This lets a type-checking /
+    -- symbolic-evaluation error flow into `translateDiags`, where
+    -- `verifyToDiagnostics` renders it through a `FileMap` to snippet-local
+    -- `line:col` like every other diagnostic — rather than leaking a raw,
+    -- file-global byte offset baked into the message text.
+    let runner tempDir : IO (Except DiagnosticModel VCResults) :=
+      (_root_.Core.verify coreProgram tempDir .none options).toBaseIO
+    let result ← match options.vcDirectory with
       | .none => IO.FS.withTempDir runner
       | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
-    return (some ioResult, translateDiags)
+    match result with
+    | .ok ioResult => return (some ioResult, translateDiags)
+    | .error dm => return (none, translateDiags ++ [dm])
   | none => return (none, translateDiags)
 
 /--

--- a/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
+++ b/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
@@ -232,8 +232,36 @@ def translate (options : LaurelTranslateOptions) (program : Program) : IO Transl
   let (core, diags, _, _) ← translateWithLaurel options program
   return (core, diags)
 
+/-- Run `Core.verify` on a translated Core program, returning the verify-phase
+    failure as a **structured** `DiagnosticModel` value (via `.toBaseIO`) rather
+    than throwing it.
+
+    `Core.verify : EIO DiagnosticModel VCResults` carries its error as a
+    `DiagnosticModel` (with byte-offset `fileRange`). Capturing it as an
+    `Except` here is the single point where that structure is preserved, so the
+    throwing (`verifyToVcResults`) and capturing
+    (`verifyToDiagnosticModelsCapturing`) entry points can't drift apart: both
+    share this verify setup (the `removeIrrelevantAxioms := .Precise` option and
+    the `vcDirectory` temp-dir handling) and only differ in how they treat the
+    `.error` case. -/
+private def runVerify (coreProgram : Core.Program) (options : LaurelVerifyOptions)
+    : IO (Except DiagnosticModel VCResults) := do
+  let verifyOptions := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
+  let runner tempDir : IO (Except DiagnosticModel VCResults) :=
+    (_root_.Core.verify coreProgram tempDir (proceduresToVerify := none) verifyOptions).toBaseIO
+  match verifyOptions.vcDirectory with
+  | .none => IO.FS.withTempDir runner
+  | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
+
 /--
 Verify a Laurel program using an SMT solver.
+
+A verify-phase failure (a type-checking / symbolic-evaluation error) is
+**thrown** as an `IO` exception, exactly as before file-relative reporting was
+introduced: the structured error is intercepted at the `runVerify` boundary and
+re-thrown via `toString`, so the CLI's control flow and exit codes are
+unchanged. Tests that need the structured error as a value (to render it to
+`line:col`) call `verifyToDiagnosticModelsCapturing` instead.
 -/
 def verifyToVcResults (program : Program)
     (options : LaurelVerifyOptions := default)
@@ -242,14 +270,11 @@ def verifyToVcResults (program : Program)
 
   match coreProgramOption with
   | some coreProgram =>
-    let options := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
-    let runner tempDir :=
-      EIO.toIO (fun f => IO.Error.userError (toString f))
-          (_root_.Core.verify coreProgram tempDir .none options)
-    let ioResult ← match options.vcDirectory with
-      | .none => IO.FS.withTempDir runner
-      | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
-    return (some ioResult, translateDiags)
+    match ← runVerify coreProgram options with
+    | .ok ioResult => return (some ioResult, translateDiags)
+    -- Reconstruct the throwing path: stringify the structured error exactly as
+    -- the previous `EIO.toIO (fun f => .userError (toString f))` did.
+    | .error dm => throw (IO.userError (toString dm))
   | none => return (none, translateDiags)
 
 /--
@@ -291,21 +316,16 @@ def verifyToDiagnosticModels (program : Program) (options : LaurelVerifyOptions 
     byte offset that a stringified exception would leave in its message text.
     Production code keeps using the throwing `verifyTo*` functions above.
 
-    The verify call mirrors `verifyToVcResults` exactly, except it intercepts the
-    `EIO DiagnosticModel` error via `.toBaseIO` instead of stringifying it. -/
+    Shares the `runVerify` boundary with `verifyToVcResults`, differing only in
+    that it returns the captured `.error` as a value instead of re-throwing it —
+    so the two can't drift apart on verify options or temp-dir handling. -/
 def verifyToDiagnosticModelsCapturing (program : Program)
     (options : LaurelVerifyOptions := default) : IO (Array DiagnosticModel) := do
   let (coreProgramOption, translateDiags) ← translate options.translateOptions program
   match coreProgramOption with
   | none => return translateDiags.toArray
   | some coreProgram =>
-    let options := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
-    let runner tempDir : IO (Except DiagnosticModel VCResults) :=
-      (_root_.Core.verify coreProgram tempDir .none options).toBaseIO
-    let result ← match options.vcDirectory with
-      | .none => IO.FS.withTempDir runner
-      | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
-    match result with
+    match ← runVerify coreProgram options with
     | .error dm => return (translateDiags ++ [dm]).toArray
     | .ok results =>
       let phases := Core.coreAbstractedPhases

--- a/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
+++ b/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
@@ -232,8 +232,33 @@ def translate (options : LaurelTranslateOptions) (program : Program) : IO Transl
   let (core, diags, _, _) ← translateWithLaurel options program
   return (core, diags)
 
+/-- Run `Core.verify` on a translated Core program, returning the verify-phase
+    failure as a **structured** `DiagnosticModel` value (via `.toBaseIO`) rather
+    than throwing it.
+
+    `Core.verify : EIO DiagnosticModel VCResults` carries its error as a
+    `DiagnosticModel` (with byte-offset `fileRange`). Capturing it as an
+    `Except` here is the single point where that structure is preserved; callers
+    decide whether to re-throw it (production) or render it (tests). Mirrors the
+    pre-existing `removeIrrelevantAxioms := .Precise` and `vcDirectory` handling. -/
+private def runVerify (coreProgram : Core.Program) (options : LaurelVerifyOptions)
+    : IO (Except DiagnosticModel VCResults) := do
+  let verifyOptions := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
+  let runner tempDir : IO (Except DiagnosticModel VCResults) :=
+    (_root_.Core.verify coreProgram tempDir (proceduresToVerify := none) verifyOptions).toBaseIO
+  match verifyOptions.vcDirectory with
+  | .none => IO.FS.withTempDir runner
+  | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
+
 /--
 Verify a Laurel program using an SMT solver.
+
+A verify-phase failure (a type-checking / symbolic-evaluation error) is
+**thrown** as an `IO` exception, exactly as before file-relative reporting was
+introduced: the structured error is intercepted at the `runVerify` boundary and
+re-thrown via `toString`, so the CLI's control flow and exit codes are
+unchanged. Tests that need the structured error as a value (to render it to
+`line:col`) call `verifyToDiagnosticModelsCapturing` instead.
 -/
 def verifyToVcResults (program : Program)
     (options : LaurelVerifyOptions := default)
@@ -242,21 +267,11 @@ def verifyToVcResults (program : Program)
 
   match coreProgramOption with
   | some coreProgram =>
-    let options := { options.verifyOptions with removeIrrelevantAxioms := .Precise }
-    -- Preserve the structured `DiagnosticModel` error (it carries a `fileRange`)
-    -- via `.toBaseIO` instead of stringifying it. This lets a type-checking /
-    -- symbolic-evaluation error flow into `translateDiags`, where
-    -- `verifyToDiagnostics` renders it through a `FileMap` to snippet-local
-    -- `line:col` like every other diagnostic — rather than leaking a raw,
-    -- file-global byte offset baked into the message text.
-    let runner tempDir : IO (Except DiagnosticModel VCResults) :=
-      (_root_.Core.verify coreProgram tempDir .none options).toBaseIO
-    let result ← match options.vcDirectory with
-      | .none => IO.FS.withTempDir runner
-      | .some p => IO.FS.createDirAll ⟨p.toString⟩; runner ⟨p.toString⟩
-    match result with
+    match ← runVerify coreProgram options with
     | .ok ioResult => return (some ioResult, translateDiags)
-    | .error dm => return (none, translateDiags ++ [dm])
+    -- Reconstruct the throwing path: stringify the structured error exactly as
+    -- the previous `EIO.toIO (fun f => .userError (toString f))` did.
+    | .error dm => throw (IO.userError (toString dm))
   | none => return (none, translateDiags)
 
 /--
@@ -287,6 +302,28 @@ def verifyToDiagnosticModels (program : Program) (options : LaurelVerifyOptions 
   | none => []
   | some vcResults => vcResults.toList.filterMap (fun (vcr : VCResult) => toDiagnosticModel vcr phases)
   return (results.snd ++ vcDiags).toArray
+
+/-- Like `verifyToDiagnosticModels`, but a verify-phase failure is **captured**
+    as a structured `DiagnosticModel` (the same value `verifyToVcResults` would
+    have thrown) and returned in the list, rather than thrown.
+
+    This is the test-framework entry point: the structured error still carries
+    its byte-offset `fileRange`, so the caller can render it to snippet-local /
+    file-relative `line:col` like every other diagnostic — instead of the raw
+    byte offset that a stringified exception would leave in its message text.
+    Production code keeps using the throwing `verifyTo*` functions above. -/
+def verifyToDiagnosticModelsCapturing (program : Program)
+    (options : LaurelVerifyOptions := default) : IO (Array DiagnosticModel) := do
+  let (coreProgramOption, translateDiags) ← translate options.translateOptions program
+  match coreProgramOption with
+  | none => return translateDiags.toArray
+  | some coreProgram =>
+    match ← runVerify coreProgram options with
+    | .error dm => return (translateDiags ++ [dm]).toArray
+    | .ok results =>
+      let phases := Core.coreAbstractedPhases
+      let vcDiags := results.mergeByAssertion.toList.filterMap (toDiagnosticModel · phases)
+      return (translateDiags ++ vcDiags).toArray
 
 end -- public section
 end Laurel

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T22_ArityMismatch.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T22_ArityMismatch.lean
@@ -9,14 +9,19 @@ import StrataTest.Util.TestLaurel
 open StrataTest.Util
 open Strata
 
-/-! ## Function called with too many arguments -/
+/-! ## Function called with too many arguments
+
+`showLocations := true` prints each diagnostic's file-relative `file:line:col`
+(computed from the snippet's base line — no manual offsets), while the inline
+`// ^^^` annotation still asserts the error. The golden below thus *shows* the
+localization without catching a spurious "unexpected diagnostic". -/
 
 /--
-error: <#strata>(436-457) ❌ Type checking error.
+info: T22_ArityMismatch.lean:32:2  7:2-23  error: ❌ Type checking error.
 Impossible to unify int with (arrow int $__ty35).
 -/
 #guard_msgs in
-#eval testLaurel <|
+#eval testLaurel (showLocations := true) <|
 #strata
 program Laurel;
 function f(x: int): int { x };
@@ -25,6 +30,7 @@ procedure caller()
   opaque
 {
   var y: int := f(1, 2)
+//^^^^^^^^^^^^^^^^^^^^^ error: Impossible to unify int with (arrow int $__ty35).
 };
 #end
 

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T22_ArityMismatch.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T22_ArityMismatch.lean
@@ -11,17 +11,16 @@ open Strata
 
 /-! ## Function called with too many arguments
 
-`showLocations := true` prints each diagnostic's file-relative `file:line:col`
-(computed from the snippet's base line — no manual offsets), while the inline
+`testLaurel` prints each diagnostic's file-relative `line:col` range (computed
+from the snippet's base line — no manual offsets) by default, while the inline
 `// ^^^` annotation still asserts the error. The golden below thus *shows* the
 localization without catching a spurious "unexpected diagnostic". -/
 
 /--
-info: T22_ArityMismatch.lean:32:2  7:2-23  error: ❌ Type checking error.
-Impossible to unify int with (arrow int $__ty35).
+info: 31:16-23  error: call to 'f' expects 1 argument(s) but 2 were provided
 -/
 #guard_msgs in
-#eval testLaurel (showLocations := true) <|
+#eval testLaurel <|
 #strata
 program Laurel;
 function f(x: int): int { x };
@@ -30,7 +29,7 @@ procedure caller()
   opaque
 {
   var y: int := f(1, 2)
-//^^^^^^^^^^^^^^^^^^^^^ error: Impossible to unify int with (arrow int $__ty35).
+//              ^^^^^^^ error: call to 'f' expects 1 argument(s) but 2 were provided
 };
 #end
 

--- a/StrataTest/Languages/Laurel/Examples/Fundamentals/T8c_BodilessInlining.lean
+++ b/StrataTest/Languages/Laurel/Examples/Fundamentals/T8c_BodilessInlining.lean
@@ -17,7 +17,7 @@ body, so inlining would make everything after the call trivially provable.
 Now the body assumes the postconditions instead, so `assert false` after
 the inlined call is correctly rejected. -/
 
-#eval testLaurel (options := { translateOptions := { inlineFunctionsWhenPossible := true } }) <|
+#eval testLaurel (options := { verifyOptions := .quiet, translateOptions := { inlineFunctionsWhenPossible := true } }) <|
 #strata
 program Laurel;
 procedure bodilessProcedure() returns (r: int)

--- a/StrataTest/Util/TestLaurel.lean
+++ b/StrataTest/Util/TestLaurel.lean
@@ -28,23 +28,33 @@ def translateLaurel (program : StrataDDM.Program) : IO Laurel.Program := do
   | .ok laurelProgram => pure laurelProgram
 
 /-- Pretty-print a `Diagnostic` for error reporting, prefixed with its
-    **file-relative** `file:line:col` — anchored to the enclosing `.lean`
+    **file-relative** `line:col` range — anchored to the enclosing `.lean`
     source rather than the `#strata` snippet. A snippet line `L` is file line
     `block.baseLine + L - 1` (`baseLine` is the file line of the snippet's first
-    line); columns coincide. Only the file's *basename* is shown (like
-    `FileRange.format`), so the location is stable whether the file was opened
-    via a relative or absolute path — and thus safe to pin in a `#guard_msgs`
-    golden across machines.
-    Format: `<file>:<fileLine>:<col>  <line>:<colStart>-<colEnd>  <kind>: <message>` -/
-def formatDiagnostic (block : SourcedProgram) (d : Strata.Diagnostic) : String :=
-  let baseName := (System.FilePath.mk block.fileName).fileName.getD block.fileName
+    line); columns coincide. The filename is intentionally omitted: the Lean
+    test runner already reports which file a diagnostic came from, and dropping
+    it keeps `#guard_msgs` goldens stable regardless of how the file was opened.
+
+    With `showSnippet := true`, the snippet-relative `line:col` range is also
+    shown in parentheses — useful when correlating against inline `// ^^^`
+    annotations, which are snippet-local. It is off by default so goldens show
+    only the file-relative location.
+
+    Format: `<fileLine>:<colStart>-<colEnd>  <kind>: <message>`,
+    or with `showSnippet`:
+    `<fileLine>:<colStart>-<colEnd> (snippet <line>:<colStart>-<colEnd>)  <kind>: <message>` -/
+def formatDiagnostic (block : SourcedProgram) (d : Strata.Diagnostic)
+    (showSnippet : Bool := false) : String :=
   let kind := match d.type with
     | .Warning => "warning"
     | .UserError => "error"
     | .NotYetImplemented => "not-yet-implemented"
     | .StrataBug => "strata-bug"
-  s!"{baseName}:{block.baseLine + d.start.line - 1}:{d.start.column}  \
-    {d.start.line}:{d.start.column}-{d.ending.column}  {kind}: {d.message}"
+  let fileLine := block.baseLine + d.start.line - 1
+  let snippet := if showSnippet then
+      s!" (snippet {d.start.line}:{d.start.column}-{d.ending.column})"
+    else ""
+  s!"{fileLine}:{d.start.column}-{d.ending.column}{snippet}  {kind}: {d.message}"
 
 /-- Convert pipeline `DiagnosticModel`s (carrying file-global byte offsets in
     their `FileRange`) into `Diagnostic`s with snippet-local line/col, by
@@ -225,22 +235,22 @@ private def formatAnnotation (a : DiagnosticAnnotation) : String :=
       every annotation must fire. Throws on mismatch. -/
 private def runAndCheck (block : SourcedProgram)
     (run : StrataDDM.Program → IO (Array Strata.DiagnosticModel))
-    (showLocations : Bool := false) : IO Unit := do
+    (showSnippet : Bool := false) : IO Unit := do
   let annotations := parseAnnotations block.source
   let dms ← run block.program
   let actual := renderSnippetLocal block.basePos block.source dms
-  -- Echo each diagnostic's file-relative `file:line:col` (computed from the
-  -- snippet's `baseLine`, no manual offsets) so a `#guard_msgs` golden can
-  -- demonstrate the localization. The annotation matching below still runs, so
-  -- the test asserts correctness rather than just printing.
-  if showLocations then
-    for d in actual do
-      IO.println (formatDiagnostic block d)
+  -- Echo each diagnostic's file-relative `line:col` (computed from the snippet's
+  -- `baseLine`, no manual offsets) so the localization is always visible — and a
+  -- `#guard_msgs` golden can pin it. The annotation matching below still runs, so
+  -- the test asserts correctness rather than just printing. `showSnippet` adds
+  -- the snippet-relative range for correlating against inline `// ^^^` markers.
+  for d in actual do
+    IO.println (formatDiagnostic block d showSnippet)
   if annotations.isEmpty then
     unless actual.isEmpty do
       let mut report := s!"expected no diagnostics, got {actual.size}:\n"
       for d in actual do
-        report := report ++ s!"  {formatDiagnostic block d}\n"
+        report := report ++ s!"  {formatDiagnostic block d showSnippet}\n"
       throw <| IO.userError report
     return
   -- Pair up: every actual diagnostic must match exactly one annotation.
@@ -280,19 +290,24 @@ private def runAndCheck (block : SourcedProgram)
     solver). Pass an explicit value to override the solver, timeout, etc. — for
     example, `(options := { verifyOptions := { .quiet with solver := "z3" } })`.
 
-    Set `showLocations := true` to also print each diagnostic's file-relative
-    `file:line:col` (still asserting the inline annotations), so a `#guard_msgs`
-    golden can demonstrate the localization. -/
+    Each diagnostic's file-relative `line:col` range is always printed. Set
+    `showSnippet := true` to also append the snippet-relative range — useful for
+    correlating against the inline `// ^^^` annotations, which are
+    snippet-local. -/
 def testLaurel (block : SourcedProgram)
     (options : LaurelVerifyOptions := defaultLaurelTestOptions)
-    (showLocations : Bool := false) : IO Unit :=
-  runAndCheck block (runLaurelPipelineRaw · options) showLocations
+    (showSnippet : Bool := false) : IO Unit :=
+  runAndCheck block (runLaurelPipelineRaw · options) showSnippet
 
 /-- Like `testLaurel` but skips SMT verification (translate + resolve only).
     Use when the test only cares about resolution, not the verifier — e.g.
     "shadowing in nested blocks is OK", or asserting a specific resolution
-    error without the verifier surfacing unrelated noise. -/
-def testLaurelResolution (block : SourcedProgram) : IO Unit :=
-  runAndCheck block runLaurelResolutionRaw
+    error without the verifier surfacing unrelated noise.
+
+    As with `testLaurel`, each diagnostic's file-relative `line:col` range is
+    printed; `showSnippet := true` appends the snippet-relative range. -/
+def testLaurelResolution (block : SourcedProgram)
+    (showSnippet : Bool := false) : IO Unit :=
+  runAndCheck block runLaurelResolutionRaw showSnippet
 
 end StrataTest.Util

--- a/StrataTest/Util/TestLaurel.lean
+++ b/StrataTest/Util/TestLaurel.lean
@@ -93,7 +93,11 @@ private def runLaurelPipelineRaw (program : StrataDDM.Program)
   | .error e =>
     return #[Strata.DiagnosticModel.fromMessage s!"Translation error: {e}"]
   | .ok laurelProgram =>
-    Laurel.verifyToDiagnosticModels laurelProgram options
+    -- Use the *capturing* entry point: a verify-phase type/symbolic error comes
+    -- back as a structured `DiagnosticModel` (rather than thrown like the CLI),
+    -- so it flows through the same snippet-local `line:col` rendering as every
+    -- other diagnostic instead of leaking a raw byte offset in its message.
+    Laurel.verifyToDiagnosticModelsCapturing laurelProgram options
 
 /-! ## Inline-annotation matcher
 

--- a/StrataTest/Util/TestLaurel.lean
+++ b/StrataTest/Util/TestLaurel.lean
@@ -27,15 +27,24 @@ def translateLaurel (program : StrataDDM.Program) : IO Laurel.Program := do
   | .error e => throw (IO.userError s!"Translation errors: {e}")
   | .ok laurelProgram => pure laurelProgram
 
-/-- Pretty-print a `Diagnostic` for error reporting.
-    Format: `<line>:<colStart>-<colEnd>  <kind>: <message>` -/
-def formatDiagnostic (d : Strata.Diagnostic) : String :=
+/-- Pretty-print a `Diagnostic` for error reporting, prefixed with its
+    **file-relative** `file:line:col` — anchored to the enclosing `.lean`
+    source rather than the `#strata` snippet. A snippet line `L` is file line
+    `block.baseLine + L - 1` (`baseLine` is the file line of the snippet's first
+    line); columns coincide. Only the file's *basename* is shown (like
+    `FileRange.format`), so the location is stable whether the file was opened
+    via a relative or absolute path — and thus safe to pin in a `#guard_msgs`
+    golden across machines.
+    Format: `<file>:<fileLine>:<col>  <line>:<colStart>-<colEnd>  <kind>: <message>` -/
+def formatDiagnostic (block : SourcedProgram) (d : Strata.Diagnostic) : String :=
+  let baseName := (System.FilePath.mk block.fileName).fileName.getD block.fileName
   let kind := match d.type with
     | .Warning => "warning"
     | .UserError => "error"
     | .NotYetImplemented => "not-yet-implemented"
     | .StrataBug => "strata-bug"
-  s!"{d.start.line}:{d.start.column}-{d.ending.column}  {kind}: {d.message}"
+  s!"{baseName}:{block.baseLine + d.start.line - 1}:{d.start.column}  \
+    {d.start.line}:{d.start.column}-{d.ending.column}  {kind}: {d.message}"
 
 /-- Convert pipeline `DiagnosticModel`s (carrying file-global byte offsets in
     their `FileRange`) into `Diagnostic`s with snippet-local line/col, by
@@ -211,15 +220,23 @@ private def formatAnnotation (a : DiagnosticAnnotation) : String :=
     - Otherwise asserts an exact match: every diagnostic must be annotated,
       every annotation must fire. Throws on mismatch. -/
 private def runAndCheck (block : SourcedProgram)
-    (run : StrataDDM.Program → IO (Array Strata.DiagnosticModel)) : IO Unit := do
+    (run : StrataDDM.Program → IO (Array Strata.DiagnosticModel))
+    (showLocations : Bool := false) : IO Unit := do
   let annotations := parseAnnotations block.source
   let dms ← run block.program
   let actual := renderSnippetLocal block.basePos block.source dms
+  -- Echo each diagnostic's file-relative `file:line:col` (computed from the
+  -- snippet's `baseLine`, no manual offsets) so a `#guard_msgs` golden can
+  -- demonstrate the localization. The annotation matching below still runs, so
+  -- the test asserts correctness rather than just printing.
+  if showLocations then
+    for d in actual do
+      IO.println (formatDiagnostic block d)
   if annotations.isEmpty then
     unless actual.isEmpty do
       let mut report := s!"expected no diagnostics, got {actual.size}:\n"
       for d in actual do
-        report := report ++ s!"  {formatDiagnostic d}\n"
+        report := report ++ s!"  {formatDiagnostic block d}\n"
       throw <| IO.userError report
     return
   -- Pair up: every actual diagnostic must match exactly one annotation.
@@ -248,7 +265,7 @@ private def runAndCheck (block : SourcedProgram)
   if !unmatchedDiags.isEmpty then
     report := report ++ s!"\nActual diagnostics with no matching annotation:\n"
     for d in unmatchedDiags do
-      report := report ++ s!"  {formatDiagnostic d}\n"
+      report := report ++ s!"  {formatDiagnostic block d}\n"
   throw <| IO.userError report
 
 /-- Run the full Laurel pipeline (translate + resolve + verify) on a
@@ -257,10 +274,15 @@ private def runAndCheck (block : SourcedProgram)
 
     `options` defaults to `defaultLaurelTestOptions` (quiet verifier, default
     solver). Pass an explicit value to override the solver, timeout, etc. — for
-    example, `(options := { verifyOptions := { .quiet with solver := "z3" } })`. -/
+    example, `(options := { verifyOptions := { .quiet with solver := "z3" } })`.
+
+    Set `showLocations := true` to also print each diagnostic's file-relative
+    `file:line:col` (still asserting the inline annotations), so a `#guard_msgs`
+    golden can demonstrate the localization. -/
 def testLaurel (block : SourcedProgram)
-    (options : LaurelVerifyOptions := defaultLaurelTestOptions) : IO Unit :=
-  runAndCheck block (runLaurelPipelineRaw · options)
+    (options : LaurelVerifyOptions := defaultLaurelTestOptions)
+    (showLocations : Bool := false) : IO Unit :=
+  runAndCheck block (runLaurelPipelineRaw · options) showLocations
 
 /-- Like `testLaurel` but skips SMT verification (translate + resolve only).
     Use when the test only cares about resolution, not the verifier — e.g.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -88,6 +88,18 @@ the message and the test stays robust as messages are reworded.
 
 `kind` is one of `error`, `warning`, `not-yet-implemented`, `strata-bug`.
 
+#### Reported locations
+
+Each diagnostic is printed as `<fileLine>:<colStart>-<colEnd>  <kind>: <message>`,
+where `fileLine` is the line in the enclosing `.lean` file (computed from the
+snippet's base line — no manual offsets). The filename is omitted: the Lean
+test runner already reports which file a diagnostic came from. This line is
+always printed; pin it with `#guard_msgs` when you want to assert the
+localization itself. Pass `showSnippet := true` to also append the
+snippet-relative range — `… (snippet <line>:<colStart>-<colEnd>)` — which is
+handy when correlating against the inline `// ^^^` annotations (those are
+snippet-local, so their `line` differs from the file line).
+
 ### 3. Resolution-only tests — skip the verifier
 
 When the test is about resolution (kind mismatches, duplicate names, scope


### PR DESCRIPTION
The last testing framework update regressed the error reporting to be tested-snippet-relative, but that is inconvenient. So whenever we flag an error now, it is relative to the entire file (easier to jump to)