### PR TITLE
Laurel: field-granular modifies frame

### DIFF
--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.lean
@@ -8,7 +8,7 @@ module
 -- Laurel dialect definition, loaded from LaurelGrammar.st
 -- NOTE: Changes to LaurelGrammar.st are not automatically tracked by the build system.
 -- Update this file (e.g. this comment) to trigger a recompile after modifying LaurelGrammar.st.
--- Last grammar change: fieldAccess prec raised 90 -> 95 (paren-free `c#n++`); shares prec(95) with `call`.
+-- Last grammar change: modifiesClause refs parsed at prec 0 so `modifies o#f` (field target) parses.
 public import StrataDDM.AST
 import StrataDDM.BuiltinDialects.Init
 import StrataDDM.Integration.Lean.HashCommands

--- a/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
+++ b/Strata/Languages/Laurel/Grammar/LaurelGrammar.st
@@ -186,7 +186,7 @@ category EnsuresClause;
 op ensuresClause(cond: StmtExpr, errorMessage: Option ErrorSummary): EnsuresClause => "\n  ensures " cond:0 errorMessage;
 
 category ModifiesClause;
-op modifiesClause(refs: CommaSepBy StmtExpr): ModifiesClause => "\n  modifies " refs;
+op modifiesClause(refs: CommaSepBy StmtExpr): ModifiesClause => "\n  modifies " refs:0;
 op modifiesWildcard: ModifiesClause => "\n  modifies *";
 
 category ReturnParameters;

--- a/Strata/Languages/Laurel/HeapParameterization.lean
+++ b/Strata/Languages/Laurel/HeapParameterization.lean
@@ -475,6 +475,16 @@ where
       simp_all
       omega)
 
+/-- Heap-transform a modifies entry. A field target `o#f` is kept symbolic
+(only its owner is lowered) so the modifies pass can match it structurally. -/
+def heapTransformModifiesEntry (heapName : Identifier) (model : SemanticModel)
+    (entry : StmtExprMd) : TransformM StmtExprMd := do
+  match entry.val with
+  | .Var (.Field target fieldName) =>
+      let target' ← heapTransformExpr heapName model target
+      return { entry with val := .Var (.Field target' fieldName) }
+  | _ => heapTransformExpr heapName model entry
+
 def heapTransformProcedure (model: SemanticModel) (proc : Procedure) : TransformM Procedure := do
   let heapName := heapVarName
   let readsHeap := (← get).heapReaders.contains proc.name
@@ -503,7 +513,7 @@ def heapTransformProcedure (model: SemanticModel) (proc : Procedure) : Transform
                 let implExpr' ← heapTransformExpr heapName model implExpr bodyValueIsUsed
                 pure (some implExpr')
             | none => pure none
-          let modif' ← modif.mapM (heapTransformExpr heapName model ·)
+          let modif' ← modif.mapM (heapTransformModifiesEntry heapName model ·)
           pure (.Opaque postconds' impl' modif')
       | .Abstract postconds =>
           let postconds' ← postconds.mapM (·.mapM (heapTransformExpr heapName model))
@@ -532,7 +542,7 @@ def heapTransformProcedure (model: SemanticModel) (proc : Procedure) : Transform
       | .Opaque postconds impl modif =>
           let postconds' ← postconds.mapM (·.mapM (heapTransformExpr heapName model))
           let impl' ← impl.mapM (heapTransformExpr heapName model ·)
-          let modif' ← modif.mapM (heapTransformExpr heapName model ·)
+          let modif' ← modif.mapM (heapTransformModifiesEntry heapName model ·)
           pure (.Opaque postconds' impl' modif')
       | .Abstract postconds =>
           let postconds' ← postconds.mapM (·.mapM (heapTransformExpr heapName model))

--- a/Strata/Languages/Laurel/LaurelAST.lean
+++ b/Strata/Languages/Laurel/LaurelAST.lean
@@ -265,10 +265,23 @@ or abstract (requiring overriding in extending types).
 inductive Body where
   /-- A transparent body whose implementation is visible to callers. -/
   | Transparent (body : AstNode StmtExpr)
-  /-- An opaque body with a postcondition, optional implementation, and modifies clause. Without an implementation the postcondition is assumed. -/
+  /-- An opaque body with a postcondition, optional implementation, and modifies clause. Without an implementation the postcondition is assumed.
+
+      Each `modifies` entry lists state the procedure may change; everything else
+      on the heap is preserved. The legal forms, recognized by the downstream
+      `ModifiesClauses` pass, are:
+      - `modifies o` — a single object reference; any field of `o` may change.
+      - `modifies s` — an object set; any field of any member of `s` may change.
+      - `modifies o#f` — a single field of a single object; only field `f` of `o`
+        may change (field-granular).
+      - `modifies *` — the wildcard (`StmtExpr.All`); the procedure may change anything.
+
+      A 'field of an object set' (e.g. `s#f`) is intentionally not yet supported:
+      Laurel cannot yet construct set values, so there is no way to test it. -/
   | Opaque
       (postconditions : List Condition)
       (implementation : Option (AstNode StmtExpr))
+      -- See the constructor doc above for the allowed `modifies` forms.
       (modifies : List (AstNode StmtExpr))
       -- TODO: add back non-determinism together with an implementation
       -- deterministic : Bool

--- a/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
+++ b/Strata/Languages/Laurel/LaurelCompilationPipeline.lean
@@ -102,7 +102,6 @@ def laurelPipeline : Array LoweringPass := #[
   eliminateIncrDecrPass,
   typeAliasElimPass,
   constrainedTypeElimPass,
-  filterNonCompositeModifiesPass,
   mergeAndLiftReturnsPass,
   liftInstanceProceduresPass,
   eliminateValueInReturnsPass,

--- a/Strata/Languages/Laurel/ModifiesClauses.lean
+++ b/Strata/Languages/Laurel/ModifiesClauses.lean
@@ -56,25 +56,6 @@ inductive ModifiesEntry where
   | field (objExpr : StmtExprMd) (fieldConst : StmtExprMd)
 
 /--
-Recognize a heap-parameterized field read `readField($heap, obj, fieldConst)`
-(optionally under one Box destructor), as emitted for a field target like `o#f`.
-`fieldConst` is the per-declaring-type `Field` constructor (`A.x` ≠ `B.x`), the
-same one `readField` uses — so the soundness gate holds by construction.
--/
-def matchModifiesFieldRead (e : StmtExpr) : Option (StmtExprMd × StmtExprMd) :=
-  let tryReadField : StmtExpr → Option (StmtExprMd × StmtExprMd) := fun
-    | .StaticCall callee [_heap, objExpr, fieldConst] =>
-        if callee.text == "readField" then some (objExpr, fieldConst) else none
-    | _ => none
-  match tryReadField e with
-  | some r => some r
-  | none =>
-    -- Unwrap one Box destructor; gate on `Box` so unrelated unary calls aren't matched.
-    match e with
-    | .StaticCall callee [arg] => if callee.text.startsWith "Box" then tryReadField arg.val else none
-    | _ => none
-
-/--
 Classify a heap-relevant type into a `ModifiesEntry`, or `none` for
 non-heap-relevant types. Delegates to `classifyModifiesHighType` for the
 type classification.
@@ -85,20 +66,22 @@ def classifyModifiesType (expr : StmtExprMd) (ty : HighType) : Option ModifiesEn
   | some .compositeSet => some (.set expr)
   | none               => none
 
-/--
-Extract modifies entries. A field-access target (lowered to a `readField`)
-yields a field-granular entry; otherwise it is classified by type. Non-composite
-types (e.g. primitive globals) are filtered out — the frame applies to heap objects.
--/
+/-- Extract modifies entries: a field target `o#f` (kept symbolic by heap
+parameterization) becomes a field-granular entry; other entries are classified
+by type. Non-heap-relevant entries are dropped during resolution. -/
 def extractModifiesEntries (model: SemanticModel)
     (modifiesExprs : List StmtExprMd) : List ModifiesEntry :=
   modifiesExprs.filterMap fun expr =>
-    -- Soundness: a `.field` entry is only built for a field read of a heap object.
-    -- Targets with a non-composite owner are dropped upstream by
-    -- filterBodyNonCompositeModifies before heap parameterization.
-    match matchModifiesFieldRead expr.val with
-    | some (objExpr, fieldConst) => some (.field objExpr fieldConst)
-    | none => classifyModifiesType expr (computeExprType model expr).val
+    match expr.val with
+    -- Field target `o#f`. Soundness: targets with a non-composite owner are
+    -- dropped (with a diagnostic) upstream by `filterBodyNonCompositeModifies`
+    -- before heap parameterization, so every field target reaching here owns a
+    -- heap object. A field whose name fails to resolve (already diagnosed by
+    -- the resolution pass) yields `none` and is dropped.
+    | .Var (.Field objExpr fieldName) =>
+      (resolveQualifiedFieldName model fieldName).map fun qualifiedName =>
+        .field objExpr (mkMd <| .StaticCall qualifiedName [])
+    | _ => classifyModifiesType expr (computeExprType model expr).val
 /--
 Build the "obj is not modified" condition for a single modifies entry as a Laurel StmtExpr.
 - For a single Composite `e`: `$obj != e`

--- a/Strata/Languages/Laurel/ModifiesClauses.lean
+++ b/Strata/Languages/Laurel/ModifiesClauses.lean
@@ -24,15 +24,19 @@ This pass should run after heap parameterization, which has already:
 - Transformed field accesses to readField/updateField calls
 - Collected field constants
 
-The frame condition states: for every object not mentioned in the modifies clause,
-all field values are preserved between the input and output heaps.
+The frame condition is field-granular: each allocated (object, field) pair not
+named in the modifies clause is preserved across the call. A clause may name a
+whole object (all its fields may change) or a single field `o#f` (only that
+field of `o` may change).
 
 Generates:
   forall $obj: Composite, $fld: Field =>
-    $obj < old($heap).nextReference && notModified($obj) ==> readField(old($heap), $obj, $fld) == readField($heap, $obj, $fld)
+    $obj < old($heap).nextReference && notModified($obj, $fld) ==> readField(old($heap), $obj, $fld) == readField($heap, $obj, $fld)
 
-where `notModified($obj)` is the conjunction of `$obj != e` for each single entry `e`,
-and `!(select(s, $obj))` for each set entry `s`.
+where notModified($obj, $fld) conjoins, per entry:
+- `$obj != e`                 single object `e`
+- `!(select(s, $obj))`        Set `s`
+- `!($obj == o && $fld == f)` field `(o, f)`
 -/
 
 namespace Strata.Laurel
@@ -42,12 +46,33 @@ public section
 private def mkMd (e : StmtExpr) : StmtExprMd := { val := e, source := none }
 
 /--
-A single entry in a modifies clause, either a single Composite expression
-or a Set of Composite expressions.
+A single entry in a modifies clause: a single Composite expression, a Set of
+Composite expressions, or a single `(object, field)` pair (field-granular).
 -/
 inductive ModifiesEntry where
   | single (expr : StmtExprMd)       -- a single Composite reference
   | set (expr : StmtExprMd)          -- a Set Composite expression
+  -- field-granular: only `fieldConst` of `objExpr` may change
+  | field (objExpr : StmtExprMd) (fieldConst : StmtExprMd)
+
+/--
+Recognize a heap-parameterized field read `readField($heap, obj, fieldConst)`
+(optionally under one Box destructor), as emitted for a field target like `o#f`.
+`fieldConst` is the per-declaring-type `Field` constructor (`A.x` ≠ `B.x`), the
+same one `readField` uses — so the soundness gate holds by construction.
+-/
+def matchModifiesFieldRead (e : StmtExpr) : Option (StmtExprMd × StmtExprMd) :=
+  let tryReadField : StmtExpr → Option (StmtExprMd × StmtExprMd) := fun
+    | .StaticCall callee [_heap, objExpr, fieldConst] =>
+        if callee.text == "readField" then some (objExpr, fieldConst) else none
+    | _ => none
+  match tryReadField e with
+  | some r => some r
+  | none =>
+    -- Unwrap one Box destructor; gate on `Box` so unrelated unary calls aren't matched.
+    match e with
+    | .StaticCall callee [arg] => if callee.text.startsWith "Box" then tryReadField arg.val else none
+    | _ => none
 
 /--
 Classify a heap-relevant type into a `ModifiesEntry`, or `none` for
@@ -61,27 +86,38 @@ def classifyModifiesType (expr : StmtExprMd) (ty : HighType) : Option ModifiesEn
   | none               => none
 
 /--
-Extract modifies entries from the list of modifies StmtExprs, using the type
-environment and type definitions to distinguish Composite from Set Composite.
-Non-composite types (e.g., global variables of primitive type) are filtered out
-since the frame condition only applies to heap objects.
+Extract modifies entries. A field-access target (lowered to a `readField`)
+yields a field-granular entry; otherwise it is classified by type. Non-composite
+types (e.g. primitive globals) are filtered out — the frame applies to heap objects.
 -/
 def extractModifiesEntries (model: SemanticModel)
     (modifiesExprs : List StmtExprMd) : List ModifiesEntry :=
   modifiesExprs.filterMap fun expr =>
-    classifyModifiesType expr (computeExprType model expr).val
+    -- Soundness: a `.field` entry is only built for a field read of a heap object.
+    -- Targets with a non-composite owner are dropped upstream by
+    -- filterBodyNonCompositeModifies before heap parameterization.
+    match matchModifiesFieldRead expr.val with
+    | some (objExpr, fieldConst) => some (.field objExpr fieldConst)
+    | none => classifyModifiesType expr (computeExprType model expr).val
 /--
 Build the "obj is not modified" condition for a single modifies entry as a Laurel StmtExpr.
 - For a single Composite `e`: `$obj != e`
 - For a Set Composite `e`: `!(select(e, $obj))` i.e. $obj is not in the set
+- For a field `(o, f)`: `!($obj == o && $fld == f)` i.e. the quantified
+  `($obj, $fld)` pair is not the modified `(object, field)` pair (field-granular)
 -/
-def buildNotModifiedForEntry (obj : StmtExprMd) (entry : ModifiesEntry) : StmtExprMd :=
+def buildNotModifiedForEntry (obj : StmtExprMd) (fld : StmtExprMd) (entry : ModifiesEntry) : StmtExprMd :=
   match entry with
   | .single expr =>
     mkMd <| .PrimitiveOp .Neq [obj, expr]
   | .set expr =>
     let membership := mkMd <| .StaticCall "select" [expr, obj]
     mkMd <| .PrimitiveOp .Not [membership]
+  | .field objExpr fieldConst =>
+    let objEq := mkMd <| .PrimitiveOp .Eq [obj, objExpr]
+    let fldEq := mkMd <| .PrimitiveOp .Eq [fld, fieldConst]
+    let bothMatch := mkMd <| .PrimitiveOp .And [objEq, fldEq]
+    mkMd <| .PrimitiveOp .Not [bothMatch]
 
 /-- Conjoin a list of StmtExprs with `&&`. -/
 def conjoinAll (exprs : List StmtExprMd) : StmtExprMd :=
@@ -96,7 +132,7 @@ Build the modifies frame condition as a Laurel StmtExpr.
 Generates a single quantified formula:
 
   forall $obj: Composite, $fld: Field =>
-    notModified($obj) && $obj < old($heap).nextReference ==> readField(old($heap), $obj, $fld) == readField($heap, $obj, $fld)
+    notModified($obj, $fld) && $obj < old($heap).nextReference ==> readField(old($heap), $obj, $fld) == readField($heap, $obj, $fld)
 
 Returns `none` if there are no entries.
 -/
@@ -118,7 +154,7 @@ def buildModifiesEnsures (proc: Procedure) (model: SemanticModel) (modifiesExprs
     else
       -- Build the "not modified" precondition from all entries
       -- Combine: $obj < old($heap).nextReference && notModified($obj)
-      let notModified := conjoinAll (entries.map (buildNotModifiedForEntry obj))
+      let notModified := conjoinAll (entries.map (buildNotModifiedForEntry obj fld))
       mkMd <| .PrimitiveOp .And [objAllocated, notModified]
   -- Build: readField(old($heap), $obj, $fld) == readField($heap, $obj, $fld)
   let readIn := mkMd <| .StaticCall "readField" [heapIn, obj, fld]
@@ -184,6 +220,12 @@ def filterBodyNonCompositeModifies (model : SemanticModel) (body : Body)
     let (kept, diags) := mods.foldl (fun (acc, ds) e =>
       match e.val with
       | .All => (acc ++ [e], ds)  -- wildcard is always kept
+      | .Var (.Field target _) =>
+        -- Field target `o#f`: keep when the owner is a heap object (the field's own type is irrelevant).
+        let ownerTy := (computeExprType model target).val
+        if isHeapRelevantType ownerTy then (acc ++ [e], ds)
+        else
+          (acc, ds ++ [diagnosticFromSource e.source s!"modifies clause field target has non-composite owner type '{formatHighTypeVal ownerTy}' and will be ignored"])
       | _ =>
         let ty := (computeExprType model e).val
         if isHeapRelevantType ty then (acc ++ [e], ds)

--- a/Strata/Languages/Laurel/ModifiesClauses.lean
+++ b/Strata/Languages/Laurel/ModifiesClauses.lean
@@ -218,19 +218,20 @@ def filterBodyNonCompositeModifies (model : SemanticModel) (body : Body)
   match body with
   | .Opaque posts impl mods =>
     let (kept, diags) := mods.foldl (fun (acc, ds) e =>
+      -- Shared rejection: drop the entry and emit the "non-composite type" diagnostic.
+      let reject := fun (ty : HighType) (kind : String) =>
+        (acc, ds ++ [diagnosticFromSource e.source s!"modifies clause {kind} has non-composite type '{formatHighTypeVal ty}' and will be ignored"])
       match e.val with
       | .All => (acc ++ [e], ds)  -- wildcard is always kept
       | .Var (.Field target _) =>
         -- Field target `o#f`: keep when the owner is a heap object (the field's own type is irrelevant).
         let ownerTy := (computeExprType model target).val
         if isHeapRelevantType ownerTy then (acc ++ [e], ds)
-        else
-          (acc, ds ++ [diagnosticFromSource e.source s!"modifies clause field target has non-composite owner type '{formatHighTypeVal ownerTy}' and will be ignored"])
+        else reject ownerTy "field target"
       | _ =>
         let ty := (computeExprType model e).val
         if isHeapRelevantType ty then (acc ++ [e], ds)
-        else
-          (acc, ds ++ [diagnosticFromSource e.source s!"modifies clause entry has non-composite type '{formatHighTypeVal ty}' and will be ignored"])
+        else reject ty "entry"
     ) ([], [])
     (.Opaque posts impl kept, diags)
   | other => (other, [])

--- a/Strata/Languages/Laurel/ModifiesClauses.lean
+++ b/Strata/Languages/Laurel/ModifiesClauses.lean
@@ -73,11 +73,8 @@ def extractModifiesEntries (model: SemanticModel)
     (modifiesExprs : List StmtExprMd) : List ModifiesEntry :=
   modifiesExprs.filterMap fun expr =>
     match expr.val with
-    -- Field target `o#f`. Soundness: targets with a non-composite owner are
-    -- dropped (with a diagnostic) upstream by `filterBodyNonCompositeModifies`
-    -- before heap parameterization, so every field target reaching here owns a
-    -- heap object. A field whose name fails to resolve (already diagnosed by
-    -- the resolution pass) yields `none` and is dropped.
+    -- Field target `o#f`: non-composite owners are already dropped during
+    -- resolution, so any field target reaching here owns a heap object.
     | .Var (.Field objExpr fieldName) =>
       (resolveQualifiedFieldName model fieldName).map fun qualifiedName =>
         .field objExpr (mkMd <| .StaticCall qualifiedName [])
@@ -191,58 +188,6 @@ def transformModifiesClauses (model: SemanticModel)
   | _ => .ok proc
 
 /--
-Filter non-composite modifies entries from a procedure body, collecting diagnostics
-for each filtered entry. This pre-pass ensures that global variables of primitive type
-do not incorrectly trigger heap parameterization.
-Should run before heap parameterization.
--/
-def filterBodyNonCompositeModifies (model : SemanticModel) (body : Body)
-    : Body × List DiagnosticModel :=
-  match body with
-  | .Opaque posts impl mods =>
-    let (kept, diags) := mods.foldl (fun (acc, ds) e =>
-      -- Shared rejection: drop the entry and emit the "non-composite type" diagnostic.
-      let reject := fun (ty : HighType) (kind : String) =>
-        (acc, ds ++ [diagnosticFromSource e.source s!"modifies clause {kind} has non-composite type '{formatHighTypeVal ty}' and will be ignored"])
-      match e.val with
-      | .All => (acc ++ [e], ds)  -- wildcard is always kept
-      | .Var (.Field target _) =>
-        -- Field target `o#f`: keep when the owner is a heap object (the field's own type is irrelevant).
-        let ownerTy := (computeExprType model target).val
-        if isHeapRelevantType ownerTy then (acc ++ [e], ds)
-        else reject ownerTy "field target"
-      | _ =>
-        let ty := (computeExprType model e).val
-        if isHeapRelevantType ty then (acc ++ [e], ds)
-        else reject ty "entry"
-    ) ([], [])
-    (.Opaque posts impl kept, diags)
-  | other => (other, [])
-
-/--
-Filter non-composite modifies entries from all procedures in a program,
-collecting diagnostics. Should run before heap parameterization so that
-the heap parameterization phase remains agnostic to modifies clauses.
--/
-def filterNonCompositeModifies (model : SemanticModel) (program : Program)
-    : Program × List DiagnosticModel :=
-  let (staticProcs, staticDiags) := program.staticProcedures.foldl (fun (ps, ds) proc =>
-    let (body', bodyDiags) := filterBodyNonCompositeModifies model proc.body
-    (ps ++ [{ proc with body := body' }], ds ++ bodyDiags)
-  ) ([], [])
-  let (types', typeDiags) := program.types.foldl (fun (ts, ds) td =>
-    match td with
-    | .Composite ct =>
-      let (instProcs, instDiags) := ct.instanceProcedures.foldl (fun (ps, ds) proc =>
-        let (body', bodyDiags) := filterBodyNonCompositeModifies model proc.body
-        (ps ++ [{ proc with body := body' }], ds ++ bodyDiags)
-      ) ([], [])
-      (ts ++ [.Composite { ct with instanceProcedures := instProcs }], ds ++ instDiags)
-    | other => (ts ++ [other], ds)
-  ) ([], [])
-  ({ program with staticProcedures := staticProcs, types := types' }, staticDiags ++ typeDiags)
-
-/--
 Transform a Laurel program: apply modifies clause transformation to all procedures.
 This is a Laurel → Laurel pass that should run after heap parameterization.
 
@@ -258,14 +203,6 @@ def modifiesClausesTransform (model: SemanticModel) (program : Program) : Progra
   ({ program with staticProcedures := procs' }, errors)
 
 end -- public section
-
-/-- Pipeline pass: filter non-composite modifies clauses. -/
-public def filterNonCompositeModifiesPass : LoweringPass where
-  name := "FilterNonCompositeModifies"
-  documentation := "Filters modifies clauses that refer to non-composite types (e.g. primitives), which cannot be heap-parameterized. Emits a warning for each removed clause. Should run before heap parameterization so that phase remains agnostic to modifies clauses."
-  run := fun p m _ =>
-    let (p', diags) := filterNonCompositeModifies m p
-    (p', diags, {})
 
 /-- Pipeline pass: translate modifies clauses into ensures clauses. -/
 public def modifiesClausesTransformPass : LoweringPass where

--- a/Strata/Languages/Laurel/Resolution.lean
+++ b/Strata/Languages/Laurel/Resolution.lean
@@ -2559,6 +2559,51 @@ open Resolution
 private def resolveStmtExpr (e : StmtExprMd) : ResolveM StmtExprMd := do
   let (e', _) ← Synth.resolveStmtExpr e; pure e'
 
+/-- Resolve a single modifies-clause entry, dropping it (with a diagnostic) when
+    its type is not heap-relevant — the frame only applies to heap objects. For a
+    field target `o#f` the *owner* must be heap-relevant; `*` (`.All`) is always
+    kept. The type is unfolded through the `TypeLattice` so aliases/constrained
+    types are classified by their underlying type. Replaces the former
+    `FilterNonCompositeModifies` pass. -/
+private def resolveModifiesEntry (e : StmtExprMd) : ResolveM (Option StmtExprMd) := do
+  let ctx := (← get).typeLattice
+  match e.val with
+  | .All =>
+    -- `modifies *` wildcard: kept regardless of type.
+    let e' ← resolveStmtExpr e
+    return some e'
+  | .Var (.Field target fieldName) =>
+    -- Resolve the owner directly (as `Synth.varField` does) to gate on its type.
+    let (target', ownerTy) ← Synth.resolveStmtExpr target
+    let fieldName' ← resolveFieldRef target' fieldName e.source
+    let e' : StmtExprMd := { val := .Var (.Field target' fieldName'), source := e.source }
+    let ownerTy' := (ctx.unfold ownerTy).val
+    if isHeapRelevantType ownerTy' then
+      return some e'
+    else
+      let diag := diagnosticFromSource e.source
+        s!"modifies clause field target has non-composite owner type \
+           '{formatHighTypeVal ownerTy'}' and will be ignored"
+      modify fun s => { s with errors := s.errors.push diag }
+      return none
+  | _ =>
+    let (e', ty) ← Synth.resolveStmtExpr e
+    let ty' := (ctx.unfold ty).val
+    if isHeapRelevantType ty' then
+      return some e'
+    else
+      let diag := diagnosticFromSource e.source
+        s!"modifies clause entry has non-composite type \
+           '{formatHighTypeVal ty'}' and will be ignored"
+      modify fun s => { s with errors := s.errors.push diag }
+      return none
+
+/-- Resolve the modifies entries of an `Opaque` body, dropping the
+    non-heap-relevant ones via `resolveModifiesEntry`. -/
+private def resolveModifies (mods : List StmtExprMd) : ResolveM (List StmtExprMd) := do
+  let resolved ← mods.mapM resolveModifiesEntry
+  return resolved.filterMap id
+
 /-- Resolve a parameter: assign a fresh ID and add to scope. -/
 def resolveParameter (param : Parameter) : ResolveM Parameter := do
   let ty' ← resolveHighType param.type
@@ -2590,7 +2635,7 @@ def resolveBody (body : Body) : ResolveM Body := do
   | .Opaque posts impl mods =>
     let posts' ← posts.mapM (·.mapM resolveStmtExpr)
     let impl' ← impl.mapM Synth.resolveStmtExpr
-    let mods' ← mods.mapM resolveStmtExpr
+    let mods' ← resolveModifies mods
     return .Opaque posts' (impl'.map (fun t => t.1)) mods'
   | .Abstract posts =>
     let posts' ← posts.mapM (·.mapM resolveStmtExpr)

--- a/StrataTest/Languages/Laurel/Examples/Objects/T2_ModifiesClauses.lean
+++ b/StrataTest/Languages/Laurel/Examples/Objects/T2_ModifiesClauses.lean
@@ -154,3 +154,301 @@ procedure modifiesWildcardAndSpecificCaller()
 //^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
 };
 #end
+
+/-
+Field-granular modifies clauses (issue #1402).
+
+A `modifies o#f` clause frames only the `(o, f)` pair: every *other* field of `o`
+(and every other object) is preserved across the call, while `o#f` may change.
+This is strictly more precise than the object-granular `modifies o`.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Account {
+  var balance: int
+  var count: int
+}
+
+// Opaque stub framing only `self#balance`. Its body writes *only* balance, so it
+// must satisfy its own field-granular frame (callee-side enforcement).
+procedure deposit(self: Account, amount: int) returns (r: bool)
+  opaque
+  modifies self#balance
+{
+  self#balance := self#balance + amount;
+  true
+};
+
+procedure fieldGranularCaller()
+  opaque
+{
+  var a: Account := new Account;
+  var b: Account := new Account;
+  var oldCount: int := a#count;
+  var oldBalance: int := a#balance;
+  var oldBCount: int := b#count;
+  var oldBBalance: int := b#balance;
+  var ok: bool := deposit(a, 100);
+  // Field-granular precision: the unmodified field of the modified object is preserved.
+  assert a#count == oldCount;
+  // Sibling object is fully preserved (object-granular frame already gave this).
+  assert b#count == oldBCount;
+  assert b#balance == oldBBalance;
+  // The modified field may change -> not provable. This negative control proves
+  // the frame is NOT vacuous: it does not silently preserve everything.
+  assert a#balance == oldBalance
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end
+
+/-
+Callee-side enforcement: a body that writes a field OUTSIDE its field-granular
+modifies clause must fail to verify. Here `modifies self#balance` is declared
+but the body also writes `self#count`, which is not framed.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Account2 {
+  var balance: int
+  var count: int
+}
+
+procedure overreachingDeposit(self: Account2, amount: int) returns (r: bool)
+//        ^^^^^^^^^^^^^^^^^^^ error: modifies clause could not be proved
+  opaque
+  modifies self#balance
+{
+  self#balance := self#balance + amount;
+  self#count := self#count + 1;
+  true
+};
+#end
+
+/-
+SOUNDNESS GATE (issue #1402): cross-type shared field name.
+
+Cross-type field names: `Box1.x` and `Box2.x` are distinct constants, so framing
+`b1#x` must not leak to `b2#x`. The three sibling asserts hold; modified `b1#x` is UNKNOWN.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Box1 {
+  var x: int
+  var y: int
+}
+composite Box2 {
+  var x: int
+  var y: int
+}
+
+procedure bumpBox1X(self: Box1) returns (r: bool)
+  opaque
+  modifies self#x
+{
+  self#x := self#x + 1;
+  true
+};
+
+procedure crossTypeCaller()
+  opaque
+{
+  var b1: Box1 := new Box1;
+  var b2: Box2 := new Box2;
+  var oldB1x: int := b1#x;
+  var oldB1y: int := b1#y;
+  var oldB2x: int := b2#x;
+  var oldB2y: int := b2#y;
+  var ok: bool := bumpBox1X(b1);
+  // Same object, other field: preserved (field granularity).
+  assert b1#y == oldB1y;
+  // Different type, SAME field name `x`: must be preserved (no cross-type leak).
+  assert b2#x == oldB2x;
+  // Different type, other field: preserved.
+  assert b2#y == oldB2y;
+  // Non-vacuity control: modified `b1#x` -> UNKNOWN.
+  assert b1#x == oldB1x
+//^^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end
+
+/-
+Vacuity trap: a BODILESS opaque stub must still emit its field frame. The mixed
+PROVED/UNKNOWN outcome proves the frame is emitted and non-vacuous with no body.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite AccountA {
+  var balance: int
+  var count: int
+}
+
+// Bodiless opaque stub: frames only `self#balance`, no implementation.
+procedure depositStub(self: AccountA)
+  opaque
+  modifies self#balance;
+
+procedure vacuityTrapCaller()
+  opaque
+{
+  var a: AccountA := new AccountA;
+  var b: AccountA := new AccountA;
+  var oldCount: int := a#count;
+  var oldBalance: int := a#balance;
+  var oldBCount: int := b#count;
+  depositStub(a);
+  // Unmodified field of the receiver: preserved (field granularity).
+  assert a#count == oldCount;
+  // Sibling object's field: preserved.
+  assert b#count == oldBCount;
+  // The MODIFIED field may change -> UNKNOWN (non-vacuity).
+  assert a#balance == oldBalance
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end
+
+/-
+Multi-field: `modifies self#x, self#y` frames two fields of one object; the
+third field `z` stays preserved while `x` and `y` may change.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Triple {
+  var x: int
+  var y: int
+  var z: int
+}
+
+procedure writeXY(self: Triple)
+  opaque
+  modifies self#x, self#y
+{
+  self#x := self#x + 1;
+  self#y := self#y + 1
+};
+
+procedure multiFieldCaller()
+  opaque
+{
+  var t: Triple := new Triple;
+  var oldX: int := t#x;
+  var oldY: int := t#y;
+  var oldZ: int := t#z;
+  writeXY(t);
+  // Unframed field: preserved.
+  assert t#z == oldZ;
+  // Framed fields: may change -> UNKNOWN.
+  assert t#x == oldX;
+//^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+  assert t#y == oldY
+//^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end
+
+/-
+Mixed: `modifies o, p#f` combines a whole-object entry with a field entry.
+`p`'s other field and a sibling stay preserved; `o#w` and `p#f` go UNKNOWN.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Whole {
+  var w: int
+}
+composite Part {
+  var f: int
+  var g: int
+}
+
+procedure mixedMod(o: Whole, p: Part)
+  opaque
+  modifies o, p#f
+{
+  o#w := o#w + 1;
+  p#f := p#f + 1
+};
+
+procedure mixedCaller()
+  opaque
+{
+  var o: Whole := new Whole;
+  var p: Part := new Part;
+  var s: Whole := new Whole;
+  var oldOw: int := o#w;
+  var oldPf: int := p#f;
+  var oldPg: int := p#g;
+  var oldSw: int := s#w;
+  mixedMod(o, p);
+  // `p`'s OTHER field: preserved (field granularity on p#f).
+  assert p#g == oldPg;
+  // Sibling whole object: preserved.
+  assert s#w == oldSw;
+  // Whole-object entry `o`: any field may change -> UNKNOWN.
+  assert o#w == oldOw;
+//^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+  // Framed field `p#f`: may change -> UNKNOWN.
+  assert p#f == oldPf
+//^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end
+
+/-
+Inheritance: `modifies d#bval` names an INHERITED field (declared in `Base`,
+qualified `Base.bval`). Derived-only `dval` stays preserved; inherited `bval` is UNKNOWN.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Base {
+  var bval: int
+}
+composite Derived extends Base {
+  var dval: int
+}
+
+procedure bumpInherited(d: Derived)
+  opaque
+  modifies d#bval
+{
+  d#bval := d#bval + 1
+};
+
+procedure inheritanceCaller()
+  opaque
+{
+  var d: Derived := new Derived;
+  var oldBval: int := d#bval;
+  var oldDval: int := d#dval;
+  bumpInherited(d);
+  // Derived-only field: preserved (inherited field framed, not this one).
+  assert d#dval == oldDval;
+  // Inherited framed field: may change -> UNKNOWN.
+  assert d#bval == oldBval
+//^^^^^^^^^^^^^^^^^^^^^^^^ error: assertion could not be proved
+};
+#end
+
+
+/-
+Callee-side field enforcement: declaring modifies o.x but writing o.y must fail.
+-/
+#eval testLaurel <|
+#strata
+program Laurel;
+composite Pair {
+  var x: int
+  var y: int
+}
+
+procedure overreachX(self: Pair)
+//        ^^^^^^^^^^ error: modifies clause could not be proved
+  opaque
+  modifies self#x
+{
+  self#y := self#y + 1
+};
+#end


### PR DESCRIPTION
Makes `modifies o#f` frame only the (o, f) pair instead of the whole owner object: that field may change while all other fields and every other object stay fixed.

https://github.com/strata-org/Strata/issues/1402