### PR TITLE
docs: update renamed #strataGenAST command to #strata_gen

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -44,7 +44,7 @@ assert [test]: (x == 0);
 The DDM also offers a capability to generate Lean types automatically
 from these definitions using the following command:
 ```bash
-#strataGenAST ArithPrograms
+#strata_gen ArithPrograms
 ```
 
 For instance, we can see the generated type for expressions in


### PR DESCRIPTION
Hi, just a quick fix to the documentation that I ran into while getting started with Strata.

The #strataGenAST command was renamed to #strata_gen in #6 (commit 9cfb1dee9) for Lean naming convention compatibility, but docs/GettingStarted.md still referenced the old name.