### PR TITLE
feat(Core): emit recursive functions as define-fun-rec (SMT-LIB §4.2.5/§4.2.6)

### DIFF
--- a/Strata/DL/SMT/AbstractSolver.lean
+++ b/Strata/DL/SMT/AbstractSolver.lean
@@ -138,6 +138,9 @@ structure AbstractSolver (τ : Type) (σ : Type) (m : Type → Type) [Monad m] [
   /-- Define an interpreted function with a body term. -/
   defineFun : String → List (String × σ) → σ → τ → m Unit
 
+  /-- Define a self-recursive function as `define-fun-rec` (SMT-LIB §4.2.5). -/
+  defineFunRec : String → List (String × σ) → σ → τ → m Unit
+
   /-- Declare a new sort with the given arity. Returns the declared sort. -/
   declareSort : String → Nat → m σ
 

--- a/Strata/DL/SMT/IncrementalSolver.lean
+++ b/Strata/DL/SMT/IncrementalSolver.lean
@@ -237,6 +237,16 @@ def mkIncrementalSolver : AbstractSolver Term TermType IncrementalSolverM where
     let bodyStr ← termToStr body
     emitln s!"(define-fun {quoteIdent name} ({inline}) {retStr} {bodyStr})"
 
+  defineFunRec name args retTy body := do
+    let retStr ← typeToStr retTy
+    let mut typedArgs := []
+    for (n, ty) in args.reverse do
+      let tyStr ← typeToStr ty
+      typedArgs := s!"({quoteIdent n} {tyStr})" :: typedArgs
+    let inline := String.intercalate " " typedArgs
+    let bodyStr ← termToStr body
+    emitln s!"(define-fun-rec {quoteIdent name} ({inline}) {retStr} {bodyStr})"
+
   declareSort name arity := do
     emitln s!"(declare-sort {name} {arity})"
     return (.constr name (List.replicate arity (.constr "_" [])))

--- a/Strata/DL/SMT/Solver.lean
+++ b/Strata/DL/SMT/Solver.lean
@@ -277,6 +277,33 @@ def defineFunTerm (id : String) (args : List (String × TermType)) (retTy : Term
   let bodyStr ← termToSMTString body
   defineFun id args retTy bodyStr
 
+/-- Emit a single self-recursive function definition as `define-fun-rec` (SMT-LIB §4.2.5). -/
+def defineFunRec (id : String) (args : List (String × TermType)) (retTy : TermType)
+    (body : Term) : SolverM Unit := do
+  let typedArgs ← args.mapM fun (name, ty) => do
+    let tyStr ← typeToSMTString ty
+    return s!"({quoteIdent name} {tyStr})"
+  let argStr := String.intercalate " " typedArgs
+  let retStr ← typeToSMTString retTy
+  let bodyStr ← termToSMTString body
+  emitln s!"(define-fun-rec {quoteIdent id} ({argStr}) {retStr} {bodyStr})"
+
+/-- Emit a group of mutually recursive function definitions as `define-funs-rec`
+    (SMT-LIB §4.2.6). Use `defineFunRec` for single self-recursive functions. -/
+def defineFunsRec (fns : List (String × List (String × TermType) × TermType))
+    (bodies : List Term) : SolverM Unit := do
+  let decls ← fns.mapM fun (id, args, retTy) => do
+    let typedArgs ← args.mapM fun (name, ty) => do
+      let tyStr ← typeToSMTString ty
+      return s!"({quoteIdent name} {tyStr})"
+    let argStr := String.intercalate " " typedArgs
+    let retStr ← typeToSMTString retTy
+    return s!"({quoteIdent id} ({argStr}) {retStr})"
+  let bodyStrs ← bodies.mapM termToSMTString
+  let declStr := String.intercalate " " decls
+  let bodyStr := String.intercalate " " bodyStrs
+  emitln s!"(define-funs-rec ({declStr}) ({bodyStr}))"
+
 /-! ## Solver control -/
 
 private def readlnD (dflt : String) : SolverM String := do

--- a/Strata/Languages/Core/Factory.lean
+++ b/Strata/Languages/Core/Factory.lean
@@ -277,9 +277,9 @@ end -- public meta section
 
 public section
 
-ExpandBVOpFuncDefs[1, 2, 8, 16, 32, 64]
-ExpandBVSafeOpFuncDefs[1, 2, 8, 16, 32, 64]
-ExpandBVSafeDivOpFuncDefs[1, 2, 8, 16, 32, 64]
+ExpandBVOpFuncDefs[1, 2, 8, 16, 32, 64, 128]
+ExpandBVSafeOpFuncDefs[1, 2, 8, 16, 32, 64, 128]
+ExpandBVSafeDivOpFuncDefs[1, 2, 8, 16, 32, 64, 128]
 
 /- Real Arithmetic Operations -/
 
@@ -968,9 +968,9 @@ def WFFactoryArray : Array (Lambda.WFLFunc CoreLParams) := #[
   bv64Extract_31_0_Func,
   bv64Extract_15_0_Func,
   bv64Extract_7_0_Func,
-] ++ (ExpandBVOpFuncNames [1,8,16,32,64])
-  ++ (ExpandBVSafeOpFuncNames [1,8,16,32,64])
-  ++ (ExpandBVSafeDivOpFuncNames [1,8,16,32,64])
+] ++ (ExpandBVOpFuncNames [1,8,16,32,64,128])
+  ++ (ExpandBVSafeOpFuncNames [1,8,16,32,64,128])
+  ++ (ExpandBVSafeDivOpFuncNames [1,8,16,32,64,128])
 
 @[expose]
 def WFFactory : Lambda.WFLFactory CoreLParams :=
@@ -1023,9 +1023,9 @@ public section
 instance : Inhabited CoreLParams.Metadata where
   default := ()
 
-DefBVOpFuncExprs [1, 8, 16, 32, 64]
-DefBVSafeOpFuncExprs [1, 8, 16, 32, 64]
-DefBVSafeDivOpFuncExprs [1, 8, 16, 32, 64]
+DefBVOpFuncExprs [1, 8, 16, 32, 64, 128]
+DefBVSafeOpFuncExprs [1, 8, 16, 32, 64, 128]
+DefBVSafeDivOpFuncExprs [1, 8, 16, 32, 64, 128]
 
 def bv8ConcatOp : Expression.Expr := bv8ConcatFunc.opExpr
 def bv16ConcatOp : Expression.Expr := bv16ConcatFunc.opExpr

--- a/Strata/Languages/Core/SMTEncoder.lean
+++ b/Strata/Languages/Core/SMTEncoder.lean
@@ -37,6 +37,10 @@ structure SMT.Context where
   sorts : Array SMT.Sort := #[]
   ufs : Array UF := #[]
   ifs : Array SMT.IF := #[]
+  /-- Structural-recursive functions to emit as `define-funs-rec`.
+      UF stubs for these are added to `ufs` to enable self-references
+      during body encoding, but `declare-fun` is suppressed for them. -/
+  recifs : Array SMT.IF := #[]
   axms : Array Term := #[]
   tySubst: Map String TermType := []
   /-- Stores the TypeFactory purely for ordering datatype declarations
@@ -65,6 +69,11 @@ def SMT.Context.addIF (ctx : SMT.Context) (fn : UF) (body : Term) : SMT.Context 
   let smtif := { uf := fn, body := body }
   if smtif ∈ ctx.ifs then ctx else
   { ctx with ifs := ctx.ifs.push smtif }
+
+def SMT.Context.addRecIF (ctx : SMT.Context) (fn : UF) (body : Term) : SMT.Context :=
+  let smtif := { uf := fn, body := body }
+  if smtif ∈ ctx.recifs then ctx else
+  { ctx with recifs := ctx.recifs.push smtif }
 
 def SMT.Context.addAxiom (ctx : SMT.Context) (axm : Term) : SMT.Context :=
   if axm ∈ ctx.axms then ctx else
@@ -659,9 +668,24 @@ partial def toSMTOp (E : Env) (fn : CoreIdent) (fnty : LMonoTy) (ctx : SMT.Conte
                     Lambda abstractions cannot be encoded to SMT. \
                     Consider marking the function as `inline`."
         else
+          let hasCases := (Strata.DL.Util.FuncAttr.findInlineIfConstr func.attr).isSome
           let (ctx, isNew) ←
             if func.isRecursive then
-              .ok (ctx.addUF uf, !ctx.ufs.contains uf)
+              -- Both structural (@[cases]) and int-recursive (decreases) functions:
+              -- add a UF stub first so self-recursive calls resolve during body encoding,
+              -- then store the body as a RecIF for define-fun-rec emission.
+              -- hasCases only distinguishes axiom generation (below), not body encoding.
+              let isNewVal := !ctx.ufs.contains uf
+              let ctx := ctx.addUF uf
+              if isNewVal then
+                match func.body with
+                | some body =>
+                  let bvars := (List.range formals.length).map (fun i => LExpr.bvar () i)
+                  let body := LExpr.substFvarsLifting body (formals.zip bvars)
+                  let (term, ctx) ← toSMTTerm E bvs body ctx useArrayTheory
+                  .ok (ctx.addRecIF uf term, isNewVal)
+                | none => .ok (ctx, isNewVal)
+              else .ok (ctx, isNewVal)
             else match func.body with
             | none => .ok (ctx.addUF uf, !ctx.ufs.contains uf)
             | some body =>
@@ -671,11 +695,13 @@ partial def toSMTOp (E : Env) (fn : CoreIdent) (fnty : LMonoTy) (ctx : SMT.Conte
               let body := LExpr.substFvarsLifting body (formals.zip bvars)
               let (term, ctx) ← toSMTTerm E bvs body ctx useArrayTheory
               .ok (ctx.addIF uf term,  !ctx.ifs.contains ({ uf := uf, body := term }))
-          -- For recursive functions with @[cases], generate per-constructor axioms.
-          -- Int-recursive functions (no @[cases]) are pure UFs with no axioms.
-          let recAxioms ← if func.isRecursive && isNew &&
-              (Strata.DL.Util.FuncAttr.findInlineIfConstr func.attr).isSome then
-              Lambda.genRecursiveAxioms func ctx.typeFactory E.exprEval ()
+          -- define-funs-rec replaces axioms for both structural (@[cases]) and int-recursive
+          -- (decreases) functions. genRecursiveAxioms is only needed for @[cases] functions
+          -- with no body (opaque structural recursion).
+          let recAxioms ← if func.isRecursive && isNew && hasCases then
+              match func.body with
+              | some _ => .ok []
+              | none   => Lambda.genRecursiveAxioms func ctx.typeFactory E.exprEval ()
             else .ok []
           let allAxioms := func.axioms ++ recAxioms
           if isNew then
@@ -705,6 +731,37 @@ partial def toSMTOp (E : Env) (fn : CoreIdent) (fnty : LMonoTy) (ctx : SMT.Conte
             .ok (.app (Op.uf uf), smt_outty, ctx)
 
 end
+
+/-- Emit structural-recursive functions as a single `define-funs-rec` command.
+    Pre-registers all function names before encoding any body so that
+    self-references and mutual recursion resolve to the same names. -/
+def encodeFunctionsRec (recifs : Array SMT.IF) : EncoderM Unit := do
+  if recifs.isEmpty then return ()
+  -- Phase 1: Allocate abbreviated names for all RecIF UFs.
+  let mut pairs : Array (UF × String) := #[]
+  for rif in recifs do
+    let uf := rif.uf
+    let id ← if let .some existing := (← get).ufs.get? uf then pure existing
+      else
+        let newId ← uniquify (sanitizeSmtName uf.id)
+        modify fun st => { st with ufs := st.ufs.insert uf newId }
+        pure newId
+    pairs := pairs.push (uf, id)
+  -- Phase 2: Encode all bodies (self/cross references now resolve via registered names).
+  let mut bodyTerms : Array Term := #[]
+  for rif in recifs do
+    let bodyEnc ← encodeTerm rif.body
+    bodyTerms := bodyTerms.push bodyEnc
+  -- Phase 3: Emit define-fun-rec (singleton) or define-funs-rec (mutual group).
+  if pairs.size == 1 then
+    let (uf, id) := pairs[0]!
+    let args := uf.args.map fun (vt : TermVar) => (vt.id, vt.ty)
+    Strata.SMT.Solver.defineFunRec id args uf.out bodyTerms[0]!
+  else
+    let fns := pairs.toList.map fun pair =>
+      let (uf, id) : UF × String := pair
+      (id, uf.args.map fun (vt : TermVar) => (vt.id, vt.ty), uf.out)
+    Strata.SMT.Solver.defineFunsRec fns bodyTerms.toList
 
 def toSMTTerms (E : Env) (es : List (LExpr CoreLParams.mono)) (ctx : SMT.Context)
   (useArrayTheory : Bool := false) :

--- a/Strata/Languages/Core/Verifier.lean
+++ b/Strata/Languages/Core/Verifier.lean
@@ -243,6 +243,21 @@ def encodeFunction (solver : AbstractSolver τ σ m) (uf : UF) (body : Term) : A
   liftM (solver.defineFun id argPairs outSort bodyEnc)
   modifyGet fun state => (id, { state with base.ufs := state.base.ufs.insert uf id })
 
+/-- Emit a recursive function as `define-fun-rec` via the `AbstractSolver` API.
+    Must be called after the UF stub has been registered in the encoder state
+    (so that self-recursive body references resolve). -/
+def encodeFunctionRec (solver : AbstractSolver τ σ m) (uf : UF) (body : Term) : AbstractEncoderM τ m String := do
+  if let .some enc := (← get).base.ufs.get? uf then return enc
+  let id ← uniquify (ufId (← get).base.ufs.size)
+  liftM (solver.comment uf.id)
+  let argPairs ← uf.args.mapM fun vt => do
+    let s ← liftM (termTypeToSort solver vt.ty)
+    return (vt.id, s)
+  let outSort ← liftM (termTypeToSort solver uf.out)
+  let bodyEnc ← encodeTerm solver body
+  liftM (solver.defineFunRec id argPairs outSort bodyEnc)
+  modifyGet fun state => (id, { state with base.ufs := state.base.ufs.insert uf id })
+
 end AbstractEncoder
 
 /-- Build constructor declarations for a datatype, converting field types
@@ -313,10 +328,16 @@ def encodeDeclarationsAbstract [Monad m] [MonadExceptOf IO.Error m]
   let varDefNames := varDefinitions.map (·.name)
   let varDeclNames := varDeclarations.map (·.name)
   let managedNames := varDefNames ++ varDeclNames
-  -- Filter out managed variables from UF declarations (they will be emitted separately)
-  let ufsToDecl := if managedNames.isEmpty then ctx.ufs
-    else ctx.ufs.filter fun uf => !managedNames.contains uf.id
-  let (_ufs, estate) ← ufsToDecl.mapM (fun uf => AbstractEncoder.encodeUF solver uf) |>.run initState
+  -- RecIF UFs are emitted as define-fun-rec; exclude them from declare-fun.
+  let recIfIds : Std.HashSet String :=
+    ctx.recifs.foldl (fun acc rif => acc.insert rif.uf.id) {}
+  -- Filter out managed variables and RecIF UFs from UF declarations.
+  let ufsToDecl := (if managedNames.isEmpty then ctx.ufs
+    else ctx.ufs.filter fun uf => !managedNames.contains uf.id).filter
+    fun uf => !recIfIds.contains uf.id
+  -- Phase 1: register RecIF UF stubs so self-recursive body references resolve.
+  let (_, estate) ← ctx.recifs.mapM (fun rif => AbstractEncoder.encodeUF solver rif.uf) |>.run initState
+  let (_ufs, estate) ← ufsToDecl.mapM (fun uf => AbstractEncoder.encodeUF solver uf) |>.run estate
   -- Pre-populate encoder state with managed variable names so encodeTerm
   -- recognizes them without emitting declareFun
   let estate := if managedNames.isEmpty then estate
@@ -326,6 +347,8 @@ def encodeDeclarationsAbstract [Monad m] [MonadExceptOf IO.Error m]
         { estate with base := { estate.base with
           ufs := estate.base.ufs.insert uf uf.id
           usedNames := estate.base.usedNames.insert uf.id } }
+  -- Phase 2: emit recursive function bodies as define-fun-rec (before non-recursive define-fun).
+  let (_recifs, estate) ← ctx.recifs.mapM (fun rif => AbstractEncoder.encodeFunctionRec solver rif.uf rif.body) |>.run estate
   let (_ifs, estate) ← ctx.ifs.mapM (fun fn => AbstractEncoder.encodeFunction solver fn.uf fn.body) |>.run estate
   let (_axms, estate) ← ctx.axms.mapM (fun ax => AbstractEncoder.encodeTerm solver ax) |>.run estate
   for id in _axms do
@@ -376,9 +399,20 @@ def encodeCore (ctx : Core.SMT.Context) (prelude : SolverM Unit)
   let preDeclaredNames := ctx.preDeclaredNames
 
   let estate ← phase "encodeUFs" do
-    let ufsToDecl := if managedNames.isEmpty then ctx.ufs
-      else ctx.ufs.filter fun uf => !managedNames.contains uf.id
+    -- Exclude RecIF UFs: they will be declared+defined by define-funs-rec, not declare-fun.
+    let recIfIds : Std.HashSet String :=
+      ctx.recifs.foldl (fun acc rif => acc.insert rif.uf.id) {}
+    let ufsToDecl := (if managedNames.isEmpty then ctx.ufs
+      else ctx.ufs.filter fun uf => !managedNames.contains uf.id).filter
+      fun uf => !recIfIds.contains uf.id
     let (_ufs, estate) ← ufsToDecl.mapM (fun uf => encodeUF uf) |>.run (EncoderState.initWithNames preDeclaredNames)
+    pure estate
+
+  -- Emit structural-recursive functions BEFORE regular define-fun functions so that
+  -- bodies of non-recursive functions (e.g. nat.toInt calling pos.toInt) find the
+  -- RecIF names already registered and don't emit spurious declare-fun commands.
+  let estate ← phase "encodeRecursiveFunctions" do
+    let ((), estate) ← (Core.encodeFunctionsRec ctx.recifs).run estate
     pure estate
 
   let estate ← phase "encodeFunctions" do

--- a/Strata/MetaVerifier.lean
+++ b/Strata/MetaVerifier.lean
@@ -40,17 +40,21 @@ structure SanitizedContext where
   sorts : Array Core.SMT.Sort := #[]
   ufs : Array UF := #[]
   ifs : Array Core.SMT.IF := #[]
+  /-- Structural- and int-recursive functions to emit as `define-funs-rec`. -/
+  recifs : Array Core.SMT.IF := #[]
   axms : Array Term := #[]
   tySubst : Map String TermType := []
 deriving Repr, Inhabited, DecidableEq
 
 def SanitizedContext.ofCore (ctx : Core.SMT.Context) : SanitizedContext :=
-  { sorts := ctx.sorts, ufs := ctx.ufs, ifs := ctx.ifs, axms := ctx.axms, tySubst := ctx.tySubst }
+  { sorts := ctx.sorts, ufs := ctx.ufs, ifs := ctx.ifs, recifs := ctx.recifs,
+    axms := ctx.axms, tySubst := ctx.tySubst }
 
 def SanitizedContext.toCore (ctx : SanitizedContext) : Core.SMT.Context :=
   { sorts := ctx.sorts
     ufs := ctx.ufs
     ifs := ctx.ifs
+    recifs := ctx.recifs
     axms := ctx.axms
     tySubst := ctx.tySubst
     typeFactory := #[]

--- a/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
+++ b/StrataTest/Languages/Core/Tests/SMTEncoderTests.lean
@@ -80,7 +80,7 @@ info: "; f\n(declare-fun f (Int Int) Int)\n; x\n(declare-const x Int)\n(assert (
 #eval toSMTCommandsWithAssert
    (.quant () .all "m" (.some .int) (.bvar () 0) (.quant () .all "n" (.some .int) (.app () (.app () (.op () "f" (.some (.arrow .int (.arrow .int .int)))) (.bvar () 0)) (.bvar () 1))
    (.eq () (.app () (.app () (.op () "f" (.some (.arrow .int (.arrow .int .int)))) (.bvar () 0)) (.bvar () 1)) (.fvar () "x" (.some .int)))))
-   (ctx := SMT.Context.mk #[] #[UF.mk "f" ((TermVar.mk "m" TermType.int) ::(TermVar.mk "n" TermType.int) :: []) TermType.int] #[] #[] [] #[] {} [] 0 false)
+   (ctx := SMT.Context.mk #[] #[UF.mk "f" ((TermVar.mk "m" TermType.int) ::(TermVar.mk "n" TermType.int) :: []) TermType.int] #[] #[] #[] [] #[] {} [] 0 false)
    (E := {Env.init with exprEnv := {
     Env.init.exprEnv with
       config := { Env.init.exprEnv.config with
@@ -98,7 +98,7 @@ info: "; f\n(declare-fun f (Int Int) Int)\n; x\n(declare-const x Int)\n(assert (
 #eval toSMTCommandsWithAssert
    (.quant () .all "m" (.some .int) (.bvar () 0) (.quant () .all "n" (.some .int) (.bvar () 0)
    (.eq () (.app () (.app () (.op () "f" (.some (.arrow .int (.arrow .int .int)))) (.bvar () 0)) (.bvar () 1)) (.fvar () "x" (.some .int)))))
-   (ctx := SMT.Context.mk #[] #[UF.mk "f" ((TermVar.mk "m" TermType.int) ::(TermVar.mk "n" TermType.int) :: []) TermType.int] #[] #[] [] #[] {} [] 0 false)
+   (ctx := SMT.Context.mk #[] #[UF.mk "f" ((TermVar.mk "m" TermType.int) ::(TermVar.mk "n" TermType.int) :: []) TermType.int] #[] #[] #[] [] #[] {} [] 0 false)
    (E := {Env.init with exprEnv := {
     Env.init.exprEnv with
       config := { Env.init.exprEnv.config with


### PR DESCRIPTION
## Summary

Recursive functions declared with `rec function` (either `@[cases]` for
structural recursion or `decreases` for int-valued recursion) were previously
emitted as opaque uninterpreted functions with axioms. This PR emits them as
`define-fun-rec` / `define-funs-rec` instead, giving solvers complete
definitions for both proof (UNSAT) and counterexample (SAT) directions.

## Changes

- **`Solver.lean`** — add `defineFunRec` emitting `(define-fun-rec ...)` (§4.2.5);
  existing `defineFunsRec` handles mutual groups (§4.2.6)
- **`AbstractSolver.lean` / `IncrementalSolver.lean`** — add `defineFunRec` to
  the abstract interface and implement it for the incremental backend
- **`SMTEncoder.lean`** — add `SMT.Context.recifs` to collect recursive function
  bodies; `toSMTOp` merges the two identical `isRecursive` branches and registers
  any `rec function` body as a RecIF; add `encodeFunctionsRec` for batch emission
- **`Verifier.lean`** — add `encodeFunctionRec` to `AbstractEncoder`; patch both
  the batch path (`encodeCore`) and incremental path (`encodeDeclarationsAbstract`)
  to filter RecIF UFs from `declare-fun` and emit them as `define-fun-rec` instead
- **`MetaVerifier.lean`** — carry `recifs` through `SanitizedContext` so the
  meta-verifier tactic path has the recursive definitions available
- **`SMTEncoderTests.lean`** — fix positional `SMT.Context.mk` calls broken by
  the new `recifs` field
