### PR TITLE
feat(core): freshen type variables per call-site in CallElim

### DIFF
--- a/Strata/Transform/CallElim.lean
+++ b/Strata/Transform/CallElim.lean
@@ -44,6 +44,17 @@ def callElimCmd (cmd: Command)
 
         let some proc := Program.Procedure.find? p procName | throw (Strata.DiagnosticModel.fromFormat f!"Procedure {procName} not found in program")
 
+        -- Per-call-site type-variable freshening for polymorphic procedures.
+        -- The inlined contract carries the callee's source type vars (`x : T`). Copied
+        -- verbatim, the SAME `T` is shared across call sites, so two calls at different
+        -- concrete types (`idp(5)`, `idp(true)`) force `T` to unify with both `int` and
+        -- `bool` — a whole-program type-check abort masking unrelated obligations. Rename
+        -- the type vars to globally-fresh ones per call site. For a monomorphic callee
+        -- (`typeArgs = []`) the substitution is empty and the applications below are no-ops.
+        let tySubst ← freshenTypeArgsSubst proc.header.typeArgs
+        let freshTy (ty : Lambda.LMonoTy) : Lambda.LMonoTy := Lambda.LMonoTy.subst tySubst ty
+        let freshExpr (e : Expression.Expr) : Expression.Expr := Lambda.LExpr.applySubst e tySubst
+
         -- Identify output parameters that also appear as input parameters
         -- and are referenced via "old" in postconditions.
         let postExprs := proc.spec.postconditions.values.map Procedure.Check.expr
@@ -54,12 +65,15 @@ def callElimCmd (cmd: Command)
           (inputNames.contains g && outputNames.contains g) && -- Inout params
           postExprs.any (fun e => Lambda.LExpr.freeVars e |>.any (fun (id, _) => id == CoreIdent.mkOld g.name))
 
-        let genArgTrips := genArgExprIdentsTrip (Lambda.LMonoTySignature.toTrivialLTy proc.header.inputs) args
+        let freshInputs := proc.header.inputs.map (fun (id, ty) => (id, freshTy ty))
+        let freshOutputs := proc.header.outputs.map (fun (id, ty) => (id, freshTy ty))
+
+        let genArgTrips := genArgExprIdentsTrip (Lambda.LMonoTySignature.toTrivialLTy freshInputs) args
         let argTrips
             : List ((Expression.Ident × Expression.Ty) × Expression.Expr)
             ← genArgTrips
 
-        let genOutTrips := genOutExprIdentsTrip (Lambda.LMonoTySignature.toTrivialLTy proc.header.outputs) lhs
+        let genOutTrips := genOutExprIdentsTrip (Lambda.LMonoTySignature.toTrivialLTy freshOutputs) lhs
         let outTrips
             : List ((Expression.Ident × Expression.Ty) × Expression.Ident)
             ← genOutTrips
@@ -69,7 +83,7 @@ def callElimCmd (cmd: Command)
         let genOldIdents ← genOldExprIdents oldVars
         let oldTys ← oldVars.mapM fun id => do
           match proc.header.inputs.find? id with
-          | some ty => pure (Lambda.LTy.forAll [] ty)
+          | some ty => pure (Lambda.LTy.forAll [] (freshTy ty))
           | none => throw (Strata.DiagnosticModel.fromFormat f!"failed to find type for {Std.format id}")
         let oldTripsRaw := (genOldIdents.zip oldTys).zip oldVars
         let oldGVars := oldVars.map (fun g => CoreIdent.mkOld g.name)
@@ -93,8 +107,13 @@ def callElimCmd (cmd: Command)
             else none
         let oldSubst := createOldVarsSubst oldTrips ++ inputOnlyOldSubst
 
+        -- Freshen type variables in the postcondition expressions (binder/op/fvar
+        -- annotations) with the same per-call-site substitution used for the
+        -- temp types above, then substitute the "old" actuals. `freshExpr` only
+        -- rewrites type annotations; `substFvars` only rewrites fvar leaves — they
+        -- touch disjoint slots, so the order is immaterial.
         let postconditions : List Expression.Expr := proc.spec.postconditions.values.map
-          (fun c => Lambda.LExpr.substFvars c.expr oldSubst)
+          (fun c => Lambda.LExpr.substFvars (freshExpr c.expr) oldSubst)
 
         -- generate havoc for output variables
         let havocs := createHavocs lhs md
@@ -105,8 +124,12 @@ def callElimCmd (cmd: Command)
         let ret_subst : List (Expression.Ident × Expression.Expr)
                       := (ListMap.keys proc.header.outputs).zip $ createFvars lhs
 
-        -- construct assumes and asserts in place of pre/post conditions
-        let asserts ← createAsserts (proc.spec.preconditions.filter (fun (_, check) => check.attr != .Free))
+        -- construct assumes and asserts in place of pre/post conditions.
+        -- Freshen type variables in the precondition expressions with the same
+        -- per-call-site substitution (no-op for monomorphic callees).
+        let freshPreconditions := (proc.spec.preconditions.filter (fun (_, check) => check.attr != .Free)).map
+          (fun (l, check) => (l, { check with expr := freshExpr check.expr }))
+        let asserts ← createAsserts freshPreconditions
                         (arg_subst ++ ret_subst)
                         md
                         callElimAssertPrefix

--- a/Strata/Transform/CoreTransform.lean
+++ b/Strata/Transform/CoreTransform.lean
@@ -77,6 +77,45 @@ def genOldExprIdents (idents : List Expression.Ident)
   : CoreGenM (List Expression.Ident)
   := List.mapM genOldExprIdent idents
 
+/-- Prefix for fresh call-site type variables introduced during call elimination.
+    In the `$__`-reserved internal namespace (documented "cannot appear in user
+    identifiers", see `SMTEncoder.lean`), so a freshened call-site type variable
+    is far from any user-written type-variable name. Distinct from the type
+    checker's own fresh prefix `$__ty` (`LExprTypeEnv.lean` `TState.tyPrefix`) —
+    `$__cety` differs at the 5th char, so the two generators never alias — and
+    distinct from the term-temp prefixes (`tmp_`/`old_`).
+    NB: `$` is a legal identifier char (`Parser.strataIsIdFirst`) and the gen
+    counter does NOT ingest existing program names, so collision-resistance here
+    rests on the `$__` reservation convention, not a parser-enforced rejection. -/
+def freshTyVarPrefix : String := "$__cety"
+
+/-- Generate one fresh type-variable name (`TyIdentifier = String`) from the
+    shared `CoreGenState` counter — the same monotonic counter that backs the
+    term-temp generators — so names are deterministic, resume-safe, and unique
+    across call sites without adding any new state. Mirrors `genIdent`. -/
+def genTyVarName : CoreGenM Lambda.TyIdentifier := do
+  let id ← CoreGenState.gen freshTyVarPrefix
+  return id.name
+
+def genTyVarNames (n : Nat) : CoreGenM (List Lambda.TyIdentifier) :=
+  List.mapM (fun _ => genTyVarName) (List.replicate n ())
+
+/-- Build a one-scope type substitution mapping each declared type variable of a
+    polymorphic callee to a globally-fresh type variable, for per-call-site
+    contract freshening in call elimination. Returns the empty substitution
+    (a verified identity for `LMonoTy.subst`/`LExpr.applySubst`, which
+    short-circuit on `Subst.hasEmptyScopes`) when `typeArgs` is empty — so the
+    transform is an exact no-op for monomorphic procedures. -/
+def freshenTypeArgsSubst (typeArgs : List Lambda.TyIdentifier)
+  : CoreGenM Lambda.Subst := do
+  if typeArgs.isEmpty then
+    return Lambda.Subst.empty
+  else
+    let fresh ← genTyVarNames typeArgs.length
+    let scope : Lambda.SubstOne :=
+      (typeArgs.zip fresh).map (fun (t, f) => (t, Lambda.LMonoTy.ftvar f))
+    return [scope]
+
 
 /-- Cached results of program analyses that are helpful for program
     transformation.

--- a/StrataTest/Languages/Core/Tests/PolyProcFreshenTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolyProcFreshenTest.lean
@@ -109,8 +109,10 @@ namespace Strata.PolyProcFreshenSoundness
 -- Soundness twin of the multi-instantiation case: the bool-slot assertion is
 -- FALSE (`bb == false` after `idp(true)`). The freshened postcondition keeps the
 -- bool call coupled to its own concrete type, so the WRONG obligation — `assert_1`
--- specifically — fails (not `assert_0`, not merely "one of them"). This pins the
--- per-obligation identity that a count-only oracle cannot.
+-- specifically, not `assert_0` — is the one that does NOT pass: it reports `unknown`
+-- (model `bb = true`), since the inlined CallElim contract is an over-approximation
+-- (sat is demoted to unknown, never a wrong `pass`). Pins the per-obligation identity
+-- a count-only oracle cannot.
 def wrongBoolPgm : Program :=
 #strata
 program Core;
@@ -247,69 +249,5 @@ Result: ✅ pass
 #eval Core.verify noAbortMaskPgm
 
 end Strata.PolyProcFreshenNoAbortMask
-
----------------------------------------------------------------------
-
-namespace Strata.PolyProcFreshenOldInout
-
--- Exercises the `old`-typed inout freshening branch specifically (the `oldVars`
--- path in `callElimCmd`, distinct from the plain input/output and postcondition
--- freshening the cases above cover). `bump<a>` takes an inout `g : a` and a
--- `free ensures (z == old g)`, so the type of the `old g` temp is the callee's
--- SOURCE type variable `a` and must be freshened per call site like every other
--- slot. `g := 5` before the call makes `old g` load-bearing (≠ the post-call `g`),
--- and the inlined assume becomes `r == 5`, so `assert (r == 5)` passes only if the
--- freshened `old`-typed temp resolved correctly.
-def oldInoutPgm : Program :=
-#strata
-program Core;
-procedure bump<a>(inout g : a, out z : a)
-spec {
-  free ensures (z == old g);
-}
-{
-  z := g;
-};
-procedure Test(inout g : int, out r : int) spec { ensures true; }
-{
-  g := 5;
-  call bump(g, out g, out r);
-  assert (r == 5);
-};
-#end
-
-/--
-info: [Strata.Core] Type checking succeeded.
-
-
-VCs:
-Label: assert_0
-Property: assert
-Assumptions:
-callElimAssume_bump_ensures_0_5: r@2 == 5
-Obligation:
-r@2 == 5
-
-Label: Test_ensures_0
-Property: assert
-Assumptions:
-callElimAssume_bump_ensures_0_5: r@2 == 5
-Obligation:
-true
-
----
-info:
-Obligation: assert_0
-Property: assert
-Result: ✅ pass
-
-Obligation: Test_ensures_0
-Property: assert
-Result: ✅ pass
--/
-#guard_msgs in
-#eval Core.verify oldInoutPgm
-
-end Strata.PolyProcFreshenOldInout
 
 end

--- a/StrataTest/Languages/Core/Tests/PolyProcFreshenTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolyProcFreshenTest.lean
@@ -1,0 +1,251 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+module
+
+meta import Strata.Languages.Core
+import StrataDDM.Integration.Lean.HashCommands
+
+meta section
+open StrataDDM (Program)
+
+/-!
+# Per-call-site type-variable freshening (CallElim) — Core regression tests
+
+`Core.CallElim.callElimCmd` inlines a polymorphic procedure's contract at each
+call site, freshening the callee's declared type variables to globally-fresh
+names per site (`freshenTypeArgsSubst`, `Strata/Transform/CoreTransform.lean`).
+Without that, the inlined contract reuses the LITERAL type variable at every
+site, so calling one polymorphic procedure at two concrete types in one body
+forces the variable to unify with both — a whole-program type-check ABORT that
+masked unrelated obligations.
+
+These exercise the fix at the Core layer DIRECTLY (the bug lives in CallElim, a
+Core transform). Unlike the Laurel corpus — whose oracle is a failure *count* —
+`Core.verify` reports each obligation by LABEL and verdict, so these pin WHICH
+obligation fails, not just how many. The callees use `free ensures` so the
+postcondition is inlined as an assume at the call site (the path the freshening
+governs) without emitting a proof obligation for the polymorphic body itself
+(whose free type variable has no SMT sort).
+-/
+
+namespace Strata.PolyProcFreshenMultiInst
+
+-- One polymorphic procedure called at `int` AND `bool` in a single body — the
+-- exact shape that pre-fix aborted with "Impossible to unify a with bool".
+-- Per-call-site freshening gives each call its own type variable, so both
+-- call-site obligations are well-formed and pass.
+def multiInstPgm : Program :=
+#strata
+program Core;
+procedure idp<a>(x : a, out r : a)
+spec {
+  free ensures (r == x);
+};
+procedure Test() spec { ensures true; }
+{
+  var ai : int;
+  call idp(7, out ai);
+  assert (ai == 7);
+  var bb : bool;
+  call idp(true, out bb);
+  assert (bb == true);
+};
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: assert_0
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+Obligation:
+ai@1 == 7
+
+Label: assert_1
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+callElimAssume_idp_ensures_0_3: bb@1 == true
+Obligation:
+bb@1 == true
+
+Label: Test_ensures_0
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+callElimAssume_idp_ensures_0_3: bb@1 == true
+Obligation:
+true
+
+---
+info:
+Obligation: assert_0
+Property: assert
+Result: ✅ pass
+
+Obligation: assert_1
+Property: assert
+Result: ✅ pass
+
+Obligation: Test_ensures_0
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval Core.verify multiInstPgm
+
+end Strata.PolyProcFreshenMultiInst
+
+---------------------------------------------------------------------
+
+namespace Strata.PolyProcFreshenSoundness
+
+-- Soundness twin of the multi-instantiation case: the bool-slot assertion is
+-- FALSE (`bb == false` after `idp(true)`). The freshened postcondition keeps the
+-- bool call coupled to its own concrete type, so the WRONG obligation — `assert_1`
+-- specifically — fails (not `assert_0`, not merely "one of them"). This pins the
+-- per-obligation identity that a count-only oracle cannot.
+def wrongBoolPgm : Program :=
+#strata
+program Core;
+procedure idp<a>(x : a, out r : a)
+spec {
+  free ensures (r == x);
+};
+procedure Test() spec { ensures true; }
+{
+  var ai : int;
+  call idp(7, out ai);
+  assert (ai == 7);
+  var bb : bool;
+  call idp(true, out bb);
+  assert (bb == false);
+};
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: assert_0
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+Obligation:
+ai@1 == 7
+
+Label: assert_1
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+callElimAssume_idp_ensures_0_3: bb@1 == true
+Obligation:
+bb@1 == false
+
+Label: Test_ensures_0
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+callElimAssume_idp_ensures_0_3: bb@1 == true
+Obligation:
+true
+
+---
+info:
+Obligation: assert_0
+Property: assert
+Result: ✅ pass
+
+Obligation: assert_1
+Property: assert
+Result: ❓ unknown
+Model:
+(bb@1, true) (ai@1, 7) 
+
+Obligation: Test_ensures_0
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval Core.verify wrongBoolPgm
+
+end Strata.PolyProcFreshenSoundness
+
+---------------------------------------------------------------------
+
+namespace Strata.PolyProcFreshenNoAbortMask
+
+-- The ship-blocker regression. A poison multi-instantiation of `idp` (int + bool
+-- in one body) must NOT abort whole-program type-checking and mask a real bug.
+-- `RealBug`'s false `assert (1 == 2)` must still be REPORTED — and at its own
+-- label, `assert_0`. Pre-fix, the unify abort suppressed this obligation entirely.
+def noAbortMaskPgm : Program :=
+#strata
+program Core;
+procedure idp<a>(x : a, out r : a)
+spec {
+  free ensures (r == x);
+};
+procedure RealBug() spec { ensures true; }
+{
+  assert (1 == 2);
+};
+procedure Poison() spec { ensures true; }
+{
+  var ai : int;
+  call idp(7, out ai);
+  var bb : bool;
+  call idp(true, out bb);
+};
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: assert_0
+Property: assert
+Obligation:
+false
+
+Label: RealBug_ensures_0
+Property: assert
+Obligation:
+true
+
+Label: Poison_ensures_0
+Property: assert
+Assumptions:
+callElimAssume_idp_ensures_0_7: ai@1 == 7
+callElimAssume_idp_ensures_0_3: bb@1 == true
+Obligation:
+true
+
+---
+info:
+Obligation: assert_0
+Property: assert
+Result: ❌ fail
+
+Obligation: RealBug_ensures_0
+Property: assert
+Result: ✅ pass
+
+Obligation: Poison_ensures_0
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval Core.verify noAbortMaskPgm
+
+end Strata.PolyProcFreshenNoAbortMask
+
+end

--- a/StrataTest/Languages/Core/Tests/PolyProcFreshenTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolyProcFreshenTest.lean
@@ -248,4 +248,68 @@ Result: ✅ pass
 
 end Strata.PolyProcFreshenNoAbortMask
 
+---------------------------------------------------------------------
+
+namespace Strata.PolyProcFreshenOldInout
+
+-- Exercises the `old`-typed inout freshening branch specifically (the `oldVars`
+-- path in `callElimCmd`, distinct from the plain input/output and postcondition
+-- freshening the cases above cover). `bump<a>` takes an inout `g : a` and a
+-- `free ensures (z == old g)`, so the type of the `old g` temp is the callee's
+-- SOURCE type variable `a` and must be freshened per call site like every other
+-- slot. `g := 5` before the call makes `old g` load-bearing (≠ the post-call `g`),
+-- and the inlined assume becomes `r == 5`, so `assert (r == 5)` passes only if the
+-- freshened `old`-typed temp resolved correctly.
+def oldInoutPgm : Program :=
+#strata
+program Core;
+procedure bump<a>(inout g : a, out z : a)
+spec {
+  free ensures (z == old g);
+}
+{
+  z := g;
+};
+procedure Test(inout g : int, out r : int) spec { ensures true; }
+{
+  g := 5;
+  call bump(g, out g, out r);
+  assert (r == 5);
+};
+#end
+
+/--
+info: [Strata.Core] Type checking succeeded.
+
+
+VCs:
+Label: assert_0
+Property: assert
+Assumptions:
+callElimAssume_bump_ensures_0_5: r@2 == 5
+Obligation:
+r@2 == 5
+
+Label: Test_ensures_0
+Property: assert
+Assumptions:
+callElimAssume_bump_ensures_0_5: r@2 == 5
+Obligation:
+true
+
+---
+info:
+Obligation: assert_0
+Property: assert
+Result: ✅ pass
+
+Obligation: Test_ensures_0
+Property: assert
+Result: ✅ pass
+-/
+#guard_msgs in
+#eval Core.verify oldInoutPgm
+
+end Strata.PolyProcFreshenOldInout
+
 end

--- a/StrataTest/Languages/Core/Tests/PolymorphicProcedureTest.lean
+++ b/StrataTest/Languages/Core/Tests/PolymorphicProcedureTest.lean
@@ -45,7 +45,7 @@ info: [Strata.Core] Type checking succeeded.
 
 
 VCs:
-Label: callElimAssert_Extract_requires_0_2
+Label: callElimAssert_Extract_requires_0_3
 Property: assert
 Obligation:
 List..isCons(xs@3)
@@ -57,7 +57,7 @@ true
 
 ---
 info:
-Obligation: callElimAssert_Extract_requires_0_2
+Obligation: callElimAssert_Extract_requires_0_3
 Property: assert
 Result: ❌ fail
 Model:
@@ -100,14 +100,14 @@ VCs:
 Label: assert_0
 Property: assert
 Assumptions:
-callElimAssume_MkCons_ensures_0_2: List..isCons(r@3)
+callElimAssume_MkCons_ensures_0_3: List..isCons(r@3)
 Obligation:
 List..isCons(r@3)
 
 Label: Test_ensures_0
 Property: assert
 Assumptions:
-callElimAssume_MkCons_ensures_0_2: List..isCons(r@3)
+callElimAssume_MkCons_ensures_0_3: List..isCons(r@3)
 Obligation:
 true
 


### PR DESCRIPTION
## What

When `CallElim` inlines a polymorphic Core procedure's contract, the inlined pre/postconditions carry the callee's **source** type variables (`x : a`). Copied verbatim, the same `a` is shared across call sites, so two calls at different concrete types (e.g. `idp(7)` and `idp(true)` in one body) force `a` to unify with both `int` and `bool` — a whole-program type-check abort that also **masks unrelated obligations** in sibling procedures.

**Fix:** rename the callee's declared type variables to globally-fresh names per call site (`freshenTypeArgsSubst` in `CoreTransform`), applied consistently to the temp input/output types, the `old`-referenced inout types, and the pre/postcondition expressions.

## Why it's safe on existing code

For a monomorphic callee (`typeArgs = []`), `freshenTypeArgsSubst` returns `Subst.empty`, which is:
- a **proven identity** for `LMonoTy.subst` (`LMonoTy.subst_emptyS`), and
- a definitional **short-circuit** in `LExpr.applySubst` (`Subst.hasEmptyScopes`, with `Subst.hasEmptyScopes_empty` proven).

So the transform is an exact no-op on all existing non-polymorphic code — it cannot regress current verification.

## Scope / stacking

This is a self-contained `Strata/Transform` fix, **independent of the Laurel polymorphism front-end** (#1394) that produces such callees. `PolyProcFreshenTest` exercises it directly on Core programs, one case per freshening path: single-instantiation soundness, multi-instantiation, the abort-masking regression, and `old`-typed inout freshening. `PolymorphicProcedureTest`'s expected VC labels shift by one (`_0_2` → `_0_3`) because fresh-name allocation advances the shared `CoreGenM` counter — updated here alongside the code that causes it.

#1394 (Laurel polymorphism) currently still contains this change; once this lands into `reviewed-kbd-will-merge-to-main`, rebasing #1394 drops these files from its diff automatically.

## Test

Full `lake test` green (only the pre-existing ion-java JAR fails, unrelated).
