### PR TITLE
Address CR-285788236 rev 5 review comments

### DIFF
--- a/StrataCLI/README.md
+++ b/StrataCLI/README.md
@@ -59,7 +59,7 @@ lake exe strata <command> --help
 
 | Command | Description |
 |---------|-------------|
-| `javaGen <dialect> <package> <output-dir>` | Generate Java source files to represent the language defined by a DDM dialect |
+| `lake exe laurelJavaGen <package> <output-dir>` | Generate Java source files for Laurel AST types (standalone Lake executable) |
 
 ## Common Flags
 

--- a/StrataDDM/StrataDDM/Integration/Java/Gen.lean
+++ b/StrataDDM/StrataDDM/Integration/Java/Gen.lean
@@ -326,10 +326,9 @@ private meta partial def serializeExprForInfo (ti : FieldTypeInfo) (accessor : S
   | .leaf name => (leafSerializeExpr name accessor).getD "ion.newNull()"
   | .compound _ _ => s!"{accessor}.toIon(ion)"
   | .typeParam _ => s!"{accessor}.toIon(ion)"
-  | .list _ =>
-    -- List serialization requires multiple statements; handled by toIon body generators.
-    -- This branch is used for inner elements of containers (e.g., Option (List T)).
-    s!"{accessor}.toIon(ion)"
+  | .list elem =>
+    let inner := serializeExprForInfo elem "e"
+    s!"({accessor}.stream().reduce(ion.newEmptyList(), (l, e) -> \{ l.add({inner}); return l; }, (a, b) -> \{ a.addAll(b); return a; }))"
   | .option elem =>
     let inner := serializeExprForInfo elem accessor
     s!"({accessor} != null ? {inner} : ion.newNull())"

--- a/StrataTest/Util/IonDeserializer.lean
+++ b/StrataTest/Util/IonDeserializer.lean
@@ -142,3 +142,36 @@ partial def deserializeMaybeLine : ByteArray → Except Std.Format MaybeLine :=
   getIonDeserializer% MaybeLine
 
 #check (deserializeMaybeLine : ByteArray → Except Std.Format MaybeLine)
+
+-- Value-level roundtrip tests: construct Ion bytes and verify deserialization
+section ValueTests
+
+private def pointIon : ByteArray :=
+  Ion.internAndSerialize [.struct #[("x", .int 3), ("y", .int 7)]]
+
+#guard match deserializePoint pointIon with
+  | .ok p => p == { x := 3, y := 7 }
+  | .error _ => false
+
+private def colorIon : ByteArray :=
+  Ion.internAndSerialize [.sexp #[.symbol "red"]]
+
+#guard match deserializeColor colorIon with
+  | .ok c => c == .red
+  | .error _ => false
+
+private def shapeIon : ByteArray :=
+  Ion.internAndSerialize [.sexp #[.symbol "circle", .int 5]]
+
+#guard match deserializeShape shapeIon with
+  | .ok s => s == .circle 5
+  | .error _ => false
+
+private def personIon : ByteArray :=
+  Ion.internAndSerialize [.struct #[("name", .string "Alice"), ("age", .int 30), ("active", .bool true)]]
+
+#guard match deserializePerson personIon with
+  | .ok p => p == { name := "Alice", age := 30, active := true }
+  | .error _ => false
+
+end ValueTests

--- a/StrataTestExtra/Languages/Java/TestGen.lean
+++ b/StrataTestExtra/Languages/Java/TestGen.lean
@@ -273,4 +273,233 @@ public class RoundtripTest {
 
 #testRoundtrip
 
+-- Test 11: Roundtrip multi-constructor type (Shape.circle)
+elab "#testRoundtripShapeCircle" : command => do
+  let javacCheck ← IO.Process.output { cmd := "javac", args := #["--version"] }
+  if javacCheck.exitCode != 0 then
+    Lean.logWarning "Roundtrip test skipped: javac not found"
+    return
+
+  let jarPath := "StrataTestExtra/Languages/Java/testdata/ion-java-1.11.11.jar"
+  if !(← System.FilePath.pathExists jarPath) then
+    Lean.logWarning s!"Roundtrip test skipped: ion-java jar not found at {jarPath}"
+    return
+
+  let dir : System.FilePath := "/tmp/strata-java-roundtrip-shape-circle"
+  if ← dir.pathExists then IO.FS.removeDirAll dir
+
+  let shapeFiles := getIonSerializer% Shape "com.test"
+  let pkgDir := dir / "com" / "test"
+  IO.FS.createDirAll pkgDir
+  for (name, content) in shapeFiles.files do
+    IO.FS.writeFile (pkgDir / name) content
+
+  let driverContent := "
+import com.test.*;
+import com.amazon.ion.*;
+import com.amazon.ion.system.*;
+import java.io.*;
+
+public class RoundtripShapeCircleTest {
+    public static void main(String[] args) throws Exception {
+        var ionSystem = IonSystemBuilder.standard().build();
+        var shape = new Shape.Circle(5);
+        var ionValue = shape.toIon(ionSystem);
+        try (var out = new FileOutputStream(args[0])) {
+            var writer = IonBinaryWriterBuilder.standard().build(out);
+            ionValue.writeTo(writer);
+            writer.close();
+        }
+    }
+}
+"
+  IO.FS.writeFile (dir / "RoundtripShapeCircleTest.java") driverContent
+
+  let mut javaPaths : Array String := #[(dir / "RoundtripShapeCircleTest.java").toString]
+  for (name, _) in shapeFiles.files do
+    javaPaths := javaPaths.push (pkgDir / name).toString
+
+  let compileResult ← IO.Process.output {
+    cmd := "javac"
+    args := #["-cp", s!"{jarPath}:{dir}"] ++ javaPaths
+  }
+  if compileResult.exitCode != 0 then
+    Lean.logError s!"Roundtrip Shape.circle compile failed:\n{compileResult.stderr}"
+    IO.FS.removeDirAll dir
+    return
+
+  let ionFile := dir / "shape.ion"
+  let runResult ← IO.Process.output {
+    cmd := "java"
+    args := #["-cp", s!"{jarPath}:{dir}", "RoundtripShapeCircleTest", ionFile.toString]
+  }
+  if runResult.exitCode != 0 then
+    Lean.logError s!"Roundtrip Shape.circle run failed:\n{runResult.stderr}"
+    IO.FS.removeDirAll dir
+    return
+
+  let ionBytes ← IO.FS.readBinFile ionFile
+  let deserializeShape : ByteArray → Except Std.Format Shape := getIonDeserializer% Shape
+  match deserializeShape ionBytes with
+  | .ok (.circle 5) => pure ()
+  | .ok other => Lean.logError s!"Shape roundtrip mismatch: expected circle 5, got {repr other}"
+  | .error e => Lean.logError s!"Shape roundtrip deser failed: {e}"
+
+  IO.FS.removeDirAll dir
+
+#testRoundtripShapeCircle
+
+-- Test 12: Roundtrip multi-constructor type (Shape.rect)
+elab "#testRoundtripShapeRect" : command => do
+  let javacCheck ← IO.Process.output { cmd := "javac", args := #["--version"] }
+  if javacCheck.exitCode != 0 then
+    Lean.logWarning "Roundtrip test skipped: javac not found"
+    return
+
+  let jarPath := "StrataTestExtra/Languages/Java/testdata/ion-java-1.11.11.jar"
+  if !(← System.FilePath.pathExists jarPath) then
+    Lean.logWarning s!"Roundtrip test skipped: ion-java jar not found at {jarPath}"
+    return
+
+  let dir : System.FilePath := "/tmp/strata-java-roundtrip-shape-rect"
+  if ← dir.pathExists then IO.FS.removeDirAll dir
+
+  let shapeFiles := getIonSerializer% Shape "com.test"
+  let pkgDir := dir / "com" / "test"
+  IO.FS.createDirAll pkgDir
+  for (name, content) in shapeFiles.files do
+    IO.FS.writeFile (pkgDir / name) content
+
+  let driverContent := "
+import com.test.*;
+import com.amazon.ion.*;
+import com.amazon.ion.system.*;
+import java.io.*;
+
+public class RoundtripShapeRectTest {
+    public static void main(String[] args) throws Exception {
+        var ionSystem = IonSystemBuilder.standard().build();
+        var shape = new Shape.Rect(3, 4);
+        var ionValue = shape.toIon(ionSystem);
+        try (var out = new FileOutputStream(args[0])) {
+            var writer = IonBinaryWriterBuilder.standard().build(out);
+            ionValue.writeTo(writer);
+            writer.close();
+        }
+    }
+}
+"
+  IO.FS.writeFile (dir / "RoundtripShapeRectTest.java") driverContent
+
+  let mut javaPaths : Array String := #[(dir / "RoundtripShapeRectTest.java").toString]
+  for (name, _) in shapeFiles.files do
+    javaPaths := javaPaths.push (pkgDir / name).toString
+
+  let compileResult ← IO.Process.output {
+    cmd := "javac"
+    args := #["-cp", s!"{jarPath}:{dir}"] ++ javaPaths
+  }
+  if compileResult.exitCode != 0 then
+    Lean.logError s!"Roundtrip Shape.rect compile failed:\n{compileResult.stderr}"
+    IO.FS.removeDirAll dir
+    return
+
+  let ionFile := dir / "shape.ion"
+  let runResult ← IO.Process.output {
+    cmd := "java"
+    args := #["-cp", s!"{jarPath}:{dir}", "RoundtripShapeRectTest", ionFile.toString]
+  }
+  if runResult.exitCode != 0 then
+    Lean.logError s!"Roundtrip Shape.rect run failed:\n{runResult.stderr}"
+    IO.FS.removeDirAll dir
+    return
+
+  let ionBytes ← IO.FS.readBinFile ionFile
+  let deserializeShape : ByteArray → Except Std.Format Shape := getIonDeserializer% Shape
+  match deserializeShape ionBytes with
+  | .ok (.rect 3 4) => pure ()
+  | .ok other => Lean.logError s!"Shape roundtrip mismatch: expected rect 3 4, got {repr other}"
+  | .error e => Lean.logError s!"Shape roundtrip deser failed: {e}"
+
+  IO.FS.removeDirAll dir
+
+#testRoundtripShapeRect
+
+-- Test 13: Roundtrip recursive type (Tree)
+elab "#testRoundtripTree" : command => do
+  let javacCheck ← IO.Process.output { cmd := "javac", args := #["--version"] }
+  if javacCheck.exitCode != 0 then
+    Lean.logWarning "Roundtrip test skipped: javac not found"
+    return
+
+  let jarPath := "StrataTestExtra/Languages/Java/testdata/ion-java-1.11.11.jar"
+  if !(← System.FilePath.pathExists jarPath) then
+    Lean.logWarning s!"Roundtrip test skipped: ion-java jar not found at {jarPath}"
+    return
+
+  let dir : System.FilePath := "/tmp/strata-java-roundtrip-tree"
+  if ← dir.pathExists then IO.FS.removeDirAll dir
+
+  let treeFiles := getIonSerializer% Tree "com.test"
+  let pkgDir := dir / "com" / "test"
+  IO.FS.createDirAll pkgDir
+  for (name, content) in treeFiles.files do
+    IO.FS.writeFile (pkgDir / name) content
+
+  let driverContent := "
+import com.test.*;
+import com.amazon.ion.*;
+import com.amazon.ion.system.*;
+import java.io.*;
+
+public class RoundtripTreeTest {
+    public static void main(String[] args) throws Exception {
+        var ionSystem = IonSystemBuilder.standard().build();
+        // Tree.node(Tree.leaf(1), Tree.leaf(2))
+        var tree = new Tree.Node(new Tree.Leaf(1), new Tree.Leaf(2));
+        var ionValue = tree.toIon(ionSystem);
+        try (var out = new FileOutputStream(args[0])) {
+            var writer = IonBinaryWriterBuilder.standard().build(out);
+            ionValue.writeTo(writer);
+            writer.close();
+        }
+    }
+}
+"
+  IO.FS.writeFile (dir / "RoundtripTreeTest.java") driverContent
+
+  let mut javaPaths : Array String := #[(dir / "RoundtripTreeTest.java").toString]
+  for (name, _) in treeFiles.files do
+    javaPaths := javaPaths.push (pkgDir / name).toString
+
+  let compileResult ← IO.Process.output {
+    cmd := "javac"
+    args := #["-cp", s!"{jarPath}:{dir}"] ++ javaPaths
+  }
+  if compileResult.exitCode != 0 then
+    Lean.logError s!"Roundtrip Tree compile failed:\n{compileResult.stderr}"
+    IO.FS.removeDirAll dir
+    return
+
+  let ionFile := dir / "tree.ion"
+  let runResult ← IO.Process.output {
+    cmd := "java"
+    args := #["-cp", s!"{jarPath}:{dir}", "RoundtripTreeTest", ionFile.toString]
+  }
+  if runResult.exitCode != 0 then
+    Lean.logError s!"Roundtrip Tree run failed:\n{runResult.stderr}"
+    IO.FS.removeDirAll dir
+    return
+
+  let ionBytes ← IO.FS.readBinFile ionFile
+  let deserializeTree : ByteArray → Except Std.Format Tree := getIonDeserializer% Tree
+  match deserializeTree ionBytes with
+  | .ok (.node (.leaf 1) (.leaf 2)) => pure ()
+  | .ok other => Lean.logError s!"Tree roundtrip mismatch: expected node(leaf 1, leaf 2), got {repr other}"
+  | .error e => Lean.logError s!"Tree roundtrip deser failed: {e}"
+
+  IO.FS.removeDirAll dir
+
+#testRoundtripTree
+
 end Strata.Java.Test

--- a/docs/DDMJavaCodeGen.md
+++ b/docs/DDMJavaCodeGen.md
@@ -7,74 +7,48 @@ consumption by Strata.
 
 ## Usage from the CLI
 
-The `strata` CLI provides the `javaGen` command for generating Java source
-files directly from a dialect definition.
+The `laurelJavaGen` Lake executable generates Java source files for the
+Laurel AST types.
 
 ```
-strata javaGen <dialect> <package> <output-dir> [--include <path>]
+lake exe laurelJavaGen <package> <output-dir>
 ```
 
 ### Arguments
 
 | Argument | Description |
 |----------|-------------|
-| `dialect` | A dialect name (e.g. `Laurel`) or a path to a `.dialect.st` file |
-| `package` | Java package name (e.g. `com.example.mydialect`) |
+| `package` | Java package name (e.g. `org.strata.jverify.laurel`) |
 | `output-dir` | Directory where generated Java files will be written |
 
-### Flags
-
-| Flag | Description |
-|------|-------------|
-| `--include <path>` | Add a dialect search path (may be repeated) |
-
-### Examples
-
-Generate Java files from a built-in dialect by name:
+### Example
 
 ```bash
-strata javaGen Laurel com.example.laurel ./generated
-```
-
-Generate from a dialect file on disk:
-
-```bash
-strata javaGen StrataTest/DDM/Integration/Java/testdata/Simple.dialect.st com.example.simple ./generated
-```
-
-Use `--include` to add search paths when the dialect references other
-dialect files:
-
-```bash
-strata javaGen MyDialect com.example.mydialect ./generated \
-  --include ./dialects --include ./deps
+lake exe laurelJavaGen org.strata.jverify.laurel ../jverify/verifier/src/main/java
 ```
 
 The command creates the Java package directory structure under `output-dir`
-and writes all generated files. On success it prints the output path, e.g.:
-
-```
-Generated Java files for Laurel in ./generated/com/example/laurel
-```
+and writes all generated files. On success it prints the number of files
+generated.
 
 ## Usage from Lean
 
 ```lean
-import Strata.DDM.Integration.Java.Gen
+import StrataDDM.Integration.Java.Gen
 
 open Strata.Java
 
--- Obtain a Dialect value. The CLI builds one via DialectFileMap;
--- see the javaGenCommand in StrataMain.lean for the full pattern.
--- Here we assume `myDialect : Strata.Dialect` is already loaded.
+-- getIonSerializer% inspects a Lean type and generates Java source files
+-- at compile time. The second argument is the Java package name.
+def myFiles : GeneratedFiles := getIonSerializer% MyType "com.example.mypackage"
 
-let files ← IO.ofExcept (generateDialect myDialect "com.example.mypackage")
-writeJavaFiles "./generated" "com.example.mypackage" files
+-- Write the generated files to disk:
+#eval writeJavaFiles "./generated" "com.example.mypackage" myFiles
 ```
 
-`generateDialect` returns `Except String GeneratedFiles`, failing if the
-dialect contains unsupported declarations. `writeJavaFiles` creates the
-package directory structure and writes all files.
+`getIonSerializer%` is a term-level elaborator that generates Java records
+with Ion serialization. `writeJavaFiles` creates the package directory
+structure and writes all files.
 
 ## Generated Files
 
@@ -374,4 +348,5 @@ collision.
 
 ## Implementation
 
-The generator lives in `Strata/DDM/Integration/Java/Gen.lean`.
+The generator lives in `StrataDDM/StrataDDM/Integration/Java/Gen.lean`.
+The Laurel-specific CLI wrapper is `Scripts/LaurelJavaGen.lean`.


### PR DESCRIPTION
## Summary
- Fix nested list serialization bug in `serializeExprForInfo`: emit stream-reduce for `Option (List T)` instead of non-compiling `.toIon(ion)` on `java.util.List`
- Update stale documentation (`docs/DDMJavaCodeGen.md`, `StrataCLI/README.md`) to reference `lake exe laurelJavaGen` / `getIonSerializer%` instead of removed `strata javaGen`
- Add roundtrip tests for multi-constructor (`Shape`) and recursive (`Tree`) types
- Add value-level deserialization tests that verify actual Ion bytes decode to expected Lean values

## Review comments addressed
- Post 3 + 7 (AutoSDE + Heimdall): `.list` branch bug in `serializeExprForInfo`
- Post 5 (Heimdall): stale docs referencing removed `javaGen` command
- Post 1 (AutoSDE): missing roundtrip coverage for nested/recursive types
- Post 2 (AutoSDE): deserializer tests only check types, not values

## Not addressable from this package
- Post 4 + 10: `SwitchDesugaring` skip in `StrataJavaFrontEnd` (separate repo)
- Post 6 + 9: `.crux_dry_run_build` deletion in `StrataInternal` (separate repo)

## Test plan
- [ ] `lake build StrataTest.Util.IonDeserializer` passes (value-level #guard tests)
- [ ] `lake build StrataTestExtra.Languages.Java.TestGen` passes (roundtrip tests)
- [ ] Generated Java for `Option (List Nat)` field compiles with javac