### PR TITLE
fix(docs): Update verso lakefile for split Laurel guides

### DIFF
--- a/docs/verso/lakefile.toml
+++ b/docs/verso/lakefile.toml
@@ -1,5 +1,5 @@
 name = "StrataDoc"
-defaultTargets = ["ddm", "langdef", "laurel", "transforms", "irtranslation"]
+defaultTargets = ["ddm", "langdef", "laureldesign", "laurelimpl", "laurelguide", "transforms", "irtranslation"]
 
 [[require]]
 name = "Strata"
@@ -25,11 +25,25 @@ name = "langdef"
 root = "LangDefDocMain"
 
 [[lean_lib]]
-name = "LaurelDoc"
+name = "LaurelDesignerGuide"
 
 [[lean_exe]]
-name = "laurel"
-root = "LaurelDocMain"
+name = "laureldesign"
+root = "LaurelDesignerGuideMain"
+
+[[lean_lib]]
+name = "LaurelImplementorGuide"
+
+[[lean_exe]]
+name = "laurelimpl"
+root = "LaurelImplementorGuideMain"
+
+[[lean_lib]]
+name = "LaurelUserGuide"
+
+[[lean_exe]]
+name = "laurelguide"
+root = "LaurelUserGuideMain"
 
 [[lean_lib]]
 name = "TransformsDoc"


### PR DESCRIPTION
The Laurel documentation was split into three separate guides (Designer, Implementor, User) with corresponding `Main.lean` files, but `docs/verso/lakefile.toml` was not updated to match.

### Changes
- Update `defaultTargets` from `["ddm", "langdef", "laurel", ...]` to `["ddm", "langdef", "laureldesign", "laurelimpl", "laurelguide", ...]`
- Replace single `LaurelDoc`/`laurel` lib+exe with three: `LaurelDesignerGuide`/`laureldesign`, `LaurelImplementorGuide`/`laurelimpl`, `LaurelUserGuide`/`laurelguide`
- Matches the version in the Brazil `Strata` package on mainline