### PR TITLE
fix(build): raise clang bracket-depth for generated Translate.c

### DIFF
--- a/lakefile.toml
+++ b/lakefile.toml
@@ -4,6 +4,8 @@ defaultTargets = ["Strata", "StrataToCBMC", "StrataCoreToGoto"]
 testDriver = "StrataTestMain"
 lintDriver = "CheckImports"
 
+moreLeancArgs = ["-fbracket-depth=4096"]
+
 [leanOptions]
 warningAsError = true
 


### PR DESCRIPTION
## What
Add `moreLeancArgs = ["-fbracket-depth=4096"]` to `lakefile.toml`.

## Why
The GitHub Build has been red since the type-specific named-operator work landed. Root cause: `translateFn` in `Strata/Languages/Core/DDMTransform/Translate.lean` is now a ~300-arm `match` over operator names, which Lean compiles into a deeply nested if/else chain in the generated `Translate.c`. clang's default `-fbracket-depth=256` rejects it:

```
Translate.c:31544:1: fatal error: bracket nesting level exceeded maximum of 256
note: use -fbracket-depth=N to increase maximum nesting level
```

The internal build uses GCC, which has no such cap — so it stayed green there while GitHub broke.

## Validation
Reproduced locally at this HEAD with Lean 4.29.1: generated `Translate.c` fails under clang by default (exit 1, same file:line) and **compiles clean with `-fbracket-depth=4096`** (exit 0); GCC compiles it either way. Opening as draft to let CI confirm end-to-end.

Follow-up worth considering: split the operator table into per-type helpers / a lookup map so the generated C doesn't keep growing toward compiler limits.