### PR TITLE
feat(smt): typing, denotation, and well-formedness for an SMT query

### DIFF
--- a/Strata.lean
+++ b/Strata.lean
@@ -97,6 +97,7 @@ import Strata.DL.SMT.Translate
 import Strata.DL.SMT.DenoteTyped
 import Strata.DL.SMT.DenoteTypedProps
 import Strata.DL.SMT.DenoteSemanticsEquiv
+import Strata.DL.SMT.DenoteTypedSMTQuery
 
 /- Other -/
 import Strata.MetaVerifier

--- a/Strata/DL/SMT/DenoteTyped.lean
+++ b/Strata/DL/SMT/DenoteTyped.lean
@@ -50,9 +50,7 @@ import all Strata.Util.HList
 
 namespace Strata.SMT.DenoteTyped
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Sort well-formedness
-   ═══════════════════════════════════════════════════════════════════════════ -/
+/-! ## Sort well-formedness -/
 
 /-- Typing contexts: declared sort constructors, functions, and variables. -/
 abbrev USCtx := List Strata.DL.SMT.Sort
@@ -91,9 +89,7 @@ def TermType.WFSorts (uss : USCtx) : List TermType → Bool
   | ty :: tys => TermType.WFSort uss ty && TermType.WFSorts uss tys
 end
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   SMT-term type checker
-   ═══════════════════════════════════════════════════════════════════════════ -/
+/-! ## SMT-term type checker -/
 
 mutual
 /-- Type-check a term against a UF context and a variable context, additionally certifying
@@ -218,9 +214,7 @@ def Term.wfTriggers (ctx : TypedContext) : List (List Term) → Bool
   | group :: rest => typeCheckAll ctx group && wfTriggers ctx rest
 end
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Typed Term denotation
-   ═══════════════════════════════════════════════════════════════════════════ -/
+/-! ## Typed Term denotation -/
 
 /-- Interpretation of the non-primitive sorts: assigns each sort constructor `TermType.constr id args`
     a Lean carrier. -/
@@ -298,9 +292,7 @@ def UFInterp (σ : SortInterp) (𝒜 : ArrayTheory) := (uf : UF) → UF.denoteTy
 def VarEnv (σ : SortInterp) (𝒜 : ArrayTheory) := (x : TermVar) → (TermType.denoteTyped σ 𝒜 x.ty)
 
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Type-checking inversion lemmas (consumed by `Term.denoteTyped`)
-   ═══════════════════════════════════════════════════════════════════════════ -/
+/-! ## Type-checking inversion lemmas (consumed by `Term.denoteTyped`) -/
 
 private def Term.typeCheck_prim_inv {ctx : TypedContext} {p : TermPrim} {τ : TermType}
     (h : Term.typeCheck ctx (.prim p) = .ok τ) : τ = p.typeOf := by

--- a/Strata/DL/SMT/DenoteTypedProps.lean
+++ b/Strata/DL/SMT/DenoteTypedProps.lean
@@ -420,13 +420,12 @@ private theorem Term.denoteTyped_env_congr {ctx : TypedContext}
     Term.denoteTyped ufInterp env dz mz tm τ htc = Term.denoteTyped ufInterp env' dz mz tm τ htc := by
   rw [h]
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   `Term.typeCheck` monotonicity under UF-context extension.
+/-! ## `Term.typeCheck` monotonicity under UF-context extension
 
-   The UF-app arm gates on `uf ∈ ctx.ufs` (exact membership), which is monotone under a superset; every
-   other arm ignores `ctx.ufs` (recurses / uses `uss`/`Γ` only). So a term well-typed at `ufs` stays
-   well-typed (to the same type) at any `ufs' ⊇ ufs`.
-   ═══════════════════════════════════════════════════════════════════════════ -/
+The UF-app arm gates on `uf ∈ ctx.ufs` (exact membership), which is monotone under a superset; every
+other arm ignores `ctx.ufs` (recurses / uses `uss`/`Γ` only). So a term well-typed at `ufs` stays
+well-typed (to the same type) at any `ufs' ⊇ ufs`.
+-/
 
 mutual
 theorem typeCheck_ufs_mono {uss : USCtx} {ufs ufs' : UFCtx}

--- a/Strata/DL/SMT/DenoteTypedProps.lean
+++ b/Strata/DL/SMT/DenoteTypedProps.lean
@@ -177,20 +177,20 @@ theorem Term.denoteTyped_exists_eq_true
 /-- Unfolding lemma for `Term.denoteTyped` on a UF application, exposing `UF.applyDenoteTyped'` on the
     denoted argument `HList`. -/
 private theorem Term.denoteTyped_uf {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (uf : UF) (args : List Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core (.uf uf)) args rty) = .ok τ)
     (hargs : Term.typeCheckArgs ctx args uf.args = true) (hout : τ = uf.out) :
     Term.denoteTyped ufInterp env dz mz (.app (.core (.uf uf)) args rty) τ htc
       = cast (by rw [hout])
-          (UF.applyDenoteTyped' σ SmtArrayTheory uf.args uf.out (ufInterp uf)
+          (UF.applyDenoteTyped' σ 𝒜 uf.args uf.out (ufInterp uf)
             (Term.denoteTypedArgs ufInterp env dz mz args uf.args hargs)) := by
   unfold Term.denoteTyped
   rfl
 
 /-- Unfolding lemma for `Term.denoteTyped` on `not`. -/
 private theorem Term.denoteTyped_not {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (t : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core .not) [t] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.core .not) [t] rty) τ htc
@@ -202,21 +202,21 @@ private theorem Term.denoteTyped_not {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on `none`. -/
 private theorem Term.denoteTyped_none {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (ty τ : TermType) (htc : Term.typeCheck ctx (.none ty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.none ty) τ htc
-      = cast (by rw [Term.typeCheck_none_inv htc]) (none : TermType.denoteTyped σ SmtArrayTheory (.option ty)) := by
+      = cast (by rw [Term.typeCheck_none_inv htc]) (none : TermType.denoteTyped σ 𝒜 (.option ty)) := by
   simp only [Term.denoteTyped]
 
 /-- Unfolding lemma for `Term.denoteTyped` on `some`. -/
 private theorem Term.denoteTyped_some {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (t : Term) (τ : TermType) (htc : Term.typeCheck ctx (.some t) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.some t) τ htc
-      = cast (congrArg (TermType.denoteTyped σ SmtArrayTheory) (Term.typeCheck_some_inv htc).2.2.symm)
+      = cast (congrArg (TermType.denoteTyped σ 𝒜) (Term.typeCheck_some_inv htc).2.2.symm)
           (some (Term.denoteTyped ufInterp env dz mz t (Term.typeCheck_some_inv htc).1
                   (Term.typeCheck_some_inv htc).2.1)
-            : TermType.denoteTyped σ SmtArrayTheory (.option (Term.typeCheck_some_inv htc).1)) := by
+            : TermType.denoteTyped σ 𝒜 (.option (Term.typeCheck_some_inv htc).1)) := by
   simp only [Term.denoteTyped]
   obtain ⟨τ', ht, heq⟩ := Term.typeCheck_some_inv htc
   rfl
@@ -258,7 +258,7 @@ private theorem Term.denoteTyped_store {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on `eq`, exposing `decide (· = ·)`. -/
 private theorem Term.denoteTyped_eq {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core .eq) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.core .eq) [t1, t2] rty) τ htc
@@ -270,7 +270,7 @@ private theorem Term.denoteTyped_eq {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on `ite`, exposing the boolean `bif`. -/
 private theorem Term.denoteTyped_ite {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (c t e : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core .ite) [c, t, e] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.core .ite) [c, t, e] rty) τ htc
@@ -281,7 +281,7 @@ private theorem Term.denoteTyped_ite {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on `and`, exposing `&&`. -/
 private theorem Term.denoteTyped_and {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core .and) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.core .and) [t1, t2] rty) τ htc
@@ -292,7 +292,7 @@ private theorem Term.denoteTyped_and {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on `or`, exposing `||`. -/
 private theorem Term.denoteTyped_or {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core .or) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.core .or) [t1, t2] rty) τ htc
@@ -303,7 +303,7 @@ private theorem Term.denoteTyped_or {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on `implies`, exposing `!… || …`. -/
 private theorem Term.denoteTyped_implies {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int)
     (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.core .implies) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.core .implies) [t1, t2] rty) τ htc
@@ -314,7 +314,7 @@ private theorem Term.denoteTyped_implies {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `add`. -/
 private theorem Term.denoteTyped_add {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .add) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .add) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intBin_inv htc (.inl rfl)).2.2])
@@ -324,7 +324,7 @@ private theorem Term.denoteTyped_add {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `sub`. -/
 private theorem Term.denoteTyped_sub {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .sub) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .sub) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intBin_inv htc (.inr (.inl rfl))).2.2])
@@ -334,7 +334,7 @@ private theorem Term.denoteTyped_sub {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `mul`. -/
 private theorem Term.denoteTyped_mul {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .mul) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .mul) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intBin_inv htc (.inr (.inr (.inl rfl)))).2.2])
@@ -344,7 +344,7 @@ private theorem Term.denoteTyped_mul {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `le`. -/
 private theorem Term.denoteTyped_le {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .le) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .le) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intCmp_inv htc (.inl rfl)).2.2])
@@ -354,7 +354,7 @@ private theorem Term.denoteTyped_le {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `lt`. -/
 private theorem Term.denoteTyped_lt {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .lt) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .lt) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intCmp_inv htc (.inr (.inl rfl))).2.2])
@@ -364,7 +364,7 @@ private theorem Term.denoteTyped_lt {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `ge`. -/
 private theorem Term.denoteTyped_ge {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .ge) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .ge) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intCmp_inv htc (.inr (.inr (.inl rfl)))).2.2])
@@ -374,7 +374,7 @@ private theorem Term.denoteTyped_ge {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `gt`. -/
 private theorem Term.denoteTyped_gt {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .gt) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .gt) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intCmp_inv htc (.inr (.inr (.inr rfl)))).2.2])
@@ -384,7 +384,7 @@ private theorem Term.denoteTyped_gt {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `div`. -/
 private theorem Term.denoteTyped_div {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .div) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .div) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intBin_inv htc (.inr (.inr (.inr (.inl rfl))))).2.2])
@@ -395,7 +395,7 @@ private theorem Term.denoteTyped_div {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int `mod`. -/
 private theorem Term.denoteTyped_mod {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t1 t2 : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .mod) [t1, t2] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .mod) [t1, t2] rty) τ htc
       = cast (by rw [(Term.typeCheck_intBin_inv htc (.inr (.inr (.inr (.inr rfl))))).2.2])
@@ -406,7 +406,7 @@ private theorem Term.denoteTyped_mod {ctx : TypedContext}
 
 /-- Unfolding lemma for `Term.denoteTyped` on int negation. -/
 private theorem Term.denoteTyped_neg {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env : VarEnv σ SmtArrayTheory) (dz mz : Int → Int) (t : Term) (rty τ : TermType)
+    (ufInterp : UFInterp σ 𝒜) (env : VarEnv σ 𝒜) (dz mz : Int → Int) (t : Term) (rty τ : TermType)
     (htc : Term.typeCheck ctx (.app (.num .neg) [t] rty) = .ok τ) :
     Term.denoteTyped ufInterp env dz mz (.app (.num .neg) [t] rty) τ htc
       = cast (by rw [(Term.typeCheck_intUn_inv htc).2]) (-(Term.denoteTyped ufInterp env dz mz t .int (Term.typeCheck_intUn_inv htc).1)) := by
@@ -414,10 +414,208 @@ private theorem Term.denoteTyped_neg {ctx : TypedContext}
 
 /-- `Term.denoteTyped` depends on its `env` argument only up to function equality. -/
 private theorem Term.denoteTyped_env_congr {ctx : TypedContext}
-    (ufInterp : UFInterp σ SmtArrayTheory) (env env' : VarEnv σ SmtArrayTheory) (dz mz : Int → Int)
+    (ufInterp : UFInterp σ 𝒜) (env env' : VarEnv σ 𝒜) (dz mz : Int → Int)
     (tm : Term) (τ : TermType) (htc : Term.typeCheck ctx tm = .ok τ)
     (h : env = env') :
     Term.denoteTyped ufInterp env dz mz tm τ htc = Term.denoteTyped ufInterp env' dz mz tm τ htc := by
   rw [h]
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   `Term.typeCheck` monotonicity under UF-context extension.
+
+   The UF-app arm gates on `uf ∈ ctx.ufs` (exact membership), which is monotone under a superset; every
+   other arm ignores `ctx.ufs` (recurses / uses `uss`/`Γ` only). So a term well-typed at `ufs` stays
+   well-typed (to the same type) at any `ufs' ⊇ ufs`.
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+mutual
+theorem typeCheck_ufs_mono {uss : USCtx} {ufs ufs' : UFCtx}
+    (hsub : ∀ u ∈ ufs, u ∈ ufs') (Γ : List TermVar) (t : Term) (τ : TermType)
+    (h : Term.typeCheck ⟨uss, ufs, Γ⟩ t = .ok τ) :
+    Term.typeCheck ⟨uss, ufs', Γ⟩ t = .ok τ := by
+  match t with
+  | .prim p => simpa only [Term.typeCheck] using h
+  | .var v => simpa only [Term.typeCheck] using h
+  | .none ty => simpa only [Term.typeCheck] using h
+  | .some t1 =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ t1 ty1 h1, bind, Except.bind]
+      exact h
+  | .quant k vs tr body =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨tyb, hb, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub (vs.reverse ++ Γ) body tyb hb, bind, Except.bind]
+      revert h
+      split <;> intro h <;> rename_i hcond
+      · rw [if_pos ?_]
+        · exact h
+        · simp only [Bool.and_eq_true] at hcond ⊢
+          exact ⟨hcond.1, wfTriggers_ufs_mono hsub (vs.reverse ++ Γ) tr hcond.2⟩
+      · exact absurd h (by simp)
+  | .app (.core (.uf uf)) args rty =>
+      simp only [Term.typeCheck] at h ⊢
+      split at h
+      · rename_i hc
+        rw [if_pos ⟨hsub uf hc.1, hc.2⟩]
+        split at h
+        · rename_i hchk
+          simp only [Bool.and_eq_true] at hchk
+          obtain ⟨⟨⟨hrty, hargs⟩, hall⟩, hout⟩ := hchk
+          rw [if_pos ?_]
+          · exact h
+          · simp only [Bool.and_eq_true]
+            exact ⟨⟨⟨hrty, typeCheckArgs_ufs_mono hsub Γ args uf.args hargs⟩, hall⟩, hout⟩
+        · exact absurd h (by simp)
+      · exact absurd h (by simp)
+  | .app (.core .not) [t1] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ t1 ty1 h1, bind, Except.bind]
+      exact h
+  | .app (.core .and) [t1, t2] rty | .app (.core .or) [t1, t2] rty
+  | .app (.core .implies) [t1, t2] rty | .app (.core .eq) [t1, t2] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      obtain ⟨ty2, h2, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ t1 ty1 h1, typeCheck_ufs_mono hsub Γ t2 ty2 h2,
+        bind, Except.bind]
+      exact h
+  | .app (.core .ite) [c, t1, e] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨tyc, hc, h⟩ := Except.bind_eq_ok'.mp h
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      obtain ⟨tye, he, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ c tyc hc, typeCheck_ufs_mono hsub Γ t1 ty1 h1,
+        typeCheck_ufs_mono hsub Γ e tye he, bind, Except.bind]
+      exact h
+  | .app (.num .neg) [t1] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ t1 ty1 h1, bind, Except.bind]
+      exact h
+  | .app (.num .add) [t1, t2] rty | .app (.num .sub) [t1, t2] rty
+  | .app (.num .mul) [t1, t2] rty | .app (.num .div) [t1, t2] rty
+  | .app (.num .mod) [t1, t2] rty
+  | .app (.num .le) [t1, t2] rty | .app (.num .lt) [t1, t2] rty
+  | .app (.num .ge) [t1, t2] rty | .app (.num .gt) [t1, t2] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      obtain ⟨ty2, h2, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ t1 ty1 h1, typeCheck_ufs_mono hsub Γ t2 ty2 h2,
+        bind, Except.bind]
+      exact h
+  | .app (.core .distinct) (t1 :: t2 :: ts) rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨ty1, h1, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ t1 ty1 h1, bind, Except.bind]
+      revert h
+      split <;> intro h <;> rename_i hcond
+      · rw [if_pos ?_]
+        · exact h
+        · simp only [Bool.and_eq_true] at hcond ⊢
+          exact ⟨typeCheckArgs_ufs_mono hsub Γ (t2 :: ts) _ hcond.1, hcond.2⟩
+      · exact absurd h (by simp)
+  | .app .select [a, i] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨tya, ha, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ a tya ha, bind, Except.bind]
+      revert h
+      split <;> intro h
+      · obtain ⟨tyi, hi, h⟩ := Except.bind_eq_ok'.mp h
+        simp only [typeCheck_ufs_mono hsub Γ i tyi hi]
+        exact h
+      · exact absurd h (by simp)
+  | .app .store [a, i, e] rty =>
+      simp only [Term.typeCheck] at h ⊢
+      obtain ⟨tya, ha, h⟩ := Except.bind_eq_ok'.mp h
+      simp only [typeCheck_ufs_mono hsub Γ a tya ha, bind, Except.bind]
+      revert h
+      split <;> intro h
+      · obtain ⟨tyi, hi, h⟩ := Except.bind_eq_ok'.mp h
+        obtain ⟨tye, he, h⟩ := Except.bind_eq_ok'.mp h
+        simp only [typeCheck_ufs_mono hsub Γ i tyi hi, typeCheck_ufs_mono hsub Γ e tye he]
+        exact h
+      · exact absurd h (by simp)
+  -- All remaining `.app` shapes are malformed: an unhandled operator, or a handled operator applied at
+  -- the wrong arity. In every case `Term.typeCheck` falls through to its `.error` arm, contradicting a
+  -- `.ok` result. A `match` catch-all cannot see the earlier arms' negative constraints, so the concrete
+  -- residual shapes are enumerated to let `typeCheck` reduce.
+  | .app (.core .not) [] rty | .app (.core .not) (_ :: _ :: _) rty
+  | .app (.core .and) [] rty | .app (.core .and) [_] rty | .app (.core .and) (_ :: _ :: _ :: _) rty
+  | .app (.core .or) [] rty | .app (.core .or) [_] rty | .app (.core .or) (_ :: _ :: _ :: _) rty
+  | .app (.core .implies) [] rty | .app (.core .implies) [_] rty
+  | .app (.core .implies) (_ :: _ :: _ :: _) rty
+  | .app (.core .eq) [] rty | .app (.core .eq) [_] rty | .app (.core .eq) (_ :: _ :: _ :: _) rty
+  | .app (.core .ite) [] rty | .app (.core .ite) [_] rty | .app (.core .ite) [_, _] rty
+  | .app (.core .ite) (_ :: _ :: _ :: _ :: _) rty
+  | .app (.core .distinct) [] rty | .app (.core .distinct) [_] rty
+  | .app (.num .neg) [] rty | .app (.num .neg) (_ :: _ :: _) rty
+  | .app (.num .add) [] rty | .app (.num .add) [_] rty | .app (.num .add) (_ :: _ :: _ :: _) rty
+  | .app (.num .sub) [] rty | .app (.num .sub) [_] rty | .app (.num .sub) (_ :: _ :: _ :: _) rty
+  | .app (.num .mul) [] rty | .app (.num .mul) [_] rty | .app (.num .mul) (_ :: _ :: _ :: _) rty
+  | .app (.num .div) [] rty | .app (.num .div) [_] rty | .app (.num .div) (_ :: _ :: _ :: _) rty
+  | .app (.num .mod) [] rty | .app (.num .mod) [_] rty | .app (.num .mod) (_ :: _ :: _ :: _) rty
+  | .app (.num .le) [] rty | .app (.num .le) [_] rty | .app (.num .le) (_ :: _ :: _ :: _) rty
+  | .app (.num .lt) [] rty | .app (.num .lt) [_] rty | .app (.num .lt) (_ :: _ :: _ :: _) rty
+  | .app (.num .ge) [] rty | .app (.num .ge) [_] rty | .app (.num .ge) (_ :: _ :: _ :: _) rty
+  | .app (.num .gt) [] rty | .app (.num .gt) [_] rty | .app (.num .gt) (_ :: _ :: _ :: _) rty
+  | .app .select [] rty | .app .select [_] rty | .app .select (_ :: _ :: _ :: _) rty
+  | .app .store [] rty | .app .store [_] rty | .app .store [_, _] rty
+  | .app .store (_ :: _ :: _ :: _ :: _) rty
+  | .app (.num .rdiv) _ rty | .app (.num .abs) _ rty
+  | .app (.bv _) _ rty | .app (.str _) _ rty
+  | .app .option_get _ rty | .app (.datatype_op _ _) _ rty =>
+      simp [Term.typeCheck] at h
+
+theorem typeCheckArgs_ufs_mono {uss : USCtx} {ufs ufs' : UFCtx}
+    (hsub : ∀ u ∈ ufs, u ∈ ufs') (Γ : List TermVar) (ts : List Term) (tys : List TermType)
+    (h : Term.typeCheckArgs ⟨uss, ufs, Γ⟩ ts tys = true) :
+    Term.typeCheckArgs ⟨uss, ufs', Γ⟩ ts tys = true := by
+  match ts, tys with
+  | [], [] => simp only [Term.typeCheckArgs]
+  | t :: ts, ety :: rest =>
+      simp only [Term.typeCheckArgs] at h ⊢
+      revert h
+      split <;> intro h <;> rename_i hty
+      · rename_i ty
+        rw [typeCheck_ufs_mono hsub Γ t ty hty]
+        simp only [Bool.and_eq_true] at h ⊢
+        exact ⟨h.1, typeCheckArgs_ufs_mono hsub Γ ts rest h.2⟩
+      · exact absurd h (by simp)
+  | [], _ :: _ => simp [Term.typeCheckArgs] at h
+  | _ :: _, [] => simp [Term.typeCheckArgs] at h
+
+theorem typeCheckAll_ufs_mono {uss : USCtx} {ufs ufs' : UFCtx}
+    (hsub : ∀ u ∈ ufs, u ∈ ufs') (Γ : List TermVar) (ts : List Term)
+    (h : Term.typeCheckAll ⟨uss, ufs, Γ⟩ ts = true) :
+    Term.typeCheckAll ⟨uss, ufs', Γ⟩ ts = true := by
+  match ts with
+  | [] => simp only [Term.typeCheckAll]
+  | t :: ts =>
+      simp only [Term.typeCheckAll, Bool.and_eq_true] at h ⊢
+      obtain ⟨hsome, hrest⟩ := h
+      refine ⟨?_, typeCheckAll_ufs_mono hsub Γ ts hrest⟩
+      rcases hok : Term.typeCheck ⟨uss, ufs, Γ⟩ t with _ | ty
+      · rw [hok] at hsome; simp [Except.toOption] at hsome
+      · rw [typeCheck_ufs_mono hsub Γ t ty hok]; simp [Except.toOption]
+
+theorem wfTriggers_ufs_mono {uss : USCtx} {ufs ufs' : UFCtx}
+    (hsub : ∀ u ∈ ufs, u ∈ ufs') (Γ : List TermVar) (trs : List (List Term))
+    (h : Term.wfTriggers ⟨uss, ufs, Γ⟩ trs = true) :
+    Term.wfTriggers ⟨uss, ufs', Γ⟩ trs = true := by
+  match trs with
+  | [] => simp only [Term.wfTriggers]
+  | group :: rest =>
+      simp only [Term.wfTriggers, Bool.and_eq_true] at h ⊢
+      exact ⟨typeCheckAll_ufs_mono hsub Γ group h.1, wfTriggers_ufs_mono hsub Γ rest h.2⟩
+end
+
+/-- Membership-subset (the hypothesis of `typeCheck_ufs_mono`) for an append extension. -/
+theorem typeCheck_ufs_mono_append {uss : USCtx} {ufs tail : UFCtx}
+    {Γ : List TermVar} {t : Term} {τ : TermType}
+    (h : Term.typeCheck ⟨uss, ufs, Γ⟩ t = .ok τ) :
+    Term.typeCheck ⟨uss, ufs ++ tail, Γ⟩ t = .ok τ :=
+  typeCheck_ufs_mono (fun _ hu => List.mem_append_left _ hu) Γ t τ h
 
 end Strata.SMT.DenoteTyped

--- a/Strata/DL/SMT/DenoteTypedSMTQuery.lean
+++ b/Strata/DL/SMT/DenoteTypedSMTQuery.lean
@@ -4,7 +4,16 @@
   SPDX-License-Identifier: Apache-2.0 OR MIT
 -/
 
-/-
+module
+
+public import Strata.DL.SMT.Factory
+import all Strata.DL.SMT.Factory
+public import Strata.DL.SMT.DenoteTyped
+import all Strata.DL.SMT.DenoteTyped
+public import Strata.DL.SMT.DenoteTypedProps
+import all Strata.DL.SMT.DenoteTypedProps
+
+/-!
 # `SMTQuery`: definition, typing, and denotation for an SMT query
 
 The `SMTQuery` record models an SMT query as the production pipeline's SMT emitter groups it (sorts,
@@ -23,15 +32,6 @@ Key definitions: `SMTQuery.WF`, `SMTQuery.checkSat`, `SMTQuery.UnsatWithNegObl` 
 `SMTQuery.EntailsObl` / `EntailsNegObl`. Key results: `SMTQuery.WF.fsTypeCheck`,
 `SMTQuery.WF.assertOrLitTypeCheck`.
 -/
-
-module
-
-public import Strata.DL.SMT.Factory
-import all Strata.DL.SMT.Factory
-public import Strata.DL.SMT.DenoteTyped
-import all Strata.DL.SMT.DenoteTyped
-public import Strata.DL.SMT.DenoteTypedProps
-import all Strata.DL.SMT.DenoteTypedProps
 
 open Strata.SMT Std
 
@@ -60,15 +60,16 @@ public structure SMTQuery where
   varDecls : List UF
   /-- Variable definitions (nullary `define-fun`). -/
   varDefs : List IF
-  /-- Program assumptions (including `distinct` terms). -/
+  /-- Assumptions (including `distinct` terms). These are not fundamentally different from `obl`: both
+      are emitted as `(assert <t>)`. `obl` is carried separately only because the last term is frequently
+      negated before the satisfiability check; this file provides `UnsatWithNegObl` / `UnsatWithObl` as
+      helpers for that case. -/
   assumptions : List Term
-  /-- The proof obligation / goal. -/
+  /-- The goal term. -/
   obl : Term
   deriving Inhabited
 
----------------------------------------------------------------------
--- Projections: UF context, define-fun preamble, persistent asserts
----------------------------------------------------------------------
+/-! ## Projections: UF context, define-fun preamble, persistent asserts -/
 
 /-- The `define-fun` preamble: interpreted functions followed by variable definitions. -/
 def SMTQuery.fs (q : SMTQuery) : List IF := q.fnDefs ++ q.varDefs
@@ -78,12 +79,10 @@ def SMTQuery.fs (q : SMTQuery) : List IF := q.fnDefs ++ q.varDefs
 def SMTQuery.ufs (q : SMTQuery) : UFCtx :=
   q.fnDecls ++ q.fnDefs.map IF.toUF ++ q.varDecls ++ q.varDefs.map IF.toUF
 
-/-- The persistent assertions: function axioms followed by program assumptions. -/
+/-- The persistent assertions: function axioms followed by assumptions. -/
 def SMTQuery.asserts (q : SMTQuery) : List Term := q.fnAxioms ++ q.assumptions
 
----------------------------------------------------------------------
--- UF-context hygiene and lookup
----------------------------------------------------------------------
+/-! ## UF-context hygiene and lookup -/
 
 /-- SMT symbol names are distinct, and none collides with a reserved `$__bv{n}` binder id. -/
 structure UFCtxWF (ufs : UFCtx) : Prop where
@@ -94,9 +93,7 @@ structure UFCtxWF (ufs : UFCtx) : Prop where
 def lookupUF (ufs : UFCtx) (name : String) : Option UF :=
   ufs.find? (·.id == name)
 
----------------------------------------------------------------------
--- Order-aware well-formedness (SMT-LIB emission faithfulness)
----------------------------------------------------------------------
+/-! ## Order-aware well-formedness (SMT-LIB emission faithfulness) -/
 
 /-- Well-formedness of a single `define-fun` at UF context `ufs`: its body type-checks to its declared
     output `f.out` under `ufs` extended with its formal parameters `f.args`. -/
@@ -129,9 +126,7 @@ structure SMTQuery.WF (q : SMTQuery) : Prop where
   /-- The goal type-checks to `bool` against the full context `q.ufs`. -/
   oblWF : Term.typeCheck ⟨[], q.ufs, []⟩ q.obl = .ok .bool
 
----------------------------------------------------------------------
--- Typing at the full context
----------------------------------------------------------------------
+/-! ## Typing at the full context -/
 
 /-- Each function in an `IFsWF ufsBase fs` type-checks at the full context `ufsBase ++ fs.map IF.toUF`. -/
 private theorem IFsWF.mem_wf {ufsBase : UFCtx} {fs : List IF} (h : IFsWF ufsBase fs) :
@@ -174,9 +169,7 @@ theorem SMTQuery.WF.notOblTypeCheck {q : SMTQuery} (hwf : SMTQuery.WF q) :
     Term.typeCheck ⟨[], q.ufs, []⟩ (Term.app (.core .not) [q.obl] .bool) = .ok .bool := by
   simp [Term.typeCheck, hwf.oblWF, bind, Except.bind]
 
----------------------------------------------------------------------
--- Model-side satisfaction (denotation)
----------------------------------------------------------------------
+/-! ## Model-side satisfaction (denotation) -/
 
 /-- The trivial sort interpretation, mapping every sort to `Unit`. -/
 def defaultσ : SortInterp := fun _ _ => Unit
@@ -261,9 +254,7 @@ def SMTQuery.EntailsNegObl (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
       Term.denoteTyped ufInterp smtEnv divByZero modByZero t .bool (hwf.assertsWF t ht) = true) →
     Term.denoteTyped ufInterp smtEnv divByZero modByZero q.obl .bool hwf.oblWF = false
 
----------------------------------------------------------------------
--- Entailment / unsatisfiability equivalences
----------------------------------------------------------------------
+/-! ## Entailment / unsatisfiability equivalences -/
 
 /-- The assertions entail `obl` iff they are unsatisfiable together with `¬obl`. -/
 theorem SMTQuery.entailsObl_iff_unsatWithNegObl (q : SMTQuery) (hwf : SMTQuery.WF q) :

--- a/Strata/DL/SMT/DenoteTypedSMTQuery.lean
+++ b/Strata/DL/SMT/DenoteTypedSMTQuery.lean
@@ -10,7 +10,7 @@
 The `SMTQuery` record models an SMT query as the production pipeline's SMT emitter groups it (sorts,
 datatypes, function declarations/definitions, function axioms, variable declarations/definitions,
 assumptions, goal). This file gives its typing (via `Term.typeCheck`), its order-aware well-formedness
-`SMTQuery.WF`, and its denotation in terms of satisfiability (`checkSat` / `ProvesGoal`, via
+`SMTQuery.WF`, and its denotation in terms of (un)satisfiability (`checkSat` / `UnsatWithNegObl`, via
 `Term.denoteTyped`). In emission order, every `define-fun` body type-checks against only the context
 accumulated up to it (prior declarations + earlier definitions + its own params, no forward references)
 and every assertion placed after the declarations and definitions type-checks against the full symbol context.
@@ -19,8 +19,9 @@ Scope: the well-formedness judgments type-check terms against an EMPTY sort cont
 they currently assume the query declares no uninterpreted sorts or datatypes — the `sorts` and
 `datatypes` fields are carried for structural fidelity but are not yet threaded into typing/denotation.
 
-Key definitions: `SMTQuery.WF`, `SMTQuery.checkSat`, `SMTQuery.ProvesGoal`. Key results:
-`SMTQuery.WF.fsTypeCheck`, `SMTQuery.WF.assertOrLitTypeCheck`.
+Key definitions: `SMTQuery.WF`, `SMTQuery.checkSat`, `SMTQuery.UnsatWithNegObl` / `UnsatWithObl`,
+`SMTQuery.EntailsObl` / `EntailsNegObl`. Key results: `SMTQuery.WF.fsTypeCheck`,
+`SMTQuery.WF.assertOrLitTypeCheck`.
 -/
 
 module
@@ -42,27 +43,32 @@ public structure RConstructor where
   args : List (String × TermType)
   deriving Repr, Inhabited
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   The emitted query record.
-   ═══════════════════════════════════════════════════════════════════════════ -/
-
+/-- The query record. -/
 public structure SMTQuery where
-  sorts : List Strata.DL.SMT.Sort  -- uninterpreted sorts (declare-sort)
+  /-- Uninterpreted sorts (`declare-sort`). -/
+  sorts : List Strata.DL.SMT.Sort
   /-- User datatype declarations (`declare-datatype[s]`), in topological/mutual-block order. Emitted
       after `sorts`, since datatype constructors may reference the declared sorts. -/
   datatypes : List (List (String × List String × List RConstructor))
-  fnDecls : List UF              -- uninterpreted factory functions (declare-fun)
-  fnDefs : List IF               -- interpreted functions (define-fun)
+  /-- Uninterpreted functions (`declare-fun`). -/
+  fnDecls : List UF
+  /-- Interpreted functions (`define-fun`). -/
+  fnDefs : List IF
+  /-- Function axioms. -/
   fnAxioms : List Term
-  varDecls : List UF             -- variables; declare-fun
-  varDefs : List IF              -- nullary define-funs
-  assumptions : List Term        -- including `.distinct` terms
-  obl : Term                     -- obligation / goal
+  /-- Variable declarations (`declare-fun`). -/
+  varDecls : List UF
+  /-- Variable definitions (nullary `define-fun`). -/
+  varDefs : List IF
+  /-- Program assumptions (including `distinct` terms). -/
+  assumptions : List Term
+  /-- The proof obligation / goal. -/
+  obl : Term
   deriving Inhabited
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Projections: the UF typing context, the define-fun preamble, the persistent asserts.
-   ═══════════════════════════════════════════════════════════════════════════ -/
+---------------------------------------------------------------------
+-- Projections: UF context, define-fun preamble, persistent asserts
+---------------------------------------------------------------------
 
 /-- The `define-fun` preamble: interpreted functions followed by variable definitions. -/
 def SMTQuery.fs (q : SMTQuery) : List IF := q.fnDefs ++ q.varDefs
@@ -75,9 +81,9 @@ def SMTQuery.ufs (q : SMTQuery) : UFCtx :=
 /-- The persistent assertions: function axioms followed by program assumptions. -/
 def SMTQuery.asserts (q : SMTQuery) : List Term := q.fnAxioms ++ q.assumptions
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   UF-context hygiene + lookup.
-   ═══════════════════════════════════════════════════════════════════════════ -/
+---------------------------------------------------------------------
+-- UF-context hygiene and lookup
+---------------------------------------------------------------------
 
 /-- SMT symbol names are distinct, and none collides with a reserved `$__bv{n}` binder id. -/
 structure UFCtxWF (ufs : UFCtx) : Prop where
@@ -88,9 +94,9 @@ structure UFCtxWF (ufs : UFCtx) : Prop where
 def lookupUF (ufs : UFCtx) (name : String) : Option UF :=
   ufs.find? (·.id == name)
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Order-aware well-formedness (SMT-LIB emission faithfulness).
-   ═══════════════════════════════════════════════════════════════════════════ -/
+---------------------------------------------------------------------
+-- Order-aware well-formedness (SMT-LIB emission faithfulness)
+---------------------------------------------------------------------
 
 /-- Well-formedness of a single `define-fun` at UF context `ufs`: its body type-checks to its declared
     output `f.out` under `ufs` extended with its formal parameters `f.args`. -/
@@ -123,9 +129,9 @@ structure SMTQuery.WF (q : SMTQuery) : Prop where
   /-- The goal type-checks to `bool` against the full context `q.ufs`. -/
   oblWF : Term.typeCheck ⟨[], q.ufs, []⟩ q.obl = .ok .bool
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Typing at the full context: every define-fun, assertion, and the goal type-check against `q.ufs`.
-   ═══════════════════════════════════════════════════════════════════════════ -/
+---------------------------------------------------------------------
+-- Typing at the full context
+---------------------------------------------------------------------
 
 /-- Each function in an `IFsWF ufsBase fs` type-checks at the full context `ufsBase ++ fs.map IF.toUF`. -/
 private theorem IFsWF.mem_wf {ufsBase : UFCtx} {fs : List IF} (h : IFsWF ufsBase fs) :
@@ -168,9 +174,9 @@ theorem SMTQuery.WF.notOblTypeCheck {q : SMTQuery} (hwf : SMTQuery.WF q) :
     Term.typeCheck ⟨[], q.ufs, []⟩ (Term.app (.core .not) [q.obl] .bool) = .ok .bool := by
   simp [Term.typeCheck, hwf.oblWF, bind, Except.bind]
 
-/- ═══════════════════════════════════════════════════════════════════════════
-   Model-side satisfaction (denotation), over the trivial base-sort interpretation.
-   ═══════════════════════════════════════════════════════════════════════════ -/
+---------------------------------------------------------------------
+-- Model-side satisfaction (denotation)
+---------------------------------------------------------------------
 
 /-- The trivial sort interpretation, mapping every sort to `Unit`. -/
 def defaultσ : SortInterp := fun _ _ => Unit
@@ -180,7 +186,7 @@ instance : SortInterp.AllInhabited defaultσ := ⟨fun _ _ => ⟨()⟩⟩
 variable {σ : SortInterp} {𝒜 : ArrayTheory} [SortInterp.AllInhabited σ]
 
 /-- Build a `VarEnv` binding the variables `bvs` to an HList of values, with `default` elsewhere. -/
-noncomputable def hlToEnv : (bvs : TermVarCtx) → HList (TermType.denoteTyped σ 𝒜) (bvs.map (·.ty)) → VarEnv σ 𝒜
+def hlToEnv : (bvs : TermVarCtx) → HList (TermType.denoteTyped σ 𝒜) (bvs.map (·.ty)) → VarEnv σ 𝒜
   | [], _ => fun _ => default
   | v :: rest, hl =>
     match hl with
@@ -221,16 +227,117 @@ def SMTQuery.checkSat (q : SMTQuery) (hwf : SMTQuery.WF q) (lits : List Term)
       Term.denoteTyped ufInterp smtEnv divByZero modByZero t .bool
         (hwf.assertOrLitTypeCheck hlits ht) = true)
 
-/-- Validity verdict: no model satisfies the assertions together with the negated goal (so the
-    assertions entail the goal). -/
-def SMTQuery.ProvesGoal (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
+/-- The assertions together with `¬obl` are unsatisfiable (equivalently, the assertions entail `obl` —
+    see `EntailsObl`). -/
+def SMTQuery.UnsatWithNegObl (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
   ¬ q.checkSat hwf [Term.app (.core .not) [q.obl] .bool]
       (fun t ht => by rw [List.mem_singleton] at ht; subst ht; exact hwf.notOblTypeCheck)
 
-/-- Refutation verdict: no model satisfies the assertions together with the goal (so the assertions
-    entail `¬goal`). -/
-def SMTQuery.RefutesGoal (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
+/-- The assertions together with `obl` are unsatisfiable (equivalently, the assertions entail `¬obl` —
+    see `EntailsNegObl`). -/
+def SMTQuery.UnsatWithObl (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
   ¬ q.checkSat hwf [q.obl]
       (fun t ht => by rw [List.mem_singleton] at ht; subst ht; exact hwf.oblWF)
+
+/-- The assertions entail `obl`: in every model respecting the `define-fun` preamble in which all
+    persistent assertions denote `true`, `obl` denotes `true`. -/
+def SMTQuery.EntailsObl (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
+  ∀ (σ : SortInterp) (hσ : SortInterp.AllInhabited σ) (𝒜 : ArrayTheory)
+    (ufInterp : UFInterp σ 𝒜) (smtEnv : VarEnv σ 𝒜) (divByZero modByZero : Int → Int),
+    haveI := hσ
+    IFs.UFConsistent q.fs hwf.fsTypeCheck ufInterp divByZero modByZero →
+    (∀ t (ht : t ∈ q.asserts),
+      Term.denoteTyped ufInterp smtEnv divByZero modByZero t .bool (hwf.assertsWF t ht) = true) →
+    Term.denoteTyped ufInterp smtEnv divByZero modByZero q.obl .bool hwf.oblWF = true
+
+/-- The assertions entail `¬obl`: in every model respecting the `define-fun` preamble in which all
+    persistent assertions denote `true`, `obl` denotes `false`. -/
+def SMTQuery.EntailsNegObl (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
+  ∀ (σ : SortInterp) (hσ : SortInterp.AllInhabited σ) (𝒜 : ArrayTheory)
+    (ufInterp : UFInterp σ 𝒜) (smtEnv : VarEnv σ 𝒜) (divByZero modByZero : Int → Int),
+    haveI := hσ
+    IFs.UFConsistent q.fs hwf.fsTypeCheck ufInterp divByZero modByZero →
+    (∀ t (ht : t ∈ q.asserts),
+      Term.denoteTyped ufInterp smtEnv divByZero modByZero t .bool (hwf.assertsWF t ht) = true) →
+    Term.denoteTyped ufInterp smtEnv divByZero modByZero q.obl .bool hwf.oblWF = false
+
+---------------------------------------------------------------------
+-- Entailment / unsatisfiability equivalences
+---------------------------------------------------------------------
+
+/-- The assertions entail `obl` iff they are unsatisfiable together with `¬obl`. -/
+theorem SMTQuery.entailsObl_iff_unsatWithNegObl (q : SMTQuery) (hwf : SMTQuery.WF q) :
+    q.EntailsObl hwf ↔ q.UnsatWithNegObl hwf := by
+  constructor
+  · -- Entails → Unsat
+    intro hE hsat
+    obtain ⟨σ, hσ, 𝒜, ufInterp, smtEnv, dz, mz, hUF, hall⟩ := hsat
+    haveI := hσ
+    have hasserts : ∀ t (ht : t ∈ q.asserts),
+        Term.denoteTyped ufInterp smtEnv dz mz t .bool (hwf.assertsWF t ht) = true := by
+      intro t ht
+      exact hall t (List.mem_append.mpr (Or.inl ht))
+    have hobl := hE σ hσ 𝒜 ufInterp smtEnv dz mz hUF hasserts
+    have hlit := hall (Term.app (.core .not) [q.obl] .bool)
+      (List.mem_append.mpr (Or.inr (List.mem_singleton.mpr rfl)))
+    rw [Term.denoteTyped_not] at hlit
+    simp only [cast_eq] at hlit
+    -- `hlit : (! denote q.obl) = true`, with a proof-arg defeq to `hwf.oblWF`
+    have key : (! Term.denoteTyped ufInterp smtEnv dz mz q.obl .bool hwf.oblWF) = true := hlit
+    rw [hobl] at key
+    simp at key
+  · -- Unsat → Entails
+    intro hU σ hσ 𝒜 ufInterp smtEnv dz mz hUF hasserts
+    haveI := hσ
+    rcases Bool.eq_false_or_eq_true
+        (Term.denoteTyped ufInterp smtEnv dz mz q.obl .bool hwf.oblWF) with hb | hb
+    · exact hb
+    · exfalso
+      apply hU
+      refine ⟨σ, hσ, 𝒜, ufInterp, smtEnv, dz, mz, hUF, ?_⟩
+      intro t ht
+      rcases List.mem_append.mp ht with h | h
+      · exact hasserts t h
+      · rw [List.mem_singleton] at h
+        subst h
+        rw [Term.denoteTyped_not]
+        simp only [cast_eq]
+        show (! Term.denoteTyped ufInterp smtEnv dz mz q.obl .bool hwf.oblWF) = true
+        rw [hb]
+        rfl
+
+/-- The assertions entail `¬obl` iff they are unsatisfiable together with `obl`. -/
+theorem SMTQuery.entailsNegObl_iff_unsatWithObl (q : SMTQuery) (hwf : SMTQuery.WF q) :
+    q.EntailsNegObl hwf ↔ q.UnsatWithObl hwf := by
+  constructor
+  · -- EntailsNeg → Unsat
+    intro hE hsat
+    obtain ⟨σ, hσ, 𝒜, ufInterp, smtEnv, dz, mz, hUF, hall⟩ := hsat
+    haveI := hσ
+    have hasserts : ∀ t (ht : t ∈ q.asserts),
+        Term.denoteTyped ufInterp smtEnv dz mz t .bool (hwf.assertsWF t ht) = true := by
+      intro t ht
+      exact hall t (List.mem_append.mpr (Or.inl ht))
+    have hobl := hE σ hσ 𝒜 ufInterp smtEnv dz mz hUF hasserts
+    have hlit := hall q.obl (List.mem_append.mpr (Or.inr (List.mem_singleton.mpr rfl)))
+    have key : Term.denoteTyped ufInterp smtEnv dz mz q.obl .bool hwf.oblWF = true := hlit
+    rw [hobl] at key
+    simp at key
+  · -- Unsat → EntailsNeg
+    intro hU σ hσ 𝒜 ufInterp smtEnv dz mz hUF hasserts
+    haveI := hσ
+    rcases Bool.eq_false_or_eq_true
+        (Term.denoteTyped ufInterp smtEnv dz mz q.obl .bool hwf.oblWF) with hb | hb
+    · exfalso
+      apply hU
+      refine ⟨σ, hσ, 𝒜, ufInterp, smtEnv, dz, mz, hUF, ?_⟩
+      intro t ht
+      rcases List.mem_append.mp ht with h | h
+      · exact hasserts t h
+      · rw [List.mem_singleton] at h
+        subst h
+        show Term.denoteTyped ufInterp smtEnv dz mz q.obl .bool hwf.oblWF = true
+        exact hb
+    · exact hb
 
 end Strata.SMT.DenoteTyped

--- a/Strata/DL/SMT/DenoteTypedSMTQuery.lean
+++ b/Strata/DL/SMT/DenoteTypedSMTQuery.lean
@@ -1,0 +1,236 @@
+/-
+  Copyright Strata Contributors
+
+  SPDX-License-Identifier: Apache-2.0 OR MIT
+-/
+
+/-
+# `SMTQuery`: definition, typing, and denotation for an SMT query
+
+The `SMTQuery` record models an SMT query as the production pipeline's SMT emitter groups it (sorts,
+datatypes, function declarations/definitions, function axioms, variable declarations/definitions,
+assumptions, goal). This file gives its typing (via `Term.typeCheck`), its order-aware well-formedness
+`SMTQuery.WF`, and its denotation in terms of satisfiability (`checkSat` / `ProvesGoal`, via
+`Term.denoteTyped`). In emission order, every `define-fun` body type-checks against only the context
+accumulated up to it (prior declarations + earlier definitions + its own params, no forward references)
+and every assertion placed after the declarations and definitions type-checks against the full symbol context.
+
+Scope: the well-formedness judgments type-check terms against an EMPTY sort context (`uss = []`), so
+they currently assume the query declares no uninterpreted sorts or datatypes — the `sorts` and
+`datatypes` fields are carried for structural fidelity but are not yet threaded into typing/denotation.
+
+Key definitions: `SMTQuery.WF`, `SMTQuery.checkSat`, `SMTQuery.ProvesGoal`. Key results:
+`SMTQuery.WF.fsTypeCheck`, `SMTQuery.WF.assertOrLitTypeCheck`.
+-/
+
+module
+
+public import Strata.DL.SMT.Factory
+import all Strata.DL.SMT.Factory
+public import Strata.DL.SMT.DenoteTyped
+import all Strata.DL.SMT.DenoteTyped
+public import Strata.DL.SMT.DenoteTypedProps
+import all Strata.DL.SMT.DenoteTypedProps
+
+open Strata.SMT Std
+
+namespace Strata.SMT.DenoteTyped
+
+/-- A datatype constructor's SMT declaration shape: constructor name + typed fields. -/
+public structure RConstructor where
+  name : String
+  args : List (String × TermType)
+  deriving Repr, Inhabited
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   The emitted query record.
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+public structure SMTQuery where
+  sorts : List Strata.DL.SMT.Sort  -- uninterpreted sorts (declare-sort)
+  /-- User datatype declarations (`declare-datatype[s]`), in topological/mutual-block order. Emitted
+      after `sorts`, since datatype constructors may reference the declared sorts. -/
+  datatypes : List (List (String × List String × List RConstructor))
+  fnDecls : List UF              -- uninterpreted factory functions (declare-fun)
+  fnDefs : List IF               -- interpreted functions (define-fun)
+  fnAxioms : List Term
+  varDecls : List UF             -- variables; declare-fun
+  varDefs : List IF              -- nullary define-funs
+  assumptions : List Term        -- including `.distinct` terms
+  obl : Term                     -- obligation / goal
+  deriving Inhabited
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   Projections: the UF typing context, the define-fun preamble, the persistent asserts.
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- The `define-fun` preamble: interpreted functions followed by variable definitions. -/
+def SMTQuery.fs (q : SMTQuery) : List IF := q.fnDefs ++ q.varDefs
+
+/-- The full UF context: all declared and defined functions, in emission order
+    (`fnDecls`, `fnDefs`, `varDecls`, `varDefs`). -/
+def SMTQuery.ufs (q : SMTQuery) : UFCtx :=
+  q.fnDecls ++ q.fnDefs.map IF.toUF ++ q.varDecls ++ q.varDefs.map IF.toUF
+
+/-- The persistent assertions: function axioms followed by program assumptions. -/
+def SMTQuery.asserts (q : SMTQuery) : List Term := q.fnAxioms ++ q.assumptions
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   UF-context hygiene + lookup.
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- SMT symbol names are distinct, and none collides with a reserved `$__bv{n}` binder id. -/
+structure UFCtxWF (ufs : UFCtx) : Prop where
+  uf_nodup : (ufs.map (·.id)).Nodup
+  no_reserved : ∀ n : Nat, s!"$__bv{n}" ∉ ufs.map (·.id)
+
+/-- Look up a UF signature in `ufs` by its printed name (`id`). -/
+def lookupUF (ufs : UFCtx) (name : String) : Option UF :=
+  ufs.find? (·.id == name)
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   Order-aware well-formedness (SMT-LIB emission faithfulness).
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- Well-formedness of a single `define-fun` at UF context `ufs`: its body type-checks to its declared
+    output `f.out` under `ufs` extended with its formal parameters `f.args`. -/
+def IF.WF (ufs : UFCtx) (f : IF) : Prop :=
+  Term.typeCheck ⟨[], ufs, f.args⟩ f.body = .ok f.out
+
+/-- Well-formedness of a `define-fun` preamble: each function is `IF.WF` against the context accumulated
+    so far (prior declarations and earlier definitions) plus its own parameters, so there are no forward
+    references. -/
+inductive IFsWF : UFCtx → List IF → Prop where
+  | nil {ufs} : IFsWF ufs []
+  | cons {ufs f rest} :
+      IF.WF ufs f →
+      IFsWF (ufs ++ [f.toUF]) rest →
+      IFsWF ufs (f :: rest)
+
+/-- Well-formedness of an `SMTQuery`: a non-shadowing UF context (`ufsWF`), an order-well-typed
+    `define-fun` preamble with no forward references (`fnDefsWF`, `varDefsWF`), and every assertion and
+    the goal type-checking to `bool` against the full context (`assertsWF`, `oblWF`). -/
+structure SMTQuery.WF (q : SMTQuery) : Prop where
+  /-- All declared/defined names are distinct and avoid the reserved binder prefix. -/
+  ufsWF : UFCtxWF q.ufs
+  /-- Each `fnDef` body type-checks against `fnDecls` and strictly-earlier `fnDefs`. -/
+  fnDefsWF : IFsWF q.fnDecls q.fnDefs
+  /-- Each `varDef` body type-checks against `fnDecls`, all `fnDefs`, `varDecls`, and strictly-earlier
+      `varDefs`. -/
+  varDefsWF : IFsWF (q.fnDecls ++ q.fnDefs.map IF.toUF ++ q.varDecls) q.varDefs
+  /-- Every persistent assertion type-checks to `bool` against the full context `q.ufs`. -/
+  assertsWF : ∀ t ∈ q.asserts, Term.typeCheck ⟨[], q.ufs, []⟩ t = .ok .bool
+  /-- The goal type-checks to `bool` against the full context `q.ufs`. -/
+  oblWF : Term.typeCheck ⟨[], q.ufs, []⟩ q.obl = .ok .bool
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   Typing at the full context: every define-fun, assertion, and the goal type-check against `q.ufs`.
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- Each function in an `IFsWF ufsBase fs` type-checks at the full context `ufsBase ++ fs.map IF.toUF`. -/
+private theorem IFsWF.mem_wf {ufsBase : UFCtx} {fs : List IF} (h : IFsWF ufsBase fs) :
+    ∀ f ∈ fs, IF.WF (ufsBase ++ fs.map IF.toUF) f := by
+  induction h with
+  | nil => intro f hf; simp at hf
+  | @cons ufs f rest hf _ ih =>
+      intro g hg
+      rcases List.mem_cons.mp hg with rfl | hg
+      · unfold IF.WF at hf ⊢
+        exact typeCheck_ufs_mono_append hf
+      · have hih := ih g hg
+        unfold IF.WF at hih ⊢
+        simpa only [List.map_cons, List.append_assoc, List.cons_append, List.nil_append] using hih
+
+/-- Every `define-fun` in `q.fs` type-checks at the full context `q.ufs`. -/
+theorem SMTQuery.WF.fsTypeCheck {q : SMTQuery} (hwf : SMTQuery.WF q) :
+    ∀ f ∈ q.fs, IF.WF q.ufs f := by
+  intro f hf
+  rw [SMTQuery.fs, List.mem_append] at hf
+  rcases hf with hf | hf
+  · have h1 := hwf.fnDefsWF.mem_wf f hf
+    unfold IF.WF at h1 ⊢
+    have h2 := typeCheck_ufs_mono_append (tail := q.varDecls ++ q.varDefs.map IF.toUF) h1
+    simpa only [SMTQuery.ufs, List.append_assoc] using h2
+  · have h1 := hwf.varDefsWF.mem_wf f hf
+    unfold IF.WF at h1 ⊢
+    simpa only [SMTQuery.ufs, List.append_assoc] using h1
+
+/-- Typing of any assertion OR trailing literal, at the full `q.ufs`. -/
+theorem SMTQuery.WF.assertOrLitTypeCheck {q : SMTQuery} (hwf : SMTQuery.WF q) {lits : List Term}
+    (hlits : ∀ t ∈ lits, Term.typeCheck ⟨[], q.ufs, []⟩ t = .ok .bool)
+    {t : Term} (ht : t ∈ q.asserts ++ lits) : Term.typeCheck ⟨[], q.ufs, []⟩ t = .ok .bool := by
+  rcases List.mem_append.mp ht with h | h
+  · exact hwf.assertsWF t h
+  · exact hlits t h
+
+/-- The negated goal `¬obl` type-checks to `bool` at the full context `q.ufs`. -/
+theorem SMTQuery.WF.notOblTypeCheck {q : SMTQuery} (hwf : SMTQuery.WF q) :
+    Term.typeCheck ⟨[], q.ufs, []⟩ (Term.app (.core .not) [q.obl] .bool) = .ok .bool := by
+  simp [Term.typeCheck, hwf.oblWF, bind, Except.bind]
+
+/- ═══════════════════════════════════════════════════════════════════════════
+   Model-side satisfaction (denotation), over the trivial base-sort interpretation.
+   ═══════════════════════════════════════════════════════════════════════════ -/
+
+/-- The trivial sort interpretation, mapping every sort to `Unit`. -/
+def defaultσ : SortInterp := fun _ _ => Unit
+
+instance : SortInterp.AllInhabited defaultσ := ⟨fun _ _ => ⟨()⟩⟩
+
+variable {σ : SortInterp} {𝒜 : ArrayTheory} [SortInterp.AllInhabited σ]
+
+/-- Build a `VarEnv` binding the variables `bvs` to an HList of values, with `default` elsewhere. -/
+noncomputable def hlToEnv : (bvs : TermVarCtx) → HList (TermType.denoteTyped σ 𝒜) (bvs.map (·.ty)) → VarEnv σ 𝒜
+  | [], _ => fun _ => default
+  | v :: rest, hl =>
+    match hl with
+    | .cons x xs => fun w => if h : w = v then cast (by rw [h]) x else hlToEnv rest xs w
+
+/-- `ufInterp` is consistent with the interpreted function `f`: for every argument valuation, `ufInterp`
+    applied to `f`'s UF signature equals the denotation of `f.body` under the environment binding `f`'s
+    parameters to those arguments. -/
+def IF.UFConsistent {ufs : UFCtx} (f : IF)
+    (htc : IF.WF ufs f)
+    (ufInterp : UFInterp σ 𝒜) (divByZero modByZero : Int → Int) : Prop :=
+  ∀ hl : HList (TermType.denoteTyped σ 𝒜) f.toUF.args,
+    UF.applyDenoteTyped σ 𝒜 f.toUF (ufInterp f.toUF) hl
+    = Term.denoteTyped ufInterp (hlToEnv f.args hl) divByZero modByZero f.body f.out htc
+
+/-- **`ufInterp` respects the whole `define-fun` preamble `fs`.** -/
+def IFs.UFConsistent {ufs : UFCtx} (fs : List IF)
+    (htc : ∀ f ∈ fs, IF.WF ufs f)
+    (ufInterp : UFInterp σ 𝒜) (divByZero modByZero : Int → Int) : Prop :=
+  ∀ (f : IF) (hmem : f ∈ fs),
+    IF.UFConsistent f (htc f hmem) ufInterp divByZero modByZero
+
+/-- The SMT variable environment. -/
+noncomputable def mkVarEnv : VarEnv defaultσ SmtArrayTheory :=
+  fun v => (default : TermType.denoteTyped defaultσ SmtArrayTheory v.ty)
+
+/-- The query is satisfiable together with `lits`: there is a model — a sort interpretation, array
+    theory, UF interpretation, and variable environment — that respects the `define-fun` preamble
+    (`IFs.UFConsistent`) and makes every persistent assertion and every literal in `lits` denote `true`,
+    all typed against the full context `q.ufs`. -/
+def SMTQuery.checkSat (q : SMTQuery) (hwf : SMTQuery.WF q) (lits : List Term)
+    (hlits : ∀ t ∈ lits, Term.typeCheck ⟨[], q.ufs, []⟩ t = .ok .bool) : Prop :=
+  ∃ (σ : SortInterp) (hσ : SortInterp.AllInhabited σ) (𝒜 : ArrayTheory)
+    (ufInterp : UFInterp σ 𝒜) (smtEnv : VarEnv σ 𝒜) (divByZero modByZero : Int → Int),
+    haveI := hσ
+    IFs.UFConsistent q.fs hwf.fsTypeCheck ufInterp divByZero modByZero ∧
+    (∀ t (ht : t ∈ q.asserts ++ lits),
+      Term.denoteTyped ufInterp smtEnv divByZero modByZero t .bool
+        (hwf.assertOrLitTypeCheck hlits ht) = true)
+
+/-- Validity verdict: no model satisfies the assertions together with the negated goal (so the
+    assertions entail the goal). -/
+def SMTQuery.ProvesGoal (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
+  ¬ q.checkSat hwf [Term.app (.core .not) [q.obl] .bool]
+      (fun t ht => by rw [List.mem_singleton] at ht; subst ht; exact hwf.notOblTypeCheck)
+
+/-- Refutation verdict: no model satisfies the assertions together with the goal (so the assertions
+    entail `¬goal`). -/
+def SMTQuery.RefutesGoal (q : SMTQuery) (hwf : SMTQuery.WF q) : Prop :=
+  ¬ q.checkSat hwf [q.obl]
+      (fun t ht => by rw [List.mem_singleton] at ht; subst ht; exact hwf.oblWF)
+
+end Strata.SMT.DenoteTyped


### PR DESCRIPTION
Add DenoteTypedSMTQuery: an `SMTQuery` record modeling an SMT query as the production pipeline's SMT emitter groups it — sorts, datatypes, function declarations and definitions, function axioms, variable declarations and definitions, assumptions, and the goal — with its order-aware well-formedness and denotation-level satisfaction.

- SMTQuery: the record plus its projections — `ufs` (the full UF context in emission order), `fs` (the define-fun preamble), and `asserts` (the persistent assertions).
- SMTQuery.WF: emission-order well-formedness — a non-shadowing UF context, the define-fun preamble order-well-typed with no forward references (IFsWF / IF.WF), and every assertion and the goal type-checking to `bool` against the full context. The WF judgments type-check against an empty sort context, so they assume a query with no uninterpreted sorts or datatypes for now.
- Typing at the full context (WF.fsTypeCheck / assertOrLitTypeCheck / notOblTypeCheck): emission-prefix typing lifted to the full accumulated `ufs`.
- Denotation: checkSat (a model respecting the define-fun preamble via IFs.UFConsistent and satisfying asserts + trailing literals) and the ProvesGoal / RefutesGoal verdicts.

Supporting lemmas in DenoteTypedProps: typeCheck monotonicity under UF-context extension (typeCheck_ufs_mono / typeCheck_ufs_mono_append), for the prefix->full-context lift.

Register the new module in `Strata.lean`.